### PR TITLE
Phase 3b: Temporal Memory & Agent Lifecycle

### DIFF
--- a/benches/search_bench.rs
+++ b/benches/search_bench.rs
@@ -54,7 +54,15 @@ fn setup_engine(n: usize) -> MemoryEngine {
         let topic = topics[i % topics.len()];
         let content = format!("{topic} — fact number {i}");
         engine
-            .add_fact(&content, FactType::Semantic, None, &embedder, None, None)
+            .add_fact(
+                &content,
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
             .expect("add_fact");
     }
 
@@ -88,6 +96,7 @@ fn setup_scoped_engine(n: usize) -> MemoryEngine {
                 None,
                 &embedder,
                 Some(scope),
+                None,
                 None,
             )
             .expect("add_fact");

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -139,7 +139,7 @@ Research (OQ1 in `docs/research/08-open-questions-research.md`) evaluated 4 stor
 | 5    | Forgetting: pinned bypass + importance_score materialization         | ✅     |
 | 6    | Consolidation: pinned skip + importance_score inheritance            | ✅     |
 | 7    | `resume_context()` rework — 5-tier pipeline                          | ✅     |
-| 8    | Engine facade: drain_due, next_due_time, pin/unpin, classifier       | ✅     |
+| 8    | Engine facade: list_due, next_due_time, pin/unpin, classifier        | ✅     |
 | 9    | AsyncMemoryEngine mirror                                             | ✅     |
 | 10   | Documentation                                                        | ✅     |
 | 11   | Integration tests                                                    | ✅     |
@@ -149,8 +149,8 @@ Research (OQ1 in `docs/research/08-open-questions-research.md`) evaluated 4 stor
 **Key features:**
 
 - **Pinned facts** (`is_pinned`) — unforgettable, bypass forgetting and dedup. Agent identity and core beliefs.
-- **Future memory** (`t_valid`) — facts with `t_valid` in the future remain invisible until their scheduled time. `drain_due(now)` for incremental, `resume_context()` for full boot.
-- **Scheduling API** — `drain_due()`, `next_due_time()` let consumers implement timer-based polling.
+- **Future memory** (`t_valid`) — facts with `t_valid` in the future remain invisible until their scheduled time. `list_due(now)` for incremental, `resume_context()` for full boot.
+- **Scheduling API** — `list_due()`, `next_due_time()` let consumers implement timer-based polling.
 - **`PersistenceClassifier` trait** — consumer-provided auto-pinning logic. Explicit `opts.pinned` always overrides.
 - **Materialized `importance_score`** — composite score updated during `prune()` and `consolidate()`. O(1) sort in `resume_context()`.
 - **Event envelope** — `origin_node_id`, `sequence_id`, `created_at` for future multi-node sync. No behavioral change.
@@ -190,7 +190,7 @@ Consumer (AI agent, CLI tool, MCP server)
 │           MemoryEngine (Send + Sync)     │
 │  ingest · add_fact · query               │  ← Phase 1
 │  consolidate · forget · resolve          │  ← Phase 2
-│  resume_context · drain_due · pin/unpin  │  ← Phase 3/3b
+│  resume_context · list_due · pin/unpin  │  ← Phase 3/3b
 ├──────────────────────────────────────────┤
 │  AsyncMemoryEngine (tokio wrapper)       │  ← Phase 3
 ├──────────────────────────────────────────┤

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,18 +104,65 @@ Research (OQ1 in `docs/research/08-open-questions-research.md`) evaluated 4 stor
 
 ---
 
-### Phase 3: Hardening & Scalability 🔲
+### Phase 3: Hardening & Scalability ✅
 
-Design tensions surfaced during Phase 1 implementation and code review. Tracked as individual issues.
+**PR:** [#20](https://github.com/dutiona/memory-engine/pull/20) (squash-merged)
+**Plan:** [Issue #15](https://github.com/dutiona/memory-engine/issues/15)
 
-| Issue                                                   | Concern                                                  | Trigger                                                |
-| ------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------ |
-| [#3](https://github.com/dutiona/memory-engine/issues/3) | Brute-force vector search → ANN index                    | Fact count exceeds ~50K-100K                           |
-| [#4](https://github.com/dutiona/memory-engine/issues/4) | Post-overfetch filtering → SQL-level filters             | Skewed type distributions or restrictive `valid_at`    |
-| [#5](https://github.com/dutiona/memory-engine/issues/5) | `!Send`/`!Sync` → thread-safe engine                     | Async-first consumers, concurrent MCP requests         |
-| [#6](https://github.com/dutiona/memory-engine/issues/6) | Hardcoded `add_fact` defaults → `AddFactOptions` builder | Consumers needing per-fact importance/metadata control |
+| Task | Component                                                   | Status |
+| ---- | ----------------------------------------------------------- | ------ |
+| T1   | Thread safety (`Send + Sync`, `parking_lot`)                | ✅     |
+| T2   | `AddFactOptions` builder (importance, metadata, temporal)   | ✅     |
+| T3   | Connection pool (N readers + 1 writer, WAL)                 | ✅     |
+| T4   | Async engine (`AsyncMemoryEngine`, tokio `spawn_blocking`)  | ✅     |
+| T5   | Schema migration framework (versioned, forward-only, v1→v2) | ✅     |
+| T6   | Hierarchical scoping (`ScopeTree`, path resolution)         | ✅     |
+| T7   | Criterion benchmarks (search, ingest, consolidate)          | ✅     |
+| T8   | FTS/SQL-level scope filtering                               | ✅     |
+| T9   | `resume_context()` — tiered cognitive boot                  | ✅     |
 
-**Approach:** Data-driven. Add criterion benchmarks first, then migrate when numbers justify it. No speculative optimization.
+**Deliverable:** Thread-safe engine with connection pool, async wrapper, scoping, migration framework, and `resume_context()`. 158 tests.
+
+---
+
+### Phase 3b: Temporal Memory & Agent Lifecycle ✅
+
+**PR:** (pending)
+**Plan:** [Issue #25](https://github.com/dutiona/memory-engine/issues/25)
+
+| Task | Component                                                            | Status |
+| ---- | -------------------------------------------------------------------- | ------ |
+| 1    | Schema migration v2→v3 (is_pinned, importance_score, event envelope) | ✅     |
+| 2    | Type changes (Fact, NewFact, Event, NewEvent, AddFactOptions)        | ✅     |
+| 3    | FactStore: list_pinned, list_due, next_due_time, set_pinned          | ✅     |
+| 4    | `PersistenceClassifier` trait (auto-pinning)                         | ✅     |
+| 5    | Forgetting: pinned bypass + importance_score materialization         | ✅     |
+| 6    | Consolidation: pinned skip + importance_score inheritance            | ✅     |
+| 7    | `resume_context()` rework — 5-tier pipeline                          | ✅     |
+| 8    | Engine facade: drain_due, next_due_time, pin/unpin, classifier       | ✅     |
+| 9    | AsyncMemoryEngine mirror                                             | ✅     |
+| 10   | Documentation                                                        | ✅     |
+| 11   | Integration tests                                                    | ✅     |
+
+**Deliverable:** Time-aware memory with unforgettable facts, future memory surfacing, scheduling API, 5-tier cognitive boot sequence. 183 tests (179 unit + 4 integration).
+
+**Key features:**
+
+- **Pinned facts** (`is_pinned`) — unforgettable, bypass forgetting and dedup. Agent identity and core beliefs.
+- **Future memory** (`t_valid`) — facts with `t_valid` in the future remain invisible until their scheduled time. `drain_due(now)` for incremental, `resume_context()` for full boot.
+- **Scheduling API** — `drain_due()`, `next_due_time()` let consumers implement timer-based polling.
+- **`PersistenceClassifier` trait** — consumer-provided auto-pinning logic. Explicit `opts.pinned` always overrides.
+- **Materialized `importance_score`** — composite score updated during `prune()` and `consolidate()`. O(1) sort in `resume_context()`.
+- **Event envelope** — `origin_node_id`, `sequence_id`, `created_at` for future multi-node sync. No behavioral change.
+- **5-tier `resume_context()`** — pinned → high_importance → due → recent → kb_stubs.
+
+**Implementation learnings:**
+
+- `importance_score` is on `Fact` only (engine-computed composite), not on `NewFact` (consumer input). DB default handles it.
+- `PersistenceClassifier` receives a synthetic `Fact` with `id=0` during `add_fact()` — classifiers should rely on `content`, `fact_type`, `importance`, `metadata` only.
+- Event envelope fields are metadata-only — no behavioral change, defaults to `'local'/0/NULL`.
+- Pinned facts are cross-scope in `resume_context()` tier 1 (always present regardless of scope filter).
+- Consolidation dedup skips pinned facts in both inner and outer loops to prevent merging identity facts.
 
 ---
 
@@ -123,13 +170,13 @@ Design tensions surfaced during Phase 1 implementation and code review. Tracked 
 
 These are not committed to any phase. They represent directions the research suggests but that we haven't validated need for.
 
-- **Async API** — `async fn query(...)` wrapper, likely via `tokio::task::spawn_blocking`
 - **MCP server adapter** — Expose engine as a Model Context Protocol tool server
-- **Schema migrations** — `schema_version` is 1. Migration framework when schema evolves.
 - **Hierarchical summarization** — Multi-level abstractions (Memento-style). Currently consolidation is flat (local/cluster/global).
 - **Cross-session memory sharing** — Multiple agents sharing one store. Requires session isolation or namespacing.
 - **Multimodal memory** — Image/audio embeddings alongside text. Schema supports it (BLOB embeddings are dimension-agnostic) but no consumer integration.
 - **Parameter updates** — Doc-to-LoRA style adapter generation from memory contents. Explicitly out of scope — engine is retrieval-only.
+- **Knowledge Base integration** — `kb_stubs` placeholder in `ResumeContext` for Phase 5 external knowledge references.
+- **Multi-node sync** — Event envelope fields (`origin_node_id`, `sequence_id`) are forward-compatible for distributed sync.
 
 ---
 
@@ -139,45 +186,54 @@ These are not committed to any phase. They represent directions the research sug
 Consumer (AI agent, CLI tool, MCP server)
     │
     ▼
-┌──────────────────────────────────────┐
-│           MemoryEngine               │
-│  ingest · add_fact · query           │  ← Phase 1 ✅
-│  consolidate · forget · resolve      │  ← Phase 2
-├──────────────────────────────────────┤
-│  Search                              │
-│  ├─ FTS5 (BM25)                      │
-│  ├─ Vector (cosine, brute-force)     │
-│  └─ Hybrid (RRF k=60)               │
-├──────────────────────────────────────┤
-│  Store                               │
-│  ├─ EventStore (append-only log)     │
-│  ├─ FactStore (bi-temporal + BLOB)   │
-│  ├─ EdgeStore (graph persistence)    │  ← Phase 2
-│  └─ SummaryStore                     │  ← Phase 2
-├──────────────────────────────────────┤
-│  Graph (petgraph DiGraph)            │  ← Phase 2
-├──────────────────────────────────────┤
-│  Forgetting (Ebbinghaus decay)       │  ← Phase 2
-├──────────────────────────────────────┤
-│  Consolidation (3-pass)              │  ← Phase 2
-├──────────────────────────────────────┤
-│  Conflict (bi-temporal arbiter)      │  ← Phase 2
-└──────────────────────────────────────┘
+┌──────────────────────────────────────────┐
+│           MemoryEngine (Send + Sync)     │
+│  ingest · add_fact · query               │  ← Phase 1
+│  consolidate · forget · resolve          │  ← Phase 2
+│  resume_context · drain_due · pin/unpin  │  ← Phase 3/3b
+├──────────────────────────────────────────┤
+│  AsyncMemoryEngine (tokio wrapper)       │  ← Phase 3
+├──────────────────────────────────────────┤
+│  ConnectionPool (N readers + 1 writer)   │  ← Phase 3
+├──────────────────────────────────────────┤
+│  Search                                  │
+│  ├─ FTS5 (BM25, scope-filtered)          │
+│  ├─ Vector (cosine, brute-force)         │
+│  └─ Hybrid (RRF k=60)                   │
+├──────────────────────────────────────────┤
+│  Store                                   │
+│  ├─ EventStore (append-only log)         │
+│  ├─ FactStore (bi-temporal + pinned)     │
+│  ├─ EdgeStore (graph persistence)        │
+│  ├─ SummaryStore                         │
+│  └─ ScopeStore (hierarchical scoping)   │  ← Phase 3
+├──────────────────────────────────────────┤
+│  Graph (petgraph DiGraph)                │
+├──────────────────────────────────────────┤
+│  Forgetting (Ebbinghaus + pinned bypass) │  ← Phase 3b
+├──────────────────────────────────────────┤
+│  Consolidation (3-pass + pinned skip)    │  ← Phase 3b
+├──────────────────────────────────────────┤
+│  Conflict (bi-temporal arbiter)          │
+├──────────────────────────────────────────┤
+│  Resume (5-tier cognitive boot)          │  ← Phase 3b
+└──────────────────────────────────────────┘
     │
     ▼
   SQLite WAL (rusqlite bundled-full)
-  ├─ events, facts, edges, summaries, config
+  ├─ events, facts, edges, summaries, scopes, config
   ├─ facts_fts (FTS5 virtual table)
-  └─ 9 indexes
+  └─ 19 indexes (schema v3)
 ```
 
 ## Consumer-Provided Traits
 
 ```
-EmbeddingProvider::embed(text) → Vec<f32>        ← Phase 1 ✅
-SummaryGenerator::summarize(facts) → String      ← Phase 2
-SummaryGenerator::embed(text) → Vec<f32>         ← Phase 2
-ConflictArbiter::arbitrate(old, new) → CrudDecision  ← Phase 2
+EmbeddingProvider::embed(text) → Vec<f32>              ← Phase 1
+SummaryGenerator::summarize(facts) → String            ← Phase 2
+SummaryGenerator::embed(text) → Vec<f32>               ← Phase 2
+ConflictArbiter::arbitrate(old, new) → CrudDecision    ← Phase 2
+PersistenceClassifier::should_pin(fact) → bool         ← Phase 3b
 ```
 
 The engine has zero LLM/network dependencies. All intelligence is injected by the consumer via these traits.

--- a/docs/design/adr/0008-materialized-importance.md
+++ b/docs/design/adr/0008-materialized-importance.md
@@ -1,0 +1,49 @@
+# ADR-0008: Materialized Importance Score on Facts
+
+**Status:** Accepted
+**Date:** 2026-03-10
+**Phase:** 3b
+
+## Context
+
+`resume_context()` returns facts sorted by importance for the "high-importance" tier. The importance formula is a weighted composite of 4 signals: recency (Ebbinghaus decay), access frequency, graph connectivity (degree), and base importance.
+
+Computing this on-the-fly during `resume_context()` requires:
+
+1. Loading all active facts
+2. For each fact, querying its graph degree (O(1) per fact but N lookups)
+3. Sorting by the computed score
+
+This is O(N × degree-lookup) per resume call. At scale (thousands of active facts), this adds latency to what should be a fast boot operation.
+
+## Decision
+
+Store `importance_score` as a materialized column on the `facts` table (`REAL NOT NULL DEFAULT 0.5`). Update it during:
+
+1. **`prune()`** — scores are recomputed for all active facts as part of the forgetting pass
+2. **`consolidate()`** — the surviving fact in a dedup pair inherits the max importance of the merged set
+
+`resume_context()` reads the materialized score directly via `ORDER BY importance_score DESC`, making it an O(1) index scan.
+
+## Consequences
+
+**Positive:**
+
+- `resume_context()` sorting is O(1) via the `idx_facts_importance_score` index
+- No graph lock needed during resume (scores are pre-computed)
+- Scores are available for any future query that needs importance-based ranking
+
+**Negative:**
+
+- Score staleness: between `prune()`/`consolidate()` calls, scores may be stale (new facts get default 0.5, access counts change, graph evolves)
+- Acceptable trade-off: consumers who need fresh scores call `forget()` first, which triggers a full recomputation
+
+**Alternatives considered:**
+
+- On-demand computation: rejected due to O(N × degree) cost per resume call
+- Background refresh thread: over-engineering for current scale; `prune()` already runs periodically
+
+## Notes
+
+- `importance_score` exists on `Fact` (read from DB) but NOT on `NewFact` (consumer input). The engine computes it; consumers don't set it.
+- Default value of 0.5 means newly inserted facts appear in the middle of the ranking until the next prune cycle materializes their true score.

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -210,9 +210,9 @@ impl AsyncMemoryEngine {
     }
 
     /// Get facts whose scheduled time has arrived.
-    pub async fn drain_due(&self, now: DateTime<Utc>, scope: Option<String>) -> Result<Vec<Fact>> {
+    pub async fn list_due(&self, now: DateTime<Utc>, scope: Option<String>) -> Result<Vec<Fact>> {
         let engine = self.inner.clone();
-        tokio::task::spawn_blocking(move || engine.drain_due(now, scope.as_deref()))
+        tokio::task::spawn_blocking(move || engine.list_due(now, scope.as_deref()))
             .await
             .map_err(join_err)?
     }
@@ -355,7 +355,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn async_drain_due() {
+    async fn async_list_due() {
         let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
         let embedder: Arc<dyn EmbeddingProvider + Send + Sync> =
             Arc::new(MockEmbedder { dim: DIM });
@@ -377,7 +377,7 @@ mod tests {
             .await
             .unwrap();
 
-        let due = engine.drain_due(Utc::now(), None).await.unwrap();
+        let due = engine.list_due(Utc::now(), None).await.unwrap();
         assert_eq!(due.len(), 1);
         assert!(due[0].content.contains("reminder"));
     }

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -105,6 +105,7 @@ impl AsyncMemoryEngine {
                 embedder.as_ref(),
                 scope.as_deref(),
                 opts.as_ref(),
+                None, // classifier — added in Task 9
             )
         })
         .await

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -89,6 +89,7 @@ impl AsyncMemoryEngine {
     }
 
     /// Add a fact with embedding computation.
+    #[allow(clippy::too_many_arguments)]
     pub async fn add_fact(
         &self,
         content: String,

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -9,9 +9,11 @@ use std::sync::Arc;
 use crate::engine::{EngineConfig, MemoryEngine};
 use crate::error::{MemoryError, Result};
 use crate::search::hybrid::{SearchQuery, SearchResult};
+use chrono::{DateTime, Utc};
+
 use crate::traits::{
     ConflictArbiter, ConflictResolution, ConsolidationConfig, ConsolidationStats,
-    EmbeddingProvider, ForgetPolicy, PruneStats, SummaryGenerator,
+    EmbeddingProvider, ForgetPolicy, PersistenceClassifier, PruneStats, SummaryGenerator,
 };
 use crate::resume::context::{ResumeConfig, ResumeContext};
 use crate::types::{AddFactOptions, ConsolidationLevel, Fact, FactType, NewEvent, NewFact, Summary};
@@ -95,6 +97,7 @@ impl AsyncMemoryEngine {
         embedder: Arc<dyn EmbeddingProvider + Send + Sync>,
         scope: Option<String>,
         opts: Option<AddFactOptions>,
+        classifier: Option<Arc<dyn PersistenceClassifier + Send + Sync>>,
     ) -> Result<i64> {
         let engine = self.inner.clone();
         tokio::task::spawn_blocking(move || {
@@ -105,7 +108,9 @@ impl AsyncMemoryEngine {
                 embedder.as_ref(),
                 scope.as_deref(),
                 opts.as_ref(),
-                None, // classifier — added in Task 9
+                classifier
+                    .as_ref()
+                    .map(|c| c.as_ref() as &dyn PersistenceClassifier),
             )
         })
         .await
@@ -203,6 +208,38 @@ impl AsyncMemoryEngine {
             .map_err(join_err)?
     }
 
+    /// Get facts whose scheduled time has arrived.
+    pub async fn drain_due(&self, now: DateTime<Utc>, scope: Option<String>) -> Result<Vec<Fact>> {
+        let engine = self.inner.clone();
+        tokio::task::spawn_blocking(move || engine.drain_due(now, scope.as_deref()))
+            .await
+            .map_err(join_err)?
+    }
+
+    /// Scheduling hint: earliest `t_valid` among active future-dated facts.
+    pub async fn next_due_time(&self, scope: Option<String>) -> Result<Option<DateTime<Utc>>> {
+        let engine = self.inner.clone();
+        tokio::task::spawn_blocking(move || engine.next_due_time(scope.as_deref()))
+            .await
+            .map_err(join_err)?
+    }
+
+    /// Pin a fact (make it unforgettable).
+    pub async fn pin_fact(&self, id: i64) -> Result<()> {
+        let engine = self.inner.clone();
+        tokio::task::spawn_blocking(move || engine.pin_fact(id))
+            .await
+            .map_err(join_err)?
+    }
+
+    /// Unpin a fact (allow forgetting).
+    pub async fn unpin_fact(&self, id: i64) -> Result<()> {
+        let engine = self.inner.clone();
+        tokio::task::spawn_blocking(move || engine.unpin_fact(id))
+            .await
+            .map_err(join_err)?
+    }
+
     /// Graph degree for a fact.
     #[must_use]
     pub fn graph_degree(&self, fact_id: i64) -> usize {
@@ -252,6 +289,7 @@ mod tests {
                 embedder,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -285,6 +323,7 @@ mod tests {
                 embedder,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -312,6 +351,59 @@ mod tests {
         for h in handles {
             h.await.unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn async_drain_due() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        let embedder: Arc<dyn EmbeddingProvider + Send + Sync> =
+            Arc::new(MockEmbedder { dim: DIM });
+        let past = Utc::now() - chrono::Duration::hours(1);
+        let opts = AddFactOptions {
+            t_valid: Some(past),
+            ..Default::default()
+        };
+        engine
+            .add_fact(
+                "reminder".into(),
+                FactType::Semantic,
+                None,
+                embedder,
+                None,
+                Some(opts),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let due = engine.drain_due(Utc::now(), None).await.unwrap();
+        assert_eq!(due.len(), 1);
+        assert!(due[0].content.contains("reminder"));
+    }
+
+    #[tokio::test]
+    async fn async_pin_unpin() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        let embedder: Arc<dyn EmbeddingProvider + Send + Sync> =
+            Arc::new(MockEmbedder { dim: DIM });
+        let id = engine
+            .add_fact(
+                "pinnable".into(),
+                FactType::Semantic,
+                None,
+                embedder,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(!engine.get_fact(id).await.unwrap().is_pinned);
+        engine.pin_fact(id).await.unwrap();
+        assert!(engine.get_fact(id).await.unwrap().is_pinned);
+        engine.unpin_fact(id).await.unwrap();
+        assert!(!engine.get_fact(id).await.unwrap().is_pinned);
     }
 
     #[tokio::test]

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -61,6 +61,8 @@ pub fn resolve_conflict(
         access_count: new_fact.access_count,
         last_accessed: new_fact.last_accessed,
         metadata: new_fact.metadata.clone(),
+        is_pinned: new_fact.is_pinned,
+        importance_score: 0.5,
     };
 
     let decision = arbiter.arbitrate(&old_fact, &new_as_fact)?;
@@ -254,6 +256,7 @@ mod tests {
             access_count: 0,
             last_accessed: now,
             metadata: serde_json::json!({}),
+            is_pinned: false,
         }
     }
 

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -169,6 +169,7 @@ mod tests {
                 access_count: 0,
                 last_accessed: Utc::now(),
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             })
             .unwrap()
     }

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -119,6 +119,7 @@ mod tests {
                 access_count: 0,
                 last_accessed: Utc::now(),
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             })
             .unwrap()
     }
@@ -177,6 +178,7 @@ mod tests {
                 access_count: 0,
                 last_accessed: old_time,
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             })
             .unwrap();
 
@@ -197,6 +199,7 @@ mod tests {
                 access_count: 0,
                 last_accessed: Utc::now(),
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             })
             .unwrap();
 

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -74,25 +74,16 @@ pub fn local_dedup(
                 duplicates_removed += 1;
 
                 // Update survivor's importance: inherit max from merged pair
-                let (survivor_id, loser_importance, loser_score) = if expire_id == new_fact.id {
-                    (candidate.id, new_fact.importance, new_fact.importance_score)
+                let (survivor, loser) = if expire_id == new_fact.id {
+                    (&candidate, new_fact)
                 } else {
-                    (
-                        new_fact.id,
-                        candidate.importance,
-                        candidate.importance_score,
-                    )
+                    (new_fact, &candidate)
                 };
-                let (survivor_importance, survivor_score) = if expire_id == new_fact.id {
-                    (candidate.importance, candidate.importance_score)
-                } else {
-                    (new_fact.importance, new_fact.importance_score)
-                };
-                if loser_importance > survivor_importance {
-                    fact_store.update_importance(survivor_id, loser_importance)?;
+                if loser.importance > survivor.importance {
+                    fact_store.update_importance(survivor.id, loser.importance)?;
                 }
-                if loser_score > survivor_score {
-                    fact_store.update_importance_score(survivor_id, loser_score)?;
+                if loser.importance_score > survivor.importance_score {
+                    fact_store.update_importance_score(survivor.id, loser.importance_score)?;
                 }
 
                 // If the new_fact itself was expired, stop comparing it

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -356,17 +356,27 @@ mod tests {
     #[test]
     fn survivor_inherits_max_importance() {
         let (conn, dim) = setup();
-        // Low importance fact with high importance_score, high importance fact with low score
+        // Low importance fact, high importance fact — near-duplicate embeddings
         insert_fact(&conn, dim, "low imp", vec![1.0, 0.0, 0.0, 0.0], 0.3);
         insert_fact(&conn, dim, "high imp", vec![0.99, 0.01, 0.0, 0.0], 0.9);
 
+        // Set distinct importance_scores before dedup
+        let store = FactStore::new(&conn, dim);
+        store.update_importance_score(1, 0.8).unwrap(); // low imp fact gets higher score
+        store.update_importance_score(2, 0.4).unwrap(); // high imp fact gets lower score
+
         local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
 
-        let store = FactStore::new(&conn, dim);
         let active = store.list_active().unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].content, "high imp");
-        // Survivor should keep its own importance (0.9 > 0.3, no update needed)
+        // Survivor inherits max base importance (0.9 > 0.3)
         assert!((active[0].importance - 0.9).abs() < f64::EPSILON);
+        // Survivor inherits max importance_score (0.8 > 0.4)
+        assert!(
+            (active[0].importance_score - 0.8).abs() < f64::EPSILON,
+            "expected importance_score 0.8, got {}",
+            active[0].importance_score
+        );
     }
 }

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -44,13 +44,16 @@ pub fn local_dedup(
     let mut duplicates_removed = 0;
 
     for new_fact in &new_facts {
-        if expired_ids.contains(&new_fact.id) {
-            continue;
+        if expired_ids.contains(&new_fact.id) || new_fact.is_pinned {
+            continue; // pinned facts are never dedup candidates
         }
 
         for candidate in &active_facts {
-            if candidate.id == new_fact.id || expired_ids.contains(&candidate.id) {
-                continue;
+            if candidate.id == new_fact.id
+                || expired_ids.contains(&candidate.id)
+                || candidate.is_pinned
+            {
+                continue; // skip pinned candidates too
             }
 
             let similarity = cosine_similarity(&new_fact.embedding, &candidate.embedding);
@@ -69,6 +72,28 @@ pub fn local_dedup(
                 edge_store.expire_by_fact(expire_id, now)?;
                 expired_ids.insert(expire_id);
                 duplicates_removed += 1;
+
+                // Update survivor's importance: inherit max from merged pair
+                let (survivor_id, loser_importance, loser_score) = if expire_id == new_fact.id {
+                    (candidate.id, new_fact.importance, new_fact.importance_score)
+                } else {
+                    (
+                        new_fact.id,
+                        candidate.importance,
+                        candidate.importance_score,
+                    )
+                };
+                let (survivor_importance, survivor_score) = if expire_id == new_fact.id {
+                    (candidate.importance, candidate.importance_score)
+                } else {
+                    (new_fact.importance, new_fact.importance_score)
+                };
+                if loser_importance > survivor_importance {
+                    fact_store.update_importance(survivor_id, loser_importance)?;
+                }
+                if loser_score > survivor_score {
+                    fact_store.update_importance_score(survivor_id, loser_score)?;
+                }
 
                 // If the new_fact itself was expired, stop comparing it
                 if expire_id == new_fact.id {
@@ -246,5 +271,102 @@ mod tests {
         let active = store.list_active().unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].content, "older fact");
+    }
+
+    fn insert_pinned_fact(
+        conn: &Connection,
+        embed_dim: usize,
+        content: &str,
+        embedding: Vec<f32>,
+        importance: f64,
+        is_pinned: bool,
+    ) -> i64 {
+        let store = FactStore::new(conn, embed_dim);
+        store
+            .insert(&NewFact {
+                content: content.into(),
+                content_hash: blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string(),
+                embedding,
+                fact_type: FactType::Semantic,
+                t_created: Utc::now(),
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                scope_id: 1,
+                importance,
+                access_count: 0,
+                last_accessed: Utc::now(),
+                metadata: serde_json::json!({}),
+                is_pinned,
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn pinned_facts_not_deduped() {
+        let (conn, dim) = setup();
+        // Insert a pinned fact and a near-duplicate unpinned fact
+        insert_pinned_fact(
+            &conn,
+            dim,
+            "pinned fact",
+            vec![1.0, 0.0, 0.0, 0.0],
+            0.5,
+            true,
+        );
+        insert_pinned_fact(
+            &conn,
+            dim,
+            "pinned fact copy",
+            vec![0.99, 0.01, 0.0, 0.0],
+            0.5,
+            false,
+        );
+
+        let removed = local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+        // Neither should be deduped because one is pinned
+        assert_eq!(removed, 0);
+
+        let store = FactStore::new(&conn, dim);
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 2);
+    }
+
+    #[test]
+    fn both_pinned_not_deduped() {
+        let (conn, dim) = setup();
+        insert_pinned_fact(&conn, dim, "pinned A", vec![1.0, 0.0, 0.0, 0.0], 0.5, true);
+        insert_pinned_fact(
+            &conn,
+            dim,
+            "pinned B",
+            vec![0.99, 0.01, 0.0, 0.0],
+            0.8,
+            true,
+        );
+
+        let removed = local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+        assert_eq!(removed, 0);
+
+        let store = FactStore::new(&conn, dim);
+        assert_eq!(store.list_active().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn survivor_inherits_max_importance() {
+        let (conn, dim) = setup();
+        // Low importance fact with high importance_score, high importance fact with low score
+        insert_fact(&conn, dim, "low imp", vec![1.0, 0.0, 0.0, 0.0], 0.3);
+        insert_fact(&conn, dim, "high imp", vec![0.99, 0.01, 0.0, 0.0], 0.9);
+
+        local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+
+        let store = FactStore::new(&conn, dim);
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].content, "high imp");
+        // Survivor should keep its own importance (0.9 > 0.3, no update needed)
+        assert!((active[0].importance - 0.9).abs() < f64::EPSILON);
     }
 }

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -50,6 +50,8 @@ pub fn global_integration(
             access_count: 0,
             last_accessed: s.created_at,
             metadata: serde_json::json!({}),
+            is_pinned: false,
+            importance_score: 0.5,
         })
         .collect();
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -177,21 +177,10 @@ impl MemoryEngine {
         let embedding = embedder.embed(content)?;
         let now = Utc::now();
         let opts = opts.cloned().unwrap_or_default();
+        let base_importance = opts.importance.unwrap_or(0.5);
 
-        // Resolve scope + insert fact in a single write lock
-        let conn = self.write_conn();
-        let scope_id = match scope {
-            Some(path) => {
-                let scope_store = ScopeStore::new(&conn);
-                let id = scope_store.ensure_path(path)?;
-                let node = scope_store.get(id)?;
-                self.scope_tree.write().insert(node);
-                id
-            }
-            None => 1, // root scope
-        };
-
-        // Explicit opts.pinned always wins; classifier only runs when pinned is None.
+        // Classify OUTSIDE the write lock (potentially slow — LLM, I/O, etc.)
+        // Uses scope_id=0 placeholder; classifiers should rely on content/type/importance/metadata.
         let is_pinned = match opts.pinned {
             Some(p) => p,
             None => classifier.is_some_and(|c| {
@@ -206,19 +195,32 @@ impl MemoryEngine {
                     t_valid: opts.t_valid,
                     t_invalid: opts.t_invalid,
                     source_event_id,
-                    importance: opts.importance.unwrap_or(0.5),
+                    importance: base_importance,
                     access_count: 0,
                     last_accessed: now,
                     metadata: opts
                         .metadata
                         .clone()
                         .unwrap_or_else(|| serde_json::json!({})),
-                    scope_id,
+                    scope_id: 0,
                     is_pinned: false,
-                    importance_score: 0.5,
+                    importance_score: base_importance,
                 };
                 c.should_pin(&temp)
             }),
+        };
+
+        // Resolve scope + insert fact in a single write lock
+        let conn = self.write_conn();
+        let scope_id = match scope {
+            Some(path) => {
+                let scope_store = ScopeStore::new(&conn);
+                let id = scope_store.ensure_path(path)?;
+                let node = scope_store.get(id)?;
+                self.scope_tree.write().insert(node);
+                id
+            }
+            None => 1, // root scope
         };
 
         let new_fact = NewFact {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -204,6 +204,7 @@ impl MemoryEngine {
             access_count: 0,
             last_accessed: now,
             metadata: opts.metadata.unwrap_or_else(|| serde_json::json!({})),
+            is_pinned: opts.pinned.unwrap_or(false),
         };
 
         FactStore::new(&conn, self.embed_dim).insert(&new_fact)
@@ -493,6 +494,7 @@ mod tests {
             access_count: 0,
             last_accessed: now,
             metadata: serde_json::json!({}),
+            is_pinned: false,
         }
     }
 
@@ -522,6 +524,9 @@ mod tests {
             source: "test".into(),
             session_id: None,
             scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
         };
         let id = engine.ingest(&event).unwrap();
         assert_eq!(id, 1);
@@ -685,6 +690,7 @@ mod tests {
                 access_count: 0,
                 last_accessed: old_time,
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             },
         );
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -403,10 +403,12 @@ impl MemoryEngine {
 
     /// Retrieve tiered context for resuming a session.
     ///
-    /// Returns three tiers of facts (mutually exclusive):
-    /// 1. **Identity** — root scope, highest importance
-    /// 2. **Core** — importance >= threshold, from scope ancestors
-    /// 3. **Recent** — most recent, from scope ancestors
+    /// Returns five tiers of facts (mutually exclusive):
+    /// 1. **Pinned** — all pinned facts (cross-scope)
+    /// 2. **High-importance** — top-N by materialized importance_score
+    /// 3. **Due** — facts with t_valid <= now
+    /// 4. **Recent** — most recent, from scope ancestors
+    /// 5. **KB stubs** — placeholder for Phase 5
     ///
     /// # Errors
     ///
@@ -995,8 +997,9 @@ mod tests {
     fn resume_empty_engine() {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         let ctx = engine.resume_context(&ResumeConfig::default()).unwrap();
-        assert!(ctx.identity.is_empty());
-        assert!(ctx.core.is_empty());
+        assert!(ctx.pinned.is_empty());
+        assert!(ctx.high_importance.is_empty());
+        assert!(ctx.due.is_empty());
         assert!(ctx.recent.is_empty());
     }
 
@@ -1005,9 +1008,10 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         let embedder = MockEmbedder { dim: DIM };
 
-        // Add a high-importance root fact (identity tier)
-        let opts = AddFactOptions {
+        // Add a pinned fact (appears in tier 1)
+        let opts_pinned = AddFactOptions {
             importance: Some(0.95),
+            pinned: Some(true),
             ..Default::default()
         };
         engine
@@ -1017,7 +1021,7 @@ mod tests {
                 None,
                 &embedder,
                 None,
-                Some(&opts),
+                Some(&opts_pinned),
             )
             .unwrap();
 
@@ -1037,14 +1041,14 @@ mod tests {
             )
             .unwrap();
 
-        let config = ResumeConfig {
-            core_min_importance: 0.7,
-            ..ResumeConfig::default()
-        };
+        let config = ResumeConfig::default();
         let ctx = engine.resume_context(&config).unwrap();
-        // Both facts are in root scope — identity gets the high-importance one
-        assert!(!ctx.identity.is_empty());
-        assert!(ctx.identity[0].importance >= 0.7);
+        // The pinned fact should appear in the pinned tier
+        assert_eq!(ctx.pinned.len(), 1);
+        assert!(ctx.pinned[0].is_pinned);
+        assert!(ctx.pinned[0].content.contains("Rust"));
+        // The low-importance fact should appear in recent
+        assert!(!ctx.recent.is_empty());
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -162,6 +162,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns errors from embedding computation, dimension validation, or DB insert.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_fact(
         &self,
         content: &str,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use parking_lot::{MutexGuard, RwLock};
 use rusqlite::Connection;
 
@@ -17,7 +17,7 @@ use crate::store::scopes::ScopeStore;
 use crate::store::summaries::SummaryStore;
 use crate::traits::{
     ConflictArbiter, ConflictResolution, ConsolidationConfig, ConsolidationStats,
-    EmbeddingProvider, ForgetPolicy, PruneStats, SummaryGenerator,
+    EmbeddingProvider, ForgetPolicy, PersistenceClassifier, PruneStats, SummaryGenerator,
 };
 use crate::types::{AddFactOptions, ConsolidationLevel, Fact, FactType, NewEvent, NewFact};
 
@@ -170,6 +170,7 @@ impl MemoryEngine {
         embedder: &dyn EmbeddingProvider,
         scope: Option<&str>,
         opts: Option<&AddFactOptions>,
+        classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<i64> {
         // Embed OUTSIDE the write lock (potentially slow)
         let embedding = embedder.embed(content)?;
@@ -189,6 +190,36 @@ impl MemoryEngine {
             None => 1, // root scope
         };
 
+        // Explicit opts.pinned always wins; classifier only runs when pinned is None.
+        let is_pinned = match opts.pinned {
+            Some(p) => p,
+            None => classifier.map_or(false, |c| {
+                let temp = Fact {
+                    id: 0,
+                    content: content.into(),
+                    content_hash: String::new(),
+                    embedding: embedding.clone(),
+                    fact_type: fact_type.clone(),
+                    t_created: now,
+                    t_expired: None,
+                    t_valid: opts.t_valid,
+                    t_invalid: opts.t_invalid,
+                    source_event_id,
+                    importance: opts.importance.unwrap_or(0.5),
+                    access_count: 0,
+                    last_accessed: now,
+                    metadata: opts
+                        .metadata
+                        .clone()
+                        .unwrap_or_else(|| serde_json::json!({})),
+                    scope_id,
+                    is_pinned: false,
+                    importance_score: 0.5,
+                };
+                c.should_pin(&temp)
+            }),
+        };
+
         let new_fact = NewFact {
             content: content.into(),
             content_hash: String::new(), // FactStore::insert computes this via blake3
@@ -204,7 +235,7 @@ impl MemoryEngine {
             access_count: 0,
             last_accessed: now,
             metadata: opts.metadata.unwrap_or_else(|| serde_json::json!({})),
-            is_pinned: opts.pinned.unwrap_or(false),
+            is_pinned,
         };
 
         FactStore::new(&conn, self.embed_dim).insert(&new_fact)
@@ -399,6 +430,55 @@ impl MemoryEngine {
         self.with_read(|conn| SummaryStore::new(conn, self.embed_dim).list_by_level(level))
     }
 
+    // --- Public API: Scheduling ---
+
+    /// Get facts whose scheduled time has arrived.
+    /// Returns facts where `t_valid <= now` and `t_valid IS NOT NULL`.
+    pub fn drain_due(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>> {
+        let scope_ids = self.resolve_scope_ids(scope)?;
+        self.with_read(|conn| FactStore::new(conn, self.embed_dim).list_due(now, &scope_ids))
+    }
+
+    /// Scheduling hint: when should the consumer next call `drain_due()`?
+    /// Returns the earliest `t_valid` among active future-dated facts.
+    pub fn next_due_time(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>> {
+        let scope_ids = self.resolve_scope_ids(scope)?;
+        self.with_read(|conn| {
+            FactStore::new(conn, self.embed_dim).next_due_time(Utc::now(), &scope_ids)
+        })
+    }
+
+    // --- Public API: Pinning ---
+
+    /// Pin a fact (make it unforgettable).
+    pub fn pin_fact(&self, id: i64) -> Result<()> {
+        let conn = self.write_conn();
+        FactStore::new(&conn, self.embed_dim).set_pinned(id, true)
+    }
+
+    /// Unpin a fact (allow forgetting).
+    pub fn unpin_fact(&self, id: i64) -> Result<()> {
+        let conn = self.write_conn();
+        FactStore::new(&conn, self.embed_dim).set_pinned(id, false)
+    }
+
+    // --- Private helpers ---
+
+    /// Resolve scope IDs from an optional scope path.
+    /// Returns [root_id] when scope is None, or ancestor IDs when scope exists.
+    fn resolve_scope_ids(&self, scope: Option<&str>) -> Result<Vec<i64>> {
+        let tree = self.scope_tree.read();
+        match scope {
+            Some(path) => {
+                let id = tree
+                    .resolve_path(path)
+                    .ok_or_else(|| MemoryError::NotFound(format!("scope path: {path}")))?;
+                Ok(tree.ancestors(id))
+            }
+            None => Ok(vec![tree.root_id()]),
+        }
+    }
+
     // --- Public API: Resume ---
 
     /// Retrieve tiered context for resuming a session.
@@ -441,7 +521,7 @@ impl MemoryEngine {
 mod tests {
     use super::*;
     use crate::search::hybrid::SearchMode;
-    use crate::traits::{ConsolidationConfig, CrudDecision, ForgetPolicy};
+    use crate::traits::{ConsolidationConfig, CrudDecision, ForgetPolicy, PersistenceClassifier};
     use crate::types::{EventType, Fact, FactType};
 
     const DIM: usize = 4;
@@ -546,6 +626,7 @@ mod tests {
                 &embedder,
                 None,
                 None,
+                None,
             )
             .unwrap();
         assert!(id > 0);
@@ -561,6 +642,7 @@ mod tests {
                 FactType::Semantic,
                 None,
                 &embedder,
+                None,
                 None,
                 None,
             )
@@ -820,6 +902,7 @@ mod tests {
                 &embedder,
                 None,
                 Some(&opts),
+                None,
             )
             .unwrap();
         let fact = engine.get_fact(id).unwrap();
@@ -844,6 +927,7 @@ mod tests {
                 &embedder,
                 None,
                 Some(&opts),
+                None,
             )
             .unwrap();
         let fact = engine.get_fact(id).unwrap();
@@ -863,6 +947,7 @@ mod tests {
                 &embedder,
                 Some("user:test/project:demo"),
                 None,
+                None,
             )
             .unwrap();
         let fact = engine.get_fact(id).unwrap();
@@ -879,6 +964,7 @@ mod tests {
                 FactType::Semantic,
                 None,
                 &embedder,
+                None,
                 None,
                 None,
             )
@@ -912,6 +998,7 @@ mod tests {
                 &embedder,
                 None,
                 None,
+                None,
             )
             .unwrap();
         engine
@@ -920,6 +1007,7 @@ mod tests {
                 FactType::Semantic,
                 None,
                 &embedder,
+                None,
                 None,
                 None,
             )
@@ -966,6 +1054,7 @@ mod tests {
                 FactType::Semantic,
                 None,
                 &embedder,
+                None,
                 None,
                 None,
             )
@@ -1022,6 +1111,7 @@ mod tests {
                 &embedder,
                 None,
                 Some(&opts_pinned),
+                None,
             )
             .unwrap();
 
@@ -1038,6 +1128,7 @@ mod tests {
                 &embedder,
                 None,
                 Some(&opts_low),
+                None,
             )
             .unwrap();
 
@@ -1078,6 +1169,7 @@ mod tests {
                 &embedder,
                 None,
                 None,
+                None,
             )
             .unwrap();
 
@@ -1097,5 +1189,184 @@ mod tests {
             "expected empty results for nonexistent scope, got {}",
             results.len()
         );
+    }
+
+    // --- Phase 3b / T8: Engine facade new methods ---
+
+    #[test]
+    fn drain_due_returns_scheduled_facts() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let past = Utc::now() - chrono::Duration::hours(1);
+        let future = Utc::now() + chrono::Duration::hours(1);
+
+        // Past-due fact
+        engine
+            .add_fact(
+                "check release",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                Some(&AddFactOptions {
+                    t_valid: Some(past),
+                    ..Default::default()
+                }),
+                None,
+            )
+            .unwrap();
+
+        // Future fact
+        engine
+            .add_fact(
+                "future check",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                Some(&AddFactOptions {
+                    t_valid: Some(future),
+                    ..Default::default()
+                }),
+                None,
+            )
+            .unwrap();
+
+        // Regular fact (no t_valid)
+        engine
+            .add_fact(
+                "regular",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let due = engine.drain_due(Utc::now(), None).unwrap();
+        assert_eq!(due.len(), 1);
+        assert!(due[0].content.contains("check release"));
+
+        let next = engine.next_due_time(None).unwrap();
+        assert!(next.is_some()); // the future fact
+    }
+
+    #[test]
+    fn pin_unpin_fact() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let id = engine
+            .add_fact(
+                "pinnable",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert!(!engine.get_fact(id).unwrap().is_pinned);
+        engine.pin_fact(id).unwrap();
+        assert!(engine.get_fact(id).unwrap().is_pinned);
+        engine.unpin_fact(id).unwrap();
+        assert!(!engine.get_fact(id).unwrap().is_pinned);
+    }
+
+    #[test]
+    fn add_fact_with_explicit_pin() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let opts = AddFactOptions {
+            pinned: Some(true),
+            ..Default::default()
+        };
+        let id = engine
+            .add_fact(
+                "identity",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                Some(&opts),
+                None,
+            )
+            .unwrap();
+        assert!(engine.get_fact(id).unwrap().is_pinned);
+    }
+
+    #[test]
+    fn add_fact_with_classifier() {
+        struct PinSemantic;
+        impl PersistenceClassifier for PinSemantic {
+            fn should_pin(&self, fact: &Fact) -> bool {
+                fact.fact_type == FactType::Semantic
+            }
+        }
+
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let classifier = PinSemantic;
+
+        let id = engine
+            .add_fact(
+                "auto-pinned",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                None,
+                Some(&classifier),
+            )
+            .unwrap();
+        assert!(engine.get_fact(id).unwrap().is_pinned);
+
+        let id2 = engine
+            .add_fact(
+                "not pinned",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                Some(&classifier),
+            )
+            .unwrap();
+        assert!(!engine.get_fact(id2).unwrap().is_pinned);
+    }
+
+    #[test]
+    fn explicit_pin_overrides_classifier() {
+        struct AlwaysPin;
+        impl PersistenceClassifier for AlwaysPin {
+            fn should_pin(&self, _fact: &Fact) -> bool {
+                true
+            }
+        }
+
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let classifier = AlwaysPin;
+
+        // Explicitly set pinned=false — should override the classifier
+        let opts = AddFactOptions {
+            pinned: Some(false),
+            ..Default::default()
+        };
+        let id = engine
+            .add_fact(
+                "not pinned despite classifier",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                Some(&opts),
+                Some(&classifier),
+            )
+            .unwrap();
+        assert!(!engine.get_fact(id).unwrap().is_pinned);
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -435,14 +435,18 @@ impl MemoryEngine {
 
     // --- Public API: Scheduling ---
 
-    /// Get facts whose scheduled time has arrived.
-    /// Returns facts where `t_valid <= now` and `t_valid IS NOT NULL`.
-    pub fn drain_due(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>> {
+    /// List facts whose scheduled time has arrived.
+    /// Returns active facts where `t_valid <= now` and `t_valid IS NOT NULL`.
+    ///
+    /// This is a read-only query — facts are not consumed or marked as delivered.
+    /// Consumers should track delivery state externally if incremental delivery
+    /// is needed, or use `pin_fact()`/`forget()` to manage fact lifecycle.
+    pub fn list_due(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>> {
         let scope_ids = self.resolve_scope_ids(scope)?;
         self.with_read(|conn| FactStore::new(conn, self.embed_dim).list_due(now, &scope_ids))
     }
 
-    /// Scheduling hint: when should the consumer next call `drain_due()`?
+    /// Scheduling hint: when should the consumer next call `list_due()`?
     /// Returns the earliest `t_valid` among active future-dated facts.
     pub fn next_due_time(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>> {
         let scope_ids = self.resolve_scope_ids(scope)?;
@@ -1196,7 +1200,7 @@ mod tests {
     // --- Phase 3b / T8: Engine facade new methods ---
 
     #[test]
-    fn drain_due_returns_scheduled_facts() {
+    fn list_due_returns_scheduled_facts() {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         let embedder = MockEmbedder { dim: DIM };
         let past = Utc::now() - chrono::Duration::hours(1);
@@ -1247,12 +1251,43 @@ mod tests {
             )
             .unwrap();
 
-        let due = engine.drain_due(Utc::now(), None).unwrap();
+        let due = engine.list_due(Utc::now(), None).unwrap();
         assert_eq!(due.len(), 1);
         assert!(due[0].content.contains("check release"));
 
         let next = engine.next_due_time(None).unwrap();
         assert!(next.is_some()); // the future fact
+
+        // Future-dated facts should be invisible to regular search (no valid_at)
+        let search = engine
+            .query(&SearchQuery {
+                text: Some("future check".into()),
+                embedding: None,
+                mode: SearchMode::Fts,
+                limit: 10,
+                valid_at: None,
+                fact_type: None,
+                scope: None,
+            })
+            .unwrap();
+        assert!(
+            search.is_empty(),
+            "future-dated facts should not appear in regular search"
+        );
+
+        // But past-due facts should be visible
+        let search2 = engine
+            .query(&SearchQuery {
+                text: Some("check release".into()),
+                embedding: None,
+                mode: SearchMode::Fts,
+                limit: 10,
+                valid_at: None,
+                fact_type: None,
+                scope: None,
+            })
+            .unwrap();
+        assert_eq!(search2.len(), 1, "past-due facts should appear in search");
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -194,7 +194,7 @@ impl MemoryEngine {
         // Explicit opts.pinned always wins; classifier only runs when pinned is None.
         let is_pinned = match opts.pinned {
             Some(p) => p,
-            None => classifier.map_or(false, |c| {
+            None => classifier.is_some_and(|c| {
                 let temp = Fact {
                     id: 0,
                     content: content.into(),
@@ -496,10 +496,10 @@ impl MemoryEngine {
     /// Returns `MemoryError::NotFound` if the requested scope path doesn't exist.
     pub fn resume_context(&self, config: &ResumeConfig) -> Result<ResumeContext> {
         // Step 1: Resolve scope IDs from cache (short-lived read lock)
-        let (root_id, scope_ids) = {
+        let scope_ids = {
             let tree = self.scope_tree.read();
             let root = tree.root_id();
-            let ids = match config.scope_path.as_ref() {
+            match config.scope_path.as_ref() {
                 Some(path) => {
                     let id = tree
                         .resolve_path(path)
@@ -507,13 +507,12 @@ impl MemoryEngine {
                     tree.ancestors(id)
                 }
                 None => vec![root],
-            };
-            (root, ids)
+            }
         }; // scope_tree read lock dropped here
 
         // Step 2: Query DB (no locks held)
         self.with_read(|conn| {
-            crate::resume::resume_context(conn, root_id, &scope_ids, self.embed_dim, config)
+            crate::resume::resume_context(conn, &scope_ids, self.embed_dim, config)
         })
     }
 }

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -92,10 +92,14 @@ pub fn prune(
     let active_facts = fact_store.list_active()?;
     let facts_evaluated = active_facts.len();
 
-    // Score all facts before mutating, so degree values are consistent
+    // Score all facts before mutating, so degree values are consistent.
+    // Pinned facts are unforgettable — they bypass the decay filter entirely.
     let to_expire: Vec<i64> = active_facts
         .iter()
         .filter(|fact| {
+            if fact.is_pinned {
+                return false;
+            }
             let degree = graph.degree(fact.id);
             compute_importance(fact, degree, now, policy) < policy.min_importance
         })
@@ -106,6 +110,14 @@ pub fn prune(
     let fact_store = FactStore::new(&tx, embed_dim);
     let edge_store = EdgeStore::new(&tx);
 
+    // Materialize importance scores for all active facts
+    for fact in &active_facts {
+        let degree = graph.degree(fact.id);
+        let score = compute_importance(fact, degree, now, policy);
+        fact_store.update_importance_score(fact.id, score)?;
+    }
+
+    // Expire low-importance unpinned facts
     for &fact_id in &to_expire {
         fact_store.expire(fact_id, now)?;
         edge_store.expire_by_fact(fact_id, now)?;
@@ -349,6 +361,120 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM facts", [], |r| r.get(0))
             .unwrap();
         assert_eq!(all_count, 3, "All facts should still exist in DB");
+    }
+
+    #[test]
+    fn prune_skips_pinned_facts() {
+        use crate::types::NewFact;
+
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let now = Utc::now();
+        let old_time = now - Duration::days(200);
+        let embed_dim = 4;
+        let fact_store = FactStore::new(&conn, embed_dim);
+
+        // Pinned fact with low importance and old age — would normally be pruned
+        fact_store
+            .insert(&NewFact {
+                content: "pinned identity".into(),
+                content_hash: "hp".into(),
+                embedding: vec![0.1; embed_dim],
+                fact_type: FactType::Semantic,
+                t_created: old_time,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                scope_id: 1,
+                importance: 0.01,
+                access_count: 0,
+                last_accessed: old_time,
+                metadata: serde_json::json!({}),
+                is_pinned: true,
+            })
+            .unwrap();
+
+        // Unpinned fact with same characteristics — should be pruned
+        fact_store
+            .insert(&NewFact {
+                content: "forgettable".into(),
+                content_hash: "hf".into(),
+                embedding: vec![0.2; embed_dim],
+                fact_type: FactType::Episodic,
+                t_created: old_time,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                scope_id: 1,
+                importance: 0.01,
+                access_count: 0,
+                last_accessed: old_time,
+                metadata: serde_json::json!({}),
+                is_pinned: false,
+            })
+            .unwrap();
+
+        let mut graph = MemoryGraph::new();
+        let policy = ForgetPolicy {
+            min_importance: 0.3,
+            ..ForgetPolicy::default()
+        };
+        let stats = prune(&conn, &mut graph, &policy, embed_dim, now).unwrap();
+
+        assert_eq!(stats.facts_expired, 1); // only unpinned
+        assert_eq!(stats.facts_evaluated, 2);
+
+        // Pinned fact still active
+        let active = fact_store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert!(active[0].is_pinned);
+    }
+
+    #[test]
+    fn prune_materializes_importance_scores() {
+        use crate::types::NewFact;
+
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let now = Utc::now();
+        let embed_dim = 4;
+        let fact_store = FactStore::new(&conn, embed_dim);
+
+        fact_store
+            .insert(&NewFact {
+                content: "scored fact".into(),
+                content_hash: "hs".into(),
+                embedding: vec![0.1; embed_dim],
+                fact_type: FactType::Semantic,
+                t_created: now,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                scope_id: 1,
+                importance: 0.8,
+                access_count: 10,
+                last_accessed: now,
+                metadata: serde_json::json!({}),
+                is_pinned: false,
+            })
+            .unwrap();
+
+        let mut graph = MemoryGraph::new();
+        let policy = ForgetPolicy::default();
+        prune(&conn, &mut graph, &policy, embed_dim, now).unwrap();
+
+        // After prune, importance_score should be updated from default
+        let fact = fact_store.get(1).unwrap();
+        assert!(
+            (fact.importance_score - 0.5).abs() > f64::EPSILON,
+            "importance_score should have been updated from default 0.5, got {}",
+            fact.importance_score
+        );
     }
 
     #[test]

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -173,6 +173,8 @@ mod tests {
             access_count: 100,
             last_accessed: now - Duration::hours(1),
             metadata: serde_json::json!({}),
+            is_pinned: false,
+            importance_score: 0.5,
         };
 
         // Fact B: old, rarely accessed, isolated, low importance
@@ -192,6 +194,8 @@ mod tests {
             access_count: 1,
             last_accessed: now - Duration::days(90),
             metadata: serde_json::json!({}),
+            is_pinned: false,
+            importance_score: 0.5,
         };
 
         let importance_a = compute_importance(&fact_a, 5, now, &policy);
@@ -230,6 +234,8 @@ mod tests {
             access_count: 5,
             last_accessed: now - Duration::days(60),
             metadata: serde_json::json!({}),
+            is_pinned: false,
+            importance_score: 0.5,
         };
 
         let mut procedural_fact = base_fact.clone();
@@ -277,6 +283,7 @@ mod tests {
                 access_count: 50,
                 last_accessed: now,
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             })
             .unwrap();
 
@@ -297,6 +304,7 @@ mod tests {
                 access_count: 2,
                 last_accessed: old_time,
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             })
             .unwrap();
 
@@ -317,6 +325,7 @@ mod tests {
                 access_count: 0,
                 last_accessed: old_time,
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             })
             .unwrap();
 

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
 use crate::error::Result;
@@ -11,13 +12,17 @@ use crate::types::Fact;
 pub struct ResumeConfig {
     /// Scope path to resume from. None = root only.
     pub scope_path: Option<String>,
-    /// Max facts in identity tier (root scope, highest importance). Default: 5.
-    pub identity_cap: usize,
-    /// Max facts in core tier (importance >= threshold). Default: 20.
-    pub core_cap: usize,
-    /// Importance threshold for core tier. Default: 0.7.
-    pub core_min_importance: f64,
-    /// Max facts in recent tier (newest by t_created). Default: 10.
+    /// Current time for due-fact evaluation.
+    pub now: DateTime<Utc>,
+    /// Max pinned facts. Default: 50.
+    pub pinned_cap: usize,
+    /// Max high-importance facts (by materialized score). Default: 20.
+    pub high_importance_cap: usize,
+    /// Minimum importance_score for high-importance tier. Default: 0.7.
+    pub high_importance_min: f64,
+    /// Max due facts (future memory now surfacing). Default: 10.
+    pub due_cap: usize,
+    /// Max recent facts (scope-filtered). Default: 10.
     pub recent_cap: usize,
 }
 
@@ -25,9 +30,11 @@ impl Default for ResumeConfig {
     fn default() -> Self {
         Self {
             scope_path: None,
-            identity_cap: 5,
-            core_cap: 20,
-            core_min_importance: 0.7,
+            now: Utc::now(),
+            pinned_cap: 50,
+            high_importance_cap: 20,
+            high_importance_min: 0.7,
+            due_cap: 10,
             recent_cap: 10,
         }
     }
@@ -36,53 +43,74 @@ impl Default for ResumeConfig {
 /// Result of [`resume_context`].
 #[derive(Debug, Clone)]
 pub struct ResumeContext {
-    /// High-importance facts from root scope (user/agent identity).
-    pub identity: Vec<Fact>,
-    /// Important facts from the resolved scope and ancestors.
-    pub core: Vec<Fact>,
-    /// Most recent facts from the resolved scope and ancestors.
+    /// Pinned (unforgettable) facts — agent identity, core beliefs.
+    pub pinned: Vec<Fact>,
+    /// High-importance facts by materialized score.
+    pub high_importance: Vec<Fact>,
+    /// Future-memory facts whose t_valid has arrived.
+    pub due: Vec<Fact>,
+    /// Most recent facts from active scope.
     pub recent: Vec<Fact>,
+    /// Placeholder: KB reference URIs for Phase 5.
+    pub kb_stubs: Vec<String>,
 }
 
 /// Retrieve tiered context for resuming a session.
 ///
-/// Three tiers, mutually exclusive (no fact appears in multiple tiers):
+/// Five tiers, mutually exclusive (no fact appears in multiple tiers):
 ///
-/// 1. **Identity** — root scope, highest importance, capped at `config.identity_cap`
-/// 2. **Core** — importance >= threshold, from resolved scope ancestors, excluding identity
-/// 3. **Recent** — most recent by `t_created`, from scope ancestors, excluding identity + core
+/// 1. **Pinned** — all pinned facts (always present, cross-scope)
+/// 2. **High-importance** — top-N by materialized `importance_score`
+/// 3. **Due** — active facts with `t_valid <= now` (future memory surfacing)
+/// 4. **Scope-filtered recent** — newest by `t_created` from active scope
+/// 5. **KB stubs** — placeholder `Vec<String>` for Phase 5
 ///
 /// Takes pre-resolved scope IDs to avoid holding cache locks across DB access.
 pub fn resume_context(
     conn: &Connection,
-    root_id: i64,
+    _root_id: i64,
     scope_ids: &[i64],
     embed_dim: usize,
     config: &ResumeConfig,
 ) -> Result<ResumeContext> {
     let fact_store = FactStore::new(conn, embed_dim);
+    let mut seen: HashSet<i64> = HashSet::new();
 
-    // Tier 1: Identity — root scope, highest importance
-    let identity = fact_store.list_by_scope_importance(root_id, config.identity_cap)?;
-    let identity_ids: HashSet<i64> = identity.iter().map(|f| f.id).collect();
+    // Tier 1: Pinned facts (always present, cross-scope)
+    let pinned_all = fact_store.list_pinned(&[])?;
+    let pinned: Vec<Fact> = pinned_all.into_iter().take(config.pinned_cap).collect();
+    seen.extend(pinned.iter().map(|f| f.id));
 
-    // Tier 2: Core — importance >= threshold, from scope ancestors, excluding identity
-    let core = fact_store.list_by_scopes_importance(
+    // Tier 2: High-importance by materialized score
+    let high_importance = fact_store.list_by_importance_score(
         scope_ids,
-        config.core_min_importance,
-        config.core_cap,
-        &identity_ids,
+        config.high_importance_min,
+        config.high_importance_cap,
+        &seen,
     )?;
-    let core_ids: HashSet<i64> = core.iter().map(|f| f.id).collect();
+    seen.extend(high_importance.iter().map(|f| f.id));
 
-    // Tier 3: Recent — newest first, excluding identity + core
-    let exclude: HashSet<i64> = identity_ids.union(&core_ids).copied().collect();
-    let recent = fact_store.list_by_scopes_recent(scope_ids, config.recent_cap, &exclude)?;
+    // Tier 3: Due facts (future memory now surfacing)
+    let due_all = fact_store.list_due(config.now, scope_ids)?;
+    let due: Vec<Fact> = due_all
+        .into_iter()
+        .filter(|f| !seen.contains(&f.id))
+        .take(config.due_cap)
+        .collect();
+    seen.extend(due.iter().map(|f| f.id));
+
+    // Tier 4: Scope-filtered recent
+    let recent = fact_store.list_by_scopes_recent(scope_ids, config.recent_cap, &seen)?;
+
+    // Tier 5: KB stubs (Phase 5 placeholder)
+    let kb_stubs = Vec::new();
 
     Ok(ResumeContext {
-        identity,
-        core,
+        pinned,
+        high_importance,
+        due,
         recent,
+        kb_stubs,
     })
 }
 
@@ -127,106 +155,108 @@ mod tests {
     #[test]
     fn resume_empty_db() {
         let conn = setup();
-        let ctx = resume_context(&conn, 1, &[1], DIM, &ResumeConfig::default()).unwrap();
-        assert!(ctx.identity.is_empty());
-        assert!(ctx.core.is_empty());
+        let config = ResumeConfig::default();
+        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
+        assert!(ctx.pinned.is_empty());
+        assert!(ctx.high_importance.is_empty());
+        assert!(ctx.due.is_empty());
         assert!(ctx.recent.is_empty());
+        assert!(ctx.kb_stubs.is_empty());
     }
 
     #[test]
-    fn resume_identity_from_root() {
+    fn resume_pinned_always_present() {
         let conn = setup();
         let fs = FactStore::new(&conn, DIM);
-        fs.insert(&make_fact("identity fact", 0.9, 1)).unwrap();
+        let mut pinned = make_fact("pinned identity", 0.9, 1);
+        pinned.is_pinned = true;
+        fs.insert(&pinned).unwrap();
 
-        let ctx = resume_context(&conn, 1, &[1], DIM, &ResumeConfig::default()).unwrap();
-        assert_eq!(ctx.identity.len(), 1);
-        assert!(ctx.identity[0].content.contains("identity"));
+        let config = ResumeConfig::default();
+        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
+        assert_eq!(ctx.pinned.len(), 1);
+        assert!(ctx.pinned[0].is_pinned);
     }
 
     #[test]
-    fn resume_core_filters_by_importance() {
+    fn resume_due_surfaces_at_time() {
         let conn = setup();
         let fs = FactStore::new(&conn, DIM);
-        // Insert scope for non-root facts
-        conn.execute(
-            "INSERT OR IGNORE INTO scopes (id, parent_id, label, depth) VALUES (2, 1, 'proj', 1)",
-            [],
-        )
-        .unwrap();
-        fs.insert(&make_fact("low importance", 0.3, 2)).unwrap();
-        fs.insert(&make_fact("high importance", 0.9, 2)).unwrap();
+        let now = Utc::now();
+        let past = now - chrono::Duration::hours(1);
+
+        let mut due_fact = make_fact("reminder", 0.5, 1);
+        due_fact.t_valid = Some(past);
+        fs.insert(&due_fact).unwrap();
 
         let config = ResumeConfig {
-            scope_path: None,
-            core_min_importance: 0.5,
-            ..ResumeConfig::default()
-        };
-        let ctx = resume_context(&conn, 1, &[1, 2], DIM, &config).unwrap();
-        // Only the 0.9 fact should be in core
-        assert_eq!(ctx.core.len(), 1);
-        assert!(ctx.core[0].importance >= 0.5);
-    }
-
-    #[test]
-    fn resume_recent_chronological() {
-        let conn = setup();
-        let fs = FactStore::new(&conn, DIM);
-        // Insert 8 facts with low importance so they don't appear in core.
-        // identity_cap=2 will consume 2, leaving 6 for recent (we cap at 3).
-        for i in 0..8 {
-            let mut fact = make_fact(&format!("recent fact {i}"), 0.1, 1);
-            fact.t_created = Utc::now() + chrono::Duration::milliseconds(i * 100);
-            fs.insert(&fact).unwrap();
-        }
-
-        let config = ResumeConfig {
-            identity_cap: 2,
-            core_min_importance: 0.5, // none qualify for core
-            recent_cap: 3,
+            now,
             ..ResumeConfig::default()
         };
         let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
-        assert_eq!(ctx.identity.len(), 2);
-        assert_eq!(ctx.recent.len(), 3);
-        // Most recent first
-        assert!(ctx.recent[0].t_created >= ctx.recent[1].t_created);
-        assert!(ctx.recent[1].t_created >= ctx.recent[2].t_created);
+        assert_eq!(ctx.due.len(), 1);
     }
 
     #[test]
     fn resume_tiers_mutually_exclusive() {
         let conn = setup();
         let fs = FactStore::new(&conn, DIM);
-        // One very important root fact (should go to identity)
-        fs.insert(&make_fact("identity", 0.95, 1)).unwrap();
-        // One important non-root fact (should go to core)
-        conn.execute(
-            "INSERT OR IGNORE INTO scopes (id, parent_id, label, depth) VALUES (2, 1, 'proj', 1)",
-            [],
-        )
-        .unwrap();
-        fs.insert(&make_fact("core fact", 0.8, 2)).unwrap();
-        // One low-importance fact (should go to recent)
-        fs.insert(&make_fact("recent only", 0.1, 2)).unwrap();
+        let now = Utc::now();
+
+        // Pinned fact
+        let mut pinned = make_fact("pinned", 0.95, 1);
+        pinned.is_pinned = true;
+        fs.insert(&pinned).unwrap();
+
+        // High importance (needs importance_score >= 0.7)
+        let id2 = fs.insert(&make_fact("important", 0.9, 1)).unwrap();
+        fs.update_importance_score(id2, 0.85).unwrap();
+
+        // Due fact
+        let mut due = make_fact("due item", 0.5, 1);
+        due.t_valid = Some(now - chrono::Duration::hours(1));
+        fs.insert(&due).unwrap();
+
+        // Recent fact
+        fs.insert(&make_fact("recent", 0.1, 1)).unwrap();
 
         let config = ResumeConfig {
-            scope_path: None,
-            identity_cap: 5,
-            core_min_importance: 0.7,
-            core_cap: 20,
-            recent_cap: 10,
+            now,
+            ..ResumeConfig::default()
         };
-        let ctx = resume_context(&conn, 1, &[1, 2], DIM, &config).unwrap();
+        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
 
         let all_ids: Vec<i64> = ctx
-            .identity
+            .pinned
             .iter()
-            .chain(ctx.core.iter())
+            .chain(ctx.high_importance.iter())
+            .chain(ctx.due.iter())
             .chain(ctx.recent.iter())
             .map(|f| f.id)
             .collect();
         let unique: HashSet<i64> = all_ids.iter().copied().collect();
         assert_eq!(all_ids.len(), unique.len(), "no duplicates across tiers");
+    }
+
+    #[test]
+    fn resume_high_importance_uses_score() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+
+        // Fact with high importance_score
+        let id = fs.insert(&make_fact("important", 0.9, 1)).unwrap();
+        fs.update_importance_score(id, 0.85).unwrap();
+
+        // Fact with low importance_score
+        let id2 = fs.insert(&make_fact("not important", 0.1, 1)).unwrap();
+        fs.update_importance_score(id2, 0.3).unwrap();
+
+        let config = ResumeConfig {
+            high_importance_min: 0.7,
+            ..ResumeConfig::default()
+        };
+        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
+        assert_eq!(ctx.high_importance.len(), 1);
+        assert!(ctx.high_importance[0].importance_score >= 0.7);
     }
 }

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -68,7 +68,6 @@ pub struct ResumeContext {
 /// Takes pre-resolved scope IDs to avoid holding cache locks across DB access.
 pub fn resume_context(
     conn: &Connection,
-    _root_id: i64,
     scope_ids: &[i64],
     embed_dim: usize,
     config: &ResumeConfig,
@@ -156,7 +155,7 @@ mod tests {
     fn resume_empty_db() {
         let conn = setup();
         let config = ResumeConfig::default();
-        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
+        let ctx = resume_context(&conn, &[1], DIM, &config).unwrap();
         assert!(ctx.pinned.is_empty());
         assert!(ctx.high_importance.is_empty());
         assert!(ctx.due.is_empty());
@@ -173,7 +172,7 @@ mod tests {
         fs.insert(&pinned).unwrap();
 
         let config = ResumeConfig::default();
-        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
+        let ctx = resume_context(&conn, &[1], DIM, &config).unwrap();
         assert_eq!(ctx.pinned.len(), 1);
         assert!(ctx.pinned[0].is_pinned);
     }
@@ -193,7 +192,7 @@ mod tests {
             now,
             ..ResumeConfig::default()
         };
-        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
+        let ctx = resume_context(&conn, &[1], DIM, &config).unwrap();
         assert_eq!(ctx.due.len(), 1);
     }
 
@@ -224,7 +223,7 @@ mod tests {
             now,
             ..ResumeConfig::default()
         };
-        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
+        let ctx = resume_context(&conn, &[1], DIM, &config).unwrap();
 
         let all_ids: Vec<i64> = ctx
             .pinned
@@ -255,7 +254,7 @@ mod tests {
             high_importance_min: 0.7,
             ..ResumeConfig::default()
         };
-        let ctx = resume_context(&conn, 1, &[1], DIM, &config).unwrap();
+        let ctx = resume_context(&conn, &[1], DIM, &config).unwrap();
         assert_eq!(ctx.high_importance.len(), 1);
         assert!(ctx.high_importance[0].importance_score >= 0.7);
     }

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -120,6 +120,7 @@ mod tests {
             access_count: 0,
             last_accessed: now,
             metadata: serde_json::json!({}),
+            is_pinned: false,
         }
     }
 

--- a/src/search/fts.rs
+++ b/src/search/fts.rs
@@ -114,6 +114,7 @@ mod tests {
             access_count: 0,
             last_accessed: Utc::now(),
             metadata: serde_json::json!({}),
+            is_pinned: false,
         }
     }
 

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -140,17 +140,19 @@ pub fn hybrid_search(
             continue;
         };
 
-        // Apply valid_at filter (post-filter — complex temporal semantics)
-        if let Some(valid_at) = query.valid_at {
-            if let Some(t_valid) = fact.t_valid {
-                if t_valid > valid_at {
-                    continue;
-                }
+        // Apply temporal filter (post-filter — complex temporal semantics).
+        // Use explicit valid_at if provided, otherwise default to now.
+        // This ensures future-dated facts (t_valid > now) are invisible to
+        // regular queries — they only surface via list_due()/resume_context().
+        let cutoff = query.valid_at.unwrap_or_else(Utc::now);
+        if let Some(t_valid) = fact.t_valid {
+            if t_valid > cutoff {
+                continue;
             }
-            if let Some(t_invalid) = fact.t_invalid {
-                if t_invalid <= valid_at {
-                    continue;
-                }
+        }
+        if let Some(t_invalid) = fact.t_invalid {
+            if t_invalid <= cutoff {
+                continue;
             }
         }
 

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -202,6 +202,7 @@ mod tests {
             access_count: 0,
             last_accessed: Utc::now(),
             metadata: serde_json::json!({}),
+            is_pinned: false,
         }
     }
 

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -129,6 +129,7 @@ mod tests {
             access_count: 0,
             last_accessed: Utc::now(),
             metadata: serde_json::json!({}),
+            is_pinned: false,
         }
     }
 

--- a/src/store/events.rs
+++ b/src/store/events.rs
@@ -58,6 +58,22 @@ fn row_to_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
         rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, Box::new(e))
     })?;
 
+    let created_at_str: Option<String> = row.get("created_at")?;
+    let created_at = created_at_str
+        .as_deref()
+        .map(|s| {
+            DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })
+        })
+        .transpose()?;
+
     Ok(Event {
         id: row.get("id")?,
         timestamp,
@@ -66,6 +82,9 @@ fn row_to_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
         source: row.get("source")?,
         session_id: row.get("session_id")?,
         scope_id: row.get("scope_id")?,
+        origin_node_id: row.get("origin_node_id")?,
+        sequence_id: row.get("sequence_id")?,
+        created_at,
     })
 }
 
@@ -86,9 +105,12 @@ impl<'a> EventStore<'a> {
         let event_type_str = event_type_to_str(&event.event_type);
         let payload_str = serde_json::to_string(&event.payload)?;
 
+        let created_at_str = event.created_at.map(|dt| dt.to_rfc3339());
+
         self.conn.execute(
-            "INSERT INTO events (timestamp, event_type, payload, source, session_id, scope_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            "INSERT INTO events (timestamp, event_type, payload, source, session_id, scope_id,
+                origin_node_id, sequence_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 timestamp_str,
                 event_type_str,
@@ -96,6 +118,9 @@ impl<'a> EventStore<'a> {
                 event.source,
                 event.session_id,
                 event.scope_id,
+                event.origin_node_id,
+                event.sequence_id,
+                created_at_str,
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
@@ -108,7 +133,8 @@ impl<'a> EventStore<'a> {
     /// Returns `MemoryError::NotFound` if the id doesn't exist.
     pub fn get(&self, id: i64) -> Result<Event> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, timestamp, event_type, payload, source, session_id, scope_id
+            "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
+                    origin_node_id, sequence_id, created_at
              FROM events WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], row_to_event)?;
@@ -126,7 +152,8 @@ impl<'a> EventStore<'a> {
     /// Returns `MemoryError::Database` on query failure.
     pub fn list(&self, filter: &EventFilter) -> Result<Vec<Event>> {
         let (sql, values) = build_filter_query(
-            "SELECT id, timestamp, event_type, payload, source, session_id, scope_id FROM events",
+            "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
+                    origin_node_id, sequence_id, created_at FROM events",
             filter,
         );
         let mut stmt = self.conn.prepare(&sql)?;
@@ -212,6 +239,9 @@ mod tests {
             source: source.into(),
             session_id: session_id.map(Into::into),
             scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
         }
     }
 
@@ -297,6 +327,9 @@ mod tests {
             source: "test".into(),
             session_id: None,
             scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
         };
         let id = store.insert(&event).unwrap();
         let retrieved = store.get(id).unwrap();

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -72,8 +72,9 @@ impl<'a> FactStore<'a> {
         self.conn.execute(
             "INSERT INTO facts (content, content_hash, embedding, fact_type,
                 t_created, t_expired, t_valid, t_invalid,
-                source_event_id, importance, access_count, last_accessed, metadata, scope_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                is_pinned)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
             params![
                 fact.content,
                 hash,
@@ -89,6 +90,7 @@ impl<'a> FactStore<'a> {
                 last_accessed,
                 metadata_str,
                 fact.scope_id,
+                i64::from(fact.is_pinned),
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
@@ -103,7 +105,8 @@ impl<'a> FactStore<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id
+                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                    is_pinned, importance_score
              FROM facts WHERE id = ?1",
         )?;
         let dim = self.embed_dim;
@@ -124,7 +127,8 @@ impl<'a> FactStore<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id
+                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                    is_pinned, importance_score
              FROM facts WHERE t_expired IS NULL",
         )?;
         let dim = self.embed_dim;
@@ -149,7 +153,8 @@ impl<'a> FactStore<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id
+                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                    is_pinned, importance_score
              FROM facts
              WHERE t_expired IS NULL
                AND (t_valid IS NULL OR t_valid <= ?1)
@@ -227,7 +232,8 @@ impl<'a> FactStore<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id
+                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                    is_pinned, importance_score
              FROM facts
              WHERE t_expired IS NULL AND scope_id = ?1
              ORDER BY importance DESC
@@ -259,7 +265,8 @@ impl<'a> FactStore<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id
+                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                    is_pinned, importance_score
              FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
@@ -296,7 +303,8 @@ impl<'a> FactStore<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id
+                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                    is_pinned, importance_score
              FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
@@ -340,6 +348,8 @@ fn row_to_fact(row: &rusqlite::Row<'_>, embed_dim: usize) -> rusqlite::Result<Fa
         rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
     })?;
 
+    let is_pinned_i64: i64 = row.get("is_pinned")?;
+
     Ok(Fact {
         id: row.get("id")?,
         content: row.get("content")?,
@@ -356,6 +366,8 @@ fn row_to_fact(row: &rusqlite::Row<'_>, embed_dim: usize) -> rusqlite::Result<Fa
         last_accessed,
         metadata,
         scope_id: row.get("scope_id")?,
+        is_pinned: is_pinned_i64 != 0,
+        importance_score: row.get("importance_score")?,
     })
 }
 
@@ -389,6 +401,7 @@ mod tests {
             last_accessed: Utc::now(),
             metadata: serde_json::json!({}),
             scope_id: 1,
+            is_pinned: false,
         }
     }
 

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -291,21 +291,24 @@ impl<'a> FactStore<'a> {
                         source_event_id, importance, access_count, last_accessed, metadata, scope_id,
                         is_pinned, importance_score
                  FROM facts WHERE t_expired IS NULL AND is_pinned = 1";
-        let sql = if scope_ids.is_empty() {
-            format!("{base} ORDER BY importance_score DESC")
-        } else {
-            let placeholders: String = scope_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-            format!("{base} AND scope_id IN ({placeholders}) ORDER BY importance_score DESC")
-        };
-        let mut stmt = self.conn.prepare(&sql)?;
-        let params: Vec<Box<dyn rusqlite::types::ToSql>> =
-            scope_ids.iter().map(|id| Box::new(*id) as _).collect();
         let dim = self.embed_dim;
-        let rows = stmt.query_map(rusqlite::params_from_iter(params), |row| {
-            row_to_fact(row, dim)
-        })?;
-        rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+        if scope_ids.is_empty() {
+            let sql = format!("{base} ORDER BY importance_score DESC");
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(Into::into)
+        } else {
+            let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
+            let sql = format!(
+                "{base} AND scope_id IN (SELECT value FROM json_each(?1)) ORDER BY importance_score DESC"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows =
+                stmt.query_map(rusqlite::params![scope_json], |row| row_to_fact(row, dim))?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(Into::into)
+        }
     }
 
     /// List active, valid facts where `t_valid <= now` and `t_valid IS NOT NULL`.

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -283,6 +283,196 @@ impl<'a> FactStore<'a> {
             .map_err(MemoryError::Database)
     }
 
+    /// List active pinned (unforgettable) facts, optionally filtered by scope.
+    /// Pass empty slice to get all pinned facts across all scopes.
+    pub fn list_pinned(&self, scope_ids: &[i64]) -> Result<Vec<Fact>> {
+        if scope_ids.is_empty() {
+            let mut stmt = self.conn.prepare(
+                "SELECT id, content, content_hash, embedding, fact_type,
+                        t_created, t_expired, t_valid, t_invalid,
+                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                        is_pinned, importance_score
+                 FROM facts WHERE t_expired IS NULL AND is_pinned = 1
+                 ORDER BY importance_score DESC",
+            )?;
+            let dim = self.embed_dim;
+            let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(Into::into)
+        } else {
+            let placeholders: String = scope_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+            let sql = format!(
+                "SELECT id, content, content_hash, embedding, fact_type,
+                        t_created, t_expired, t_valid, t_invalid,
+                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                        is_pinned, importance_score
+                 FROM facts WHERE t_expired IS NULL AND is_pinned = 1
+                 AND scope_id IN ({placeholders})
+                 ORDER BY importance_score DESC"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let params: Vec<Box<dyn rusqlite::types::ToSql>> =
+                scope_ids.iter().map(|id| Box::new(*id) as _).collect();
+            let dim = self.embed_dim;
+            let rows = stmt.query_map(rusqlite::params_from_iter(params), |row| {
+                row_to_fact(row, dim)
+            })?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(Into::into)
+        }
+    }
+
+    /// List active, valid facts where `t_valid <= now` and `t_valid IS NOT NULL`.
+    /// Excludes facts where `t_invalid <= now` (bi-temporally invalidated).
+    pub fn list_due(&self, now: DateTime<Utc>, scope_ids: &[i64]) -> Result<Vec<Fact>> {
+        let now_str = now.to_rfc3339();
+        let base = "SELECT id, content, content_hash, embedding, fact_type,
+                    t_created, t_expired, t_valid, t_invalid,
+                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                    is_pinned, importance_score
+             FROM facts
+             WHERE t_expired IS NULL AND t_valid IS NOT NULL AND t_valid <= ?1
+             AND (t_invalid IS NULL OR t_invalid > ?1)";
+        let sql = if scope_ids.is_empty() {
+            format!("{base} ORDER BY t_valid ASC")
+        } else {
+            let placeholders: String = scope_ids
+                .iter()
+                .enumerate()
+                .map(|(i, _)| format!("?{}", i + 2))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{base} AND scope_id IN ({placeholders}) ORDER BY t_valid ASC")
+        };
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(now_str)];
+        for id in scope_ids {
+            params.push(Box::new(*id));
+        }
+        let dim = self.embed_dim;
+        let rows = stmt.query_map(rusqlite::params_from_iter(params), |row| {
+            row_to_fact(row, dim)
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    /// Earliest future `t_valid` among active facts with `t_valid > now`.
+    /// Excludes bi-temporally invalidated facts.
+    pub fn next_due_time(
+        &self,
+        now: DateTime<Utc>,
+        scope_ids: &[i64],
+    ) -> Result<Option<DateTime<Utc>>> {
+        let now_str = now.to_rfc3339();
+        let base = "SELECT MIN(t_valid) FROM facts
+             WHERE t_expired IS NULL AND t_valid IS NOT NULL AND t_valid > ?1
+             AND (t_invalid IS NULL OR t_invalid > ?1)";
+        let sql = if scope_ids.is_empty() {
+            base.to_string()
+        } else {
+            let placeholders: String = scope_ids
+                .iter()
+                .enumerate()
+                .map(|(i, _)| format!("?{}", i + 2))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{base} AND scope_id IN ({placeholders})")
+        };
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(now_str)];
+        for id in scope_ids {
+            params.push(Box::new(*id));
+        }
+        let result: Option<String> =
+            stmt.query_row(rusqlite::params_from_iter(params), |r| r.get(0))?;
+        match result {
+            Some(s) => {
+                let dt = DateTime::parse_from_rfc3339(&s)
+                    .map_err(|e| crate::error::MemoryError::Migration(format!("bad t_valid: {e}")))?
+                    .with_timezone(&Utc);
+                Ok(Some(dt))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Set the pinned flag on a fact.
+    pub fn set_pinned(&self, id: i64, pinned: bool) -> Result<()> {
+        let rows = self.conn.execute(
+            "UPDATE facts SET is_pinned = ?1 WHERE id = ?2",
+            rusqlite::params![pinned as i64, id],
+        )?;
+        if rows == 0 {
+            return Err(crate::error::MemoryError::NotFound(format!("fact {id}")));
+        }
+        Ok(())
+    }
+
+    /// Update the materialized importance score for a fact.
+    pub fn update_importance_score(&self, id: i64, score: f64) -> Result<()> {
+        self.conn.execute(
+            "UPDATE facts SET importance_score = ?1 WHERE id = ?2",
+            rusqlite::params![score, id],
+        )?;
+        Ok(())
+    }
+
+    /// List active facts ordered by materialized importance_score, excluding IDs in `exclude`.
+    /// Pass empty `scope_ids` to query across all scopes.
+    pub fn list_by_importance_score(
+        &self,
+        scope_ids: &[i64],
+        min_score: f64,
+        limit: usize,
+        exclude: &std::collections::HashSet<i64>,
+    ) -> Result<Vec<Fact>> {
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let exclude_json = serde_json::to_string(&exclude.iter().copied().collect::<Vec<_>>())
+            .expect("serialize exclude_ids");
+        let dim = self.embed_dim;
+
+        if scope_ids.is_empty() {
+            let mut stmt = self.conn.prepare(
+                "SELECT id, content, content_hash, embedding, fact_type,
+                        t_created, t_expired, t_valid, t_invalid,
+                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                        is_pinned, importance_score
+                 FROM facts
+                 WHERE t_expired IS NULL AND importance_score >= ?1
+                   AND id NOT IN (SELECT value FROM json_each(?2))
+                 ORDER BY importance_score DESC
+                 LIMIT ?3",
+            )?;
+            let rows = stmt.query_map(
+                rusqlite::params![min_score, exclude_json, limit_i64],
+                |row| row_to_fact(row, dim),
+            )?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(Into::into)
+        } else {
+            let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
+            let mut stmt = self.conn.prepare(
+                "SELECT id, content, content_hash, embedding, fact_type,
+                        t_created, t_expired, t_valid, t_invalid,
+                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                        is_pinned, importance_score
+                 FROM facts
+                 WHERE t_expired IS NULL AND importance_score >= ?1
+                   AND scope_id IN (SELECT value FROM json_each(?2))
+                   AND id NOT IN (SELECT value FROM json_each(?3))
+                 ORDER BY importance_score DESC
+                 LIMIT ?4",
+            )?;
+            let rows = stmt.query_map(
+                rusqlite::params![min_score, scope_json, exclude_json, limit_i64],
+                |row| row_to_fact(row, dim),
+            )?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(Into::into)
+        }
+    }
+
     /// List active facts in a set of scopes, excluding specific fact IDs,
     /// ordered by `t_created` DESC (most recent first).
     ///
@@ -523,6 +713,81 @@ mod tests {
         let after = store.get(id).unwrap();
         assert_eq!(after.access_count, 1);
         assert!(after.last_accessed >= before.last_accessed);
+    }
+
+    #[test]
+    fn list_pinned_returns_only_pinned_active_facts() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+        let mut pinned = make_fact("pinned fact", vec![0.1; DIM]);
+        pinned.is_pinned = true;
+        fs.insert(&pinned).unwrap();
+        fs.insert(&make_fact("normal fact", vec![0.2; DIM]))
+            .unwrap();
+
+        let result = fs.list_pinned(&[]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_pinned);
+    }
+
+    #[test]
+    fn list_due_surfaces_facts_with_past_t_valid() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+        let now = Utc::now();
+
+        let mut past = make_fact("past reminder", vec![0.1; DIM]);
+        past.t_valid = Some(now - chrono::Duration::hours(1));
+        fs.insert(&past).unwrap();
+
+        let mut future = make_fact("future reminder", vec![0.2; DIM]);
+        future.t_valid = Some(now + chrono::Duration::hours(1));
+        fs.insert(&future).unwrap();
+
+        fs.insert(&make_fact("regular fact", vec![0.3; DIM]))
+            .unwrap();
+
+        let result = fs.list_due(now, &[]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].content.contains("past"));
+    }
+
+    #[test]
+    fn next_due_time_returns_earliest_future_t_valid() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+        let now = Utc::now();
+
+        assert!(fs.next_due_time(now, &[]).unwrap().is_none());
+
+        let mut future = make_fact("reminder", vec![0.1; DIM]);
+        future.t_valid = Some(now + chrono::Duration::hours(2));
+        fs.insert(&future).unwrap();
+
+        let mut sooner = make_fact("sooner reminder", vec![0.2; DIM]);
+        sooner.t_valid = Some(now + chrono::Duration::hours(1));
+        fs.insert(&sooner).unwrap();
+
+        let next = fs.next_due_time(now, &[]).unwrap().unwrap();
+        assert!(next < now + chrono::Duration::hours(2));
+    }
+
+    #[test]
+    fn set_pinned_toggles_flag() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+        let id = fs.insert(&make_fact("toggleable", vec![0.1; DIM])).unwrap();
+
+        let fact = fs.get(id).unwrap();
+        assert!(!fact.is_pinned);
+
+        fs.set_pinned(id, true).unwrap();
+        let fact = fs.get(id).unwrap();
+        assert!(fact.is_pinned);
+
+        fs.set_pinned(id, false).unwrap();
+        let fact = fs.get(id).unwrap();
+        assert!(!fact.is_pinned);
     }
 
     #[test]

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -286,40 +286,26 @@ impl<'a> FactStore<'a> {
     /// List active pinned (unforgettable) facts, optionally filtered by scope.
     /// Pass empty slice to get all pinned facts across all scopes.
     pub fn list_pinned(&self, scope_ids: &[i64]) -> Result<Vec<Fact>> {
-        if scope_ids.is_empty() {
-            let mut stmt = self.conn.prepare(
-                "SELECT id, content, content_hash, embedding, fact_type,
+        let base = "SELECT id, content, content_hash, embedding, fact_type,
                         t_created, t_expired, t_valid, t_invalid,
                         source_event_id, importance, access_count, last_accessed, metadata, scope_id,
                         is_pinned, importance_score
-                 FROM facts WHERE t_expired IS NULL AND is_pinned = 1
-                 ORDER BY importance_score DESC",
-            )?;
-            let dim = self.embed_dim;
-            let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
-            rows.collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(Into::into)
+                 FROM facts WHERE t_expired IS NULL AND is_pinned = 1";
+        let sql = if scope_ids.is_empty() {
+            format!("{base} ORDER BY importance_score DESC")
         } else {
             let placeholders: String = scope_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-            let sql = format!(
-                "SELECT id, content, content_hash, embedding, fact_type,
-                        t_created, t_expired, t_valid, t_invalid,
-                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                        is_pinned, importance_score
-                 FROM facts WHERE t_expired IS NULL AND is_pinned = 1
-                 AND scope_id IN ({placeholders})
-                 ORDER BY importance_score DESC"
-            );
-            let mut stmt = self.conn.prepare(&sql)?;
-            let params: Vec<Box<dyn rusqlite::types::ToSql>> =
-                scope_ids.iter().map(|id| Box::new(*id) as _).collect();
-            let dim = self.embed_dim;
-            let rows = stmt.query_map(rusqlite::params_from_iter(params), |row| {
-                row_to_fact(row, dim)
-            })?;
-            rows.collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(Into::into)
-        }
+            format!("{base} AND scope_id IN ({placeholders}) ORDER BY importance_score DESC")
+        };
+        let mut stmt = self.conn.prepare(&sql)?;
+        let params: Vec<Box<dyn rusqlite::types::ToSql>> =
+            scope_ids.iter().map(|id| Box::new(*id) as _).collect();
+        let dim = self.embed_dim;
+        let rows = stmt.query_map(rusqlite::params_from_iter(params), |row| {
+            row_to_fact(row, dim)
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     /// List active, valid facts where `t_valid <= now` and `t_valid IS NOT NULL`.
@@ -432,18 +418,17 @@ impl<'a> FactStore<'a> {
             .expect("serialize exclude_ids");
         let dim = self.embed_dim;
 
-        if scope_ids.is_empty() {
-            let mut stmt = self.conn.prepare(
-                "SELECT id, content, content_hash, embedding, fact_type,
+        let base = "SELECT id, content, content_hash, embedding, fact_type,
                         t_created, t_expired, t_valid, t_invalid,
                         source_event_id, importance, access_count, last_accessed, metadata, scope_id,
                         is_pinned, importance_score
                  FROM facts
                  WHERE t_expired IS NULL AND importance_score >= ?1
-                   AND id NOT IN (SELECT value FROM json_each(?2))
-                 ORDER BY importance_score DESC
-                 LIMIT ?3",
-            )?;
+                   AND id NOT IN (SELECT value FROM json_each(?2))";
+
+        if scope_ids.is_empty() {
+            let sql = format!("{base} ORDER BY importance_score DESC LIMIT ?3");
+            let mut stmt = self.conn.prepare(&sql)?;
             let rows = stmt.query_map(
                 rusqlite::params![min_score, exclude_json, limit_i64],
                 |row| row_to_fact(row, dim),
@@ -452,20 +437,13 @@ impl<'a> FactStore<'a> {
                 .map_err(Into::into)
         } else {
             let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
-            let mut stmt = self.conn.prepare(
-                "SELECT id, content, content_hash, embedding, fact_type,
-                        t_created, t_expired, t_valid, t_invalid,
-                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                        is_pinned, importance_score
-                 FROM facts
-                 WHERE t_expired IS NULL AND importance_score >= ?1
-                   AND scope_id IN (SELECT value FROM json_each(?2))
-                   AND id NOT IN (SELECT value FROM json_each(?3))
-                 ORDER BY importance_score DESC
-                 LIMIT ?4",
-            )?;
+            let sql = format!(
+                "{base} AND scope_id IN (SELECT value FROM json_each(?3))
+                 ORDER BY importance_score DESC LIMIT ?4"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
             let rows = stmt.query_map(
-                rusqlite::params![min_score, scope_json, exclude_json, limit_i64],
+                rusqlite::params![min_score, exclude_json, scope_json, limit_i64],
                 |row| row_to_fact(row, dim),
             )?;
             rows.collect::<std::result::Result<Vec<_>, _>>()

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -73,8 +73,8 @@ impl<'a> FactStore<'a> {
             "INSERT INTO facts (content, content_hash, embedding, fact_type,
                 t_created, t_expired, t_valid, t_invalid,
                 source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                is_pinned)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                is_pinned, importance_score)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 fact.content,
                 hash,
@@ -91,6 +91,7 @@ impl<'a> FactStore<'a> {
                 metadata_str,
                 fact.scope_id,
                 i64::from(fact.is_pinned),
+                fact.importance, // seed importance_score from base importance
             ],
         )?;
         Ok(self.conn.last_insert_rowid())

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -3,7 +3,7 @@ use rusqlite::Connection;
 use crate::error::{MemoryError, Result};
 
 /// Current schema version. Bump when adding migrations.
-const CURRENT_SCHEMA_VERSION: u32 = 2;
+const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 /// Open a `SQLite` connection to a file, with pragmas set.
 ///
@@ -64,7 +64,7 @@ pub fn init_schema(conn: &Connection) -> Result<()> {
     if !is_fresh {
         return Ok(()); // existing DB — let migrate() handle evolution
     }
-    // Fresh DB: create full latest (v2) schema
+    // Fresh DB: create full latest (v3) schema
     conn.execute_batch(TABLES_DDL)?;
     conn.execute_batch(SCOPES_DDL)?;
     conn.execute_batch(FTS5_DDL)?;
@@ -107,7 +107,7 @@ pub fn set_config(conn: &Connection, key: &str, value: &str) -> Result<()> {
 
 type MigrationFn = fn(&Connection) -> Result<()>;
 
-const MIGRATIONS: &[MigrationFn] = &[migrate_v1_to_v2];
+const MIGRATIONS: &[MigrationFn] = &[migrate_v1_to_v2, migrate_v2_to_v3];
 
 /// Run forward-only migrations from the current schema version to
 /// `CURRENT_SCHEMA_VERSION`.
@@ -160,6 +160,25 @@ fn migrate_v1_to_v2(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "ALTER TABLE facts ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0;
+         ALTER TABLE facts ADD COLUMN importance_score REAL NOT NULL DEFAULT 0.5;",
+    )?;
+    conn.execute_batch(
+        "ALTER TABLE events ADD COLUMN origin_node_id TEXT NOT NULL DEFAULT 'local';
+         ALTER TABLE events ADD COLUMN sequence_id INTEGER NOT NULL DEFAULT 0;
+         ALTER TABLE events ADD COLUMN created_at TEXT;",
+    )?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_facts_pinned ON facts(is_pinned) WHERE is_pinned = 1;
+         CREATE INDEX IF NOT EXISTS idx_facts_importance_score ON facts(importance_score);
+         CREATE INDEX IF NOT EXISTS idx_facts_t_valid_due ON facts(t_valid) WHERE t_valid IS NOT NULL AND t_expired IS NULL;
+         CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, sequence_id);",
+    )?;
+    Ok(())
+}
+
 // --- DDL constants ---
 
 const TABLES_DDL: &str = "
@@ -170,7 +189,10 @@ CREATE TABLE IF NOT EXISTS events (
     payload TEXT NOT NULL DEFAULT '{}',
     source TEXT NOT NULL,
     session_id TEXT,
-    scope_id INTEGER NOT NULL DEFAULT 1
+    scope_id INTEGER NOT NULL DEFAULT 1,
+    origin_node_id TEXT NOT NULL DEFAULT 'local',
+    sequence_id INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT
 );
 
 CREATE TABLE IF NOT EXISTS facts (
@@ -188,7 +210,9 @@ CREATE TABLE IF NOT EXISTS facts (
     access_count INTEGER NOT NULL DEFAULT 0,
     last_accessed TEXT NOT NULL,
     metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)),
-    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id)
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
+    is_pinned INTEGER NOT NULL DEFAULT 0,
+    importance_score REAL NOT NULL DEFAULT 0.5
 );
 
 CREATE TABLE IF NOT EXISTS edges (
@@ -272,6 +296,10 @@ CREATE INDEX IF NOT EXISTS idx_facts_scope ON facts(scope_id);
 CREATE INDEX IF NOT EXISTS idx_edges_scope ON edges(scope_id);
 CREATE INDEX IF NOT EXISTS idx_events_scope ON events(scope_id);
 CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
+CREATE INDEX IF NOT EXISTS idx_facts_pinned ON facts(is_pinned) WHERE is_pinned = 1;
+CREATE INDEX IF NOT EXISTS idx_facts_importance_score ON facts(importance_score);
+CREATE INDEX IF NOT EXISTS idx_facts_t_valid_due ON facts(t_valid) WHERE t_valid IS NOT NULL AND t_expired IS NULL;
+CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, sequence_id);
 ";
 
 #[cfg(test)]
@@ -352,6 +380,91 @@ CREATE INDEX IF NOT EXISTS idx_facts_hash ON facts(content_hash);
 CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_fact_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_fact_id);
 CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
+";
+
+    /// Test helper: creates v2 schema (v1 + scopes + scope_id columns, no v3 columns).
+    fn init_schema_v2(conn: &Connection) -> Result<()> {
+        conn.execute_batch(TABLES_V2_DDL)?;
+        conn.execute_batch(SCOPES_DDL)?;
+        conn.execute_batch(FTS5_DDL)?;
+        conn.execute_batch(TRIGGERS_DDL)?;
+        conn.execute_batch(INDEXES_V2_DDL)?;
+        set_config(conn, "schema_version", "2")?;
+        Ok(())
+    }
+
+    /// V2 tables DDL (has scope_id columns but no v3 columns).
+    const TABLES_V2_DDL: &str = "
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    source TEXT NOT NULL,
+    session_id TEXT,
+    scope_id INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS facts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    embedding BLOB NOT NULL,
+    fact_type TEXT NOT NULL CHECK(fact_type IN ('episodic', 'semantic', 'procedural')),
+    t_created TEXT NOT NULL,
+    t_expired TEXT,
+    t_valid TEXT,
+    t_invalid TEXT,
+    source_event_id INTEGER REFERENCES events(id),
+    importance REAL NOT NULL DEFAULT 0.5,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)),
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id)
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    target_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    relation_type TEXT NOT NULL,
+    weight REAL NOT NULL DEFAULT 1.0,
+    t_created TEXT NOT NULL,
+    t_expired TEXT,
+    scope_id INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS summaries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    embedding BLOB NOT NULL,
+    level TEXT NOT NULL CHECK(level IN ('local', 'cluster', 'global')),
+    source_fact_ids TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    scope_id INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+";
+
+    /// V2 indexes DDL (has scope_id indexes but no v3 indexes).
+    const INDEXES_V2_DDL: &str = "
+CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_facts_expired ON facts(t_expired);
+CREATE INDEX IF NOT EXISTS idx_facts_type ON facts(fact_type);
+CREATE INDEX IF NOT EXISTS idx_facts_valid ON facts(t_valid, t_invalid);
+CREATE INDEX IF NOT EXISTS idx_facts_hash ON facts(content_hash);
+CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_fact_id);
+CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_fact_id);
+CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
+CREATE INDEX IF NOT EXISTS idx_facts_scope ON facts(scope_id);
+CREATE INDEX IF NOT EXISTS idx_edges_scope ON edges(scope_id);
+CREATE INDEX IF NOT EXISTS idx_events_scope ON events(scope_id);
+CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
 ";
 
     #[test]
@@ -436,8 +549,8 @@ CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
                 |r| r.get(0),
             )
             .unwrap();
-        // 9 original + 2 scopes indexes + 4 scope_id indexes
-        assert_eq!(count, 15);
+        // 9 original + 2 scopes indexes + 4 scope_id indexes + 4 v3 indexes
+        assert_eq!(count, 19);
     }
 
     // --- Migration framework tests ---
@@ -449,13 +562,13 @@ CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
         // init_schema creates latest version directly
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("2".to_string())
+            Some("3".to_string())
         );
         // migrate is a no-op
         migrate(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("2".to_string())
+            Some("3".to_string())
         );
     }
 
@@ -470,7 +583,7 @@ CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
         migrate(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("2".to_string())
+            Some("3".to_string())
         );
     }
 
@@ -483,7 +596,7 @@ CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
         migrate(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("2".to_string())
+            Some("3".to_string())
         );
     }
 
@@ -546,6 +659,79 @@ CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
                 "missing index {expected} after migration"
             );
         }
+    }
+
+    #[test]
+    fn migrate_v2_to_v3_adds_pinned_and_envelope() {
+        let conn = open_memory().unwrap();
+        init_schema_v2(&conn).unwrap();
+
+        // Insert a fact before migration
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, importance, access_count, last_accessed, metadata, scope_id)
+             VALUES ('test', 'hash', X'00', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}', 1)",
+            [],
+        ).unwrap();
+
+        // Insert an event before migration
+        conn.execute(
+            "INSERT INTO events (timestamp, event_type, payload, source, scope_id)
+             VALUES (datetime('now'), 'Interaction', '{}', 'test', 1)",
+            [],
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        // Verify new columns with defaults
+        let (is_pinned, importance_score): (i64, f64) = conn
+            .query_row(
+                "SELECT is_pinned, importance_score FROM facts WHERE content = 'test'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(is_pinned, 0);
+        assert!((importance_score - 0.5).abs() < f64::EPSILON);
+
+        // Verify event envelope fields
+        let (origin, seq_id): (String, i64) = conn
+            .query_row(
+                "SELECT origin_node_id, sequence_id FROM events WHERE source = 'test'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(origin, "local");
+        assert_eq!(seq_id, 0);
+
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap(),
+            Some("3".to_string())
+        );
+    }
+
+    #[test]
+    fn fresh_db_creates_v3_schema() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap(),
+            Some("3".to_string())
+        );
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed, is_pinned, importance_score)
+             VALUES ('test', 'h', X'00', 'episodic', datetime('now'), datetime('now'), 1, 0.9)",
+            [],
+        ).unwrap();
+        let pinned: i64 = conn
+            .query_row(
+                "SELECT is_pinned FROM facts WHERE content = 'test'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(pinned, 1);
     }
 
     #[test]

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -165,6 +165,8 @@ fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
         "ALTER TABLE facts ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0;
          ALTER TABLE facts ADD COLUMN importance_score REAL NOT NULL DEFAULT 0.5;",
     )?;
+    // Backfill: seed importance_score from base importance for existing rows
+    conn.execute("UPDATE facts SET importance_score = importance", [])?;
     conn.execute_batch(
         "ALTER TABLE events ADD COLUMN origin_node_id TEXT NOT NULL DEFAULT 'local';
          ALTER TABLE events ADD COLUMN sequence_id INTEGER NOT NULL DEFAULT 0;
@@ -666,10 +668,10 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
         let conn = open_memory().unwrap();
         init_schema_v2(&conn).unwrap();
 
-        // Insert a fact before migration
+        // Insert a fact before migration (importance=0.8 to verify backfill)
         conn.execute(
             "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, importance, access_count, last_accessed, metadata, scope_id)
-             VALUES ('test', 'hash', X'00', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}', 1)",
+             VALUES ('test', 'hash', X'00', 'episodic', datetime('now'), 0.8, 0, datetime('now'), '{}', 1)",
             [],
         ).unwrap();
 
@@ -692,7 +694,8 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
             )
             .unwrap();
         assert_eq!(is_pinned, 0);
-        assert!((importance_score - 0.5).abs() < f64::EPSILON);
+        // importance_score should be backfilled from importance (0.8), not default (0.5)
+        assert!((importance_score - 0.8).abs() < f64::EPSILON);
 
         // Verify event envelope fields
         let (origin, seq_id): (String, i64) = conn

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -66,10 +66,11 @@ pub enum CrudDecision {
 /// Default implementation returns `false` — opt-in, zero behavior change.
 ///
 /// **Classifier input caveat:** The `Fact` passed to `should_pin()` during
-/// `add_fact()` is a pre-insert synthetic with `id=0`, `importance_score=0.5`
-/// (default), and no graph connectivity. Classifiers should only rely on
-/// `content`, `fact_type`, `importance` (caller hint), and `metadata` — not
-/// on `id`, `importance_score`, or `access_count`.
+/// `add_fact()` is a pre-insert synthetic with `id=0`, `scope_id=0`,
+/// `importance_score` seeded from base `importance`, and no graph connectivity.
+/// Classifiers should only rely on `content`, `fact_type`, `importance`
+/// (caller hint), and `metadata` — not on `id`, `scope_id`,
+/// `importance_score`, or `access_count`.
 pub trait PersistenceClassifier {
     /// Decide if a fact should be pinned (never forgotten).
     fn should_pin(&self, fact: &Fact) -> bool {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -56,6 +56,28 @@ pub enum CrudDecision {
     Noop,
 }
 
+// --- Phase 3b: Persistence classifier ---
+
+/// Trait for classifying whether a fact should be pinned (unforgettable).
+///
+/// Consumers implement this to apply domain-specific rules:
+/// LLM-based classification, regex matching, importance thresholds, etc.
+///
+/// Default implementation returns `false` — opt-in, zero behavior change.
+///
+/// **Classifier input caveat:** The `Fact` passed to `should_pin()` during
+/// `add_fact()` is a pre-insert synthetic with `id=0`, `importance_score=0.5`
+/// (default), and no graph connectivity. Classifiers should only rely on
+/// `content`, `fact_type`, `importance` (caller hint), and `metadata` — not
+/// on `id`, `importance_score`, or `access_count`.
+pub trait PersistenceClassifier {
+    /// Decide if a fact should be pinned (never forgotten).
+    fn should_pin(&self, fact: &Fact) -> bool {
+        let _ = fact;
+        false
+    }
+}
+
 /// Configuration for the consolidation process (Phase 2).
 #[derive(Debug, Clone)]
 pub struct ConsolidationConfig {

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,6 +40,12 @@ pub struct Event {
     pub source: String,
     pub session_id: Option<String>,
     pub scope_id: i64,
+    /// Node that originated this event (for future multi-node sync).
+    pub origin_node_id: String,
+    /// Monotonic sequence within the origin node (for ordering/dedup in sync).
+    pub sequence_id: i64,
+    /// When the event was ingested into this node's store (ingest-time).
+    pub created_at: Option<DateTime<Utc>>,
 }
 
 /// A bi-temporal fact derived from events.
@@ -60,6 +66,8 @@ pub struct Fact {
     pub last_accessed: DateTime<Utc>,
     pub metadata: serde_json::Value,
     pub scope_id: i64,
+    pub is_pinned: bool,
+    pub importance_score: f64,
 }
 
 /// A graph edge between two facts.
@@ -129,6 +137,8 @@ pub struct AddFactOptions {
     pub t_valid: Option<DateTime<Utc>>,
     /// Set the real-world validity end time.
     pub t_invalid: Option<DateTime<Utc>>,
+    /// Pin this fact (unforgettable). Overrides auto-classification.
+    pub pinned: Option<bool>,
 }
 
 // --- New* structs (without id, for insertion) ---
@@ -142,6 +152,9 @@ pub struct NewEvent {
     pub source: String,
     pub session_id: Option<String>,
     pub scope_id: i64,
+    pub origin_node_id: String,
+    pub sequence_id: i64,
+    pub created_at: Option<DateTime<Utc>>,
 }
 
 /// Fact to insert (DB assigns id).
@@ -161,6 +174,7 @@ pub struct NewFact {
     pub last_accessed: DateTime<Utc>,
     pub metadata: serde_json::Value,
     pub scope_id: i64,
+    pub is_pinned: bool,
 }
 
 /// Edge to insert (DB assigns id).
@@ -200,6 +214,9 @@ mod tests {
             source: "test".into(),
             session_id: Some("sess-1".into()),
             scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         let back: Event = serde_json::from_str(&json).unwrap();
@@ -224,6 +241,8 @@ mod tests {
             last_accessed: Utc::now(),
             metadata: serde_json::json!({}),
             scope_id: 1,
+            is_pinned: false,
+            importance_score: 0.5,
         };
         assert!(fact.t_expired.is_none());
         assert!(fact.t_valid.is_none());

--- a/tests/phase3b_lifecycle_test.rs
+++ b/tests/phase3b_lifecycle_test.rs
@@ -101,12 +101,12 @@ fn full_lifecycle_pinned_and_future_memory() {
         "due tier should be empty (future fact not yet due)"
     );
 
-    // 5. drain_due at current time — nothing due yet
-    assert!(engine.drain_due(now, None).unwrap().is_empty());
+    // 5. list_due at current time — nothing due yet
+    assert!(engine.list_due(now, None).unwrap().is_empty());
 
-    // 6. drain_due at future time — reminder surfaces
+    // 6. list_due at future time — reminder surfaces
     let later = now + chrono::Duration::hours(25);
-    let due = engine.drain_due(later, None).unwrap();
+    let due = engine.list_due(later, None).unwrap();
     assert_eq!(due.len(), 1);
     assert!(due[0].content.contains("release notes"));
 

--- a/tests/phase3b_lifecycle_test.rs
+++ b/tests/phase3b_lifecycle_test.rs
@@ -1,0 +1,289 @@
+//! Phase 3b integration test: full lifecycle with pinned facts, future memory, and forgetting.
+
+use chrono::Utc;
+use memory_engine::engine::MemoryEngine;
+use memory_engine::error::Result;
+use memory_engine::resume::ResumeConfig;
+use memory_engine::traits::{EmbeddingProvider, ForgetPolicy, PersistenceClassifier};
+use memory_engine::types::{AddFactOptions, Fact, FactType};
+
+const DIM: usize = 8;
+
+struct TestEmbedder;
+
+impl EmbeddingProvider for TestEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        let hash = blake3::hash(text.as_bytes());
+        let bytes = hash.as_bytes();
+        let mut embedding = vec![0.0_f32; DIM];
+        for (i, val) in embedding.iter_mut().enumerate() {
+            let byte = bytes[i % 32];
+            *val = (f32::from(byte) - 128.0) / 128.0;
+        }
+        let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for val in &mut embedding {
+                *val /= norm;
+            }
+        }
+        Ok(embedding)
+    }
+}
+
+#[test]
+fn full_lifecycle_pinned_and_future_memory() {
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    let embedder = TestEmbedder;
+    let now = Utc::now();
+
+    // 1. Add pinned identity fact
+    let opts_pin = AddFactOptions {
+        pinned: Some(true),
+        importance: Some(0.95),
+        ..Default::default()
+    };
+    let pin_id = engine
+        .add_fact(
+            "I am an AI assistant",
+            FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            Some(&opts_pin),
+            None,
+        )
+        .unwrap();
+
+    // 2. Add future reminder (t_valid in 24h)
+    let future = now + chrono::Duration::hours(24);
+    let opts_future = AddFactOptions {
+        t_valid: Some(future),
+        ..Default::default()
+    };
+    engine
+        .add_fact(
+            "Check release notes tomorrow",
+            FactType::Episodic,
+            None,
+            &embedder,
+            None,
+            Some(&opts_future),
+            None,
+        )
+        .unwrap();
+
+    // 3. Add normal fact (forgettable)
+    engine
+        .add_fact(
+            "Had coffee today",
+            FactType::Episodic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    // 4. resume_context at current time — future fact should NOT appear in due tier
+    let ctx = engine
+        .resume_context(&ResumeConfig {
+            now,
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(
+        !ctx.pinned.is_empty(),
+        "pinned tier should have identity fact"
+    );
+    assert!(
+        ctx.due.is_empty(),
+        "due tier should be empty (future fact not yet due)"
+    );
+
+    // 5. drain_due at current time — nothing due yet
+    assert!(engine.drain_due(now, None).unwrap().is_empty());
+
+    // 6. drain_due at future time — reminder surfaces
+    let later = now + chrono::Duration::hours(25);
+    let due = engine.drain_due(later, None).unwrap();
+    assert_eq!(due.len(), 1);
+    assert!(due[0].content.contains("release notes"));
+
+    // 7. next_due_time should return the future fact's t_valid
+    let next = engine.next_due_time(None).unwrap();
+    assert!(next.is_some(), "should have a next due time");
+
+    // 8. Forget with aggressive policy — pinned fact survives
+    let policy = ForgetPolicy {
+        min_importance: 0.99,
+        ..ForgetPolicy::default()
+    };
+    let stats = engine.forget(&policy).unwrap();
+    // At least the coffee fact should be expired (low importance, no graph edges)
+    assert!(
+        stats.facts_expired >= 1,
+        "at least one fact should be expired"
+    );
+
+    let fact = engine.get_fact(pin_id).unwrap();
+    assert!(
+        fact.t_expired.is_none(),
+        "pinned fact must survive aggressive forget"
+    );
+    assert!(fact.is_pinned);
+
+    // 9. Pin/unpin lifecycle
+    engine.unpin_fact(pin_id).unwrap();
+    let fact = engine.get_fact(pin_id).unwrap();
+    assert!(!fact.is_pinned);
+    engine.pin_fact(pin_id).unwrap();
+    let fact = engine.get_fact(pin_id).unwrap();
+    assert!(fact.is_pinned);
+}
+
+#[test]
+fn classifier_auto_pins_semantic_facts() {
+    struct PinSemantic;
+    impl PersistenceClassifier for PinSemantic {
+        fn should_pin(&self, fact: &Fact) -> bool {
+            fact.fact_type == FactType::Semantic
+        }
+    }
+
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    let embedder = TestEmbedder;
+    let classifier = PinSemantic;
+
+    // Semantic fact → auto-pinned by classifier
+    let id1 = engine
+        .add_fact(
+            "core identity",
+            FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            Some(&classifier),
+        )
+        .unwrap();
+    assert!(engine.get_fact(id1).unwrap().is_pinned);
+
+    // Episodic fact → not pinned
+    let id2 = engine
+        .add_fact(
+            "ephemeral event",
+            FactType::Episodic,
+            None,
+            &embedder,
+            None,
+            None,
+            Some(&classifier),
+        )
+        .unwrap();
+    assert!(!engine.get_fact(id2).unwrap().is_pinned);
+
+    // Explicit pinned=false overrides classifier
+    let opts = AddFactOptions {
+        pinned: Some(false),
+        ..Default::default()
+    };
+    let id3 = engine
+        .add_fact(
+            "not pinned despite classifier",
+            FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            Some(&opts),
+            Some(&classifier),
+        )
+        .unwrap();
+    assert!(!engine.get_fact(id3).unwrap().is_pinned);
+}
+
+#[test]
+fn resume_context_5_tier_integration() {
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    let embedder = TestEmbedder;
+    let now = Utc::now();
+
+    // Tier 1: Pinned fact
+    let opts_pin = AddFactOptions {
+        pinned: Some(true),
+        importance: Some(0.95),
+        ..Default::default()
+    };
+    engine
+        .add_fact(
+            "pinned identity",
+            FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            Some(&opts_pin),
+            None,
+        )
+        .unwrap();
+
+    // Tier 3: Due fact (t_valid in the past)
+    let past = now - chrono::Duration::hours(1);
+    let opts_due = AddFactOptions {
+        t_valid: Some(past),
+        ..Default::default()
+    };
+    engine
+        .add_fact(
+            "past reminder",
+            FactType::Episodic,
+            None,
+            &embedder,
+            None,
+            Some(&opts_due),
+            None,
+        )
+        .unwrap();
+
+    // Tier 4: Regular recent fact
+    engine
+        .add_fact(
+            "recent observation",
+            FactType::Episodic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let config = ResumeConfig {
+        now,
+        ..ResumeConfig::default()
+    };
+    let ctx = engine.resume_context(&config).unwrap();
+
+    assert_eq!(ctx.pinned.len(), 1, "should have 1 pinned fact");
+    assert_eq!(ctx.due.len(), 1, "should have 1 due fact");
+    assert!(!ctx.recent.is_empty(), "should have recent facts");
+    assert!(
+        ctx.kb_stubs.is_empty(),
+        "kb_stubs placeholder should be empty"
+    );
+
+    // Verify mutual exclusivity — no fact ID appears in multiple tiers
+    let all_ids: Vec<i64> = ctx
+        .pinned
+        .iter()
+        .chain(ctx.high_importance.iter())
+        .chain(ctx.due.iter())
+        .chain(ctx.recent.iter())
+        .map(|f| f.id)
+        .collect();
+    let unique: std::collections::HashSet<i64> = all_ids.iter().copied().collect();
+    assert_eq!(
+        all_ids.len(),
+        unique.len(),
+        "no fact should appear in multiple tiers"
+    );
+}

--- a/tests/roundtrip_test.rs
+++ b/tests/roundtrip_test.rs
@@ -47,6 +47,9 @@ fn full_roundtrip() {
         source: "integration_test".into(),
         session_id: Some("sess-roundtrip".into()),
         scope_id: 1,
+        origin_node_id: "local".into(),
+        sequence_id: 0,
+        created_at: None,
     };
     let event_id = engine.ingest(&event).unwrap();
     assert!(event_id > 0);

--- a/tests/roundtrip_test.rs
+++ b/tests/roundtrip_test.rs
@@ -63,6 +63,7 @@ fn full_roundtrip() {
             &embedder,
             None,
             None,
+            None,
         )
         .unwrap();
     let fact2_id = engine
@@ -73,6 +74,7 @@ fn full_roundtrip() {
             &embedder,
             None,
             None,
+            None,
         )
         .unwrap();
     let fact3_id = engine
@@ -81,6 +83,7 @@ fn full_roundtrip() {
             FactType::Episodic,
             Some(event_id),
             &embedder,
+            None,
             None,
             None,
         )


### PR DESCRIPTION
## Summary

Implements Phase 3b: temporal intelligence for the memory engine. Builds on Phase 3's hardening foundation.

- **Pinned facts** (`is_pinned`) — unforgettable facts that bypass forgetting and dedup. Agent identity and core beliefs.
- **Future memory** (`t_valid`) — facts with scheduled surfacing times. `drain_due(now)` for incremental checks.
- **Scheduling API** — `drain_due()`, `next_due_time()`, `pin_fact()`, `unpin_fact()` public methods.
- **`PersistenceClassifier` trait** — consumer-provided auto-pinning logic. Explicit `opts.pinned` always overrides.
- **Materialized `importance_score`** — composite score updated during `prune()` and `consolidate()`. O(1) sort in `resume_context()`.
- **Event envelope** — `origin_node_id`, `sequence_id`, `created_at` forward-compat fields for future sync.
- **5-tier `resume_context()`** — pinned → high_importance → due → recent → kb_stubs.
- **Schema v3** — migration from v2 with 5 new columns and 4 new indexes.

### Breaking changes

- `add_fact()` gains `classifier: Option<&dyn PersistenceClassifier>` parameter
- `ResumeConfig` and `ResumeContext` field names changed (identity/core → pinned/high_importance/due)

### Test coverage

183 tests (179 unit + 4 integration), all passing.

Closes #25

## Test plan

- [x] All 183 tests pass (`cargo test --all-features`)
- [x] Schema migration v2→v3 roundtrip (existing data preserves defaults)
- [x] Fresh install creates v3 schema directly
- [x] Pinned facts survive aggressive `forget()` with `min_importance=0.99`
- [x] Future memory surfaces only when `drain_due(now)` is called after `t_valid`
- [x] `PersistenceClassifier` auto-pins; explicit `opts.pinned=false` overrides
- [x] 5-tier `resume_context()` produces mutually exclusive tiers
- [x] Async wrappers for all new methods work under tokio

🤖 Generated with [Claude Code](https://claude.com/claude-code)