### PR TITLE
feat: Phase 2 — graph, consolidation, forgetting, conflict resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "2"
 rusqlite = { version = "0.34", features = ["bundled-full"] }
 blake3 = "1"
 tracing = "0.1"
+petgraph = "0.7"
 
 [dev-dependencies]
 

--- a/src/conflict/mod.rs
+++ b/src/conflict/mod.rs
@@ -1,0 +1,3 @@
+mod temporal;
+
+pub use temporal::resolve_conflict;

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -1,0 +1,476 @@
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use crate::error::{MemoryError, Result};
+use crate::graph::{EdgeData, MemoryGraph};
+use crate::store::edges::EdgeStore;
+use crate::store::facts::FactStore;
+use crate::traits::{ConflictArbiter, ConflictResolution, CrudDecision};
+use crate::types::{NewEdge, NewFact};
+
+/// Resolve a conflict between an existing fact and a candidate new fact.
+///
+/// Delegates the decision to the consumer-provided [`ConflictArbiter`] trait.
+/// Based on the decision:
+/// - **Add**: Both coexist. Creates a "supplements" edge.
+/// - **Update**: Old fact expired + invalidated. New fact inserted. Creates "contradicts" edge.
+///   All active edges involving the old fact are also expired (cascade).
+/// - **Delete**: Old fact expired + invalidated. New fact NOT inserted.
+///   All active edges involving the old fact are also expired (cascade).
+/// - **Noop**: No changes.
+///
+/// All mutations happen in a single transaction. Graph is updated only after commit.
+///
+/// # Errors
+///
+/// Returns `MemoryError::NotFound` if the old fact doesn't exist.
+/// Propagates errors from the arbiter or database operations.
+pub fn resolve_conflict(
+    conn: &Connection,
+    graph: &mut MemoryGraph,
+    arbiter: &dyn ConflictArbiter,
+    old_fact_id: i64,
+    new_fact: &NewFact,
+    embed_dim: usize,
+    now: DateTime<Utc>,
+) -> Result<ConflictResolution> {
+    let fact_store = FactStore::new(conn, embed_dim);
+    let old_fact = fact_store.get(old_fact_id)?;
+
+    // Build a temporary Fact from NewFact for the arbiter (it needs both as Fact)
+    let new_as_fact = crate::types::Fact {
+        id: 0, // placeholder, not yet inserted
+        content: new_fact.content.clone(),
+        content_hash: new_fact.content_hash.clone(),
+        embedding: new_fact.embedding.clone(),
+        fact_type: new_fact.fact_type.clone(),
+        t_created: new_fact.t_created,
+        t_expired: new_fact.t_expired,
+        t_valid: new_fact.t_valid,
+        t_invalid: new_fact.t_invalid,
+        source_event_id: new_fact.source_event_id,
+        importance: new_fact.importance,
+        access_count: new_fact.access_count,
+        last_accessed: new_fact.last_accessed,
+        metadata: new_fact.metadata.clone(),
+    };
+
+    let decision = arbiter.arbitrate(&old_fact, &new_as_fact)?;
+
+    match decision {
+        CrudDecision::Noop => Ok(ConflictResolution {
+            decision: CrudDecision::Noop,
+            old_fact_id,
+            new_fact_id: None,
+        }),
+
+        CrudDecision::Add => {
+            let tx = conn.unchecked_transaction()?;
+
+            let new_id = FactStore::new(&tx, embed_dim).insert(new_fact)?;
+
+            // Create "supplements" edge: new → old
+            let edge_store = EdgeStore::new(&tx);
+            let edge_id = edge_store.insert(&NewEdge {
+                source_fact_id: new_id,
+                target_fact_id: old_fact_id,
+                relation_type: "supplements".to_string(),
+                weight: 1.0,
+                t_created: now,
+                t_expired: None,
+            })?;
+
+            tx.commit()?;
+
+            // Update in-memory graph after successful commit
+            graph.add_edge(
+                new_id,
+                old_fact_id,
+                EdgeData {
+                    edge_id,
+                    relation_type: "supplements".to_string(),
+                    weight: 1.0,
+                },
+            );
+
+            Ok(ConflictResolution {
+                decision: CrudDecision::Add,
+                old_fact_id,
+                new_fact_id: Some(new_id),
+            })
+        }
+
+        CrudDecision::Update => {
+            let tx = conn.unchecked_transaction()?;
+
+            // Expire + invalidate old fact (bi-temporal)
+            expire_and_invalidate(&tx, old_fact_id, now)?;
+
+            // Cascade: expire all edges involving the old fact
+            let edge_store = EdgeStore::new(&tx);
+            edge_store.expire_by_fact(old_fact_id, now)?;
+
+            // Insert new fact
+            let new_id = FactStore::new(&tx, embed_dim).insert(new_fact)?;
+
+            // Create "contradicts" edge: new → old
+            let edge_id = edge_store.insert(&NewEdge {
+                source_fact_id: new_id,
+                target_fact_id: old_fact_id,
+                relation_type: "contradicts".to_string(),
+                weight: 1.0,
+                t_created: now,
+                t_expired: None,
+            })?;
+
+            tx.commit()?;
+
+            // Update in-memory graph: remove expired edges, add new one
+            rebuild_graph_for_fact(graph, conn, old_fact_id, new_id, edge_id);
+
+            Ok(ConflictResolution {
+                decision: CrudDecision::Update,
+                old_fact_id,
+                new_fact_id: Some(new_id),
+            })
+        }
+
+        CrudDecision::Delete => {
+            let tx = conn.unchecked_transaction()?;
+
+            // Expire + invalidate old fact
+            expire_and_invalidate(&tx, old_fact_id, now)?;
+
+            // Cascade: expire all edges involving the old fact
+            let edge_store = EdgeStore::new(&tx);
+            edge_store.expire_by_fact(old_fact_id, now)?;
+
+            tx.commit()?;
+
+            // Remove edges from in-memory graph
+            remove_edges_for_fact(graph, old_fact_id);
+
+            Ok(ConflictResolution {
+                decision: CrudDecision::Delete,
+                old_fact_id,
+                new_fact_id: None,
+            })
+        }
+    }
+}
+
+/// Set both `t_expired` and `t_invalid` on a fact (bi-temporal expiry).
+fn expire_and_invalidate(conn: &Connection, fact_id: i64, now: DateTime<Utc>) -> Result<()> {
+    let now_str = now.to_rfc3339();
+    let changed = conn.execute(
+        "UPDATE facts SET t_expired = ?1, t_invalid = ?1 WHERE id = ?2 AND t_expired IS NULL",
+        params![now_str, fact_id],
+    )?;
+    if changed == 0 {
+        return Err(MemoryError::NotFound(format!("fact {fact_id}")));
+    }
+    Ok(())
+}
+
+/// Rebuild the in-memory graph after an Update conflict resolution.
+///
+/// Removes all edges involving the old fact, then adds the new "contradicts" edge.
+fn rebuild_graph_for_fact(
+    graph: &mut MemoryGraph,
+    _conn: &Connection,
+    old_fact_id: i64,
+    new_id: i64,
+    edge_id: i64,
+) {
+    remove_edges_for_fact(graph, old_fact_id);
+    graph.add_edge(
+        new_id,
+        old_fact_id,
+        EdgeData {
+            edge_id,
+            relation_type: "contradicts".to_string(),
+            weight: 1.0,
+        },
+    );
+}
+
+/// Remove all edges from the in-memory graph that involve a given fact id.
+fn remove_edges_for_fact(graph: &mut MemoryGraph, fact_id: i64) {
+    graph.remove_edges_by_fact(fact_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::{Fact, FactType, NewFact};
+
+    /// Mock arbiter with a fixed decision.
+    struct FixedArbiter {
+        decision: CrudDecision,
+    }
+
+    impl ConflictArbiter for FixedArbiter {
+        fn arbitrate(&self, _old: &Fact, _new: &Fact) -> Result<CrudDecision> {
+            Ok(self.decision.clone())
+        }
+    }
+
+    /// Mock arbiter that returns an error.
+    struct FailingArbiter;
+
+    impl ConflictArbiter for FailingArbiter {
+        fn arbitrate(&self, _old: &Fact, _new: &Fact) -> Result<CrudDecision> {
+            Err(MemoryError::Conflict("arbiter failed".into()))
+        }
+    }
+
+    fn setup() -> (Connection, usize) {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        (conn, 4)
+    }
+
+    fn make_new_fact(content: &str) -> NewFact {
+        let now = Utc::now();
+        NewFact {
+            content: content.into(),
+            content_hash: blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string(),
+            embedding: vec![0.1; 4],
+            fact_type: FactType::Semantic,
+            t_created: now,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: now,
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    fn insert_fact(conn: &Connection, dim: usize, content: &str) -> i64 {
+        FactStore::new(conn, dim)
+            .insert(&make_new_fact(content))
+            .unwrap()
+    }
+
+    #[test]
+    fn noop_no_changes() {
+        let (conn, dim) = setup();
+        let old_id = insert_fact(&conn, dim, "existing fact");
+        let mut graph = MemoryGraph::new();
+
+        let result = resolve_conflict(
+            &conn,
+            &mut graph,
+            &FixedArbiter {
+                decision: CrudDecision::Noop,
+            },
+            old_id,
+            &make_new_fact("new fact"),
+            dim,
+            Utc::now(),
+        )
+        .unwrap();
+
+        assert_eq!(result.decision, CrudDecision::Noop);
+        assert_eq!(result.old_fact_id, old_id);
+        assert!(result.new_fact_id.is_none());
+
+        // Old fact should be unchanged
+        let old = FactStore::new(&conn, dim).get(old_id).unwrap();
+        assert!(old.t_expired.is_none());
+    }
+
+    #[test]
+    fn add_keeps_both_creates_supplements_edge() {
+        let (conn, dim) = setup();
+        let old_id = insert_fact(&conn, dim, "existing");
+        let mut graph = MemoryGraph::new();
+
+        let result = resolve_conflict(
+            &conn,
+            &mut graph,
+            &FixedArbiter {
+                decision: CrudDecision::Add,
+            },
+            old_id,
+            &make_new_fact("supplementary"),
+            dim,
+            Utc::now(),
+        )
+        .unwrap();
+
+        assert_eq!(result.decision, CrudDecision::Add);
+        assert!(result.new_fact_id.is_some());
+
+        let new_id = result.new_fact_id.unwrap();
+
+        // Both facts should be active
+        let fact_store = FactStore::new(&conn, dim);
+        assert!(fact_store.get(old_id).unwrap().t_expired.is_none());
+        assert!(fact_store.get(new_id).unwrap().t_expired.is_none());
+
+        // Edge should exist in SQLite
+        let edge_store = EdgeStore::new(&conn);
+        let edges = edge_store.list_active_by_source(new_id).unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].relation_type, "supplements");
+        assert_eq!(edges[0].target_fact_id, old_id);
+
+        // Edge should exist in graph
+        assert!(graph.has_node(new_id));
+        assert!(graph.has_node(old_id));
+        assert_eq!(graph.neighbors(new_id), vec![old_id]);
+    }
+
+    #[test]
+    fn update_expires_old_creates_contradicts_edge() {
+        let (conn, dim) = setup();
+        let old_id = insert_fact(&conn, dim, "outdated");
+        let mut graph = MemoryGraph::new();
+
+        let result = resolve_conflict(
+            &conn,
+            &mut graph,
+            &FixedArbiter {
+                decision: CrudDecision::Update,
+            },
+            old_id,
+            &make_new_fact("updated"),
+            dim,
+            Utc::now(),
+        )
+        .unwrap();
+
+        assert_eq!(result.decision, CrudDecision::Update);
+        let new_id = result.new_fact_id.unwrap();
+
+        // Old fact should be expired AND invalidated
+        let old = FactStore::new(&conn, dim).get(old_id).unwrap();
+        assert!(old.t_expired.is_some());
+        assert!(old.t_invalid.is_some());
+
+        // New fact should be active
+        let new = FactStore::new(&conn, dim).get(new_id).unwrap();
+        assert!(new.t_expired.is_none());
+
+        // "contradicts" edge should exist
+        let edges = EdgeStore::new(&conn).list_active_by_source(new_id).unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].relation_type, "contradicts");
+    }
+
+    #[test]
+    fn delete_expires_old_no_new() {
+        let (conn, dim) = setup();
+        let old_id = insert_fact(&conn, dim, "to delete");
+        let mut graph = MemoryGraph::new();
+
+        let result = resolve_conflict(
+            &conn,
+            &mut graph,
+            &FixedArbiter {
+                decision: CrudDecision::Delete,
+            },
+            old_id,
+            &make_new_fact("irrelevant"),
+            dim,
+            Utc::now(),
+        )
+        .unwrap();
+
+        assert_eq!(result.decision, CrudDecision::Delete);
+        assert!(result.new_fact_id.is_none());
+
+        // Old fact should be expired AND invalidated
+        let old = FactStore::new(&conn, dim).get(old_id).unwrap();
+        assert!(old.t_expired.is_some());
+        assert!(old.t_invalid.is_some());
+    }
+
+    #[test]
+    fn update_cascades_edges_on_old_fact() {
+        let (conn, dim) = setup();
+        let fact_a = insert_fact(&conn, dim, "fact A");
+        let fact_b = insert_fact(&conn, dim, "fact B");
+        let fact_c = insert_fact(&conn, dim, "fact C");
+
+        // Create edges: A → B and C → A
+        let edge_store = EdgeStore::new(&conn);
+        edge_store
+            .insert(&NewEdge {
+                source_fact_id: fact_a,
+                target_fact_id: fact_b,
+                relation_type: "relates".into(),
+                weight: 1.0,
+                t_created: Utc::now(),
+                t_expired: None,
+            })
+            .unwrap();
+        edge_store
+            .insert(&NewEdge {
+                source_fact_id: fact_c,
+                target_fact_id: fact_a,
+                relation_type: "depends".into(),
+                weight: 1.0,
+                t_created: Utc::now(),
+                t_expired: None,
+            })
+            .unwrap();
+
+        let mut graph = MemoryGraph::load_from_db(&conn).unwrap();
+        assert_eq!(graph.edge_count(), 2);
+
+        // Update fact A — should cascade-expire both edges
+        resolve_conflict(
+            &conn,
+            &mut graph,
+            &FixedArbiter {
+                decision: CrudDecision::Update,
+            },
+            fact_a,
+            &make_new_fact("updated A"),
+            dim,
+            Utc::now(),
+        )
+        .unwrap();
+
+        // Only the new "contradicts" edge should be active
+        let active_edges = edge_store.list_active().unwrap();
+        assert_eq!(active_edges.len(), 1);
+        assert_eq!(active_edges[0].relation_type, "contradicts");
+    }
+
+    #[test]
+    fn arbiter_error_rolls_back_all_changes() {
+        let (conn, dim) = setup();
+        let old_id = insert_fact(&conn, dim, "should survive");
+        let mut graph = MemoryGraph::new();
+
+        let result = resolve_conflict(
+            &conn,
+            &mut graph,
+            &FailingArbiter,
+            old_id,
+            &make_new_fact("should not appear"),
+            dim,
+            Utc::now(),
+        );
+
+        assert!(result.is_err());
+
+        // Old fact should be unchanged
+        let old = FactStore::new(&conn, dim).get(old_id).unwrap();
+        assert!(old.t_expired.is_none());
+        assert!(old.t_invalid.is_none());
+
+        // No new facts should exist
+        let active = FactStore::new(&conn, dim).list_active().unwrap();
+        assert_eq!(active.len(), 1);
+    }
+}

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -126,7 +126,7 @@ pub fn resolve_conflict(
             tx.commit()?;
 
             // Update in-memory graph: remove expired edges, add new one
-            rebuild_graph_for_fact(graph, conn, old_fact_id, new_id, edge_id);
+            rebuild_graph_for_fact(graph, old_fact_id, new_id, edge_id);
 
             Ok(ConflictResolution {
                 decision: CrudDecision::Update,
@@ -175,13 +175,7 @@ fn expire_and_invalidate(conn: &Connection, fact_id: i64, now: DateTime<Utc>) ->
 /// Rebuild the in-memory graph after an Update conflict resolution.
 ///
 /// Removes all edges involving the old fact, then adds the new "contradicts" edge.
-fn rebuild_graph_for_fact(
-    graph: &mut MemoryGraph,
-    _conn: &Connection,
-    old_fact_id: i64,
-    new_id: i64,
-    edge_id: i64,
-) {
+fn rebuild_graph_for_fact(graph: &mut MemoryGraph, old_fact_id: i64, new_id: i64, edge_id: i64) {
     remove_edges_for_fact(graph, old_fact_id);
     graph.add_edge(
         new_id,

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -8,6 +8,13 @@ use crate::store::facts::FactStore;
 use crate::traits::{ConflictArbiter, ConflictResolution, CrudDecision};
 use crate::types::{NewEdge, NewFact};
 
+/// Relation type for edges created when facts supplement each other.
+const RELATION_SUPPLEMENTS: &str = "supplements";
+/// Relation type for edges created when facts contradict each other.
+const RELATION_CONTRADICTS: &str = "contradicts";
+/// Default weight for conflict resolution edges.
+const DEFAULT_EDGE_WEIGHT: f64 = 1.0;
+
 /// Resolve a conflict between an existing fact and a candidate new fact.
 ///
 /// Delegates the decision to the consumer-provided [`ConflictArbiter`] trait.
@@ -74,8 +81,8 @@ pub fn resolve_conflict(
             let edge_id = edge_store.insert(&NewEdge {
                 source_fact_id: new_id,
                 target_fact_id: old_fact_id,
-                relation_type: "supplements".to_string(),
-                weight: 1.0,
+                relation_type: RELATION_SUPPLEMENTS.to_string(),
+                weight: DEFAULT_EDGE_WEIGHT,
                 t_created: now,
                 t_expired: None,
             })?;
@@ -88,8 +95,8 @@ pub fn resolve_conflict(
                 old_fact_id,
                 EdgeData {
                     edge_id,
-                    relation_type: "supplements".to_string(),
-                    weight: 1.0,
+                    relation_type: RELATION_SUPPLEMENTS.to_string(),
+                    weight: DEFAULT_EDGE_WEIGHT,
                 },
             );
 
@@ -117,8 +124,8 @@ pub fn resolve_conflict(
             let edge_id = edge_store.insert(&NewEdge {
                 source_fact_id: new_id,
                 target_fact_id: old_fact_id,
-                relation_type: "contradicts".to_string(),
-                weight: 1.0,
+                relation_type: RELATION_CONTRADICTS.to_string(),
+                weight: DEFAULT_EDGE_WEIGHT,
                 t_created: now,
                 t_expired: None,
             })?;
@@ -182,8 +189,8 @@ fn rebuild_graph_for_fact(graph: &mut MemoryGraph, old_fact_id: i64, new_id: i64
         old_fact_id,
         EdgeData {
             edge_id,
-            relation_type: "contradicts".to_string(),
-            weight: 1.0,
+            relation_type: RELATION_CONTRADICTS.to_string(),
+            weight: DEFAULT_EDGE_WEIGHT,
         },
     );
 }

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -46,12 +46,14 @@ pub fn cluster_fusion(
             continue;
         }
 
-        let cluster_facts: Vec<&Fact> = cluster.iter().map(|&idx| &active_facts[idx]).collect();
-        let facts_slice: Vec<Fact> = cluster_facts.iter().map(|f| (*f).clone()).collect();
-
-        let summary_text = generator.summarize(&facts_slice)?;
-        let summary_embedding = generator.embed(&summary_text)?;
+        let cluster_facts: Vec<Fact> = cluster
+            .iter()
+            .map(|&idx| active_facts[idx].clone())
+            .collect();
         let source_ids: Vec<i64> = cluster_facts.iter().map(|f| f.id).collect();
+
+        let summary_text = generator.summarize(&cluster_facts)?;
+        let summary_embedding = generator.embed(&summary_text)?;
 
         summary_store.insert(&NewSummary {
             content: summary_text,

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -1,0 +1,241 @@
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::search::vector::cosine_similarity;
+use crate::store::facts::FactStore;
+use crate::store::summaries::SummaryStore;
+use crate::traits::SummaryGenerator;
+use crate::types::{ConsolidationLevel, Fact, NewSummary};
+
+/// Cluster threshold for grouping related facts (lower than dedup threshold).
+const CLUSTER_SIMILARITY_THRESHOLD: f32 = 0.85;
+
+/// Cluster fusion pass.
+///
+/// Clears prior cluster-level summaries before creating new ones (idempotent).
+/// Groups active facts by similarity (greedy single-linkage clustering).
+/// For each cluster >= `min_cluster_size`, calls `SummaryGenerator` to create a summary.
+/// Stores summaries via `SummaryStore` with `level=Cluster`.
+///
+/// Returns number of clusters created.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure, or propagates errors from
+/// the `SummaryGenerator`.
+pub fn cluster_fusion(
+    conn: &Connection,
+    generator: &dyn SummaryGenerator,
+    embed_dim: usize,
+    min_cluster_size: usize,
+) -> Result<usize> {
+    let summary_store = SummaryStore::new(conn, embed_dim);
+
+    // Idempotent: clear previous cluster summaries
+    summary_store.delete_by_level(&ConsolidationLevel::Cluster)?;
+
+    let fact_store = FactStore::new(conn, embed_dim);
+    let active_facts = fact_store.list_active()?;
+
+    // Greedy single-linkage clustering
+    let clusters = greedy_cluster(&active_facts, CLUSTER_SIMILARITY_THRESHOLD);
+
+    let mut clusters_created = 0;
+    for cluster in &clusters {
+        if cluster.len() < min_cluster_size {
+            continue;
+        }
+
+        let cluster_facts: Vec<&Fact> = cluster.iter().map(|&idx| &active_facts[idx]).collect();
+        let facts_slice: Vec<Fact> = cluster_facts.iter().map(|f| (*f).clone()).collect();
+
+        let summary_text = generator.summarize(&facts_slice)?;
+        let summary_embedding = generator.embed(&summary_text)?;
+        let source_ids: Vec<i64> = cluster_facts.iter().map(|f| f.id).collect();
+
+        summary_store.insert(&NewSummary {
+            content: summary_text,
+            embedding: summary_embedding,
+            level: ConsolidationLevel::Cluster,
+            source_fact_ids: source_ids,
+            created_at: chrono::Utc::now(),
+        })?;
+
+        clusters_created += 1;
+    }
+
+    Ok(clusters_created)
+}
+
+/// Greedy single-linkage clustering.
+///
+/// For each unassigned fact, find all facts with cosine similarity > threshold.
+/// Group them into a cluster.
+fn greedy_cluster(facts: &[Fact], threshold: f32) -> Vec<Vec<usize>> {
+    let n = facts.len();
+    let mut assigned = vec![false; n];
+    let mut clusters = Vec::new();
+
+    for i in 0..n {
+        if assigned[i] {
+            continue;
+        }
+
+        let mut cluster = vec![i];
+        assigned[i] = true;
+
+        // Expand: find all unassigned facts similar to any fact in the cluster
+        let mut j = 0;
+        while j < cluster.len() {
+            let anchor_idx = cluster[j];
+            for k in 0..n {
+                if assigned[k] {
+                    continue;
+                }
+                let sim = cosine_similarity(&facts[anchor_idx].embedding, &facts[k].embedding);
+                if sim > threshold {
+                    cluster.push(k);
+                    assigned[k] = true;
+                }
+            }
+            j += 1;
+        }
+
+        clusters.push(cluster);
+    }
+
+    clusters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::{FactType, NewFact};
+
+    /// Mock generator that concatenates fact contents and returns a fixed embedding.
+    struct MockGenerator {
+        embed_dim: usize,
+    }
+
+    impl SummaryGenerator for MockGenerator {
+        fn summarize(&self, facts: &[Fact]) -> Result<String> {
+            Ok(facts
+                .iter()
+                .map(|f| f.content.as_str())
+                .collect::<Vec<_>>()
+                .join(" + "))
+        }
+
+        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.5; self.embed_dim])
+        }
+    }
+
+    fn insert_fact(conn: &Connection, dim: usize, content: &str, embedding: Vec<f32>) -> i64 {
+        let store = FactStore::new(conn, dim);
+        store
+            .insert(&NewFact {
+                content: content.into(),
+                content_hash: blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string(),
+                embedding,
+                fact_type: FactType::Semantic,
+                t_created: Utc::now(),
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance: 0.5,
+                access_count: 0,
+                last_accessed: Utc::now(),
+                metadata: serde_json::json!({}),
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn cluster_formation() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dim = 4;
+
+        // Cluster 1: 3 similar facts (all near [1,0,0,0])
+        insert_fact(&conn, dim, "c1a", vec![1.0, 0.0, 0.0, 0.0]);
+        insert_fact(&conn, dim, "c1b", vec![0.98, 0.02, 0.0, 0.0]);
+        insert_fact(&conn, dim, "c1c", vec![0.97, 0.03, 0.0, 0.0]);
+
+        // Cluster 2: 3 similar facts (all near [0,1,0,0])
+        insert_fact(&conn, dim, "c2a", vec![0.0, 1.0, 0.0, 0.0]);
+        insert_fact(&conn, dim, "c2b", vec![0.02, 0.98, 0.0, 0.0]);
+        insert_fact(&conn, dim, "c2c", vec![0.03, 0.97, 0.0, 0.0]);
+
+        let mock_gen = MockGenerator { embed_dim: dim };
+        let clusters = cluster_fusion(&conn, &mock_gen, dim, 3).unwrap();
+        assert_eq!(clusters, 2);
+
+        let summaries = SummaryStore::new(&conn, dim)
+            .list_by_level(&ConsolidationLevel::Cluster)
+            .unwrap();
+        assert_eq!(summaries.len(), 2);
+    }
+
+    #[test]
+    fn min_cluster_size_respected() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dim = 4;
+
+        // Only 2 similar facts, min_cluster_size=3
+        insert_fact(&conn, dim, "a", vec![1.0, 0.0, 0.0, 0.0]);
+        insert_fact(&conn, dim, "b", vec![0.99, 0.01, 0.0, 0.0]);
+
+        let mock_gen = MockGenerator { embed_dim: dim };
+        let clusters = cluster_fusion(&conn, &mock_gen, dim, 3).unwrap();
+        assert_eq!(clusters, 0);
+    }
+
+    #[test]
+    fn cluster_summaries_stored() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dim = 4;
+
+        insert_fact(&conn, dim, "alpha", vec![1.0, 0.0, 0.0, 0.0]);
+        insert_fact(&conn, dim, "beta", vec![0.99, 0.01, 0.0, 0.0]);
+        insert_fact(&conn, dim, "gamma", vec![0.98, 0.02, 0.0, 0.0]);
+
+        let mock_gen = MockGenerator { embed_dim: dim };
+        cluster_fusion(&conn, &mock_gen, dim, 2).unwrap();
+
+        let summaries = SummaryStore::new(&conn, dim)
+            .list_by_level(&ConsolidationLevel::Cluster)
+            .unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert!(summaries[0].content.contains("alpha"));
+        assert_eq!(summaries[0].source_fact_ids.len(), 3);
+    }
+
+    #[test]
+    fn idempotent_rebuild() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dim = 4;
+
+        insert_fact(&conn, dim, "x", vec![1.0, 0.0, 0.0, 0.0]);
+        insert_fact(&conn, dim, "y", vec![0.99, 0.01, 0.0, 0.0]);
+        insert_fact(&conn, dim, "z", vec![0.98, 0.02, 0.0, 0.0]);
+
+        let mock_gen = MockGenerator { embed_dim: dim };
+
+        // Run twice — should have exactly the same result
+        cluster_fusion(&conn, &mock_gen, dim, 2).unwrap();
+        cluster_fusion(&conn, &mock_gen, dim, 2).unwrap();
+
+        let summaries = SummaryStore::new(&conn, dim)
+            .list_by_level(&ConsolidationLevel::Cluster)
+            .unwrap();
+        assert_eq!(summaries.len(), 1); // not 2 — idempotent
+    }
+}

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -3,6 +3,7 @@ use rusqlite::Connection;
 
 use crate::error::Result;
 use crate::search::vector::cosine_similarity;
+use crate::store::edges::EdgeStore;
 use crate::store::facts::FactStore;
 
 /// Local deduplication pass.
@@ -25,6 +26,7 @@ pub fn local_dedup(
     now: DateTime<Utc>,
 ) -> Result<usize> {
     let fact_store = FactStore::new(conn, embed_dim);
+    let edge_store = EdgeStore::new(conn);
     let active_facts = fact_store.list_active()?;
 
     // Split into "new" (to compare) and "all active" (to compare against)
@@ -64,6 +66,7 @@ pub fn local_dedup(
                 };
 
                 fact_store.expire(expire_id, now)?;
+                edge_store.expire_by_fact(expire_id, now)?;
                 expired_ids.insert(expire_id);
                 duplicates_removed += 1;
 

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -1,0 +1,236 @@
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::search::vector::cosine_similarity;
+use crate::store::facts::FactStore;
+
+/// Local deduplication pass.
+///
+/// Compares facts created since `since` (or all if `None`) against all active facts.
+/// Near-duplicates (cosine > threshold) are resolved by expiring the lower-importance
+/// fact. Deterministic tie-break: on equal importance, the newer fact (higher id) is
+/// expired.
+///
+/// Returns count of duplicates removed.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure.
+pub fn local_dedup(
+    conn: &Connection,
+    embed_dim: usize,
+    threshold: f32,
+    since: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Result<usize> {
+    let fact_store = FactStore::new(conn, embed_dim);
+    let active_facts = fact_store.list_active()?;
+
+    // Split into "new" (to compare) and "all active" (to compare against)
+    let new_facts: Vec<_> = since.map_or_else(
+        || active_facts.iter().collect(),
+        |since_dt| {
+            active_facts
+                .iter()
+                .filter(|f| f.t_created > since_dt)
+                .collect()
+        },
+    );
+
+    let mut expired_ids = std::collections::HashSet::new();
+    let mut duplicates_removed = 0;
+
+    for new_fact in &new_facts {
+        if expired_ids.contains(&new_fact.id) {
+            continue;
+        }
+
+        for candidate in &active_facts {
+            if candidate.id == new_fact.id || expired_ids.contains(&candidate.id) {
+                continue;
+            }
+
+            let similarity = cosine_similarity(&new_fact.embedding, &candidate.embedding);
+            if similarity > threshold {
+                // Expire the lower-importance fact. Tie-break: higher id (newer) expires.
+                let expire_id = if new_fact.importance < candidate.importance {
+                    new_fact.id
+                } else if new_fact.importance > candidate.importance {
+                    candidate.id
+                } else {
+                    // Equal importance: expire the newer one (higher id)
+                    new_fact.id.max(candidate.id)
+                };
+
+                fact_store.expire(expire_id, now)?;
+                expired_ids.insert(expire_id);
+                duplicates_removed += 1;
+            }
+        }
+    }
+
+    Ok(duplicates_removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::{FactType, NewFact};
+
+    fn setup() -> (Connection, usize) {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        (conn, 4)
+    }
+
+    fn insert_fact(
+        conn: &Connection,
+        embed_dim: usize,
+        content: &str,
+        embedding: Vec<f32>,
+        importance: f64,
+    ) -> i64 {
+        let store = FactStore::new(conn, embed_dim);
+        store
+            .insert(&NewFact {
+                content: content.into(),
+                content_hash: blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string(),
+                embedding,
+                fact_type: FactType::Semantic,
+                t_created: Utc::now(),
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance,
+                access_count: 0,
+                last_accessed: Utc::now(),
+                metadata: serde_json::json!({}),
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn near_duplicates_detected() {
+        let (conn, dim) = setup();
+        // Two nearly identical embeddings
+        insert_fact(&conn, dim, "fact A", vec![1.0, 0.0, 0.0, 0.0], 0.5);
+        insert_fact(&conn, dim, "fact B", vec![0.99, 0.01, 0.0, 0.0], 0.3);
+
+        let removed = local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+        assert_eq!(removed, 1);
+
+        // Lower importance (B) should be expired
+        let store = FactStore::new(&conn, dim);
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].content, "fact A");
+    }
+
+    #[test]
+    fn dissimilar_facts_not_deduped() {
+        let (conn, dim) = setup();
+        // Orthogonal embeddings
+        insert_fact(&conn, dim, "fact X", vec![1.0, 0.0, 0.0, 0.0], 0.5);
+        insert_fact(&conn, dim, "fact Y", vec![0.0, 1.0, 0.0, 0.0], 0.5);
+
+        let removed = local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+        assert_eq!(removed, 0);
+
+        let store = FactStore::new(&conn, dim);
+        assert_eq!(store.list_active().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn only_compares_new_facts_against_active() {
+        let (conn, dim) = setup();
+        let old_time = Utc::now() - Duration::days(10);
+
+        // Insert an "old" fact
+        let store = FactStore::new(&conn, dim);
+        store
+            .insert(&NewFact {
+                content: "old fact".into(),
+                content_hash: "h_old".into(),
+                embedding: vec![1.0, 0.0, 0.0, 0.0],
+                fact_type: FactType::Semantic,
+                t_created: old_time,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance: 0.5,
+                access_count: 0,
+                last_accessed: old_time,
+                metadata: serde_json::json!({}),
+            })
+            .unwrap();
+
+        // Insert a "new" near-duplicate
+        store
+            .insert(&NewFact {
+                content: "new duplicate".into(),
+                content_hash: "h_new".into(),
+                embedding: vec![0.99, 0.01, 0.0, 0.0],
+                fact_type: FactType::Semantic,
+                t_created: Utc::now(),
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance: 0.3,
+                access_count: 0,
+                last_accessed: Utc::now(),
+                metadata: serde_json::json!({}),
+            })
+            .unwrap();
+
+        // Only compare facts created since `old_time + 1 day`
+        let since = old_time + Duration::days(1);
+        let removed = local_dedup(&conn, dim, 0.90, Some(since), Utc::now()).unwrap();
+        assert_eq!(removed, 1); // new duplicate should be expired against old
+
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].content, "old fact"); // old survives (higher importance wins)
+    }
+
+    #[test]
+    fn higher_importance_survives() {
+        let (conn, dim) = setup();
+        insert_fact(&conn, dim, "low importance", vec![1.0, 0.0, 0.0, 0.0], 0.2);
+        insert_fact(
+            &conn,
+            dim,
+            "high importance",
+            vec![0.99, 0.01, 0.0, 0.0],
+            0.8,
+        );
+
+        local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+
+        let store = FactStore::new(&conn, dim);
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].content, "high importance");
+    }
+
+    #[test]
+    fn equal_importance_newer_expires() {
+        let (conn, dim) = setup();
+        // Same importance — newer (higher id) should be expired
+        insert_fact(&conn, dim, "older fact", vec![1.0, 0.0, 0.0, 0.0], 0.5);
+        insert_fact(&conn, dim, "newer fact", vec![0.99, 0.01, 0.0, 0.0], 0.5);
+
+        local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+
+        let store = FactStore::new(&conn, dim);
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].content, "older fact");
+    }
+}

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -66,6 +66,11 @@ pub fn local_dedup(
                 fact_store.expire(expire_id, now)?;
                 expired_ids.insert(expire_id);
                 duplicates_removed += 1;
+
+                // If the new_fact itself was expired, stop comparing it
+                if expire_id == new_fact.id {
+                    break;
+                }
             }
         }
     }

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -1,0 +1,168 @@
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::store::summaries::SummaryStore;
+use crate::traits::SummaryGenerator;
+use crate::types::{ConsolidationLevel, Fact, NewSummary};
+
+/// Global integration pass.
+///
+/// Summarizes all cluster-level summaries into a single global summary.
+/// Deletes prior global summaries first (idempotent).
+///
+/// Returns 1 if a global summary was created, 0 if no clusters exist.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure, or propagates errors from
+/// the `SummaryGenerator`.
+pub fn global_integration(
+    conn: &Connection,
+    generator: &dyn SummaryGenerator,
+    embed_dim: usize,
+) -> Result<usize> {
+    let summary_store = SummaryStore::new(conn, embed_dim);
+
+    // Idempotent: clear previous global summaries
+    summary_store.delete_by_level(&ConsolidationLevel::Global)?;
+
+    let cluster_summaries = summary_store.list_by_level(&ConsolidationLevel::Cluster)?;
+    if cluster_summaries.is_empty() {
+        return Ok(0);
+    }
+
+    // Convert summaries to Fact-like structs for the SummaryGenerator trait
+    let pseudo_facts: Vec<Fact> = cluster_summaries
+        .iter()
+        .map(|s| Fact {
+            id: s.id,
+            content: s.content.clone(),
+            content_hash: String::new(),
+            embedding: s.embedding.clone(),
+            fact_type: crate::types::FactType::Semantic,
+            t_created: s.created_at,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 1.0,
+            access_count: 0,
+            last_accessed: s.created_at,
+            metadata: serde_json::json!({}),
+        })
+        .collect();
+
+    let global_text = generator.summarize(&pseudo_facts)?;
+    let global_embedding = generator.embed(&global_text)?;
+
+    // Collect all source fact ids from all cluster summaries
+    let all_source_ids: Vec<i64> = cluster_summaries
+        .iter()
+        .flat_map(|s| s.source_fact_ids.iter().copied())
+        .collect();
+
+    summary_store.insert(&NewSummary {
+        content: global_text,
+        embedding: global_embedding,
+        level: ConsolidationLevel::Global,
+        source_fact_ids: all_source_ids,
+        created_at: chrono::Utc::now(),
+    })?;
+
+    Ok(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    use crate::store::schema::{init_schema, open_memory};
+
+    struct MockGenerator {
+        embed_dim: usize,
+    }
+
+    impl SummaryGenerator for MockGenerator {
+        fn summarize(&self, facts: &[Fact]) -> Result<String> {
+            Ok(facts
+                .iter()
+                .map(|f| f.content.as_str())
+                .collect::<Vec<_>>()
+                .join(" | "))
+        }
+
+        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.5; self.embed_dim])
+        }
+    }
+
+    #[test]
+    fn global_integration_summarizes_clusters() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dim = 4;
+        let store = SummaryStore::new(&conn, dim);
+
+        // Insert 3 cluster summaries
+        for i in 0..3 {
+            store
+                .insert(&NewSummary {
+                    content: format!("cluster {i}"),
+                    embedding: vec![0.1; dim],
+                    level: ConsolidationLevel::Cluster,
+                    source_fact_ids: vec![i64::from(i)],
+                    created_at: Utc::now(),
+                })
+                .unwrap();
+        }
+
+        let mock_gen = MockGenerator { embed_dim: dim };
+        let count = global_integration(&conn, &mock_gen, dim).unwrap();
+        assert_eq!(count, 1);
+
+        let global = store.list_by_level(&ConsolidationLevel::Global).unwrap();
+        assert_eq!(global.len(), 1);
+        assert!(global[0].content.contains("cluster 0"));
+        assert!(global[0].content.contains("cluster 2"));
+        assert_eq!(global[0].source_fact_ids, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn no_clusters_returns_zero() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dim = 4;
+
+        let mock_gen = MockGenerator { embed_dim: dim };
+        let count = global_integration(&conn, &mock_gen, dim).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn idempotent_global() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dim = 4;
+        let store = SummaryStore::new(&conn, dim);
+
+        store
+            .insert(&NewSummary {
+                content: "cluster A".into(),
+                embedding: vec![0.1; dim],
+                level: ConsolidationLevel::Cluster,
+                source_fact_ids: vec![1, 2],
+                created_at: Utc::now(),
+            })
+            .unwrap();
+
+        let mock_gen = MockGenerator { embed_dim: dim };
+
+        // Run twice
+        global_integration(&conn, &mock_gen, dim).unwrap();
+        global_integration(&conn, &mock_gen, dim).unwrap();
+
+        let global = store.list_by_level(&ConsolidationLevel::Global).unwrap();
+        assert_eq!(global.len(), 1); // Not 2
+    }
+}

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -32,7 +32,11 @@ pub fn consolidate(
     config: &ConsolidationConfig,
 ) -> Result<ConsolidationStats> {
     let last = get_config(conn, "last_consolidated_at")?
-        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|s| DateTime::parse_from_rfc3339(&s))
+        .transpose()
+        .map_err(|e| {
+            crate::error::MemoryError::Migration(format!("invalid last_consolidated_at: {e}"))
+        })?
         .map(|dt| dt.with_timezone(&Utc));
     let now = Utc::now();
 

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -13,11 +13,14 @@ use crate::error::Result;
 use crate::store::schema::{get_config, set_config};
 use crate::traits::{ConsolidationConfig, ConsolidationStats, SummaryGenerator};
 
-/// Orchestrate all 3 consolidation passes.
+/// Orchestrate all 3 consolidation passes atomically.
 ///
 /// 1. Local dedup — expire near-duplicate facts
 /// 2. Cluster fusion — group related facts, generate cluster summaries
 /// 3. Global integration — summarize all clusters into one global summary
+///
+/// All passes run within a single transaction. On any failure (including
+/// `SummaryGenerator` errors), the entire consolidation is rolled back.
 ///
 /// Reads `last_consolidated_at` from config to scope dedup.
 /// Updates `last_consolidated_at` after successful completion.
@@ -40,11 +43,15 @@ pub fn consolidate(
         .map(|dt| dt.with_timezone(&Utc));
     let now = Utc::now();
 
-    let duplicates_removed = local_dedup(conn, embed_dim, config.dedup_threshold, last, now)?;
-    let clusters_created = cluster_fusion(conn, generator, embed_dim, config.min_cluster_size)?;
-    let global_summaries = global_integration(conn, generator, embed_dim)?;
+    let tx = conn.unchecked_transaction()?;
 
-    set_config(conn, "last_consolidated_at", &now.to_rfc3339())?;
+    let duplicates_removed = local_dedup(&tx, embed_dim, config.dedup_threshold, last, now)?;
+    let clusters_created = cluster_fusion(&tx, generator, embed_dim, config.min_cluster_size)?;
+    let global_summaries = global_integration(&tx, generator, embed_dim)?;
+
+    set_config(&tx, "last_consolidated_at", &now.to_rfc3339())?;
+
+    tx.commit()?;
 
     Ok(ConsolidationStats {
         duplicates_removed,

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -1,0 +1,50 @@
+mod cluster;
+mod dedup;
+mod global;
+
+pub use cluster::cluster_fusion;
+pub use dedup::local_dedup;
+pub use global::global_integration;
+
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::store::schema::{get_config, set_config};
+use crate::traits::{ConsolidationConfig, ConsolidationStats, SummaryGenerator};
+
+/// Orchestrate all 3 consolidation passes.
+///
+/// 1. Local dedup — expire near-duplicate facts
+/// 2. Cluster fusion — group related facts, generate cluster summaries
+/// 3. Global integration — summarize all clusters into one global summary
+///
+/// Reads `last_consolidated_at` from config to scope dedup.
+/// Updates `last_consolidated_at` after successful completion.
+///
+/// # Errors
+///
+/// Propagates errors from any pass or the `SummaryGenerator`.
+pub fn consolidate(
+    conn: &Connection,
+    generator: &dyn SummaryGenerator,
+    embed_dim: usize,
+    config: &ConsolidationConfig,
+) -> Result<ConsolidationStats> {
+    let last = get_config(conn, "last_consolidated_at")?
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+    let now = Utc::now();
+
+    let duplicates_removed = local_dedup(conn, embed_dim, config.dedup_threshold, last, now)?;
+    let clusters_created = cluster_fusion(conn, generator, embed_dim, config.min_cluster_size)?;
+    let global_summaries = global_integration(conn, generator, embed_dim)?;
+
+    set_config(conn, "last_consolidated_at", &now.to_rfc3339())?;
+
+    Ok(ConsolidationStats {
+        duplicates_removed,
+        clusters_created,
+        global_summaries,
+    })
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -327,9 +327,7 @@ mod tests {
     #[test]
     fn forget_returns_not_implemented() {
         let mut engine = MemoryEngine::open_memory(DIM).unwrap();
-        let policy = ForgetPolicy {
-            min_importance: 0.1,
-        };
+        let policy = ForgetPolicy::default();
         let err = engine.forget(&policy).unwrap_err();
         assert!(matches!(err, MemoryError::NotImplemented(_)));
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,10 +4,12 @@ use chrono::Utc;
 use rusqlite::Connection;
 
 use crate::error::{MemoryError, Result};
+use crate::graph::MemoryGraph;
 use crate::search::hybrid::{hybrid_search, SearchQuery, SearchResult};
 use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
 use crate::store::schema::{get_config, init_schema, open_connection, open_memory, set_config};
+use crate::store::summaries::SummaryStore;
 use crate::traits::{
     ConflictArbiter, ConflictResolution, ConsolidationConfig, ConsolidationStats,
     EmbeddingProvider, ForgetPolicy, PruneStats, SummaryGenerator,
@@ -28,6 +30,7 @@ pub struct EngineConfig {
 pub struct MemoryEngine {
     conn: Connection,
     embed_dim: usize,
+    graph: MemoryGraph,
 }
 
 impl std::fmt::Debug for MemoryEngine {
@@ -53,9 +56,11 @@ impl MemoryEngine {
         let conn = open_connection(&path_str)?;
         init_schema(&conn)?;
         Self::validate_or_set_embed_dim(&conn, config.embed_dim)?;
+        let graph = MemoryGraph::load_from_db(&conn)?;
         Ok(Self {
             conn,
             embed_dim: config.embed_dim,
+            graph,
         })
     }
 
@@ -68,7 +73,12 @@ impl MemoryEngine {
         let conn = open_memory()?;
         init_schema(&conn)?;
         Self::validate_or_set_embed_dim(&conn, embed_dim)?;
-        Ok(Self { conn, embed_dim })
+        let graph = MemoryGraph::load_from_db(&conn)?;
+        Ok(Self {
+            conn,
+            embed_dim,
+            graph,
+        })
     }
 
     fn validate_or_set_embed_dim(conn: &Connection, embed_dim: usize) -> Result<()> {
@@ -172,48 +182,69 @@ impl MemoryEngine {
         set_config(&self.conn, key, value)
     }
 
-    // --- Phase 2 stubs ---
+    // --- Phase 2: fully implemented ---
 
-    /// Consolidate memories (Phase 2).
+    /// Run three-pass consolidation: local dedup, cluster fusion, global integration.
     ///
     /// # Errors
     ///
-    /// Always returns `MemoryError::NotImplemented` in Phase 1.
+    /// Propagates errors from any consolidation pass or the `SummaryGenerator`.
     pub fn consolidate(
         &mut self,
-        _generator: &dyn SummaryGenerator,
-        _config: &ConsolidationConfig,
+        generator: &dyn SummaryGenerator,
+        config: &ConsolidationConfig,
     ) -> Result<ConsolidationStats> {
-        Err(MemoryError::NotImplemented(
-            "consolidation requires Phase 2 (Tasks 9-12)".into(),
-        ))
+        crate::consolidation::consolidate(&self.conn, generator, self.embed_dim, config)
     }
 
-    /// Forget/prune stale facts (Phase 2).
+    /// Prune stale facts using Ebbinghaus decay and graph-aware importance scoring.
+    ///
+    /// Facts with computed importance below `policy.min_importance` get soft-deleted.
     ///
     /// # Errors
     ///
-    /// Always returns `MemoryError::NotImplemented` in Phase 1.
-    pub fn forget(&mut self, _policy: &ForgetPolicy) -> Result<PruneStats> {
-        Err(MemoryError::NotImplemented(
-            "forgetting requires Phase 2 (Tasks 9, 11)".into(),
-        ))
+    /// Returns `MemoryError::Conflict` if the policy is invalid.
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn forget(&mut self, policy: &ForgetPolicy) -> Result<PruneStats> {
+        crate::forgetting::prune(&self.conn, &self.graph, policy, self.embed_dim, Utc::now())
     }
 
-    /// Resolve a conflict between facts (Phase 2).
+    /// Resolve a conflict between an existing fact and a candidate new fact.
+    ///
+    /// Delegates the decision to the consumer-provided [`ConflictArbiter`].
+    /// Mutations happen in a single transaction; graph is updated only after commit.
     ///
     /// # Errors
     ///
-    /// Always returns `MemoryError::NotImplemented` in Phase 1.
+    /// Returns `MemoryError::NotFound` if the old fact doesn't exist.
+    /// Propagates errors from the arbiter or database operations.
     pub fn resolve_conflict(
         &mut self,
-        _arbiter: &dyn ConflictArbiter,
-        _old_id: i64,
-        _new_fact: NewFact,
+        arbiter: &dyn ConflictArbiter,
+        old_id: i64,
+        new_fact: &NewFact,
     ) -> Result<ConflictResolution> {
-        Err(MemoryError::NotImplemented(
-            "conflict resolution requires Phase 2 (Tasks 9, 13)".into(),
-        ))
+        crate::conflict::resolve_conflict(
+            &self.conn,
+            &mut self.graph,
+            arbiter,
+            old_id,
+            new_fact,
+            self.embed_dim,
+            Utc::now(),
+        )
+    }
+
+    /// Access the in-memory graph (read-only).
+    #[must_use]
+    pub const fn graph(&self) -> &MemoryGraph {
+        &self.graph
+    }
+
+    /// Get a `SummaryStore` borrowing this engine's connection.
+    #[must_use]
+    pub const fn summary_store(&self) -> SummaryStore<'_> {
+        SummaryStore::new(&self.conn, self.embed_dim)
     }
 }
 
@@ -221,8 +252,8 @@ impl MemoryEngine {
 mod tests {
     use super::*;
     use crate::search::hybrid::SearchMode;
-    use crate::traits::{ConsolidationConfig, ForgetPolicy};
-    use crate::types::{EventType, FactType};
+    use crate::traits::{ConsolidationConfig, CrudDecision, ForgetPolicy};
+    use crate::types::{EventType, Fact, FactType};
 
     const DIM: usize = 4;
 
@@ -236,26 +267,49 @@ mod tests {
         }
     }
 
-    struct DummyGen;
-    impl SummaryGenerator for DummyGen {
-        fn summarize(&self, _: &[crate::types::Fact]) -> Result<String> {
-            Ok(String::new())
+    struct MockGen;
+    impl SummaryGenerator for MockGen {
+        fn summarize(&self, facts: &[Fact]) -> Result<String> {
+            Ok(facts
+                .iter()
+                .map(|f| f.content.as_str())
+                .collect::<Vec<_>>()
+                .join("; "))
         }
         fn embed(&self, _: &str) -> Result<Vec<f32>> {
-            Ok(vec![])
+            Ok(vec![0.1; DIM])
         }
     }
 
-    struct DummyArbiter;
-    impl crate::traits::ConflictArbiter for DummyArbiter {
-        fn arbitrate(
-            &self,
-            _: &crate::types::Fact,
-            _: &crate::types::Fact,
-        ) -> Result<crate::traits::CrudDecision> {
-            Ok(crate::traits::CrudDecision::Noop)
+    struct FixedArbiter {
+        decision: CrudDecision,
+    }
+    impl ConflictArbiter for FixedArbiter {
+        fn arbitrate(&self, _: &Fact, _: &Fact) -> Result<CrudDecision> {
+            Ok(self.decision.clone())
         }
     }
+
+    fn make_new_fact(content: &str, embedding: Vec<f32>) -> NewFact {
+        let now = Utc::now();
+        NewFact {
+            content: content.into(),
+            content_hash: blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string(),
+            embedding,
+            fact_type: FactType::Semantic,
+            t_created: now,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: now,
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    // --- Phase 1 tests (unchanged) ---
 
     #[test]
     fn open_memory_succeeds() {
@@ -314,49 +368,6 @@ mod tests {
     }
 
     #[test]
-    fn consolidate_returns_not_implemented() {
-        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
-        let config = ConsolidationConfig {
-            dedup_threshold: 0.92,
-            min_cluster_size: 3,
-        };
-        let err = engine.consolidate(&DummyGen, &config).unwrap_err();
-        assert!(matches!(err, MemoryError::NotImplemented(_)));
-    }
-
-    #[test]
-    fn forget_returns_not_implemented() {
-        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
-        let policy = ForgetPolicy::default();
-        let err = engine.forget(&policy).unwrap_err();
-        assert!(matches!(err, MemoryError::NotImplemented(_)));
-    }
-
-    #[test]
-    fn resolve_conflict_returns_not_implemented() {
-        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
-        let new_fact = NewFact {
-            content: "test".into(),
-            content_hash: "abc".into(),
-            embedding: vec![0.1; DIM],
-            fact_type: FactType::Episodic,
-            t_created: Utc::now(),
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
-            importance: 0.5,
-            access_count: 0,
-            last_accessed: Utc::now(),
-            metadata: serde_json::json!({}),
-        };
-        let err = engine
-            .resolve_conflict(&DummyArbiter, 1, new_fact)
-            .unwrap_err();
-        assert!(matches!(err, MemoryError::NotImplemented(_)));
-    }
-
-    #[test]
     fn embed_dim_validation_rejects_mismatch() {
         let dir = std::env::temp_dir().join("memory_engine_test_dim_validation");
         let _ = std::fs::remove_dir_all(&dir);
@@ -394,5 +405,212 @@ mod tests {
             engine.get_config("custom_key").unwrap(),
             Some("custom_value".into())
         );
+    }
+
+    // --- Phase 2 tests ---
+
+    #[test]
+    fn graph_starts_empty() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        assert_eq!(engine.graph().node_count(), 0);
+        assert_eq!(engine.graph().edge_count(), 0);
+    }
+
+    #[test]
+    fn consolidate_deduplicates_similar_facts() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+        let fs = engine.fact_store();
+        // Two near-identical embeddings
+        fs.insert(&make_new_fact("fact alpha", vec![1.0, 0.0, 0.0, 0.0]))
+            .unwrap();
+        fs.insert(&make_new_fact(
+            "fact alpha copy",
+            vec![0.99, 0.01, 0.0, 0.0],
+        ))
+        .unwrap();
+
+        let config = ConsolidationConfig {
+            dedup_threshold: 0.90,
+            min_cluster_size: 10, // high threshold so no clusters form
+        };
+        let stats = engine.consolidate(&MockGen, &config).unwrap();
+        assert_eq!(stats.duplicates_removed, 1);
+
+        let active = engine.fact_store().list_active().unwrap();
+        assert_eq!(active.len(), 1);
+    }
+
+    #[test]
+    fn consolidate_is_idempotent() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+        let fs = engine.fact_store();
+        fs.insert(&make_new_fact("unique A", vec![1.0, 0.0, 0.0, 0.0]))
+            .unwrap();
+        fs.insert(&make_new_fact("unique B", vec![0.0, 1.0, 0.0, 0.0]))
+            .unwrap();
+
+        let config = ConsolidationConfig {
+            dedup_threshold: 0.92,
+            min_cluster_size: 10,
+        };
+
+        let _stats1 = engine.consolidate(&MockGen, &config).unwrap();
+        let stats2 = engine.consolidate(&MockGen, &config).unwrap();
+
+        // Second run should find 0 new duplicates
+        assert_eq!(stats2.duplicates_removed, 0);
+        // Both facts still active
+        assert_eq!(engine.fact_store().list_active().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn forget_prunes_stale_facts() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+
+        // Insert a fact with very low importance
+        let now = Utc::now();
+        let old_time = now - chrono::Duration::days(200);
+        engine
+            .fact_store()
+            .insert(&NewFact {
+                content: "ancient fact".into(),
+                content_hash: "h_ancient".into(),
+                embedding: vec![0.1; DIM],
+                fact_type: FactType::Episodic,
+                t_created: old_time,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance: 0.01,
+                access_count: 0,
+                last_accessed: old_time,
+                metadata: serde_json::json!({}),
+            })
+            .unwrap();
+
+        let policy = ForgetPolicy {
+            min_importance: 0.3,
+            ..ForgetPolicy::default()
+        };
+        let stats = engine.forget(&policy).unwrap();
+        assert_eq!(stats.facts_expired, 1);
+        assert_eq!(stats.facts_evaluated, 1);
+    }
+
+    #[test]
+    fn forget_rejects_invalid_policy() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+        let policy = ForgetPolicy {
+            half_life_days: 0.0, // invalid
+            ..ForgetPolicy::default()
+        };
+        assert!(engine.forget(&policy).is_err());
+    }
+
+    #[test]
+    fn resolve_conflict_update_creates_edge() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+        let old_id = engine
+            .fact_store()
+            .insert(&make_new_fact("outdated", vec![0.5; DIM]))
+            .unwrap();
+
+        let arbiter = FixedArbiter {
+            decision: CrudDecision::Update,
+        };
+        let result = engine
+            .resolve_conflict(&arbiter, old_id, &make_new_fact("updated", vec![0.5; DIM]))
+            .unwrap();
+
+        assert_eq!(result.decision, CrudDecision::Update);
+        assert!(result.new_fact_id.is_some());
+
+        // Old fact should be expired
+        let old = engine.fact_store().get(old_id).unwrap();
+        assert!(old.t_expired.is_some());
+
+        // Graph should have the new edge
+        let new_id = result.new_fact_id.unwrap();
+        assert!(engine.graph().has_node(new_id));
+        assert_eq!(engine.graph().neighbors(new_id), vec![old_id]);
+    }
+
+    #[test]
+    fn resolve_conflict_noop_no_changes() {
+        let mut engine = MemoryEngine::open_memory(DIM).unwrap();
+        let old_id = engine
+            .fact_store()
+            .insert(&make_new_fact("existing", vec![0.5; DIM]))
+            .unwrap();
+
+        let arbiter = FixedArbiter {
+            decision: CrudDecision::Noop,
+        };
+        let result = engine
+            .resolve_conflict(
+                &arbiter,
+                old_id,
+                &make_new_fact("candidate", vec![0.5; DIM]),
+            )
+            .unwrap();
+
+        assert_eq!(result.decision, CrudDecision::Noop);
+        assert!(result.new_fact_id.is_none());
+
+        // Old fact unchanged
+        let old = engine.fact_store().get(old_id).unwrap();
+        assert!(old.t_expired.is_none());
+    }
+
+    #[test]
+    fn graph_loads_on_reopen() {
+        let dir = std::env::temp_dir().join("memory_engine_test_graph_reload");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_path = dir.join("test.db");
+
+        let config = EngineConfig {
+            path: db_path,
+            embed_dim: DIM,
+        };
+
+        // First session: add facts and create an edge via conflict resolution
+        {
+            let mut engine = MemoryEngine::open(&config).unwrap();
+            let old_id = engine
+                .fact_store()
+                .insert(&make_new_fact("original", vec![0.5; DIM]))
+                .unwrap();
+            let arbiter = FixedArbiter {
+                decision: CrudDecision::Update,
+            };
+            engine
+                .resolve_conflict(
+                    &arbiter,
+                    old_id,
+                    &make_new_fact("replacement", vec![0.5; DIM]),
+                )
+                .unwrap();
+            assert_eq!(engine.graph().edge_count(), 1);
+        }
+
+        // Second session: graph should be restored from DB
+        {
+            let engine = MemoryEngine::open(&config).unwrap();
+            assert_eq!(engine.graph().edge_count(), 1);
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn summary_store_accessor_works() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let store = engine.summary_store();
+        let summaries = store
+            .list_by_level(&crate::types::ConsolidationLevel::Global)
+            .unwrap();
+        assert!(summaries.is_empty());
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -194,7 +194,15 @@ impl MemoryEngine {
         generator: &dyn SummaryGenerator,
         config: &ConsolidationConfig,
     ) -> Result<ConsolidationStats> {
-        crate::consolidation::consolidate(&self.conn, generator, self.embed_dim, config)
+        let stats =
+            crate::consolidation::consolidate(&self.conn, generator, self.embed_dim, config)?;
+
+        // Rebuild graph: dedup may have expired facts and their edges
+        if stats.duplicates_removed > 0 {
+            self.graph = MemoryGraph::load_from_db(&self.conn)?;
+        }
+
+        Ok(stats)
     }
 
     /// Prune stale facts using Ebbinghaus decay and graph-aware importance scoring.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -206,7 +206,13 @@ impl MemoryEngine {
     /// Returns `MemoryError::Conflict` if the policy is invalid.
     /// Returns `MemoryError::Database` on SQL failure.
     pub fn forget(&mut self, policy: &ForgetPolicy) -> Result<PruneStats> {
-        crate::forgetting::prune(&self.conn, &self.graph, policy, self.embed_dim, Utc::now())
+        crate::forgetting::prune(
+            &self.conn,
+            &mut self.graph,
+            policy,
+            self.embed_dim,
+            Utc::now(),
+        )
     }
 
     /// Resolve a conflict between an existing fact and a candidate new fact.

--- a/src/forgetting/mod.rs
+++ b/src/forgetting/mod.rs
@@ -1,0 +1,3 @@
+mod policy;
+
+pub use policy::{compute_importance, ebbinghaus_decay, prune};

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -1,0 +1,334 @@
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::graph::MemoryGraph;
+use crate::store::facts::FactStore;
+use crate::traits::{ForgetPolicy, PruneStats};
+use crate::types::Fact;
+
+/// Ebbinghaus forgetting curve: retention = 2^(-age/half_life).
+///
+/// Returns 1.0 at `age=0`, 0.5 at `age=half_life`, 0.25 at `age=2×half_life`.
+#[must_use]
+pub fn ebbinghaus_decay(age_days: f64, half_life: f64) -> f64 {
+    f64::exp2(-age_days / half_life)
+}
+
+/// Compute composite importance score for a fact.
+///
+/// Weighted sum of 4 signals, each normalized to \[0, 1\]:
+/// 1. **Recency**: `ebbinghaus_decay(age, half_life)` — already in \[0, 1\]
+/// 2. **Frequency**: `ln(access_count + 1) / ln(101)` — capped at 1.0
+///    (100 accesses = full score, chosen as a reasonable ceiling)
+/// 3. **Graph degree**: `ln(degree + 1) / ln(51)` — capped at 1.0
+///    (50 connections = full score)
+/// 4. **Base importance**: `fact.importance` — already in \[0, 1\]
+#[must_use]
+pub fn compute_importance(
+    fact: &Fact,
+    graph_degree: usize,
+    now: DateTime<Utc>,
+    policy: &ForgetPolicy,
+) -> f64 {
+    let half_life = policy
+        .half_life_overrides
+        .get(&fact.fact_type)
+        .copied()
+        .unwrap_or(policy.half_life_days);
+
+    #[allow(clippy::cast_precision_loss)]
+    let age_days = (now - fact.last_accessed).num_seconds() as f64 / 86400.0;
+    let recency = ebbinghaus_decay(age_days.max(0.0), half_life);
+
+    // Normalization: log_base(count+1), capped at 1.0.
+    // Using ln_1p for numerical accuracy near zero.
+    #[allow(clippy::cast_precision_loss)]
+    let frequency = (f64::ln_1p(fact.access_count as f64) / 101.0_f64.ln()).min(1.0);
+    #[allow(clippy::cast_precision_loss)]
+    let connectivity = (f64::ln_1p(graph_degree as f64) / 51.0_f64.ln()).min(1.0);
+
+    policy
+        .recency_weight
+        .mul_add(recency, policy.frequency_weight * frequency)
+        + policy.graph_degree_weight.mul_add(
+            connectivity,
+            policy.base_importance_weight * fact.importance,
+        )
+}
+
+/// Prune facts with importance below threshold.
+///
+/// Iterates all active facts, computes importance, soft-deletes those below
+/// `min_importance`. Returns statistics about the operation.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Conflict` if the policy fails validation.
+/// Returns `MemoryError::Database` on SQL failure.
+pub fn prune(
+    conn: &Connection,
+    graph: &MemoryGraph,
+    policy: &ForgetPolicy,
+    embed_dim: usize,
+    now: DateTime<Utc>,
+) -> Result<PruneStats> {
+    policy.validate()?;
+
+    let fact_store = FactStore::new(conn, embed_dim);
+    let active_facts = fact_store.list_active()?;
+    let facts_evaluated = active_facts.len();
+    let mut facts_expired = 0;
+
+    for fact in &active_facts {
+        let degree = graph.degree(fact.id);
+        let importance = compute_importance(fact, degree, now, policy);
+        if importance < policy.min_importance {
+            fact_store.expire(fact.id, now)?;
+            facts_expired += 1;
+        }
+    }
+
+    Ok(PruneStats {
+        facts_expired,
+        facts_evaluated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use std::collections::HashMap;
+
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::FactType;
+
+    #[test]
+    fn decay_at_zero_is_one() {
+        let result = ebbinghaus_decay(0.0, 69.0);
+        assert!((result - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn decay_at_half_life_is_half() {
+        let result = ebbinghaus_decay(69.0, 69.0);
+        assert!((result - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn decay_at_two_half_lives_is_quarter() {
+        let result = ebbinghaus_decay(138.0, 69.0);
+        assert!((result - 0.25).abs() < 1e-10);
+    }
+
+    #[test]
+    fn high_access_recent_connected_beats_neglected_isolated() {
+        let now = Utc::now();
+        let policy = ForgetPolicy::default();
+
+        // Fact A: recently accessed, high access count, connected, high importance
+        let fact_a = Fact {
+            id: 1,
+            content: "important".into(),
+            content_hash: "h1".into(),
+            embedding: vec![0.1; 4],
+            fact_type: FactType::Semantic,
+            t_created: now,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.8,
+            access_count: 100,
+            last_accessed: now - Duration::hours(1),
+            metadata: serde_json::json!({}),
+        };
+
+        // Fact B: old, rarely accessed, isolated, low importance
+        let fact_b = Fact {
+            id: 2,
+            content: "neglected".into(),
+            content_hash: "h2".into(),
+            embedding: vec![0.2; 4],
+            fact_type: FactType::Episodic,
+            t_created: now - Duration::days(180),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.3,
+            access_count: 1,
+            last_accessed: now - Duration::days(90),
+            metadata: serde_json::json!({}),
+        };
+
+        let importance_a = compute_importance(&fact_a, 5, now, &policy);
+        let importance_b = compute_importance(&fact_b, 0, now, &policy);
+        assert!(
+            importance_a > importance_b,
+            "A ({importance_a}) should be more important than B ({importance_b})"
+        );
+    }
+
+    #[test]
+    fn per_fact_type_half_life_override() {
+        let now = Utc::now();
+        let mut overrides = HashMap::new();
+        overrides.insert(FactType::Episodic, 30.0);
+        overrides.insert(FactType::Procedural, 365.0);
+
+        let policy = ForgetPolicy {
+            half_life_overrides: overrides,
+            ..ForgetPolicy::default()
+        };
+
+        let base_fact = Fact {
+            id: 1,
+            content: "test".into(),
+            content_hash: "h".into(),
+            embedding: vec![0.1; 4],
+            fact_type: FactType::Episodic,
+            t_created: now - Duration::days(60),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 5,
+            last_accessed: now - Duration::days(60),
+            metadata: serde_json::json!({}),
+        };
+
+        let mut procedural_fact = base_fact.clone();
+        procedural_fact.fact_type = FactType::Procedural;
+
+        // Same age, same access, but Episodic decays faster (half_life=30)
+        // than Procedural (half_life=365)
+        let episodic_importance = compute_importance(&base_fact, 0, now, &policy);
+        let procedural_importance = compute_importance(&procedural_fact, 0, now, &policy);
+
+        assert!(
+            procedural_importance > episodic_importance,
+            "Procedural ({procedural_importance}) should decay slower than Episodic ({episodic_importance})"
+        );
+    }
+
+    #[test]
+    fn prune_expires_low_importance_facts() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let now = Utc::now();
+        let old_time = now - Duration::days(100);
+        let embed_dim = 4;
+
+        // Insert 3 facts directly with varying importance and recency
+        let fact_store = FactStore::new(&conn, embed_dim);
+        use crate::types::NewFact;
+
+        // Fact 1: high importance, recently accessed
+        fact_store
+            .insert(&NewFact {
+                content: "very important".into(),
+                content_hash: "h1".into(),
+                embedding: vec![0.1; embed_dim],
+                fact_type: FactType::Semantic,
+                t_created: now,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance: 0.9,
+                access_count: 50,
+                last_accessed: now,
+                metadata: serde_json::json!({}),
+            })
+            .unwrap();
+
+        // Fact 2: medium importance, old
+        fact_store
+            .insert(&NewFact {
+                content: "somewhat important".into(),
+                content_hash: "h2".into(),
+                embedding: vec![0.2; embed_dim],
+                fact_type: FactType::Episodic,
+                t_created: old_time,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance: 0.3,
+                access_count: 2,
+                last_accessed: old_time,
+                metadata: serde_json::json!({}),
+            })
+            .unwrap();
+
+        // Fact 3: low importance, very old
+        fact_store
+            .insert(&NewFact {
+                content: "not important".into(),
+                content_hash: "h3".into(),
+                embedding: vec![0.3; embed_dim],
+                fact_type: FactType::Episodic,
+                t_created: old_time,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance: 0.1,
+                access_count: 0,
+                last_accessed: old_time,
+                metadata: serde_json::json!({}),
+            })
+            .unwrap();
+
+        let graph = MemoryGraph::new();
+        let policy = ForgetPolicy {
+            min_importance: 0.3,
+            ..ForgetPolicy::default()
+        };
+
+        let stats = prune(&conn, &graph, &policy, embed_dim, now).unwrap();
+        assert_eq!(stats.facts_evaluated, 3);
+        // At least 1 fact should be pruned (fact 3 with low importance + old age)
+        assert!(
+            stats.facts_expired >= 1,
+            "Expected at least 1 fact expired, got {}",
+            stats.facts_expired
+        );
+
+        // Verify expired facts still exist in DB (soft delete, not hard delete)
+        let all_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM facts", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(all_count, 3, "All facts should still exist in DB");
+    }
+
+    #[test]
+    fn policy_validation_rejects_invalid() {
+        let mut policy = ForgetPolicy::default();
+
+        // Zero half-life
+        policy.half_life_days = 0.0;
+        assert!(policy.validate().is_err());
+        policy.half_life_days = 69.0;
+
+        // Negative weight
+        policy.recency_weight = -1.0;
+        assert!(policy.validate().is_err());
+        policy.recency_weight = 0.3;
+
+        // min_importance out of range
+        policy.min_importance = 1.5;
+        assert!(policy.validate().is_err());
+        policy.min_importance = 0.1;
+
+        // Negative half-life override
+        let mut overrides = HashMap::new();
+        overrides.insert(FactType::Episodic, -10.0);
+        policy.half_life_overrides = overrides;
+        assert!(policy.validate().is_err());
+    }
+}

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -216,6 +216,8 @@ mod tests {
 
     #[test]
     fn prune_expires_low_importance_facts() {
+        use crate::types::NewFact;
+
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
 
@@ -225,7 +227,6 @@ mod tests {
 
         // Insert 3 facts directly with varying importance and recency
         let fact_store = FactStore::new(&conn, embed_dim);
-        use crate::types::NewFact;
 
         // Fact 1: high importance, recently accessed
         fact_store
@@ -307,6 +308,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn policy_validation_rejects_invalid() {
         let mut policy = ForgetPolicy::default();
 

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -7,6 +7,13 @@ use crate::store::facts::FactStore;
 use crate::traits::{ForgetPolicy, PruneStats};
 use crate::types::Fact;
 
+/// Normalization ceiling for access frequency: ln(100+1).
+/// 100 accesses = full score.
+const FREQUENCY_NORMALIZATION_CEILING: f64 = 101.0;
+/// Normalization ceiling for graph connectivity: ln(50+1).
+/// 50 connections = full score.
+const CONNECTIVITY_NORMALIZATION_CEILING: f64 = 51.0;
+
 /// Ebbinghaus forgetting curve: retention = 2^(-age/half_life).
 ///
 /// Returns 1.0 at `age=0`, 0.5 at `age=half_life`, 0.25 at `age=2×half_life`.
@@ -44,9 +51,11 @@ pub fn compute_importance(
     // Normalization: log_base(count+1), capped at 1.0.
     // Using ln_1p for numerical accuracy near zero.
     #[allow(clippy::cast_precision_loss)]
-    let frequency = (f64::ln_1p(fact.access_count as f64) / 101.0_f64.ln()).min(1.0);
+    let frequency =
+        (f64::ln_1p(fact.access_count as f64) / FREQUENCY_NORMALIZATION_CEILING.ln()).min(1.0);
     #[allow(clippy::cast_precision_loss)]
-    let connectivity = (f64::ln_1p(graph_degree as f64) / 51.0_f64.ln()).min(1.0);
+    let connectivity =
+        (f64::ln_1p(graph_degree as f64) / CONNECTIVITY_NORMALIZATION_CEILING.ln()).min(1.0);
 
     policy
         .recency_weight

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -3,6 +3,7 @@ use rusqlite::Connection;
 
 use crate::error::Result;
 use crate::graph::MemoryGraph;
+use crate::store::edges::EdgeStore;
 use crate::store::facts::FactStore;
 use crate::traits::{ForgetPolicy, PruneStats};
 use crate::types::Fact;
@@ -69,7 +70,10 @@ pub fn compute_importance(
 /// Prune facts with importance below threshold.
 ///
 /// Iterates all active facts, computes importance, soft-deletes those below
-/// `min_importance`. Returns statistics about the operation.
+/// `min_importance`. For each expired fact, cascades edge expiry in `SQLite`
+/// and removes edges from the in-memory graph to keep it consistent.
+///
+/// All mutations happen in a single transaction.
 ///
 /// # Errors
 ///
@@ -77,7 +81,7 @@ pub fn compute_importance(
 /// Returns `MemoryError::Database` on SQL failure.
 pub fn prune(
     conn: &Connection,
-    graph: &MemoryGraph,
+    graph: &mut MemoryGraph,
     policy: &ForgetPolicy,
     embed_dim: usize,
     now: DateTime<Utc>,
@@ -87,19 +91,35 @@ pub fn prune(
     let fact_store = FactStore::new(conn, embed_dim);
     let active_facts = fact_store.list_active()?;
     let facts_evaluated = active_facts.len();
-    let mut facts_expired = 0;
 
-    for fact in &active_facts {
-        let degree = graph.degree(fact.id);
-        let importance = compute_importance(fact, degree, now, policy);
-        if importance < policy.min_importance {
-            fact_store.expire(fact.id, now)?;
-            facts_expired += 1;
-        }
+    // Score all facts before mutating, so degree values are consistent
+    let to_expire: Vec<i64> = active_facts
+        .iter()
+        .filter(|fact| {
+            let degree = graph.degree(fact.id);
+            compute_importance(fact, degree, now, policy) < policy.min_importance
+        })
+        .map(|f| f.id)
+        .collect();
+
+    let tx = conn.unchecked_transaction()?;
+    let fact_store = FactStore::new(&tx, embed_dim);
+    let edge_store = EdgeStore::new(&tx);
+
+    for &fact_id in &to_expire {
+        fact_store.expire(fact_id, now)?;
+        edge_store.expire_by_fact(fact_id, now)?;
+    }
+
+    tx.commit()?;
+
+    // Update in-memory graph after successful commit
+    for &fact_id in &to_expire {
+        graph.remove_edges_by_fact(fact_id);
     }
 
     Ok(PruneStats {
-        facts_expired,
+        facts_expired: to_expire.len(),
         facts_evaluated,
     })
 }
@@ -294,13 +314,13 @@ mod tests {
             })
             .unwrap();
 
-        let graph = MemoryGraph::new();
+        let mut graph = MemoryGraph::new();
         let policy = ForgetPolicy {
             min_importance: 0.3,
             ..ForgetPolicy::default()
         };
 
-        let stats = prune(&conn, &graph, &policy, embed_dim, now).unwrap();
+        let stats = prune(&conn, &mut graph, &policy, embed_dim, now).unwrap();
         assert_eq!(stats.facts_evaluated, 3);
         // At least 1 fact should be pruned (fact 3 with low importance + old age)
         assert!(

--- a/src/graph/memory_graph.rs
+++ b/src/graph/memory_graph.rs
@@ -1,0 +1,315 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use petgraph::graph::{DiGraph, NodeIndex};
+use petgraph::Direction;
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::store::edges::EdgeStore;
+
+/// Edge weight stored in the petgraph `DiGraph`.
+#[derive(Debug, Clone)]
+pub struct EdgeData {
+    /// `SQLite` row id of the edge.
+    pub edge_id: i64,
+    /// Relationship label (e.g. "contradicts", "supplements").
+    pub relation_type: String,
+    /// Numeric weight for the edge.
+    pub weight: f64,
+}
+
+/// In-memory graph backed by `petgraph`, mirroring the active edges in `SQLite`.
+///
+/// Node weights are fact ids (`i64`). Edge weights are [`EdgeData`].
+/// The graph only contains active (non-expired) edges.
+pub struct MemoryGraph {
+    graph: DiGraph<i64, EdgeData>,
+    node_map: HashMap<i64, NodeIndex>,
+}
+
+impl MemoryGraph {
+    /// Create an empty graph.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            graph: DiGraph::new(),
+            node_map: HashMap::new(),
+        }
+    }
+
+    /// Ensure a node exists for the given fact id, returning its index.
+    pub fn ensure_node(&mut self, fact_id: i64) -> NodeIndex {
+        *self
+            .node_map
+            .entry(fact_id)
+            .or_insert_with(|| self.graph.add_node(fact_id))
+    }
+
+    /// Check whether a node exists for the given fact id.
+    #[must_use]
+    pub fn has_node(&self, fact_id: i64) -> bool {
+        self.node_map.contains_key(&fact_id)
+    }
+
+    /// Add a directed edge between two fact ids.
+    ///
+    /// Ensures both nodes exist before adding the edge.
+    pub fn add_edge(&mut self, source: i64, target: i64, data: EdgeData) {
+        let s = self.ensure_node(source);
+        let t = self.ensure_node(target);
+        self.graph.add_edge(s, t, data);
+    }
+
+    /// Remove all edges associated with the given `SQLite` edge id.
+    ///
+    /// Used after expiring an edge in `SQLite` to keep the graph in sync.
+    pub fn remove_edge_by_id(&mut self, edge_id: i64) {
+        let to_remove: Vec<_> = self
+            .graph
+            .edge_indices()
+            .filter(|&ei| self.graph[ei].edge_id == edge_id)
+            .collect();
+        for ei in to_remove {
+            self.graph.remove_edge(ei);
+        }
+    }
+
+    /// Outgoing neighbors of a fact.
+    #[must_use]
+    pub fn neighbors(&self, fact_id: i64) -> Vec<i64> {
+        self.node_map.get(&fact_id).map_or_else(Vec::new, |&idx| {
+            self.graph
+                .neighbors_directed(idx, Direction::Outgoing)
+                .map(|ni| self.graph[ni])
+                .collect()
+        })
+    }
+
+    /// Total degree (in + out) for importance scoring.
+    #[must_use]
+    pub fn degree(&self, fact_id: i64) -> usize {
+        self.node_map.get(&fact_id).map_or(0, |&idx| {
+            self.graph
+                .neighbors_directed(idx, Direction::Outgoing)
+                .count()
+                + self
+                    .graph
+                    .neighbors_directed(idx, Direction::Incoming)
+                    .count()
+        })
+    }
+
+    /// All fact ids in the connected component containing `fact_id`.
+    ///
+    /// Treats the directed graph as undirected for connectivity.
+    #[must_use]
+    pub fn connected_component(&self, fact_id: i64) -> Vec<i64> {
+        let Some(&start) = self.node_map.get(&fact_id) else {
+            return vec![];
+        };
+
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+        queue.push_back(start);
+        visited.insert(start);
+
+        while let Some(node) = queue.pop_front() {
+            // Outgoing
+            for neighbor in self.graph.neighbors_directed(node, Direction::Outgoing) {
+                if visited.insert(neighbor) {
+                    queue.push_back(neighbor);
+                }
+            }
+            // Incoming
+            for neighbor in self.graph.neighbors_directed(node, Direction::Incoming) {
+                if visited.insert(neighbor) {
+                    queue.push_back(neighbor);
+                }
+            }
+        }
+
+        visited.iter().map(|&ni| self.graph[ni]).collect()
+    }
+
+    /// Number of nodes in the graph.
+    #[must_use]
+    pub fn node_count(&self) -> usize {
+        self.graph.node_count()
+    }
+
+    /// Number of edges in the graph.
+    #[must_use]
+    pub fn edge_count(&self) -> usize {
+        self.graph.edge_count()
+    }
+
+    /// Rebuild the graph from all active (non-expired) edges in `SQLite`.
+    ///
+    /// This is the recovery path if the in-memory graph ever drifts from
+    /// the database. Called on `MemoryEngine::open`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn load_from_db(conn: &Connection) -> Result<Self> {
+        let store = EdgeStore::new(conn);
+        let active_edges = store.list_active()?;
+
+        let mut graph = Self::new();
+        for edge in &active_edges {
+            graph.add_edge(
+                edge.source_fact_id,
+                edge.target_fact_id,
+                EdgeData {
+                    edge_id: edge.id,
+                    relation_type: edge.relation_type.clone(),
+                    weight: edge.weight,
+                },
+            );
+        }
+
+        Ok(graph)
+    }
+}
+
+impl Default for MemoryGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::NewEdge;
+
+    fn make_edge_data(id: i64, rel: &str) -> EdgeData {
+        EdgeData {
+            edge_id: id,
+            relation_type: rel.to_string(),
+            weight: 1.0,
+        }
+    }
+
+    #[test]
+    fn add_node_and_query() {
+        let mut g = MemoryGraph::new();
+        g.ensure_node(42);
+        assert!(g.has_node(42));
+        assert!(!g.has_node(99));
+    }
+
+    #[test]
+    fn add_edge_and_neighbors() {
+        let mut g = MemoryGraph::new();
+        g.add_edge(1, 2, make_edge_data(1, "related"));
+        assert_eq!(g.neighbors(1), vec![2]);
+        assert!(g.neighbors(2).is_empty()); // directed: no outgoing from 2
+    }
+
+    #[test]
+    fn degree_counts_both_directions() {
+        let mut g = MemoryGraph::new();
+        g.add_edge(1, 2, make_edge_data(1, "a"));
+        g.add_edge(1, 3, make_edge_data(2, "b"));
+        g.add_edge(4, 1, make_edge_data(3, "c"));
+        // node 1: 2 outgoing + 1 incoming = 3
+        assert_eq!(g.degree(1), 3);
+        // node 2: 0 outgoing + 1 incoming = 1
+        assert_eq!(g.degree(2), 1);
+        // node 4: 1 outgoing + 0 incoming = 1
+        assert_eq!(g.degree(4), 1);
+        // unknown node
+        assert_eq!(g.degree(99), 0);
+    }
+
+    #[test]
+    fn connected_component_undirected() {
+        let mut g = MemoryGraph::new();
+        // Chain: 1 → 2 → 3
+        g.add_edge(1, 2, make_edge_data(1, "a"));
+        g.add_edge(2, 3, make_edge_data(2, "b"));
+        // Isolated node
+        g.ensure_node(4);
+
+        let mut comp = g.connected_component(1);
+        comp.sort_unstable();
+        assert_eq!(comp, vec![1, 2, 3]);
+
+        let comp4 = g.connected_component(4);
+        assert_eq!(comp4, vec![4]);
+
+        // Unknown node returns empty
+        assert!(g.connected_component(99).is_empty());
+    }
+
+    #[test]
+    fn remove_edge_by_id() {
+        let mut g = MemoryGraph::new();
+        g.add_edge(1, 2, make_edge_data(10, "a"));
+        g.add_edge(1, 3, make_edge_data(20, "b"));
+        assert_eq!(g.edge_count(), 2);
+
+        g.remove_edge_by_id(10);
+        assert_eq!(g.edge_count(), 1);
+        assert!(g.neighbors(1) == vec![3]);
+    }
+
+    #[test]
+    fn load_from_db_skips_expired() {
+        let conn = setup_db();
+        let store = EdgeStore::new(&conn);
+
+        let now = Utc::now();
+        let e1 = NewEdge {
+            source_fact_id: 1,
+            target_fact_id: 2,
+            relation_type: "active".to_string(),
+            weight: 1.0,
+            t_created: now,
+            t_expired: None,
+        };
+        let e2 = NewEdge {
+            source_fact_id: 2,
+            target_fact_id: 3,
+            relation_type: "expired".to_string(),
+            weight: 1.0,
+            t_created: now,
+            t_expired: None,
+        };
+
+        let id1 = store.insert(&e1).unwrap();
+        let id2 = store.insert(&e2).unwrap();
+        store.expire(id2, now).unwrap();
+
+        let graph = MemoryGraph::load_from_db(&conn).unwrap();
+        assert_eq!(graph.edge_count(), 1);
+        assert!(graph.has_node(1));
+        assert!(graph.has_node(2));
+        assert!(!graph.has_node(3)); // only appeared in the expired edge
+
+        // The active edge should be loadable
+        let neighbors = graph.neighbors(1);
+        assert_eq!(neighbors, vec![2]);
+
+        // Verify we loaded the right edge_id
+        let _ = id1; // used for insert, graph has it as EdgeData.edge_id
+    }
+
+    fn setup_db() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        // Insert dummy facts for FK constraints
+        for (content, hash) in &[("f1", "h1"), ("f2", "h2"), ("f3", "h3")] {
+            conn.execute(
+                "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, importance, access_count, last_accessed, metadata)
+                 VALUES (?1, ?2, X'00000000', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}')",
+                rusqlite::params![content, hash],
+            ).unwrap();
+        }
+        conn
+    }
+}

--- a/src/graph/memory_graph.rs
+++ b/src/graph/memory_graph.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use petgraph::graph::{DiGraph, NodeIndex};
+use petgraph::visit::EdgeRef;
 use petgraph::Direction;
 use rusqlite::Connection;
 
@@ -76,28 +77,23 @@ impl MemoryGraph {
 
     /// Remove all edges involving a given fact id (as source or target).
     ///
+    /// Uses directed edge iterators for O(degree) instead of O(E).
     /// Used by conflict resolution after expiring edges in `SQLite`.
-    ///
-    /// # Panics
-    ///
-    /// Cannot panic. The `expect` call is guarded by iterating only valid
-    /// edge indices from the graph.
     pub fn remove_edges_by_fact(&mut self, fact_id: i64) {
         let Some(&idx) = self.node_map.get(&fact_id) else {
             return;
         };
-        // Collect edges where fact is source or target
-        let to_remove: Vec<_> = self
+        // Collect outgoing and incoming edge indices for this node — O(degree)
+        let mut to_remove: Vec<_> = self
             .graph
-            .edge_indices()
-            .filter(|&ei| {
-                let (src, tgt) = self
-                    .graph
-                    .edge_endpoints(ei)
-                    .expect("edge index from edge_indices() is always valid");
-                src == idx || tgt == idx
-            })
+            .edges_directed(idx, Direction::Outgoing)
+            .map(|e| e.id())
             .collect();
+        to_remove.extend(
+            self.graph
+                .edges_directed(idx, Direction::Incoming)
+                .map(|e| e.id()),
+        );
         for ei in to_remove {
             self.graph.remove_edge(ei);
         }

--- a/src/graph/memory_graph.rs
+++ b/src/graph/memory_graph.rs
@@ -74,6 +74,35 @@ impl MemoryGraph {
         }
     }
 
+    /// Remove all edges involving a given fact id (as source or target).
+    ///
+    /// Used by conflict resolution after expiring edges in `SQLite`.
+    ///
+    /// # Panics
+    ///
+    /// Cannot panic. The `expect` call is guarded by iterating only valid
+    /// edge indices from the graph.
+    pub fn remove_edges_by_fact(&mut self, fact_id: i64) {
+        let Some(&idx) = self.node_map.get(&fact_id) else {
+            return;
+        };
+        // Collect edges where fact is source or target
+        let to_remove: Vec<_> = self
+            .graph
+            .edge_indices()
+            .filter(|&ei| {
+                let (src, tgt) = self
+                    .graph
+                    .edge_endpoints(ei)
+                    .expect("edge index from edge_indices() is always valid");
+                src == idx || tgt == idx
+            })
+            .collect();
+        for ei in to_remove {
+            self.graph.remove_edge(ei);
+        }
+    }
+
     /// Outgoing neighbors of a fact.
     #[must_use]
     pub fn neighbors(&self, fact_id: i64) -> Vec<i64> {

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,0 +1,3 @@
+mod memory_graph;
+
+pub use memory_graph::{EdgeData, MemoryGraph};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod engine;
 pub mod error;
+pub mod graph;
 pub mod search;
 pub mod store;
 pub mod traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod engine;
 pub mod error;
+pub mod forgetting;
 pub mod graph;
 pub mod search;
 pub mod store;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! `MemoryEngine` is `!Send` and `!Sync` (rusqlite `Connection` is not
 //! thread-safe). Consumers must wrap in a `Mutex` or use an actor pattern.
 
+pub mod consolidation;
 pub mod engine;
 pub mod error;
 pub mod forgetting;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! `MemoryEngine` is `!Send` and `!Sync` (rusqlite `Connection` is not
 //! thread-safe). Consumers must wrap in a `Mutex` or use an actor pattern.
 
+pub mod conflict;
 pub mod consolidation;
 pub mod engine;
 pub mod error;

--- a/src/store/edges.rs
+++ b/src/store/edges.rs
@@ -1,0 +1,274 @@
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use crate::error::{MemoryError, Result};
+use crate::store::{parse_optional_timestamp, parse_timestamp};
+use crate::types::{Edge, NewEdge};
+
+/// Store for graph edges with bi-temporal support.
+pub struct EdgeStore<'a> {
+    conn: &'a Connection,
+}
+
+fn row_to_edge(row: &rusqlite::Row<'_>) -> rusqlite::Result<Edge> {
+    let t_created_str: String = row.get("t_created")?;
+    let t_expired_str: Option<String> = row.get("t_expired")?;
+
+    Ok(Edge {
+        id: row.get("id")?,
+        source_fact_id: row.get("source_fact_id")?,
+        target_fact_id: row.get("target_fact_id")?,
+        relation_type: row.get("relation_type")?,
+        weight: row.get("weight")?,
+        t_created: parse_timestamp(&t_created_str)?,
+        t_expired: parse_optional_timestamp(t_expired_str.as_deref())?,
+    })
+}
+
+impl<'a> EdgeStore<'a> {
+    /// Create a new `EdgeStore` borrowing the given connection.
+    #[must_use]
+    pub const fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Insert a new edge. Returns the assigned row id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure (e.g. FK violation).
+    pub fn insert(&self, edge: &NewEdge) -> Result<i64> {
+        self.conn.execute(
+            "INSERT INTO edges (source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                edge.source_fact_id,
+                edge.target_fact_id,
+                edge.relation_type,
+                edge.weight,
+                edge.t_created.to_rfc3339(),
+                edge.t_expired.map(|dt| dt.to_rfc3339()),
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Get an edge by id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if the edge doesn't exist.
+    pub fn get(&self, id: i64) -> Result<Edge> {
+        self.conn
+            .query_row(
+                "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired
+                 FROM edges WHERE id = ?1",
+                params![id],
+                row_to_edge,
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    MemoryError::NotFound(format!("edge {id}"))
+                }
+                other => MemoryError::Database(other),
+            })
+    }
+
+    /// Expire an edge (soft-delete).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn expire(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
+        self.conn.execute(
+            "UPDATE edges SET t_expired = ?1 WHERE id = ?2",
+            params![now.to_rfc3339(), id],
+        )?;
+        Ok(())
+    }
+
+    /// Expire all active edges involving a given fact (as source or target).
+    ///
+    /// Used by conflict resolution for edge cascade on fact expiry.
+    /// Returns the number of edges expired.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn expire_by_fact(&self, fact_id: i64, now: DateTime<Utc>) -> Result<usize> {
+        let count = self.conn.execute(
+            "UPDATE edges SET t_expired = ?1
+             WHERE (source_fact_id = ?2 OR target_fact_id = ?2)
+               AND t_expired IS NULL",
+            params![now.to_rfc3339(), fact_id],
+        )?;
+        Ok(count)
+    }
+
+    /// List all active edges (`t_expired IS NULL`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn list_active(&self) -> Result<Vec<Edge>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired
+             FROM edges WHERE t_expired IS NULL",
+        )?;
+        let edges = stmt
+            .query_map([], row_to_edge)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(edges)
+    }
+
+    /// List active edges by source fact id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn list_active_by_source(&self, source_fact_id: i64) -> Result<Vec<Edge>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired
+             FROM edges WHERE source_fact_id = ?1 AND t_expired IS NULL",
+        )?;
+        let edges = stmt
+            .query_map(params![source_fact_id], row_to_edge)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(edges)
+    }
+
+    /// List active edges by target fact id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn list_active_by_target(&self, target_fact_id: i64) -> Result<Vec<Edge>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired
+             FROM edges WHERE target_fact_id = ?1 AND t_expired IS NULL",
+        )?;
+        let edges = stmt
+            .query_map(params![target_fact_id], row_to_edge)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(edges)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::{init_schema, open_memory};
+
+    fn setup() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        // Insert dummy facts for FK constraints (minimal valid rows)
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, importance, access_count, last_accessed, metadata)
+             VALUES ('fact1', 'h1', X'00000000', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, importance, access_count, last_accessed, metadata)
+             VALUES ('fact2', 'h2', X'00000000', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, importance, access_count, last_accessed, metadata)
+             VALUES ('fact3', 'h3', X'00000000', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}')",
+            [],
+        ).unwrap();
+        conn
+    }
+
+    fn make_edge(source: i64, target: i64, rel: &str) -> NewEdge {
+        NewEdge {
+            source_fact_id: source,
+            target_fact_id: target,
+            relation_type: rel.to_string(),
+            weight: 1.0,
+            t_created: Utc::now(),
+            t_expired: None,
+        }
+    }
+
+    #[test]
+    fn insert_and_get_edge() {
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        let edge = make_edge(1, 2, "related_to");
+        let id = store.insert(&edge).unwrap();
+        let got = store.get(id).unwrap();
+        assert_eq!(got.source_fact_id, 1);
+        assert_eq!(got.target_fact_id, 2);
+        assert_eq!(got.relation_type, "related_to");
+        assert!((got.weight - 1.0).abs() < f64::EPSILON);
+        assert!(got.t_expired.is_none());
+    }
+
+    #[test]
+    fn expire_edge() {
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        let id = store.insert(&make_edge(1, 2, "test")).unwrap();
+        store.expire(id, Utc::now()).unwrap();
+        let got = store.get(id).unwrap();
+        assert!(got.t_expired.is_some());
+    }
+
+    #[test]
+    fn list_active_excludes_expired() {
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        let id1 = store.insert(&make_edge(1, 2, "a")).unwrap();
+        store.insert(&make_edge(1, 3, "b")).unwrap();
+        store.expire(id1, Utc::now()).unwrap();
+
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].relation_type, "b");
+    }
+
+    #[test]
+    fn list_active_by_source() {
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        store.insert(&make_edge(1, 2, "a")).unwrap();
+        store.insert(&make_edge(1, 3, "b")).unwrap();
+        store.insert(&make_edge(2, 3, "c")).unwrap();
+
+        let from_1 = store.list_active_by_source(1).unwrap();
+        assert_eq!(from_1.len(), 2);
+
+        let from_2 = store.list_active_by_source(2).unwrap();
+        assert_eq!(from_2.len(), 1);
+    }
+
+    #[test]
+    fn list_active_by_target() {
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        store.insert(&make_edge(1, 3, "a")).unwrap();
+        store.insert(&make_edge(2, 3, "b")).unwrap();
+
+        let to_3 = store.list_active_by_target(3).unwrap();
+        assert_eq!(to_3.len(), 2);
+    }
+
+    #[test]
+    fn expire_by_fact_cascades() {
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        store.insert(&make_edge(1, 2, "a")).unwrap();
+        store.insert(&make_edge(1, 3, "b")).unwrap();
+        store.insert(&make_edge(2, 1, "c")).unwrap(); // target = 1
+        store.insert(&make_edge(2, 3, "d")).unwrap(); // unrelated
+
+        let expired_count = store.expire_by_fact(1, Utc::now()).unwrap();
+        assert_eq!(expired_count, 3); // edges a, b, c all involve fact 1
+
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].relation_type, "d");
+    }
+}

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -2,7 +2,9 @@ use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
-use crate::store::{deserialize_embedding, serialize_embedding};
+use crate::store::{
+    deserialize_embedding, parse_optional_timestamp, parse_timestamp, serialize_embedding,
+};
 use crate::types::{Fact, FactType, NewFact};
 
 /// Store for bi-temporal facts with embedding BLOBs.
@@ -32,30 +34,6 @@ fn str_to_fact_type(s: &str) -> Result<FactType> {
 fn content_hash(content: &str) -> String {
     let hash = blake3::hash(content.as_bytes());
     hash.to_hex()[..32].to_string()
-}
-
-/// Parse an optional ISO 8601 timestamp from a nullable TEXT column.
-fn parse_optional_timestamp(s: Option<&str>) -> rusqlite::Result<Option<DateTime<Utc>>> {
-    s.map_or(Ok(None), |ts| {
-        DateTime::parse_from_rfc3339(ts)
-            .map(|dt| Some(dt.with_timezone(&Utc)))
-            .map_err(|e| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    0,
-                    rusqlite::types::Type::Text,
-                    Box::new(e),
-                )
-            })
-    })
-}
-
-/// Parse a required ISO 8601 timestamp from a TEXT column.
-fn parse_timestamp(s: &str) -> rusqlite::Result<DateTime<Utc>> {
-    DateTime::parse_from_rfc3339(s)
-        .map(|dt| dt.with_timezone(&Utc))
-        .map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })
 }
 
 impl<'a> FactStore<'a> {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,10 +1,14 @@
+pub mod edges;
 pub mod events;
 pub mod facts;
 pub mod schema;
 
+pub use edges::EdgeStore;
 pub use events::{EventFilter, EventStore};
 pub use facts::FactStore;
 pub use schema::{get_config, init_schema, open_connection, open_memory, set_config};
+
+use chrono::{DateTime, Utc};
 
 use crate::error::{MemoryError, Result};
 
@@ -43,6 +47,30 @@ pub fn deserialize_embedding(blob: &[u8], dim: usize) -> Result<Vec<f32>> {
             f32::from_le_bytes(arr)
         })
         .collect())
+}
+
+/// Parse an optional ISO 8601 timestamp from a nullable TEXT column.
+pub(crate) fn parse_optional_timestamp(s: Option<&str>) -> rusqlite::Result<Option<DateTime<Utc>>> {
+    s.map_or(Ok(None), |ts| {
+        DateTime::parse_from_rfc3339(ts)
+            .map(|dt| Some(dt.with_timezone(&Utc)))
+            .map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })
+    })
+}
+
+/// Parse a required ISO 8601 timestamp from a TEXT column.
+pub(crate) fn parse_timestamp(s: &str) -> rusqlite::Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })
 }
 
 #[cfg(test)]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2,11 +2,13 @@ pub mod edges;
 pub mod events;
 pub mod facts;
 pub mod schema;
+pub mod summaries;
 
 pub use edges::EdgeStore;
 pub use events::{EventFilter, EventStore};
 pub use facts::FactStore;
 pub use schema::{get_config, init_schema, open_connection, open_memory, set_config};
+pub use summaries::SummaryStore;
 
 use chrono::{DateTime, Utc};
 

--- a/src/store/summaries.rs
+++ b/src/store/summaries.rs
@@ -1,0 +1,302 @@
+use rusqlite::{params, Connection};
+
+use crate::error::{MemoryError, Result};
+use crate::store::{deserialize_embedding, parse_timestamp, serialize_embedding};
+use crate::types::{ConsolidationLevel, NewSummary, Summary};
+
+const fn level_to_str(level: &ConsolidationLevel) -> &'static str {
+    match level {
+        ConsolidationLevel::Local => "local",
+        ConsolidationLevel::Cluster => "cluster",
+        ConsolidationLevel::Global => "global",
+    }
+}
+
+fn str_to_level(s: &str) -> rusqlite::Result<ConsolidationLevel> {
+    match s {
+        "local" => Ok(ConsolidationLevel::Local),
+        "cluster" => Ok(ConsolidationLevel::Cluster),
+        "global" => Ok(ConsolidationLevel::Global),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::from(format!("unknown consolidation level: {other}")),
+        )),
+    }
+}
+
+/// Store for consolidation summaries.
+pub struct SummaryStore<'a> {
+    conn: &'a Connection,
+    embed_dim: usize,
+}
+
+impl<'a> SummaryStore<'a> {
+    /// Create a new `SummaryStore` borrowing the given connection.
+    #[must_use]
+    pub const fn new(conn: &'a Connection, embed_dim: usize) -> Self {
+        Self { conn, embed_dim }
+    }
+
+    /// Insert a new summary. Returns the assigned row id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::EmbeddingDimension` if the embedding length
+    /// doesn't match `embed_dim`.
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn insert(&self, summary: &NewSummary) -> Result<i64> {
+        if summary.embedding.len() != self.embed_dim {
+            return Err(MemoryError::EmbeddingDimension {
+                expected: self.embed_dim,
+                actual: summary.embedding.len(),
+            });
+        }
+
+        let blob = serialize_embedding(&summary.embedding);
+        let source_ids_json = serde_json::to_string(&summary.source_fact_ids)?;
+
+        self.conn.execute(
+            "INSERT INTO summaries (content, embedding, level, source_fact_ids, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                summary.content,
+                blob,
+                level_to_str(&summary.level),
+                source_ids_json,
+                summary.created_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Get a summary by id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if the summary doesn't exist.
+    pub fn get(&self, id: i64) -> Result<Summary> {
+        self.conn
+            .query_row(
+                "SELECT id, content, embedding, level, source_fact_ids, created_at
+                 FROM summaries WHERE id = ?1",
+                params![id],
+                |row| self.row_to_summary(row),
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    MemoryError::NotFound(format!("summary {id}"))
+                }
+                other => MemoryError::Database(other),
+            })
+    }
+
+    /// List summaries by consolidation level.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn list_by_level(&self, level: &ConsolidationLevel) -> Result<Vec<Summary>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, content, embedding, level, source_fact_ids, created_at
+             FROM summaries WHERE level = ?1",
+        )?;
+        let summaries = stmt
+            .query_map(params![level_to_str(level)], |row| self.row_to_summary(row))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(summaries)
+    }
+
+    /// Delete all summaries at the given level. Returns count deleted.
+    ///
+    /// Used for idempotent consolidation rebuild.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn delete_by_level(&self, level: &ConsolidationLevel) -> Result<usize> {
+        let count = self.conn.execute(
+            "DELETE FROM summaries WHERE level = ?1",
+            params![level_to_str(level)],
+        )?;
+        Ok(count)
+    }
+
+    /// Map a row to a [`Summary`], deserializing embedding and `source_fact_ids`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `rusqlite::Error` on deserialization failure.
+    fn row_to_summary(&self, row: &rusqlite::Row<'_>) -> rusqlite::Result<Summary> {
+        let blob: Vec<u8> = row.get("embedding")?;
+        let embedding = deserialize_embedding(&blob, self.embed_dim).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Blob,
+                Box::from(e.to_string()),
+            )
+        })?;
+
+        let level_str: String = row.get("level")?;
+        let level = str_to_level(&level_str)?;
+
+        let source_ids_str: String = row.get("source_fact_ids")?;
+        let source_fact_ids: Vec<i64> = serde_json::from_str(&source_ids_str).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })?;
+
+        let created_at_str: String = row.get("created_at")?;
+        let created_at = parse_timestamp(&created_at_str)?;
+
+        Ok(Summary {
+            id: row.get("id")?,
+            content: row.get("content")?,
+            embedding,
+            level,
+            source_fact_ids,
+            created_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    use crate::store::schema::{init_schema, open_memory};
+
+    fn setup() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    fn make_summary(level: ConsolidationLevel, source_ids: Vec<i64>) -> NewSummary {
+        NewSummary {
+            content: format!("summary of facts {:?}", source_ids),
+            embedding: vec![0.1, 0.2, 0.3, 0.4],
+            level,
+            source_fact_ids: source_ids,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn insert_and_get_summary() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        let summary = make_summary(ConsolidationLevel::Local, vec![1, 2]);
+        let id = store.insert(&summary).unwrap();
+        let got = store.get(id).unwrap();
+        assert_eq!(got.content, summary.content);
+        assert_eq!(got.level, ConsolidationLevel::Local);
+        assert_eq!(got.source_fact_ids, vec![1, 2]);
+        assert_eq!(got.embedding, vec![0.1, 0.2, 0.3, 0.4]);
+    }
+
+    #[test]
+    fn list_by_level() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        store
+            .insert(&make_summary(ConsolidationLevel::Local, vec![1]))
+            .unwrap();
+        store
+            .insert(&make_summary(ConsolidationLevel::Local, vec![2]))
+            .unwrap();
+        store
+            .insert(&make_summary(ConsolidationLevel::Cluster, vec![1, 2]))
+            .unwrap();
+        store
+            .insert(&make_summary(ConsolidationLevel::Global, vec![1, 2, 3]))
+            .unwrap();
+
+        assert_eq!(
+            store
+                .list_by_level(&ConsolidationLevel::Local)
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            store
+                .list_by_level(&ConsolidationLevel::Cluster)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .list_by_level(&ConsolidationLevel::Global)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn source_fact_ids_json_roundtrip() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        let ids = vec![10, 20, 30, 40, 50];
+        let id = store
+            .insert(&make_summary(ConsolidationLevel::Local, ids.clone()))
+            .unwrap();
+        let got = store.get(id).unwrap();
+        assert_eq!(got.source_fact_ids, ids);
+    }
+
+    #[test]
+    fn wrong_embedding_dim_rejected() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        let mut summary = make_summary(ConsolidationLevel::Local, vec![1]);
+        summary.embedding = vec![0.1, 0.2]; // 2 instead of 4
+        let err = store.insert(&summary).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::EmbeddingDimension {
+                expected: 4,
+                actual: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn delete_by_level_removes_correct_entries() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        store
+            .insert(&make_summary(ConsolidationLevel::Cluster, vec![1]))
+            .unwrap();
+        store
+            .insert(&make_summary(ConsolidationLevel::Cluster, vec![2]))
+            .unwrap();
+        store
+            .insert(&make_summary(ConsolidationLevel::Global, vec![1, 2]))
+            .unwrap();
+
+        let deleted = store.delete_by_level(&ConsolidationLevel::Cluster).unwrap();
+        assert_eq!(deleted, 2);
+        assert!(store
+            .list_by_level(&ConsolidationLevel::Cluster)
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            store
+                .list_by_level(&ConsolidationLevel::Global)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn get_not_found() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        let err = store.get(999).unwrap_err();
+        assert!(matches!(err, MemoryError::NotFound(_)));
+    }
+}

--- a/src/store/summaries.rs
+++ b/src/store/summaries.rs
@@ -174,7 +174,7 @@ mod tests {
 
     fn make_summary(level: ConsolidationLevel, source_ids: Vec<i64>) -> NewSummary {
         NewSummary {
-            content: format!("summary of facts {:?}", source_ids),
+            content: format!("summary of facts {source_ids:?}"),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             level,
             source_fact_ids: source_ids,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -86,8 +86,76 @@ pub struct ConflictResolution {
     pub new_fact_id: Option<i64>,
 }
 
-/// Policy for forgetting/pruning stale facts (Phase 2).
+/// Policy for forgetting/pruning stale facts.
+///
+/// Importance is computed as a weighted sum of 4 signals:
+///
+/// `recency × decay + frequency × log(access+1) + degree × log(edges+1) + base × importance`
+///
+/// Facts with computed importance below `min_importance` get soft-deleted (`t_expired` set).
 #[derive(Debug, Clone)]
 pub struct ForgetPolicy {
-    pub min_importance: f32,
+    /// Base Ebbinghaus half-life in days (default: 69.0).
+    pub half_life_days: f64,
+    /// Per-`FactType` half-life overrides. E.g., Episodic=30, Procedural=365.
+    pub half_life_overrides: std::collections::HashMap<crate::types::FactType, f64>,
+    /// Threshold below which facts are expired (default: 0.1).
+    pub min_importance: f64,
+    /// Weight for recency signal (Ebbinghaus decay). Default: 0.3.
+    pub recency_weight: f64,
+    /// Weight for access frequency signal. Default: 0.2.
+    pub frequency_weight: f64,
+    /// Weight for graph connectivity signal. Default: 0.3.
+    pub graph_degree_weight: f64,
+    /// Weight for base importance (`fact.importance`). Default: 0.2.
+    pub base_importance_weight: f64,
+}
+
+impl Default for ForgetPolicy {
+    fn default() -> Self {
+        Self {
+            half_life_days: 69.0,
+            half_life_overrides: std::collections::HashMap::new(),
+            min_importance: 0.1,
+            recency_weight: 0.3,
+            frequency_weight: 0.2,
+            graph_degree_weight: 0.3,
+            base_importance_weight: 0.2,
+        }
+    }
+}
+
+impl ForgetPolicy {
+    /// Validate policy parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Conflict` if any parameter is out of range.
+    pub fn validate(&self) -> Result<()> {
+        use crate::error::MemoryError;
+
+        if self.half_life_days <= 0.0 {
+            return Err(MemoryError::Conflict("half_life_days must be > 0".into()));
+        }
+        for (ft, &hl) in &self.half_life_overrides {
+            if hl <= 0.0 {
+                return Err(MemoryError::Conflict(format!(
+                    "half_life for {ft:?} must be > 0"
+                )));
+            }
+        }
+        if !(0.0..=1.0).contains(&self.min_importance) {
+            return Err(MemoryError::Conflict(
+                "min_importance must be in [0, 1]".into(),
+            ));
+        }
+        if self.recency_weight < 0.0
+            || self.frequency_weight < 0.0
+            || self.graph_degree_weight < 0.0
+            || self.base_importance_weight < 0.0
+        {
+            return Err(MemoryError::Conflict("weights must be >= 0".into()));
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Completes the memory engine by implementing the remaining 3 primitives (consolidate, forget, resolve_conflict) and their supporting modules. Phase 1 delivered ingest→query; Phase 2 adds the full lifecycle.

- **Graph module** (`petgraph` DiGraph): in-memory graph mirroring SQLite edges table, loaded on open, synced via write-then-update pattern
- **EdgeStore + SummaryStore**: persistence for graph edges (bi-temporal) and consolidation outputs
- **Forgetting**: Ebbinghaus decay curve with 4-signal weighted importance scoring (recency, frequency, graph degree, base importance), per-fact_type half-life overrides
- **Three-pass consolidation**: local dedup (cosine threshold), cluster fusion (single-linkage + SummaryGenerator trait), global integration
- **Conflict resolution**: CRUD arbitration (Add/Update/Delete/Noop) via ConflictArbiter trait, bi-temporal fact expiry, edge cascade on fact invalidation
- **Engine wiring**: all NotImplemented stubs replaced with real implementations, MemoryGraph field added to MemoryEngine

**Stats:** +2,843 lines, 108 tests (107 unit + 1 integration), 0 clippy warnings, docs build clean.

Refs: Plan at `~/.claude/plans/cozy-imagining-sifakis.md` (Phase 2 section)

## Test plan
- [x] `cargo test` — 108 tests passing
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo doc --no-deps` — builds clean
- [x] Multi-model review via `/super-review`