### PR TITLE
feat: implement memory-engine Phase 1 (ingest→query loop)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ categories = ["database", "science"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
+thiserror = "2"
+rusqlite = { version = "0.34", features = ["bundled-full"] }
 
 [dev-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 rusqlite = { version = "0.34", features = ["bundled-full"] }
 blake3 = "1"
+tracing = "0.1"
 
 [dev-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["memory", "ai-agent", "semantic-search", "knowledge-graph", "event-s
 categories = ["database", "science"]
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 rusqlite = { version = "0.34", features = ["bundled-full"] }
+blake3 = "1"
 
 [dev-dependencies]
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -98,8 +98,8 @@ impl MemoryEngine {
         self.event_store().insert(event)
     }
 
-    /// Add a fact: compute embedding via `embedder`, compute blake3 hash,
-    /// delegate to `FactStore`. Returns the assigned fact id.
+    /// Add a fact: compute embedding via `embedder`, delegate to `FactStore`
+    /// (which computes blake3 content hash). Returns the assigned fact id.
     ///
     /// # Errors
     ///
@@ -112,12 +112,11 @@ impl MemoryEngine {
         embedder: &dyn EmbeddingProvider,
     ) -> Result<i64> {
         let embedding = embedder.embed(content)?;
-        let content_hash = blake3::hash(content.as_bytes()).to_hex()[..16].to_string();
         let now = Utc::now();
 
         let new_fact = NewFact {
             content: content.into(),
-            content_hash,
+            content_hash: String::new(), // FactStore::insert computes this via blake3
             embedding,
             fact_type,
             t_created: now,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,401 @@
+use std::path::PathBuf;
+
+use chrono::Utc;
+use rusqlite::Connection;
+
+use crate::error::{MemoryError, Result};
+use crate::search::hybrid::{hybrid_search, SearchQuery, SearchResult};
+use crate::store::events::EventStore;
+use crate::store::facts::FactStore;
+use crate::store::schema::{get_config, init_schema, open_connection, open_memory, set_config};
+use crate::traits::{
+    ConflictArbiter, ConflictResolution, ConsolidationConfig, ConsolidationStats,
+    EmbeddingProvider, ForgetPolicy, PruneStats, SummaryGenerator,
+};
+use crate::types::{FactType, NewEvent, NewFact};
+
+/// Configuration for opening a [`MemoryEngine`] backed by a file.
+#[derive(Debug, Clone)]
+pub struct EngineConfig {
+    pub path: PathBuf,
+    pub embed_dim: usize,
+}
+
+/// Facade over all memory primitives: ingest, query, consolidate, forget, resolve.
+///
+/// `MemoryEngine` is `!Send` and `!Sync` because `rusqlite::Connection` is not
+/// thread-safe. Consumers must wrap in a `Mutex` or use an actor pattern.
+pub struct MemoryEngine {
+    conn: Connection,
+    embed_dim: usize,
+}
+
+impl std::fmt::Debug for MemoryEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryEngine")
+            .field("embed_dim", &self.embed_dim)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MemoryEngine {
+    /// Open or create a memory engine backed by a `SQLite` file.
+    ///
+    /// On first open, writes `embed_dim` to the config table.
+    /// On subsequent opens, validates the stored `embed_dim` matches.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Migration` if the stored `embed_dim` doesn't match
+    /// the requested value.
+    pub fn open(config: &EngineConfig) -> Result<Self> {
+        let path_str = config.path.to_string_lossy();
+        let conn = open_connection(&path_str)?;
+        init_schema(&conn)?;
+        Self::validate_or_set_embed_dim(&conn, config.embed_dim)?;
+        Ok(Self {
+            conn,
+            embed_dim: config.embed_dim,
+        })
+    }
+
+    /// Open an in-memory engine for testing.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` if the connection or schema setup fails.
+    pub fn open_memory(embed_dim: usize) -> Result<Self> {
+        let conn = open_memory()?;
+        init_schema(&conn)?;
+        Self::validate_or_set_embed_dim(&conn, embed_dim)?;
+        Ok(Self { conn, embed_dim })
+    }
+
+    fn validate_or_set_embed_dim(conn: &Connection, embed_dim: usize) -> Result<()> {
+        if let Some(stored) = get_config(conn, "embed_dim")? {
+            let stored_dim: usize = stored.parse().map_err(|_| {
+                MemoryError::Migration(format!("invalid stored embed_dim: {stored}"))
+            })?;
+            if stored_dim != embed_dim {
+                return Err(MemoryError::Migration(format!(
+                    "embed_dim mismatch: stored {stored_dim} vs requested {embed_dim}"
+                )));
+            }
+        } else {
+            set_config(conn, "embed_dim", &embed_dim.to_string())?;
+        }
+        Ok(())
+    }
+
+    // --- Phase 1: fully implemented ---
+
+    /// Append an event to the event log. Returns the assigned event id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on insert failure.
+    pub fn ingest(&self, event: &NewEvent) -> Result<i64> {
+        self.event_store().insert(event)
+    }
+
+    /// Add a fact: compute embedding via `embedder`, compute blake3 hash,
+    /// delegate to `FactStore`. Returns the assigned fact id.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from embedding computation, dimension validation, or DB insert.
+    pub fn add_fact(
+        &self,
+        content: &str,
+        fact_type: FactType,
+        source_event_id: Option<i64>,
+        embedder: &dyn EmbeddingProvider,
+    ) -> Result<i64> {
+        let embedding = embedder.embed(content)?;
+        let content_hash = blake3::hash(content.as_bytes()).to_hex()[..16].to_string();
+        let now = Utc::now();
+
+        let new_fact = NewFact {
+            content: content.into(),
+            content_hash,
+            embedding,
+            fact_type,
+            t_created: now,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: now,
+            metadata: serde_json::json!({}),
+        };
+
+        self.fact_store().insert(&new_fact)
+    }
+
+    /// Query facts using hybrid search (FTS5 + vector + RRF).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn query(&self, query: &SearchQuery) -> Result<Vec<SearchResult>> {
+        hybrid_search(&self.conn, query, self.embed_dim)
+    }
+
+    /// Get a `FactStore` borrowing this engine's connection.
+    #[must_use]
+    pub const fn fact_store(&self) -> FactStore<'_> {
+        FactStore::new(&self.conn, self.embed_dim)
+    }
+
+    /// Get an `EventStore` borrowing this engine's connection.
+    #[must_use]
+    pub const fn event_store(&self) -> EventStore<'_> {
+        EventStore::new(&self.conn)
+    }
+
+    /// Read a config value by key.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn get_config(&self, key: &str) -> Result<Option<String>> {
+        get_config(&self.conn, key)
+    }
+
+    /// Write a config value (upsert).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on write failure.
+    pub fn set_config(&self, key: &str, value: &str) -> Result<()> {
+        set_config(&self.conn, key, value)
+    }
+
+    // --- Phase 2 stubs ---
+
+    /// Consolidate memories (Phase 2).
+    ///
+    /// # Errors
+    ///
+    /// Always returns `MemoryError::NotImplemented` in Phase 1.
+    pub fn consolidate(
+        &mut self,
+        _generator: &dyn SummaryGenerator,
+        _config: &ConsolidationConfig,
+    ) -> Result<ConsolidationStats> {
+        Err(MemoryError::NotImplemented(
+            "consolidation requires Phase 2 (Tasks 9-12)".into(),
+        ))
+    }
+
+    /// Forget/prune stale facts (Phase 2).
+    ///
+    /// # Errors
+    ///
+    /// Always returns `MemoryError::NotImplemented` in Phase 1.
+    pub fn forget(&mut self, _policy: &ForgetPolicy) -> Result<PruneStats> {
+        Err(MemoryError::NotImplemented(
+            "forgetting requires Phase 2 (Tasks 9, 11)".into(),
+        ))
+    }
+
+    /// Resolve a conflict between facts (Phase 2).
+    ///
+    /// # Errors
+    ///
+    /// Always returns `MemoryError::NotImplemented` in Phase 1.
+    pub fn resolve_conflict(
+        &mut self,
+        _arbiter: &dyn ConflictArbiter,
+        _old_id: i64,
+        _new_fact: NewFact,
+    ) -> Result<ConflictResolution> {
+        Err(MemoryError::NotImplemented(
+            "conflict resolution requires Phase 2 (Tasks 9, 13)".into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::search::hybrid::SearchMode;
+    use crate::traits::{ConsolidationConfig, ForgetPolicy};
+    use crate::types::{EventType, FactType};
+
+    const DIM: usize = 4;
+
+    struct MockEmbedder {
+        dim: usize,
+    }
+
+    impl EmbeddingProvider for MockEmbedder {
+        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.5; self.dim])
+        }
+    }
+
+    struct DummyGen;
+    impl SummaryGenerator for DummyGen {
+        fn summarize(&self, _: &[crate::types::Fact]) -> Result<String> {
+            Ok(String::new())
+        }
+        fn embed(&self, _: &str) -> Result<Vec<f32>> {
+            Ok(vec![])
+        }
+    }
+
+    struct DummyArbiter;
+    impl crate::traits::ConflictArbiter for DummyArbiter {
+        fn arbitrate(
+            &self,
+            _: &crate::types::Fact,
+            _: &crate::types::Fact,
+        ) -> Result<crate::traits::CrudDecision> {
+            Ok(crate::traits::CrudDecision::Noop)
+        }
+    }
+
+    #[test]
+    fn open_memory_succeeds() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        assert_eq!(engine.embed_dim, DIM);
+    }
+
+    #[test]
+    fn ingest_returns_event_id() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let event = NewEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::json!({"msg": "hello"}),
+            source: "test".into(),
+            session_id: None,
+        };
+        let id = engine.ingest(&event).unwrap();
+        assert_eq!(id, 1);
+    }
+
+    #[test]
+    fn add_fact_returns_fact_id() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let id = engine
+            .add_fact("Rust is fast", FactType::Semantic, None, &embedder)
+            .unwrap();
+        assert!(id > 0);
+    }
+
+    #[test]
+    fn query_returns_results_after_adding_facts() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        engine
+            .add_fact(
+                "Rust is a systems programming language",
+                FactType::Semantic,
+                None,
+                &embedder,
+            )
+            .unwrap();
+
+        let query = SearchQuery {
+            text: Some("Rust".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            valid_at: None,
+            fact_type: None,
+        };
+        let results = engine.query(&query).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].fact.content.contains("Rust"));
+    }
+
+    #[test]
+    fn consolidate_returns_not_implemented() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+        let config = ConsolidationConfig {
+            dedup_threshold: 0.92,
+            min_cluster_size: 3,
+        };
+        let err = engine.consolidate(&DummyGen, &config).unwrap_err();
+        assert!(matches!(err, MemoryError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn forget_returns_not_implemented() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+        let policy = ForgetPolicy {
+            min_importance: 0.1,
+        };
+        let err = engine.forget(&policy).unwrap_err();
+        assert!(matches!(err, MemoryError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn resolve_conflict_returns_not_implemented() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+        let new_fact = NewFact {
+            content: "test".into(),
+            content_hash: "abc".into(),
+            embedding: vec![0.1; DIM],
+            fact_type: FactType::Episodic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+        };
+        let err = engine
+            .resolve_conflict(&DummyArbiter, 1, new_fact)
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn embed_dim_validation_rejects_mismatch() {
+        let dir = std::env::temp_dir().join("memory_engine_test_dim_validation");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_path = dir.join("test.db");
+
+        let config_768 = EngineConfig {
+            path: db_path.clone(),
+            embed_dim: 768,
+        };
+        let config_384 = EngineConfig {
+            path: db_path,
+            embed_dim: 384,
+        };
+
+        // First open with dim=768
+        {
+            let _engine = MemoryEngine::open(&config_768).unwrap();
+        }
+
+        // Second open with dim=384 should fail
+        let err = MemoryEngine::open(&config_384).unwrap_err();
+        assert!(matches!(err, MemoryError::Migration(_)));
+        assert!(err.to_string().contains("mismatch"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn get_set_config() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        assert!(engine.get_config("custom_key").unwrap().is_none());
+        engine.set_config("custom_key", "custom_value").unwrap();
+        assert_eq!(
+            engine.get_config("custom_key").unwrap(),
+            Some("custom_value".into())
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,64 @@
+/// Errors returned by the memory engine.
+#[derive(Debug, thiserror::Error)]
+pub enum MemoryError {
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("invalid embedding dimension: expected {expected}, got {actual}")]
+    EmbeddingDimension { expected: usize, actual: usize },
+
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    #[error("schema migration failed: {0}")]
+    Migration(String),
+
+    #[error("not implemented: {0}")]
+    NotImplemented(String),
+}
+
+/// Convenience alias for `Result<T, MemoryError>`.
+pub type Result<T> = std::result::Result<T, MemoryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display() {
+        let err = MemoryError::NotFound("fact 42".into());
+        assert_eq!(err.to_string(), "not found: fact 42");
+    }
+
+    #[test]
+    fn from_rusqlite_error() {
+        let sqlite_err = rusqlite::Error::QueryReturnedNoRows;
+        let err: MemoryError = sqlite_err.into();
+        assert!(matches!(err, MemoryError::Database(_)));
+    }
+
+    #[test]
+    fn from_serde_json_error() {
+        let json_err = serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let err: MemoryError = json_err.into();
+        assert!(matches!(err, MemoryError::Serialization(_)));
+    }
+
+    #[test]
+    fn embedding_dimension_display() {
+        let err = MemoryError::EmbeddingDimension {
+            expected: 768,
+            actual: 512,
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid embedding dimension: expected 768, got 512"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,20 +12,22 @@
 //! ## Storage
 //!
 //! - `SQLite` WAL for event log, facts, and FTS5
-//! - `LanceDB` for vector similarity search
-//! - In-memory petgraph for relationship traversal
+//! - Pure Rust brute-force vector similarity (cosine)
 //!
-//! ## Consumers
+//! ## Threading
 //!
-//! Designed for two consumers from a single backend:
-//! 1. Autonomous agents (Qwen 3.5 on Mac Mini M4)
-//! 2. Developer workflows (Claude Code / IDE hooks)
+//! `MemoryEngine` is `!Send` and `!Sync` (rusqlite `Connection` is not
+//! thread-safe). Consumers must wrap in a `Mutex` or use an actor pattern.
 
+pub mod engine;
 pub mod error;
 pub mod search;
 pub mod store;
+pub mod traits;
 pub mod types;
 
+pub use engine::{EngineConfig, MemoryEngine};
 pub use error::*;
 pub use store::{deserialize_embedding, serialize_embedding};
+pub use traits::EmbeddingProvider;
 pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 //! 1. Autonomous agents (Qwen 3.5 on Mac Mini M4)
 //! 2. Developer workflows (Claude Code / IDE hooks)
 
+pub mod error;
 pub mod types;
 
+pub use error::*;
 pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@
 //! 2. Developer workflows (Claude Code / IDE hooks)
 
 pub mod error;
+pub mod store;
 pub mod types;
 
 pub use error::*;
+pub use store::{deserialize_embedding, serialize_embedding};
 pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,6 @@
 //! 1. Autonomous agents (Qwen 3.5 on Mac Mini M4)
 //! 2. Developer workflows (Claude Code / IDE hooks)
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn engine_compiles() {
-        assert!(true);
-    }
-}
+pub mod types;
+
+pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! 2. Developer workflows (Claude Code / IDE hooks)
 
 pub mod error;
+pub mod search;
 pub mod store;
 pub mod types;
 

--- a/src/search/fts.rs
+++ b/src/search/fts.rs
@@ -1,0 +1,166 @@
+use rusqlite::Connection;
+
+use crate::error::Result;
+
+/// A single FTS5 search result with the fact id and BM25 relevance score.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FtsResult {
+    pub fact_id: i64,
+    pub score: f64,
+}
+
+/// Search the FTS5 index for facts matching the given query string.
+///
+/// Uses BM25 scoring (lower/more negative = better match).
+/// Returns results sorted by relevance (best match first).
+///
+/// FTS5 syntax errors (e.g., unbalanced quotes) return an empty vec
+/// rather than propagating an error.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` for non-FTS5 database errors.
+pub fn fts_search(conn: &Connection, query: &str, limit: usize) -> Result<Vec<FtsResult>> {
+    let mut stmt = conn.prepare(
+        "SELECT rowid, bm25(facts_fts) AS score \
+         FROM facts_fts WHERE facts_fts MATCH ?1 \
+         ORDER BY score LIMIT ?2",
+    )?;
+
+    let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+
+    // FTS5 syntax errors surface at query execution time, not prepare time.
+    // Catch them here and return empty results instead of propagating.
+    let rows = match stmt.query_map(rusqlite::params![query, limit_i64], |row| {
+        Ok(FtsResult {
+            fact_id: row.get(0)?,
+            score: row.get(1)?,
+        })
+    }) {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!("FTS5 query failed (likely syntax error): {e}");
+            return Ok(vec![]);
+        }
+    };
+
+    let mut results = Vec::new();
+    for row in rows {
+        match row {
+            Ok(r) => results.push(r),
+            Err(e) => {
+                tracing::warn!("FTS5 query failed (likely syntax error): {e}");
+                return Ok(vec![]);
+            }
+        }
+    }
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::facts::FactStore;
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::{FactType, NewFact};
+    use chrono::Utc;
+
+    const DIM: usize = 4;
+
+    fn setup() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    fn make_fact(content: &str) -> NewFact {
+        NewFact {
+            content: content.into(),
+            content_hash: String::new(),
+            embedding: vec![0.1; DIM],
+            fact_type: FactType::Episodic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn search_finds_matching_facts() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store
+            .insert(&make_fact("Rust is a systems programming language"))
+            .unwrap();
+        store
+            .insert(&make_fact("Python is great for machine learning"))
+            .unwrap();
+        store
+            .insert(&make_fact("Rust has zero-cost abstractions"))
+            .unwrap();
+
+        let results = fts_search(&conn, "Rust", 10).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn search_empty_for_nonexistent_term() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store
+            .insert(&make_fact("Rust is a systems programming language"))
+            .unwrap();
+
+        let results = fts_search(&conn, "JavaScript", 10).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn bm25_ordering_most_relevant_first() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        // The fact mentioning "Rust" twice should score better than once
+        store
+            .insert(&make_fact("Python is great for data science"))
+            .unwrap();
+        store
+            .insert(&make_fact("Rust Rust Rust systems programming in Rust"))
+            .unwrap();
+        store.insert(&make_fact("Rust is a language")).unwrap();
+
+        let results = fts_search(&conn, "Rust", 10).unwrap();
+        assert_eq!(results.len(), 2);
+        // BM25 scores: lower (more negative) = better match
+        // First result should have a lower (better) score
+        assert!(results[0].score <= results[1].score);
+    }
+
+    #[test]
+    fn fts5_syntax_error_returns_empty() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store.insert(&make_fact("some content")).unwrap();
+
+        // Unbalanced quotes are an FTS5 syntax error
+        let results = fts_search(&conn, "\"unbalanced", 10).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn limit_respected() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store.insert(&make_fact("Rust language one")).unwrap();
+        store.insert(&make_fact("Rust language two")).unwrap();
+        store.insert(&make_fact("Rust language three")).unwrap();
+
+        let results = fts_search(&conn, "Rust", 2).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+}

--- a/src/search/fts.rs
+++ b/src/search/fts.rs
@@ -29,8 +29,10 @@ pub fn fts_search(conn: &Connection, query: &str, limit: usize) -> Result<Vec<Ft
 
     let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
 
-    // FTS5 syntax errors surface at query execution time, not prepare time.
-    // Catch them here and return empty results instead of propagating.
+    // FTS5 syntax errors surface at query_map execution time, not at prepare time.
+    // They are indistinguishable from other rusqlite::Error variants at the type level,
+    // so we catch all errors here. This is intentional: the only realistic failure mode
+    // for a parameterized MATCH query is malformed FTS5 syntax from the caller.
     let rows = match stmt.query_map(rusqlite::params![query, limit_i64], |row| {
         Ok(FtsResult {
             fact_id: row.get(0)?,

--- a/src/search/fts.rs
+++ b/src/search/fts.rs
@@ -44,16 +44,15 @@ pub fn fts_search(conn: &Connection, query: &str, limit: usize) -> Result<Vec<Ft
         }
     };
 
-    let mut results = Vec::new();
-    for row in rows {
-        match row {
-            Ok(r) => results.push(r),
+    let results: Vec<FtsResult> = rows
+        .filter_map(|row| match row {
+            Ok(r) => Some(r),
             Err(e) => {
-                tracing::warn!("FTS5 query failed (likely syntax error): {e}");
-                return Ok(vec![]);
+                tracing::warn!("FTS5 row mapping failed, skipping row: {e}");
+                None
             }
-        }
-    }
+        })
+        .collect();
     Ok(results)
 }
 

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -1,0 +1,400 @@
+use std::collections::{HashMap, HashSet};
+
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::search::fts::fts_search;
+use crate::search::vector::vector_search;
+use crate::store::facts::FactStore;
+use crate::types::{Fact, FactType};
+
+/// How to combine search sources.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchMode {
+    Fts,
+    Vector,
+    Hybrid,
+}
+
+/// Which source(s) contributed to a result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchType {
+    Fts,
+    Vector,
+    Both,
+}
+
+/// A unified search query across FTS5 and vector sources.
+#[derive(Debug, Clone)]
+pub struct SearchQuery {
+    pub text: Option<String>,
+    pub embedding: Option<Vec<f32>>,
+    pub mode: SearchMode,
+    pub limit: usize,
+    pub valid_at: Option<DateTime<Utc>>,
+    pub fact_type: Option<FactType>,
+}
+
+/// A search result with the full fact, combined score, and match source.
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub fact: Fact,
+    pub score: f64,
+    pub match_type: MatchType,
+}
+
+/// Reciprocal Rank Fusion merge of two ranked result lists.
+///
+/// Each item's RRF score = sum of `1 / (k + rank + 1)` across all lists
+/// where it appears (rank is 0-based). Returns merged results sorted
+/// descending by RRF score.
+#[must_use]
+pub fn rrf_merge(fts: &[(i64, f64)], vec: &[(i64, f32)], k: u32) -> Vec<(i64, f64)> {
+    let mut scores: HashMap<i64, f64> = HashMap::new();
+    for (rank, &(id, _)) in fts.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        let rank_u32 = rank as u32;
+        *scores.entry(id).or_default() += 1.0 / f64::from(k + rank_u32 + 1);
+    }
+    for (rank, &(id, _)) in vec.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        let rank_u32 = rank as u32;
+        *scores.entry(id).or_default() += 1.0 / f64::from(k + rank_u32 + 1);
+    }
+    let mut merged: Vec<_> = scores.into_iter().collect();
+    merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    merged
+}
+
+/// Perform a hybrid search combining FTS5 and vector similarity.
+///
+/// Over-fetches 3x the requested limit from each source before merging
+/// to improve result quality after RRF fusion.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on query failure.
+pub fn hybrid_search(
+    conn: &Connection,
+    query: &SearchQuery,
+    embed_dim: usize,
+) -> Result<Vec<SearchResult>> {
+    let overfetch = query.limit.saturating_mul(3).max(query.limit);
+
+    // Collect FTS results
+    let fts_results = if matches!(query.mode, SearchMode::Fts | SearchMode::Hybrid) {
+        query.text.as_ref().map_or_else(Vec::new, |text| {
+            fts_search(conn, text, overfetch).unwrap_or_default()
+        })
+    } else {
+        vec![]
+    };
+
+    // Collect vector results
+    let vec_results = if matches!(query.mode, SearchMode::Vector | SearchMode::Hybrid) {
+        query.embedding.as_ref().map_or_else(Vec::new, |emb| {
+            vector_search(conn, emb, embed_dim, overfetch).unwrap_or_default()
+        })
+    } else {
+        vec![]
+    };
+
+    // Build ID sets for match_type determination
+    let fts_ids: HashSet<i64> = fts_results.iter().map(|r| r.fact_id).collect();
+    let vec_ids: HashSet<i64> = vec_results.iter().map(|r| r.fact_id).collect();
+
+    // Determine ranked IDs with scores
+    let ranked: Vec<(i64, f64)> = match query.mode {
+        SearchMode::Fts => fts_results.iter().map(|r| (r.fact_id, r.score)).collect(),
+        SearchMode::Vector => vec_results
+            .iter()
+            .map(|r| (r.fact_id, f64::from(r.score)))
+            .collect(),
+        SearchMode::Hybrid => {
+            let fts_pairs: Vec<(i64, f64)> =
+                fts_results.iter().map(|r| (r.fact_id, r.score)).collect();
+            let vec_pairs: Vec<(i64, f32)> =
+                vec_results.iter().map(|r| (r.fact_id, r.score)).collect();
+            rrf_merge(&fts_pairs, &vec_pairs, 60)
+        }
+    };
+
+    // Load full facts and apply filters
+    let store = FactStore::new(conn, embed_dim);
+    let mut results = Vec::new();
+    for (id, score) in ranked {
+        if results.len() >= query.limit {
+            break;
+        }
+        let Ok(fact) = store.get(id) else {
+            continue;
+        };
+
+        // Apply fact_type filter
+        if let Some(ref ft) = query.fact_type {
+            if &fact.fact_type != ft {
+                continue;
+            }
+        }
+
+        // Apply valid_at filter
+        if let Some(valid_at) = query.valid_at {
+            if let Some(t_valid) = fact.t_valid {
+                if t_valid > valid_at {
+                    continue;
+                }
+            }
+            if let Some(t_invalid) = fact.t_invalid {
+                if t_invalid <= valid_at {
+                    continue;
+                }
+            }
+        }
+
+        // Skip expired facts
+        if fact.t_expired.is_some() {
+            continue;
+        }
+
+        let match_type = if fts_ids.contains(&id) && vec_ids.contains(&id) {
+            MatchType::Both
+        } else if fts_ids.contains(&id) {
+            MatchType::Fts
+        } else {
+            MatchType::Vector
+        };
+
+        results.push(SearchResult {
+            fact,
+            score,
+            match_type,
+        });
+    }
+
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::NewFact;
+
+    const DIM: usize = 4;
+
+    fn setup() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    fn make_fact_with(content: &str, embedding: Vec<f32>, fact_type: FactType) -> NewFact {
+        NewFact {
+            content: content.into(),
+            content_hash: String::new(),
+            embedding,
+            fact_type,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    fn make_fact(content: &str, embedding: Vec<f32>) -> NewFact {
+        make_fact_with(content, embedding, FactType::Episodic)
+    }
+
+    // --- rrf_merge pure function tests ---
+
+    #[test]
+    fn rrf_merge_known_scores() {
+        let fts = vec![(1_i64, -1.5_f64), (2, -1.0)];
+        let vec_results = vec![(2_i64, 0.9_f32), (3, 0.8)];
+
+        let merged = rrf_merge(&fts, &vec_results, 60);
+
+        // ID 1: FTS rank 0 → 1/(60+0+1) = 1/61
+        // ID 2: FTS rank 1 → 1/(60+1+1) = 1/62, Vec rank 0 → 1/(60+0+1) = 1/61
+        // ID 3: Vec rank 1 → 1/(60+1+1) = 1/62
+        let scores: HashMap<i64, f64> = merged.into_iter().collect();
+        let expected_2 = 1.0 / 62.0 + 1.0 / 61.0;
+        let expected_1 = 1.0 / 61.0;
+        let expected_3 = 1.0 / 62.0;
+
+        assert!((scores[&2] - expected_2).abs() < 1e-10);
+        assert!((scores[&1] - expected_1).abs() < 1e-10);
+        assert!((scores[&3] - expected_3).abs() < 1e-10);
+    }
+
+    #[test]
+    fn rrf_merge_descending_order() {
+        let fts = vec![(1_i64, -2.0_f64), (2, -1.0)];
+        let vec_results = vec![(2_i64, 0.9_f32), (3, 0.8)];
+
+        let merged = rrf_merge(&fts, &vec_results, 60);
+        // ID 2 should be first (appears in both lists)
+        assert_eq!(merged[0].0, 2);
+    }
+
+    #[test]
+    fn rrf_merge_empty_fts() {
+        let fts: Vec<(i64, f64)> = vec![];
+        let vec_results = vec![(1_i64, 0.9_f32), (2, 0.8)];
+
+        let merged = rrf_merge(&fts, &vec_results, 60);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].0, 1);
+    }
+
+    #[test]
+    fn rrf_merge_empty_vec() {
+        let fts = vec![(1_i64, -2.0_f64), (2, -1.0)];
+        let vec_results: Vec<(i64, f32)> = vec![];
+
+        let merged = rrf_merge(&fts, &vec_results, 60);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].0, 1);
+    }
+
+    // --- hybrid_search integration tests ---
+
+    #[test]
+    fn hybrid_search_integration() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store
+            .insert(&make_fact(
+                "Rust systems programming",
+                vec![1.0, 0.0, 0.0, 0.0],
+            ))
+            .unwrap();
+        store
+            .insert(&make_fact(
+                "Python machine learning",
+                vec![0.0, 1.0, 0.0, 0.0],
+            ))
+            .unwrap();
+        store
+            .insert(&make_fact("Rust memory safety", vec![0.9, 0.1, 0.0, 0.0]))
+            .unwrap();
+        store
+            .insert(&make_fact(
+                "JavaScript web development",
+                vec![0.0, 0.0, 1.0, 0.0],
+            ))
+            .unwrap();
+        store
+            .insert(&make_fact(
+                "Rust zero cost abstractions",
+                vec![0.8, 0.2, 0.0, 0.0],
+            ))
+            .unwrap();
+
+        let query = SearchQuery {
+            text: Some("Rust".into()),
+            embedding: Some(vec![1.0, 0.0, 0.0, 0.0]),
+            mode: SearchMode::Hybrid,
+            limit: 3,
+            valid_at: None,
+            fact_type: None,
+        };
+
+        let results = hybrid_search(&conn, &query, DIM).unwrap();
+        assert!(!results.is_empty());
+        assert!(results.len() <= 3);
+        // Results matching both FTS and vector should have MatchType::Both
+        let has_both = results.iter().any(|r| r.match_type == MatchType::Both);
+        assert!(has_both);
+    }
+
+    #[test]
+    fn search_mode_fts_only() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store
+            .insert(&make_fact("Rust language", vec![1.0, 0.0, 0.0, 0.0]))
+            .unwrap();
+        store
+            .insert(&make_fact("Python language", vec![0.0, 1.0, 0.0, 0.0]))
+            .unwrap();
+
+        let query = SearchQuery {
+            text: Some("Rust".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            valid_at: None,
+            fact_type: None,
+        };
+
+        let results = hybrid_search(&conn, &query, DIM).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_type, MatchType::Fts);
+    }
+
+    #[test]
+    fn search_mode_vector_only() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store
+            .insert(&make_fact("fact one", vec![1.0, 0.0, 0.0, 0.0]))
+            .unwrap();
+        store
+            .insert(&make_fact("fact two", vec![0.0, 1.0, 0.0, 0.0]))
+            .unwrap();
+
+        let query = SearchQuery {
+            text: None,
+            embedding: Some(vec![1.0, 0.0, 0.0, 0.0]),
+            mode: SearchMode::Vector,
+            limit: 1,
+            valid_at: None,
+            fact_type: None,
+        };
+
+        let results = hybrid_search(&conn, &query, DIM).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_type, MatchType::Vector);
+        assert_eq!(results[0].fact.content, "fact one");
+    }
+
+    #[test]
+    fn hybrid_search_fact_type_filter() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store
+            .insert(&make_fact_with(
+                "semantic fact",
+                vec![1.0, 0.0, 0.0, 0.0],
+                FactType::Semantic,
+            ))
+            .unwrap();
+        store
+            .insert(&make_fact_with(
+                "episodic fact",
+                vec![0.9, 0.1, 0.0, 0.0],
+                FactType::Episodic,
+            ))
+            .unwrap();
+
+        let query = SearchQuery {
+            text: Some("fact".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            valid_at: None,
+            fact_type: Some(FactType::Semantic),
+        };
+
+        let results = hybrid_search(&conn, &query, DIM).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].fact.fact_type, FactType::Semantic);
+    }
+}

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -84,18 +84,20 @@ pub fn hybrid_search(
 
     // Collect FTS results
     let fts_results = if matches!(query.mode, SearchMode::Fts | SearchMode::Hybrid) {
-        query.text.as_ref().map_or_else(Vec::new, |text| {
-            fts_search(conn, text, overfetch).unwrap_or_default()
-        })
+        match query.text.as_ref() {
+            Some(text) => fts_search(conn, text, overfetch)?,
+            None => vec![],
+        }
     } else {
         vec![]
     };
 
     // Collect vector results
     let vec_results = if matches!(query.mode, SearchMode::Vector | SearchMode::Hybrid) {
-        query.embedding.as_ref().map_or_else(Vec::new, |emb| {
-            vector_search(conn, emb, embed_dim, overfetch).unwrap_or_default()
-        })
+        match query.embedding.as_ref() {
+            Some(emb) => vector_search(conn, emb, embed_dim, overfetch)?,
+            None => vec![],
+        }
     } else {
         vec![]
     };
@@ -120,7 +122,9 @@ pub fn hybrid_search(
         }
     };
 
-    // Load full facts and apply filters
+    // Load full facts and apply filters.
+    // NOTE: filters applied post-overfetch. Highly restrictive filters may return
+    // fewer results than `limit`. Phase 2 can push filters into SQL for accuracy.
     let store = FactStore::new(conn, embed_dim);
     let mut results = Vec::new();
     for (id, score) in ranked {
@@ -128,6 +132,7 @@ pub fn hybrid_search(
             break;
         }
         let Ok(fact) = store.get(id) else {
+            tracing::warn!("failed to load fact id={id} during result collection, skipping");
             continue;
         };
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,5 +1,7 @@
 pub mod fts;
+pub mod hybrid;
 pub mod vector;
 
 pub use fts::{fts_search, FtsResult};
+pub use hybrid::{hybrid_search, rrf_merge, MatchType, SearchMode, SearchQuery, SearchResult};
 pub use vector::{cosine_similarity, vector_search, VectorResult};

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,3 +1,5 @@
 pub mod fts;
+pub mod vector;
 
 pub use fts::{fts_search, FtsResult};
+pub use vector::{cosine_similarity, vector_search, VectorResult};

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,0 +1,3 @@
+pub mod fts;
+
+pub use fts::{fts_search, FtsResult};

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -1,0 +1,182 @@
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::store::deserialize_embedding;
+
+/// A single vector search result with fact id and cosine similarity score.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorResult {
+    pub fact_id: i64,
+    pub score: f32,
+}
+
+/// Compute the cosine similarity between two vectors.
+///
+/// Returns 0.0 if either vector has zero magnitude (avoids NaN).
+#[must_use]
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let (mut dot, mut norm_a, mut norm_b) = (0.0_f32, 0.0_f32, 0.0_f32);
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        dot = x.mul_add(y, dot);
+        norm_a = x.mul_add(x, norm_a);
+        norm_b = y.mul_add(y, norm_b);
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom == 0.0 {
+        0.0
+    } else {
+        dot / denom
+    }
+}
+
+/// Brute-force vector similarity search over active facts.
+///
+/// Streams all active facts (`t_expired IS NULL`) from `SQLite`, deserializes
+/// their embeddings, computes cosine similarity against `query_embedding`,
+/// and returns the top `limit` results sorted descending by score.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on query failure, or
+/// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
+pub fn vector_search(
+    conn: &Connection,
+    query_embedding: &[f32],
+    embed_dim: usize,
+    limit: usize,
+) -> Result<Vec<VectorResult>> {
+    let mut stmt = conn.prepare("SELECT id, embedding FROM facts WHERE t_expired IS NULL")?;
+
+    let rows = stmt.query_map([], |row| {
+        let id: i64 = row.get(0)?;
+        let blob: Vec<u8> = row.get(1)?;
+        Ok((id, blob))
+    })?;
+
+    let mut scored: Vec<VectorResult> = Vec::new();
+    for row in rows {
+        let (id, blob) = row?;
+        let embedding = deserialize_embedding(&blob, embed_dim)?;
+        let score = cosine_similarity(query_embedding, &embedding);
+        scored.push(VectorResult { fact_id: id, score });
+    }
+
+    // Sort descending by score
+    scored.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    scored.truncate(limit);
+    Ok(scored)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::facts::FactStore;
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::{FactType, NewFact};
+    use chrono::Utc;
+
+    const DIM: usize = 4;
+
+    fn setup() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    fn make_fact_with_embedding(content: &str, embedding: Vec<f32>) -> NewFact {
+        NewFact {
+            content: content.into(),
+            content_hash: String::new(),
+            embedding,
+            fact_type: FactType::Episodic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn cosine_identical_vectors() {
+        let a = [1.0_f32, 0.0];
+        let b = [1.0_f32, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_orthogonal_vectors() {
+        let a = [1.0_f32, 0.0];
+        let b = [0.0_f32, 1.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_opposite_vectors() {
+        let a = [1.0_f32, 0.0];
+        let b = [-1.0_f32, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim - (-1.0)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_zero_vector_returns_zero() {
+        let a = [0.0_f32, 0.0];
+        let b = [1.0_f32, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < f32::EPSILON);
+        // Also both zero
+        let sim2 = cosine_similarity(&a, &a);
+        assert!(sim2.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn vector_search_returns_top_k_descending() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+
+        // Query embedding: [1, 0, 0, 0]
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+
+        // Insert 5 facts with known embeddings of varying similarity to query
+        store
+            .insert(&make_fact_with_embedding("exact", vec![1.0, 0.0, 0.0, 0.0]))
+            .unwrap(); // cosine = 1.0
+        store
+            .insert(&make_fact_with_embedding("close", vec![0.9, 0.1, 0.0, 0.0]))
+            .unwrap(); // high
+        store
+            .insert(&make_fact_with_embedding(
+                "medium",
+                vec![0.5, 0.5, 0.0, 0.0],
+            ))
+            .unwrap(); // medium
+        store
+            .insert(&make_fact_with_embedding("far", vec![0.0, 1.0, 0.0, 0.0]))
+            .unwrap(); // cosine = 0.0
+        store
+            .insert(&make_fact_with_embedding(
+                "opposite",
+                vec![-1.0, 0.0, 0.0, 0.0],
+            ))
+            .unwrap(); // cosine = -1.0
+
+        let results = vector_search(&conn, &query, DIM, 3).unwrap();
+        assert_eq!(results.len(), 3);
+        // Descending order by score
+        assert!(results[0].score >= results[1].score);
+        assert!(results[1].score >= results[2].score);
+        // Top result should be the exact match
+        assert!((results[0].score - 1.0).abs() < 1e-5);
+    }
+}

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -61,13 +61,20 @@ pub fn vector_search(
         scored.push(VectorResult { fact_id: id, score });
     }
 
-    // Sort descending by score
+    // Partial sort: O(N) partition then sort only top `limit` elements
+    if scored.len() > limit {
+        scored.select_nth_unstable_by(limit, |a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        scored.truncate(limit);
+    }
     scored.sort_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    scored.truncate(limit);
     Ok(scored)
 }
 

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -45,6 +45,13 @@ pub fn vector_search(
     embed_dim: usize,
     limit: usize,
 ) -> Result<Vec<VectorResult>> {
+    if query_embedding.len() != embed_dim {
+        return Err(crate::error::MemoryError::EmbeddingDimension {
+            expected: embed_dim,
+            actual: query_embedding.len(),
+        });
+    }
+
     let mut stmt = conn.prepare("SELECT id, embedding FROM facts WHERE t_expired IS NULL")?;
 
     let rows = stmt.query_map([], |row| {
@@ -145,6 +152,22 @@ mod tests {
         // Also both zero
         let sim2 = cosine_similarity(&a, &a);
         assert!(sim2.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn vector_search_rejects_wrong_query_dimension() {
+        let conn = setup();
+        let wrong_dim_query = [1.0_f32, 0.0]; // DIM is 4, query is 2
+        let result = vector_search(&conn, &wrong_dim_query, DIM, 3);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::MemoryError::EmbeddingDimension {
+                expected: 4,
+                actual: 2
+            }
+        ));
     }
 
     #[test]

--- a/src/store/events.rs
+++ b/src/store/events.rs
@@ -1,0 +1,302 @@
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use crate::error::{MemoryError, Result};
+use crate::types::{Event, EventType, NewEvent};
+
+/// Filter for querying events.
+#[derive(Debug, Clone, Default)]
+pub struct EventFilter {
+    pub since: Option<DateTime<Utc>>,
+    pub session_id: Option<String>,
+    pub event_type: Option<EventType>,
+    pub limit: Option<usize>,
+}
+
+/// Store for the append-only event log.
+pub struct EventStore<'a> {
+    conn: &'a Connection,
+}
+
+const fn event_type_to_str(et: &EventType) -> &'static str {
+    match et {
+        EventType::Interaction => "Interaction",
+        EventType::ToolCall => "ToolCall",
+        EventType::MemoryOp => "MemoryOp",
+        EventType::SystemEvent => "SystemEvent",
+    }
+}
+
+fn str_to_event_type(s: &str) -> Result<EventType> {
+    match s {
+        "Interaction" => Ok(EventType::Interaction),
+        "ToolCall" => Ok(EventType::ToolCall),
+        "MemoryOp" => Ok(EventType::MemoryOp),
+        "SystemEvent" => Ok(EventType::SystemEvent),
+        other => Err(MemoryError::NotFound(format!(
+            "unknown event type: {other}"
+        ))),
+    }
+}
+
+fn row_to_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
+    let timestamp_str: String = row.get("timestamp")?;
+    let event_type_str: String = row.get("event_type")?;
+    let payload_str: String = row.get("payload")?;
+
+    let timestamp = DateTime::parse_from_rfc3339(&timestamp_str)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, Box::new(e))
+        })?;
+
+    let event_type = str_to_event_type(&event_type_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    let payload: serde_json::Value = serde_json::from_str(&payload_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    Ok(Event {
+        id: row.get("id")?,
+        timestamp,
+        event_type,
+        payload,
+        source: row.get("source")?,
+        session_id: row.get("session_id")?,
+    })
+}
+
+impl<'a> EventStore<'a> {
+    /// Create a new `EventStore` borrowing the given connection.
+    #[must_use]
+    pub const fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Insert a new event, returning its auto-assigned id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on insert failure.
+    pub fn insert(&self, event: &NewEvent) -> Result<i64> {
+        let timestamp_str = event.timestamp.to_rfc3339();
+        let event_type_str = event_type_to_str(&event.event_type);
+        let payload_str = serde_json::to_string(&event.payload)?;
+
+        self.conn.execute(
+            "INSERT INTO events (timestamp, event_type, payload, source, session_id)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                timestamp_str,
+                event_type_str,
+                payload_str,
+                event.source,
+                event.session_id,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Get an event by id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if the id doesn't exist.
+    pub fn get(&self, id: i64) -> Result<Event> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, timestamp, event_type, payload, source, session_id
+             FROM events WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query_map(params![id], row_to_event)?;
+        match rows.next() {
+            Some(Ok(event)) => Ok(event),
+            Some(Err(e)) => Err(e.into()),
+            None => Err(MemoryError::NotFound(format!("event {id}"))),
+        }
+    }
+
+    /// List events matching the filter.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn list(&self, filter: &EventFilter) -> Result<Vec<Event>> {
+        let (sql, values) = build_filter_query(
+            "SELECT id, timestamp, event_type, payload, source, session_id FROM events",
+            filter,
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(values), row_to_event)?;
+        let mut events = Vec::new();
+        for row in rows {
+            events.push(row?);
+        }
+        Ok(events)
+    }
+
+    /// Count events matching the filter.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn count(&self, filter: &EventFilter) -> Result<i64> {
+        let (sql, values) = build_filter_query("SELECT COUNT(*) FROM events", filter);
+        let mut stmt = self.conn.prepare(&sql)?;
+        let count = stmt.query_row(rusqlite::params_from_iter(values), |row| row.get(0))?;
+        Ok(count)
+    }
+}
+
+/// Build a filtered SQL query with dynamic WHERE clauses.
+/// Returns the SQL string and a Vec of boxed parameter values.
+fn build_filter_query(
+    base: &str,
+    filter: &EventFilter,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let mut clauses: Vec<String> = Vec::new();
+    let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+
+    if let Some(ref since) = filter.since {
+        clauses.push(format!("timestamp >= ?{idx}"));
+        values.push(Box::new(since.to_rfc3339()));
+        idx += 1;
+    }
+    if let Some(ref session_id) = filter.session_id {
+        clauses.push(format!("session_id = ?{idx}"));
+        values.push(Box::new(session_id.clone()));
+        idx += 1;
+    }
+    if let Some(ref event_type) = filter.event_type {
+        clauses.push(format!("event_type = ?{idx}"));
+        values.push(Box::new(event_type_to_str(event_type).to_string()));
+        idx += 1;
+    }
+
+    let mut sql = base.to_string();
+    if !clauses.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&clauses.join(" AND "));
+    }
+    sql.push_str(" ORDER BY timestamp ASC");
+
+    if let Some(limit) = filter.limit {
+        use std::fmt::Write;
+        let _ = write!(sql, " LIMIT ?{idx}");
+        values.push(Box::new(i64::try_from(limit).unwrap_or(i64::MAX)));
+    }
+
+    (sql, values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::{init_schema, open_memory};
+
+    fn setup() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    fn make_event(source: &str, session_id: Option<&str>) -> NewEvent {
+        NewEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::json!({"key": "value"}),
+            source: source.into(),
+            session_id: session_id.map(Into::into),
+        }
+    }
+
+    #[test]
+    fn insert_returns_id() {
+        let conn = setup();
+        let store = EventStore::new(&conn);
+        let id = store.insert(&make_event("test", None)).unwrap();
+        assert_eq!(id, 1);
+        let id2 = store.insert(&make_event("test", None)).unwrap();
+        assert_eq!(id2, 2);
+    }
+
+    #[test]
+    fn get_round_trip() {
+        let conn = setup();
+        let store = EventStore::new(&conn);
+        let event = make_event("src1", Some("sess-1"));
+        let id = store.insert(&event).unwrap();
+        let retrieved = store.get(id).unwrap();
+        assert_eq!(retrieved.id, id);
+        assert_eq!(retrieved.source, "src1");
+        assert_eq!(retrieved.session_id, Some("sess-1".into()));
+        assert_eq!(retrieved.event_type, EventType::Interaction);
+    }
+
+    #[test]
+    fn get_not_found() {
+        let conn = setup();
+        let store = EventStore::new(&conn);
+        let err = store.get(999).unwrap_err();
+        assert!(matches!(err, MemoryError::NotFound(_)));
+    }
+
+    #[test]
+    fn list_with_session_id_filter() {
+        let conn = setup();
+        let store = EventStore::new(&conn);
+        store.insert(&make_event("a", Some("sess-1"))).unwrap();
+        store.insert(&make_event("b", Some("sess-2"))).unwrap();
+        store.insert(&make_event("c", Some("sess-1"))).unwrap();
+
+        let filter = EventFilter {
+            session_id: Some("sess-1".into()),
+            ..EventFilter::default()
+        };
+        let results = store.list(&filter).unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results
+            .iter()
+            .all(|e| e.session_id == Some("sess-1".into())));
+    }
+
+    #[test]
+    fn count_matches_list() {
+        let conn = setup();
+        let store = EventStore::new(&conn);
+        store.insert(&make_event("a", Some("sess-1"))).unwrap();
+        store.insert(&make_event("b", Some("sess-2"))).unwrap();
+        store.insert(&make_event("c", Some("sess-1"))).unwrap();
+
+        let filter = EventFilter {
+            session_id: Some("sess-1".into()),
+            ..EventFilter::default()
+        };
+        let count = store.count(&filter).unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn json_payload_round_trip() {
+        let conn = setup();
+        let store = EventStore::new(&conn);
+        let payload = serde_json::json!({
+            "nested": {"array": [1, 2, 3]},
+            "bool": true,
+            "null_val": null
+        });
+        let event = NewEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::ToolCall,
+            payload: payload.clone(),
+            source: "test".into(),
+            session_id: None,
+        };
+        let id = store.insert(&event).unwrap();
+        let retrieved = store.get(id).unwrap();
+        assert_eq!(retrieved.payload, payload);
+        assert_eq!(retrieved.event_type, EventType::ToolCall);
+    }
+}

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -336,7 +336,10 @@ mod tests {
         let store = FactStore::new(&conn, DIM);
         let mut embedding = vec![0.0_f32; DIM];
         for (i, val) in embedding.iter_mut().enumerate() {
-            *val = i as f32 * 0.001;
+            #[allow(clippy::cast_precision_loss)]
+            {
+                *val = i as f32 * 0.001;
+            }
         }
         let fact = make_fact("embedding test", embedding.clone());
         let id = store.insert(&fact).unwrap();

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -28,10 +28,10 @@ fn str_to_fact_type(s: &str) -> Result<FactType> {
     }
 }
 
-/// Compute blake3 hex hash of content, truncated to first 16 characters.
+/// Compute blake3 hex hash of content, truncated to first 32 characters (128 bits).
 fn content_hash(content: &str) -> String {
     let hash = blake3::hash(content.as_bytes());
-    hash.to_hex()[..16].to_string()
+    hash.to_hex()[..32].to_string()
 }
 
 /// Parse an optional ISO 8601 timestamp from a nullable TEXT column.
@@ -66,7 +66,7 @@ impl<'a> FactStore<'a> {
     }
 
     /// Insert a new fact. Validates embedding dimension, computes `content_hash`
-    /// via blake3 (hex, first 16 chars), serializes embedding as BLOB.
+    /// via blake3 (hex, first 32 chars / 128 bits), serializes embedding as BLOB.
     /// Returns the auto-assigned id.
     ///
     /// # Errors
@@ -435,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn content_hash_is_blake3_hex_16() {
+    fn content_hash_is_blake3_hex_32() {
         let conn = setup();
         let store = FactStore::new(&conn, DIM);
         let content = "hash test content";
@@ -443,8 +443,8 @@ mod tests {
         let fact = store.get(id).unwrap();
 
         // Compute expected hash
-        let expected = &blake3::hash(content.as_bytes()).to_hex()[..16];
+        let expected = &blake3::hash(content.as_bytes()).to_hex()[..32];
         assert_eq!(fact.content_hash, expected);
-        assert_eq!(fact.content_hash.len(), 16);
+        assert_eq!(fact.content_hash.len(), 32);
     }
 }

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1,0 +1,447 @@
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use crate::error::{MemoryError, Result};
+use crate::store::{deserialize_embedding, serialize_embedding};
+use crate::types::{Fact, FactType, NewFact};
+
+/// Store for bi-temporal facts with embedding BLOBs.
+pub struct FactStore<'a> {
+    conn: &'a Connection,
+    embed_dim: usize,
+}
+
+const fn fact_type_to_str(ft: &FactType) -> &'static str {
+    match ft {
+        FactType::Episodic => "episodic",
+        FactType::Semantic => "semantic",
+        FactType::Procedural => "procedural",
+    }
+}
+
+fn str_to_fact_type(s: &str) -> Result<FactType> {
+    match s {
+        "episodic" => Ok(FactType::Episodic),
+        "semantic" => Ok(FactType::Semantic),
+        "procedural" => Ok(FactType::Procedural),
+        other => Err(MemoryError::NotFound(format!("unknown fact type: {other}"))),
+    }
+}
+
+/// Compute blake3 hex hash of content, truncated to first 16 characters.
+fn content_hash(content: &str) -> String {
+    let hash = blake3::hash(content.as_bytes());
+    hash.to_hex()[..16].to_string()
+}
+
+/// Parse an optional ISO 8601 timestamp from a nullable TEXT column.
+fn parse_optional_timestamp(s: Option<&str>) -> rusqlite::Result<Option<DateTime<Utc>>> {
+    s.map_or(Ok(None), |ts| {
+        DateTime::parse_from_rfc3339(ts)
+            .map(|dt| Some(dt.with_timezone(&Utc)))
+            .map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })
+    })
+}
+
+/// Parse a required ISO 8601 timestamp from a TEXT column.
+fn parse_timestamp(s: &str) -> rusqlite::Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })
+}
+
+impl<'a> FactStore<'a> {
+    /// Create a new `FactStore` borrowing the given connection.
+    #[must_use]
+    pub const fn new(conn: &'a Connection, embed_dim: usize) -> Self {
+        Self { conn, embed_dim }
+    }
+
+    /// Insert a new fact. Validates embedding dimension, computes `content_hash`
+    /// via blake3 (hex, first 16 chars), serializes embedding as BLOB.
+    /// Returns the auto-assigned id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::EmbeddingDimension` if embedding length != `embed_dim`.
+    /// Returns `MemoryError::Database` on insert failure.
+    pub fn insert(&self, fact: &NewFact) -> Result<i64> {
+        if fact.embedding.len() != self.embed_dim {
+            return Err(MemoryError::EmbeddingDimension {
+                expected: self.embed_dim,
+                actual: fact.embedding.len(),
+            });
+        }
+
+        let hash = content_hash(&fact.content);
+        let blob = serialize_embedding(&fact.embedding);
+        let fact_type_str = fact_type_to_str(&fact.fact_type);
+        let t_created = fact.t_created.to_rfc3339();
+        let t_expired = fact.t_expired.map(|dt| dt.to_rfc3339());
+        let t_valid = fact.t_valid.map(|dt| dt.to_rfc3339());
+        let t_invalid = fact.t_invalid.map(|dt| dt.to_rfc3339());
+        let last_accessed = fact.last_accessed.to_rfc3339();
+        let metadata_str = serde_json::to_string(&fact.metadata)?;
+
+        self.conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type,
+                t_created, t_expired, t_valid, t_invalid,
+                source_event_id, importance, access_count, last_accessed, metadata)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            params![
+                fact.content,
+                hash,
+                blob,
+                fact_type_str,
+                t_created,
+                t_expired,
+                t_valid,
+                t_invalid,
+                fact.source_event_id,
+                fact.importance,
+                fact.access_count,
+                last_accessed,
+                metadata_str,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Get a fact by id, including full embedding deserialization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if the id doesn't exist.
+    pub fn get(&self, id: i64) -> Result<Fact> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, content, content_hash, embedding, fact_type,
+                    t_created, t_expired, t_valid, t_invalid,
+                    source_event_id, importance, access_count, last_accessed, metadata
+             FROM facts WHERE id = ?1",
+        )?;
+        let dim = self.embed_dim;
+        let mut rows = stmt.query_map(params![id], |row| row_to_fact(row, dim))?;
+        match rows.next() {
+            Some(Ok(fact)) => Ok(fact),
+            Some(Err(e)) => Err(e.into()),
+            None => Err(MemoryError::NotFound(format!("fact {id}"))),
+        }
+    }
+
+    /// List all active facts (`t_expired IS NULL`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn list_active(&self) -> Result<Vec<Fact>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, content, content_hash, embedding, fact_type,
+                    t_created, t_expired, t_valid, t_invalid,
+                    source_event_id, importance, access_count, last_accessed, metadata
+             FROM facts WHERE t_expired IS NULL",
+        )?;
+        let dim = self.embed_dim;
+        let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
+        let mut facts = Vec::new();
+        for row in rows {
+            facts.push(row?);
+        }
+        Ok(facts)
+    }
+
+    /// List facts active at a given point in time (bi-temporal query).
+    ///
+    /// Active means: `t_expired IS NULL` AND valid at `valid_at`:
+    /// `(t_valid IS NULL OR t_valid <= valid_at) AND (t_invalid IS NULL OR t_invalid > valid_at)`
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn list_active_at(&self, valid_at: DateTime<Utc>) -> Result<Vec<Fact>> {
+        let valid_at_str = valid_at.to_rfc3339();
+        let mut stmt = self.conn.prepare(
+            "SELECT id, content, content_hash, embedding, fact_type,
+                    t_created, t_expired, t_valid, t_invalid,
+                    source_event_id, importance, access_count, last_accessed, metadata
+             FROM facts
+             WHERE t_expired IS NULL
+               AND (t_valid IS NULL OR t_valid <= ?1)
+               AND (t_invalid IS NULL OR t_invalid > ?1)",
+        )?;
+        let dim = self.embed_dim;
+        let rows = stmt.query_map(params![valid_at_str], |row| row_to_fact(row, dim))?;
+        let mut facts = Vec::new();
+        for row in rows {
+            facts.push(row?);
+        }
+        Ok(facts)
+    }
+
+    /// Expire a fact by setting `t_expired`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if no rows affected.
+    pub fn expire(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
+        let now_str = now.to_rfc3339();
+        let changed = self.conn.execute(
+            "UPDATE facts SET t_expired = ?1 WHERE id = ?2 AND t_expired IS NULL",
+            params![now_str, id],
+        )?;
+        if changed == 0 {
+            return Err(MemoryError::NotFound(format!("fact {id}")));
+        }
+        Ok(())
+    }
+
+    /// Update the importance score for a fact.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if no rows affected.
+    pub fn update_importance(&self, id: i64, importance: f64) -> Result<()> {
+        let changed = self.conn.execute(
+            "UPDATE facts SET importance = ?1 WHERE id = ?2",
+            params![importance, id],
+        )?;
+        if changed == 0 {
+            return Err(MemoryError::NotFound(format!("fact {id}")));
+        }
+        Ok(())
+    }
+
+    /// Increment the access count and update `last_accessed`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if no rows affected.
+    pub fn increment_access(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
+        let now_str = now.to_rfc3339();
+        let changed = self.conn.execute(
+            "UPDATE facts SET access_count = access_count + 1, last_accessed = ?1 WHERE id = ?2",
+            params![now_str, id],
+        )?;
+        if changed == 0 {
+            return Err(MemoryError::NotFound(format!("fact {id}")));
+        }
+        Ok(())
+    }
+}
+
+fn row_to_fact(row: &rusqlite::Row<'_>, embed_dim: usize) -> rusqlite::Result<Fact> {
+    let t_created_str: String = row.get("t_created")?;
+    let t_expired_str: Option<String> = row.get("t_expired")?;
+    let t_valid_str: Option<String> = row.get("t_valid")?;
+    let t_invalid_str: Option<String> = row.get("t_invalid")?;
+    let last_accessed_str: String = row.get("last_accessed")?;
+    let fact_type_str: String = row.get("fact_type")?;
+    let embedding_blob: Vec<u8> = row.get("embedding")?;
+    let metadata_str: String = row.get("metadata")?;
+
+    let t_created = parse_timestamp(&t_created_str)?;
+    let t_expired = parse_optional_timestamp(t_expired_str.as_deref())?;
+    let t_valid = parse_optional_timestamp(t_valid_str.as_deref())?;
+    let t_invalid = parse_optional_timestamp(t_invalid_str.as_deref())?;
+    let last_accessed = parse_timestamp(&last_accessed_str)?;
+
+    let fact_type = str_to_fact_type(&fact_type_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    let embedding = deserialize_embedding(&embedding_blob, embed_dim).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Blob, Box::new(e))
+    })?;
+
+    let metadata: serde_json::Value = serde_json::from_str(&metadata_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    Ok(Fact {
+        id: row.get("id")?,
+        content: row.get("content")?,
+        content_hash: row.get("content_hash")?,
+        embedding,
+        fact_type,
+        t_created,
+        t_expired,
+        t_valid,
+        t_invalid,
+        source_event_id: row.get("source_event_id")?,
+        importance: row.get("importance")?,
+        access_count: row.get("access_count")?,
+        last_accessed,
+        metadata,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::{init_schema, open_memory};
+    use chrono::TimeDelta;
+
+    const DIM: usize = 768;
+
+    fn setup() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    fn make_fact(content: &str, embedding: Vec<f32>) -> NewFact {
+        NewFact {
+            content: content.into(),
+            content_hash: String::new(), // store computes this
+            embedding,
+            fact_type: FactType::Episodic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn insert_and_get_round_trip() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let embedding = vec![0.1_f32; DIM];
+        let fact = make_fact("Rust is a systems language", embedding);
+        let id = store.insert(&fact).unwrap();
+        assert!(id > 0);
+
+        let retrieved = store.get(id).unwrap();
+        assert_eq!(retrieved.id, id);
+        assert_eq!(retrieved.content, "Rust is a systems language");
+        assert_eq!(retrieved.fact_type, FactType::Episodic);
+        assert!(!retrieved.content_hash.is_empty());
+    }
+
+    #[test]
+    fn embedding_blob_round_trip() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let mut embedding = vec![0.0_f32; DIM];
+        for (i, val) in embedding.iter_mut().enumerate() {
+            *val = i as f32 * 0.001;
+        }
+        let fact = make_fact("embedding test", embedding.clone());
+        let id = store.insert(&fact).unwrap();
+        let retrieved = store.get(id).unwrap();
+
+        // Byte-exact: serialize original and compare
+        let original_blob = serialize_embedding(&embedding);
+        let retrieved_blob = serialize_embedding(&retrieved.embedding);
+        assert_eq!(original_blob, retrieved_blob);
+        assert_eq!(embedding, retrieved.embedding);
+    }
+
+    #[test]
+    fn expire_excludes_from_active() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let id1 = store.insert(&make_fact("fact 1", vec![0.1; DIM])).unwrap();
+        let id2 = store.insert(&make_fact("fact 2", vec![0.2; DIM])).unwrap();
+
+        // Both active
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 2);
+
+        // Expire fact 1
+        store.expire(id1, Utc::now()).unwrap();
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, id2);
+    }
+
+    #[test]
+    fn bi_temporal_query() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let now = Utc::now();
+        let past = now - TimeDelta::hours(2);
+        let future = now + TimeDelta::hours(2);
+
+        // Fact valid from past to future
+        let mut fact = make_fact("temporal fact", vec![0.1; DIM]);
+        fact.t_valid = Some(past);
+        fact.t_invalid = Some(future);
+        store.insert(&fact).unwrap();
+
+        // Fact valid only in the future
+        let mut fact2 = make_fact("future fact", vec![0.2; DIM]);
+        fact2.t_valid = Some(future);
+        store.insert(&fact2).unwrap();
+
+        // Query at "now" — only the first fact should match
+        let results = store.list_active_at(now).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "temporal fact");
+    }
+
+    #[test]
+    fn wrong_embedding_dimension() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let fact = make_fact("bad dim", vec![0.1; 512]); // wrong: 512 != 768
+        let err = store.insert(&fact).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::EmbeddingDimension {
+                expected: 768,
+                actual: 512
+            }
+        ));
+    }
+
+    #[test]
+    fn update_importance_works() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let id = store.insert(&make_fact("test", vec![0.1; DIM])).unwrap();
+        store.update_importance(id, 0.9).unwrap();
+        let fact = store.get(id).unwrap();
+        assert!((fact.importance - 0.9).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn increment_access_works() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let id = store.insert(&make_fact("test", vec![0.1; DIM])).unwrap();
+        let before = store.get(id).unwrap();
+        assert_eq!(before.access_count, 0);
+
+        store.increment_access(id, Utc::now()).unwrap();
+        let after = store.get(id).unwrap();
+        assert_eq!(after.access_count, 1);
+        assert!(after.last_accessed >= before.last_accessed);
+    }
+
+    #[test]
+    fn content_hash_is_blake3_hex_16() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let content = "hash test content";
+        let id = store.insert(&make_fact(content, vec![0.1; DIM])).unwrap();
+        let fact = store.get(id).unwrap();
+
+        // Compute expected hash
+        let expected = &blake3::hash(content.as_bytes()).to_hex()[..16];
+        assert_eq!(fact.content_hash, expected);
+        assert_eq!(fact.content_hash.len(), 16);
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,5 +1,7 @@
+pub mod events;
 pub mod schema;
 
+pub use events::{EventFilter, EventStore};
 pub use schema::{get_config, init_schema, open_connection, open_memory, set_config};
 
 use crate::error::{MemoryError, Result};

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,0 +1,75 @@
+pub mod schema;
+
+pub use schema::{get_config, init_schema, open_connection, open_memory, set_config};
+
+use crate::error::{MemoryError, Result};
+
+/// Serialize an embedding (`&[f32]`) to little-endian bytes for `SQLite` BLOB storage.
+#[must_use]
+pub fn serialize_embedding(embedding: &[f32]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(embedding.len() * 4);
+    for &val in embedding {
+        buf.extend_from_slice(&val.to_le_bytes());
+    }
+    buf
+}
+
+/// Deserialize a BLOB back to `Vec<f32>`, validating dimension.
+///
+/// # Errors
+///
+/// Returns `MemoryError::EmbeddingDimension` if the blob size doesn't match
+/// `dim * 4` bytes.
+///
+/// # Panics
+///
+/// Cannot panic. The `expect` call is guarded by `chunks_exact(4)` which
+/// guarantees each chunk is exactly 4 bytes.
+pub fn deserialize_embedding(blob: &[u8], dim: usize) -> Result<Vec<f32>> {
+    if blob.len() != dim * 4 {
+        return Err(MemoryError::EmbeddingDimension {
+            expected: dim,
+            actual: blob.len() / 4,
+        });
+    }
+    Ok(blob
+        .chunks_exact(4)
+        .map(|chunk| {
+            let arr: [u8; 4] = chunk.try_into().expect("chunks_exact guarantees 4 bytes");
+            f32::from_le_bytes(arr)
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedding_round_trip() {
+        let original = vec![1.0_f32, -0.5, 0.0, std::f32::consts::PI];
+        let blob = serialize_embedding(&original);
+        let recovered = deserialize_embedding(&blob, original.len()).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn embedding_wrong_dimension() {
+        let blob = serialize_embedding(&[1.0_f32, 2.0]);
+        let err = deserialize_embedding(&blob, 3).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::EmbeddingDimension {
+                expected: 3,
+                actual: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn embedding_empty() {
+        let blob = serialize_embedding(&[]);
+        let recovered = deserialize_embedding(&blob, 0).unwrap();
+        assert!(recovered.is_empty());
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,7 +1,9 @@
 pub mod events;
+pub mod facts;
 pub mod schema;
 
 pub use events::{EventFilter, EventStore};
+pub use facts::FactStore;
 pub use schema::{get_config, init_schema, open_connection, open_memory, set_config};
 
 use crate::error::{MemoryError, Result};

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -1,0 +1,277 @@
+use rusqlite::Connection;
+
+use crate::error::Result;
+
+/// Open a `SQLite` connection to a file, with pragmas set.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` if the connection or pragma setup fails.
+pub fn open_connection(path: &str) -> Result<Connection> {
+    let conn = Connection::open(path)?;
+    set_pragmas(&conn)?;
+    Ok(conn)
+}
+
+/// Open an in-memory `SQLite` connection, with pragmas set.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` if the connection or pragma setup fails.
+pub fn open_memory() -> Result<Connection> {
+    let conn = Connection::open_in_memory()?;
+    set_pragmas(&conn)?;
+    Ok(conn)
+}
+
+fn set_pragmas(conn: &Connection) -> Result<()> {
+    // All PRAGMA SET statements can return result rows in bundled SQLite.
+    // Use prepare+execute to avoid ExecuteReturnedResults from execute/execute_batch.
+    for pragma in &[
+        "PRAGMA journal_mode = WAL",
+        "PRAGMA foreign_keys = ON",
+        "PRAGMA busy_timeout = 5000",
+        "PRAGMA synchronous = NORMAL",
+    ] {
+        let mut stmt = conn.prepare(pragma)?;
+        // Consume all rows (PRAGMAs return 0 or 1 rows).
+        let _ = stmt.query([])?;
+    }
+    Ok(())
+}
+
+/// Initialize the full schema (idempotent via `IF NOT EXISTS`).
+///
+/// Creates all tables, virtual tables, triggers, and indexes.
+/// Writes `schema_version=1` to the config table if not already present.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` if any DDL statement fails.
+pub fn init_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(TABLES_DDL)?;
+    conn.execute_batch(FTS5_DDL)?;
+    conn.execute_batch(TRIGGERS_DDL)?;
+    conn.execute_batch(INDEXES_DDL)?;
+
+    // Write default config only if not already set.
+    if get_config(conn, "schema_version")?.is_none() {
+        set_config(conn, "schema_version", "1")?;
+    }
+
+    Ok(())
+}
+
+/// Read a config value by key.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on query failure.
+pub fn get_config(conn: &Connection, key: &str) -> Result<Option<String>> {
+    let mut stmt = conn.prepare("SELECT value FROM config WHERE key = ?1")?;
+    let mut rows = stmt.query_map([key], |row| row.get(0))?;
+    match rows.next() {
+        Some(Ok(val)) => Ok(Some(val)),
+        Some(Err(e)) => Err(e.into()),
+        None => Ok(None),
+    }
+}
+
+/// Write a config value (upsert).
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on write failure.
+pub fn set_config(conn: &Connection, key: &str, value: &str) -> Result<()> {
+    conn.execute(
+        "INSERT INTO config (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![key, value],
+    )?;
+    Ok(())
+}
+
+const TABLES_DDL: &str = "
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    source TEXT NOT NULL,
+    session_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS facts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,  -- blake3 hex[:16] for dedup
+    embedding BLOB NOT NULL,
+    fact_type TEXT NOT NULL CHECK(fact_type IN ('episodic', 'semantic', 'procedural')),
+    t_created TEXT NOT NULL,
+    t_expired TEXT,
+    t_valid TEXT,
+    t_invalid TEXT,
+    source_event_id INTEGER REFERENCES events(id),
+    importance REAL NOT NULL DEFAULT 0.5,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata))
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    target_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    relation_type TEXT NOT NULL,
+    weight REAL NOT NULL DEFAULT 1.0,
+    t_created TEXT NOT NULL,
+    t_expired TEXT
+);
+
+CREATE TABLE IF NOT EXISTS summaries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    embedding BLOB NOT NULL,
+    level TEXT NOT NULL CHECK(level IN ('local', 'cluster', 'global')),
+    source_fact_ids TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+";
+
+const FTS5_DDL: &str = "
+CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
+    content,
+    content='facts',
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+";
+
+const TRIGGERS_DDL: &str = "
+CREATE TRIGGER IF NOT EXISTS facts_fts_ai AFTER INSERT ON facts BEGIN
+    INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS facts_fts_ad AFTER DELETE ON facts BEGIN
+    INSERT INTO facts_fts(facts_fts, rowid, content) VALUES ('delete', old.id, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS facts_fts_au AFTER UPDATE ON facts BEGIN
+    INSERT INTO facts_fts(facts_fts, rowid, content) VALUES ('delete', old.id, old.content);
+    INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content);
+END;
+";
+
+const INDEXES_DDL: &str = "
+CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_facts_expired ON facts(t_expired);
+CREATE INDEX IF NOT EXISTS idx_facts_type ON facts(fact_type);
+CREATE INDEX IF NOT EXISTS idx_facts_valid ON facts(t_valid, t_invalid);
+CREATE INDEX IF NOT EXISTS idx_facts_hash ON facts(content_hash);
+CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_fact_id);
+CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_fact_id);
+CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_schema_creates_all_tables() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let tables: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<std::result::Result<_, _>>()
+            .unwrap();
+        assert!(tables.contains(&"events".to_string()));
+        assert!(tables.contains(&"facts".to_string()));
+        assert!(tables.contains(&"edges".to_string()));
+        assert!(tables.contains(&"summaries".to_string()));
+        assert!(tables.contains(&"config".to_string()));
+    }
+
+    #[test]
+    fn init_schema_idempotent() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        init_schema(&conn).unwrap(); // second call must not error
+    }
+
+    #[test]
+    fn fts5_trigger_fires_on_insert() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed)
+             VALUES ('hello world test', 'abc', X'00', 'episodic', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM facts_fts WHERE facts_fts MATCH 'hello'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn config_default_schema_version() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let version = get_config(&conn, "schema_version").unwrap();
+        assert_eq!(version, Some("1".to_string()));
+    }
+
+    #[test]
+    fn config_no_default_embed_dim() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dim = get_config(&conn, "embed_dim").unwrap();
+        assert!(dim.is_none());
+    }
+
+    #[test]
+    fn config_set_and_get() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        set_config(&conn, "test_key", "test_value").unwrap();
+        assert_eq!(
+            get_config(&conn, "test_key").unwrap(),
+            Some("test_value".to_string())
+        );
+        // Upsert overwrites
+        set_config(&conn, "test_key", "new_value").unwrap();
+        assert_eq!(
+            get_config(&conn, "test_key").unwrap(),
+            Some("new_value".to_string())
+        );
+    }
+
+    #[test]
+    fn all_nine_indexes_created() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 9);
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,93 @@
+use crate::error::Result;
+use crate::types::Fact;
+
+// --- Phase 1: Embedding provider (fully used) ---
+
+/// Trait for computing text embeddings.
+///
+/// Consumers implement this to integrate their embedding model (local or API).
+/// The engine calls `embed` during `add_fact` to compute the embedding vector.
+pub trait EmbeddingProvider {
+    /// Compute an embedding vector for the given text.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if embedding computation fails.
+    fn embed(&self, text: &str) -> Result<Vec<f32>>;
+}
+
+// --- Phase 2 placeholder traits and types ---
+
+/// Trait for generating summaries from fact clusters (Phase 2).
+///
+/// Used by consolidation to merge related facts into higher-level summaries.
+pub trait SummaryGenerator {
+    /// Generate a textual summary from a slice of facts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if summarization fails.
+    fn summarize(&self, facts: &[Fact]) -> Result<String>;
+
+    /// Compute an embedding for the given text.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if embedding computation fails.
+    fn embed(&self, text: &str) -> Result<Vec<f32>>;
+}
+
+/// Trait for arbitrating conflicts between contradicting facts (Phase 2).
+pub trait ConflictArbiter {
+    /// Decide how to resolve a conflict between an existing and a new fact.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if arbitration fails.
+    fn arbitrate(&self, old_fact: &Fact, new_fact: &Fact) -> Result<CrudDecision>;
+}
+
+/// Decision for conflict resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrudDecision {
+    Add,
+    Update,
+    Delete,
+    Noop,
+}
+
+/// Configuration for the consolidation process (Phase 2).
+#[derive(Debug, Clone)]
+pub struct ConsolidationConfig {
+    pub dedup_threshold: f32,
+    pub min_cluster_size: usize,
+}
+
+/// Statistics returned by consolidation (Phase 2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsolidationStats {
+    pub duplicates_removed: usize,
+    pub clusters_created: usize,
+    pub global_summaries: usize,
+}
+
+/// Statistics returned by the forget/prune operation (Phase 2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PruneStats {
+    pub facts_expired: usize,
+    pub facts_evaluated: usize,
+}
+
+/// Result of a conflict resolution (Phase 2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConflictResolution {
+    pub decision: CrudDecision,
+    pub old_fact_id: i64,
+    pub new_fact_id: Option<i64>,
+}
+
+/// Policy for forgetting/pruning stale facts (Phase 2).
+#[derive(Debug, Clone)]
+pub struct ForgetPolicy {
+    pub min_importance: f32,
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,177 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// --- Enums ---
+
+/// Type of event in the append-only log.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EventType {
+    Interaction,
+    ToolCall,
+    MemoryOp,
+    SystemEvent,
+}
+
+/// Type of fact (`CoALA` mapping: Episodic, Semantic, Procedural).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum FactType {
+    Episodic,
+    Semantic,
+    Procedural,
+}
+
+/// Consolidation level for summaries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConsolidationLevel {
+    Local,
+    Cluster,
+    Global,
+}
+
+// --- Full structs (with id, as returned from DB) ---
+
+/// An event in the append-only log (source of truth).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Event {
+    pub id: i64,
+    pub timestamp: DateTime<Utc>,
+    pub event_type: EventType,
+    pub payload: serde_json::Value,
+    pub source: String,
+    pub session_id: Option<String>,
+}
+
+/// A bi-temporal fact derived from events.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Fact {
+    pub id: i64,
+    pub content: String,
+    pub content_hash: String,
+    pub embedding: Vec<f32>,
+    pub fact_type: FactType,
+    pub t_created: DateTime<Utc>,
+    pub t_expired: Option<DateTime<Utc>>,
+    pub t_valid: Option<DateTime<Utc>>,
+    pub t_invalid: Option<DateTime<Utc>>,
+    pub source_event_id: Option<i64>,
+    pub importance: f64,
+    pub access_count: i64,
+    pub last_accessed: DateTime<Utc>,
+    pub metadata: serde_json::Value,
+}
+
+/// A graph edge between two facts.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Edge {
+    pub id: i64,
+    pub source_fact_id: i64,
+    pub target_fact_id: i64,
+    pub relation_type: String,
+    pub weight: f64,
+    pub t_created: DateTime<Utc>,
+    pub t_expired: Option<DateTime<Utc>>,
+}
+
+/// A consolidation summary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Summary {
+    pub id: i64,
+    pub content: String,
+    pub embedding: Vec<f32>,
+    pub level: ConsolidationLevel,
+    pub source_fact_ids: Vec<i64>,
+    pub created_at: DateTime<Utc>,
+}
+
+// --- New* structs (without id, for insertion) ---
+
+/// Event to insert (DB assigns id).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NewEvent {
+    pub timestamp: DateTime<Utc>,
+    pub event_type: EventType,
+    pub payload: serde_json::Value,
+    pub source: String,
+    pub session_id: Option<String>,
+}
+
+/// Fact to insert (DB assigns id).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NewFact {
+    pub content: String,
+    pub content_hash: String,
+    pub embedding: Vec<f32>,
+    pub fact_type: FactType,
+    pub t_created: DateTime<Utc>,
+    pub t_expired: Option<DateTime<Utc>>,
+    pub t_valid: Option<DateTime<Utc>>,
+    pub t_invalid: Option<DateTime<Utc>>,
+    pub source_event_id: Option<i64>,
+    pub importance: f64,
+    pub access_count: i64,
+    pub last_accessed: DateTime<Utc>,
+    pub metadata: serde_json::Value,
+}
+
+/// Edge to insert (DB assigns id).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NewEdge {
+    pub source_fact_id: i64,
+    pub target_fact_id: i64,
+    pub relation_type: String,
+    pub weight: f64,
+    pub t_created: DateTime<Utc>,
+    pub t_expired: Option<DateTime<Utc>>,
+}
+
+/// Summary to insert (DB assigns id).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NewSummary {
+    pub content: String,
+    pub embedding: Vec<f32>,
+    pub level: ConsolidationLevel,
+    pub source_fact_ids: Vec<i64>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_round_trip_json() {
+        let event = Event {
+            id: 1,
+            timestamp: Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::json!({"key": "value"}),
+            source: "test".into(),
+            session_id: Some("sess-1".into()),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let back: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn fact_defaults_none_temporals() {
+        let fact = Fact {
+            id: 1,
+            content: "test".into(),
+            content_hash: "abc".into(),
+            embedding: vec![0.1; 768],
+            fact_type: FactType::Episodic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: Some(1),
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+        };
+        assert!(fact.t_expired.is_none());
+        assert!(fact.t_valid.is_none());
+    }
+}

--- a/tests/roundtrip_test.rs
+++ b/tests/roundtrip_test.rs
@@ -1,0 +1,151 @@
+use chrono::Utc;
+use memory_engine::engine::MemoryEngine;
+use memory_engine::error::Result;
+use memory_engine::search::hybrid::{MatchType, SearchMode, SearchQuery};
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine::types::{EventType, FactType, NewEvent};
+
+/// Mock embedder that returns a vector pointing in the direction
+/// determined by a simple hash of the text, so different texts
+/// get somewhat different embeddings.
+struct TestEmbedder {
+    dim: usize,
+}
+
+impl EmbeddingProvider for TestEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        let hash = blake3::hash(text.as_bytes());
+        let bytes = hash.as_bytes();
+        let mut embedding = vec![0.0_f32; self.dim];
+        for (i, val) in embedding.iter_mut().enumerate() {
+            // Use hash bytes cyclically to produce deterministic but varied values
+            let byte = bytes[i % 32];
+            *val = (f32::from(byte) - 128.0) / 128.0;
+        }
+        // Normalize
+        let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for val in &mut embedding {
+                *val /= norm;
+            }
+        }
+        Ok(embedding)
+    }
+}
+
+#[test]
+fn full_roundtrip() {
+    let dim = 8;
+    let engine = MemoryEngine::open_memory(dim).unwrap();
+    let embedder = TestEmbedder { dim };
+
+    // 1. Ingest an event
+    let event = NewEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::Interaction,
+        payload: serde_json::json!({"user": "test", "msg": "learning Rust"}),
+        source: "integration_test".into(),
+        session_id: Some("sess-roundtrip".into()),
+    };
+    let event_id = engine.ingest(&event).unwrap();
+    assert!(event_id > 0);
+
+    // 2. Add facts derived from the event
+    let fact1_id = engine
+        .add_fact(
+            "Rust is a systems programming language",
+            FactType::Semantic,
+            Some(event_id),
+            &embedder,
+        )
+        .unwrap();
+    let fact2_id = engine
+        .add_fact(
+            "Rust has zero-cost abstractions and memory safety",
+            FactType::Semantic,
+            Some(event_id),
+            &embedder,
+        )
+        .unwrap();
+    let fact3_id = engine
+        .add_fact(
+            "Python is popular for machine learning",
+            FactType::Episodic,
+            Some(event_id),
+            &embedder,
+        )
+        .unwrap();
+    assert!(fact1_id > 0);
+    assert!(fact2_id > 0);
+    assert!(fact3_id > 0);
+
+    // 3. Query via FTS — "Rust" should match facts 1 and 2
+    let fts_results = engine
+        .query(&SearchQuery {
+            text: Some("Rust".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            valid_at: None,
+            fact_type: None,
+        })
+        .unwrap();
+    assert_eq!(fts_results.len(), 2);
+    assert!(fts_results.iter().all(|r| r.match_type == MatchType::Fts));
+    assert!(fts_results.iter().all(|r| r.fact.content.contains("Rust")));
+
+    // 4. Query via vector — use the embedding of "Rust systems programming"
+    let query_emb = embedder.embed("Rust systems programming").unwrap();
+    let vec_results = engine
+        .query(&SearchQuery {
+            text: None,
+            embedding: Some(query_emb),
+            mode: SearchMode::Vector,
+            limit: 10,
+            valid_at: None,
+            fact_type: None,
+        })
+        .unwrap();
+    assert!(!vec_results.is_empty());
+    assert!(vec_results
+        .iter()
+        .all(|r| r.match_type == MatchType::Vector));
+
+    // 5. Query via hybrid — combine text and embedding
+    let hybrid_emb = embedder.embed("Rust programming language").unwrap();
+    let hybrid_results = engine
+        .query(&SearchQuery {
+            text: Some("Rust".into()),
+            embedding: Some(hybrid_emb),
+            mode: SearchMode::Hybrid,
+            limit: 10,
+            valid_at: None,
+            fact_type: None,
+        })
+        .unwrap();
+    assert!(!hybrid_results.is_empty());
+    // At least one result should come from both sources
+    let has_both = hybrid_results
+        .iter()
+        .any(|r| r.match_type == MatchType::Both);
+    // Rust facts appear in FTS and should also rank high in vector
+    assert!(
+        has_both,
+        "expected at least one result from both FTS and vector"
+    );
+
+    // 6. Verify fact_type filter
+    let semantic_only = engine
+        .query(&SearchQuery {
+            text: Some("Rust".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            valid_at: None,
+            fact_type: Some(FactType::Semantic),
+        })
+        .unwrap();
+    assert!(semantic_only
+        .iter()
+        .all(|r| r.fact.fact_type == FactType::Semantic));
+}


### PR DESCRIPTION
## Summary

Phase 1 of the memory-engine crate — implements the core ingest→query loop for autonomous AI agent memory.

- **Core types**: `Event`, `Fact`, `Edge`, `Summary` with bi-temporal timestamps, `NewEvent`/`NewFact` builder types
- **Error handling**: `MemoryError` enum with `thiserror` conversions (rusqlite, serde_json)
- **SQLite schema**: 5 tables (events, facts, edges, summaries, config), FTS5 virtual table with auto-sync triggers, 9 indexes, WAL mode + pragmas
- **Event log**: Append-only `EventStore` with filtering by session, type, timestamp
- **Fact CRUD**: `FactStore` with bi-temporal queries (`t_expired`, `t_valid`/`t_invalid`), blake3 content hashing, embedding BLOB serialization
- **FTS5 search**: BM25-ranked keyword search with syntax error resilience
- **Vector search**: Pure Rust cosine similarity (O(N) brute-force, `mul_add` for numerical stability)
- **Hybrid search**: Reciprocal Rank Fusion (RRF) merging FTS5 + vector results, `SearchMode` enum, temporal/type filtering
- **Engine facade**: `MemoryEngine` struct unifying all primitives, `EmbeddingProvider` trait, `embed_dim` config validation
- Phase 2 stubs (`consolidate`, `forget`, `resolve_conflict`) return `NotImplemented`

58 tests (57 unit + 1 integration), clippy clean (deny all, warn pedantic+nursery).

## Architecture

Event-sourced append-only log → bi-temporal facts → hybrid retrieval (FTS5 + vector + RRF). One store, multiple projections — `fact_type` is a tag, not a partition. Consumer-provided `EmbeddingProvider` trait — engine has zero LLM/network dependencies.

## Plan

Closes #1

## Test plan

- [x] `cargo test` — 58 tests passing
- [x] `cargo clippy` — zero warnings
- [x] `cargo doc --no-deps` — builds clean
- [x] Multi-model code review (`/super-review`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)