### PR TITLE
docs: update documentation for Phase 3b integration

### DIFF
--- a/docs/advanced/bi-temporal-semantics.md
+++ b/docs/advanced/bi-temporal-semantics.md
@@ -114,9 +114,26 @@ let opts = AddFactOptions {
 };
 engine.add_fact(
     "new API version goes live next week",
-    FactType::Semantic, None, &embedder, None, Some(&opts),
+    FactType::Semantic, None, &embedder, None, Some(&opts), None,
 )?;
 ```
+
+The scheduling API provides active retrieval of due facts without requiring a full query:
+
+```rust
+// Get all facts whose t_valid has arrived
+let due_facts = engine.list_due(Utc::now(), None)?;
+for fact in &due_facts {
+    println!("Now due: {}", fact.content);
+}
+
+// Scheduling hint: when should I poll again?
+if let Some(next) = engine.next_due_time(None)? {
+    println!("Next fact becomes due at: {}", next);
+}
+```
+
+`list_due(now, scope)` returns active facts where `t_valid <= now` and `t_valid IS NOT NULL`, excluding bi-temporally invalidated facts (`t_invalid <= now`). `next_due_time(scope)` returns the earliest `t_valid` among facts where `t_valid > now`, allowing the consumer to schedule its next poll without busy-waiting.
 
 **Historical queries**. Query what the agent knew at a past point in time by setting `valid_at` to a historical timestamp.
 

--- a/docs/advanced/bi-temporal-semantics.md
+++ b/docs/advanced/bi-temporal-semantics.md
@@ -121,7 +121,9 @@ engine.add_fact(
 The scheduling API provides active retrieval of due facts without requiring a full query:
 
 ```rust
-// Get all facts whose t_valid has arrived
+// Get root-scope facts whose t_valid has arrived.
+// Pass a scope path (e.g. Some("user:alice")) to check child scopes;
+// None resolves to the root scope only.
 let due_facts = engine.list_due(Utc::now(), None)?;
 for fact in &due_facts {
     println!("Now due: {}", fact.content);
@@ -133,7 +135,7 @@ if let Some(next) = engine.next_due_time(None)? {
 }
 ```
 
-`list_due(now, scope)` returns active facts where `t_valid <= now` and `t_valid IS NOT NULL`, excluding bi-temporally invalidated facts (`t_invalid <= now`). `next_due_time(scope)` returns the earliest `t_valid` among facts where `t_valid > now`, allowing the consumer to schedule its next poll without busy-waiting.
+`list_due(now, scope)` returns active facts where `t_valid <= now` and `t_valid IS NOT NULL`, excluding bi-temporally invalidated facts (`t_invalid <= now`). `next_due_time(scope)` returns the earliest `t_valid` among facts where `t_valid > now`, allowing the consumer to schedule its next poll without busy-waiting. Both methods resolve `None` to the root scope only — pass an explicit scope path to include child scopes.
 
 **Historical queries**. Query what the agent knew at a past point in time by setting `valid_at` to a historical timestamp.
 

--- a/docs/advanced/consolidation.md
+++ b/docs/advanced/consolidation.md
@@ -16,11 +16,17 @@ All three passes execute atomically. If any pass fails (including errors from th
 
 ### Pass 1: Local Dedup
 
-Compares facts created since the last consolidation against all active facts. Pairs with cosine similarity above `dedup_threshold` are resolved by expiring the lower-importance fact. Tie-break on equal importance: the newer fact (higher id) is expired.
+Compares facts created since the last consolidation against all active facts. **Pinned facts are excluded from dedup** — they are never candidates for expiration, and pinned candidates are skipped during comparison. This ensures unforgettable facts are preserved even if near-duplicates exist.
+
+Pairs with cosine similarity above `dedup_threshold` are resolved by expiring the lower-importance fact. Tie-break on equal importance: the newer fact (higher id) is expired.
 
 ```rust
-// dedup.rs — core logic
+// dedup.rs — core logic (simplified)
+if new_fact.is_pinned { continue; }  // pinned facts skip dedup entirely
+
 let similarity = cosine_similarity(&new_fact.embedding, &candidate.embedding);
+if candidate.is_pinned { continue; }  // pinned candidates are also protected
+
 if similarity > threshold {
     let expire_id = if new_fact.importance < candidate.importance {
         new_fact.id
@@ -33,6 +39,8 @@ if similarity > threshold {
     edge_store.expire_by_fact(expire_id, now)?;
 }
 ```
+
+When a duplicate pair is resolved, the surviving fact **inherits the loser's `importance_score`** if it is higher. This prevents loss of accumulated importance during dedup.
 
 Expired facts have their edges cascade-expired as well, keeping the graph consistent.
 

--- a/docs/advanced/extensibility.md
+++ b/docs/advanced/extensibility.md
@@ -148,7 +148,7 @@ Implementation example:
 
 ```rust
 use memory_engine::traits::PersistenceClassifier;
-use memory_engine::types::{Fact, FactType};
+use memory_engine::types::Fact;
 
 struct KeywordPinner {
     keywords: Vec<String>,

--- a/docs/advanced/extensibility.md
+++ b/docs/advanced/extensibility.md
@@ -2,7 +2,7 @@
 
 **Status: Implemented**
 
-memory-engine is designed around trait-based extensibility. The core crate has zero LLM or network dependencies. Consumers bring their own models by implementing three traits and configuring one policy struct.
+memory-engine is designed around trait-based extensibility. The core crate has zero LLM or network dependencies. Consumers bring their own models by implementing four traits and configuring one policy struct.
 
 ## Design Philosophy
 
@@ -126,6 +126,44 @@ impl ConflictArbiter for SemanticArbiter {
 
 The arbiter can return an error to abort the resolution with no side effects.
 
+### PersistenceClassifier
+
+Called during `add_fact()` to decide whether a newly inserted fact should be pinned (unforgettable). This is an optional parameter — passing `None` for the classifier skips auto-pinning.
+
+```rust
+pub trait PersistenceClassifier {
+    /// Decide if a fact should be pinned (never forgotten).
+    fn should_pin(&self, fact: &Fact) -> bool {
+        let _ = fact;
+        false
+    }
+}
+```
+
+The default implementation returns `false` — opt-in, zero behavior change for existing consumers.
+
+**Classifier input caveat:** The `Fact` passed to `should_pin()` during `add_fact()` is a pre-insert synthetic with `id=0`, `scope_id=0`, and `importance_score` seeded from the base `importance`. Classifiers should only rely on `content`, `fact_type`, `importance` (caller hint), and `metadata` — not on `id`, `scope_id`, `importance_score`, or `access_count`.
+
+Implementation example:
+
+```rust
+use memory_engine::traits::PersistenceClassifier;
+use memory_engine::types::{Fact, FactType};
+
+struct KeywordPinner {
+    keywords: Vec<String>,
+}
+
+impl PersistenceClassifier for KeywordPinner {
+    fn should_pin(&self, fact: &Fact) -> bool {
+        // Pin facts containing critical keywords
+        self.keywords.iter().any(|kw| fact.content.contains(kw))
+    }
+}
+```
+
+When both the classifier returns `true` and `AddFactOptions::pinned` is explicitly set, the explicit `pinned` field takes precedence.
+
 ## VectorSearchStrategy: Internal Dispatch Trait
 
 `VectorSearchStrategy` is an internal trait that enables runtime dispatch between brute-force and HNSW vector search. Unlike the consumer traits above, this is **not** implemented by consumers — it is an engine-internal abstraction.
@@ -184,11 +222,12 @@ This is a policy (parameter set), not a strategy (pluggable algorithm). See [For
 
 ## Summary of Extension Points
 
-| Extension point        | Type           | When called          | Provided by                         |
-| ---------------------- | -------------- | -------------------- | ----------------------------------- |
-| `EmbeddingProvider`    | consumer trait | `add_fact()`         | Text-to-vector model                |
-| `SummaryGenerator`     | consumer trait | `consolidate()`      | Summarization + embedding           |
-| `ConflictArbiter`      | consumer trait | `resolve_conflict()` | Resolution logic                    |
-| `ForgetPolicy`         | struct         | `forget()`           | Decay parameters                    |
-| `VectorSearchStrategy` | internal trait | `query()`            | Engine (BruteForce or HnswStrategy) |
-| `SearchConfig`         | struct         | `open()`             | ANN dispatch threshold              |
+| Extension point         | Type           | When called          | Provided by                         |
+| ----------------------- | -------------- | -------------------- | ----------------------------------- |
+| `EmbeddingProvider`     | consumer trait | `add_fact()`         | Text-to-vector model                |
+| `SummaryGenerator`      | consumer trait | `consolidate()`      | Summarization + embedding           |
+| `ConflictArbiter`       | consumer trait | `resolve_conflict()` | Resolution logic                    |
+| `PersistenceClassifier` | consumer trait | `add_fact()`         | Auto-pinning logic                  |
+| `ForgetPolicy`          | struct         | `forget()`           | Decay parameters                    |
+| `VectorSearchStrategy`  | internal trait | `query()`            | Engine (BruteForce or HnswStrategy) |
+| `SearchConfig`          | struct         | `open()`             | ANN dispatch threshold              |

--- a/docs/advanced/forgetting.md
+++ b/docs/advanced/forgetting.md
@@ -119,10 +119,12 @@ The pruning process:
 
 1. Validate policy parameters.
 2. Load all active facts.
-3. Score each fact using the 4-signal formula with current graph degrees.
-4. Collect facts scoring below `min_importance`.
-5. In a single transaction: soft-delete each fact (`t_expired = now`) and cascade-expire its edges.
-6. After commit: remove expired edges from the in-memory graph.
+3. **Skip pinned facts** — facts with `is_pinned = true` are never candidates for pruning, regardless of their score.
+4. Score each remaining fact using the 4-signal formula with current graph degrees.
+5. **Materialize `importance_score`** — each scored fact has its `importance_score` field updated in the database via `update_importance_score()`. This makes the composite score available to `resume_context()` and other queries without recomputation.
+6. Collect facts scoring below `min_importance`.
+7. In a single transaction: soft-delete each fact (`t_expired = now`) and cascade-expire its edges.
+8. After commit: remove expired edges from the in-memory graph.
 
 Scoring happens before any mutations, so degree values are consistent across the batch.
 

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -90,7 +90,7 @@ The crate is organized into modules with clear responsibilities:
 | `search/`        | Query layer. FTS5 (BM25), vector (cosine similarity, brute-force or HNSW via `ann` feature), strategy dispatch, and hybrid (RRF) search. |
 | `graph/`         | `MemoryGraph` wrapper around `petgraph::DiGraph`. Loaded from SQLite on startup, kept in sync on mutations.                              |
 | `scope/`         | `ScopeTree` for hierarchical isolation. In-memory tree structure, backed by `ScopeStore` in SQLite.                                      |
-| `resume/`        | Session bootstrapping. `resume_context()` implements 3-tier retrieval.                                                                   |
+| `resume/`        | Session bootstrapping. `resume_context()` implements 5-tier retrieval (pinned → high_importance → due → recent → kb_stubs).              |
 | `consolidation/` | Three-pass memory compression: local dedup, cluster fusion, global integration.                                                          |
 | `forgetting/`    | Ebbinghaus decay with multi-signal importance scoring.                                                                                   |
 | `conflict/`      | Bi-temporal conflict resolution delegated to `ConflictArbiter`.                                                                          |
@@ -151,15 +151,17 @@ The core data flow follows an event-sourced pattern:
 
 ### Resume Context
 
-Session bootstrapping uses 3-tier retrieval to populate the agent's context window:
+Session bootstrapping uses 5-tier retrieval to populate the agent's context window:
 
-| Tier         | Source          | Selection Criteria                                                          |
-| ------------ | --------------- | --------------------------------------------------------------------------- |
-| **Identity** | Root scope only | Highest importance facts. These define the agent's persistent identity.     |
-| **Core**     | Scope ancestors | Facts with importance above a configurable threshold. Project/user context. |
-| **Recent**   | Scope ancestors | Most recently created facts. Current working context.                       |
+| Tier                | Source          | Selection Criteria                                                           |
+| ------------------- | --------------- | ---------------------------------------------------------------------------- |
+| **Pinned**          | Cross-scope     | Unforgettable facts (`is_pinned = true`), sorted by `importance_score` desc. |
+| **High-importance** | Scope ancestors | Facts with materialized `importance_score` above a configurable threshold.   |
+| **Due**             | Scope ancestors | Future-memory facts whose `t_valid` has arrived (`t_valid <= now`).          |
+| **Recent**          | Scope ancestors | Most recently created facts. Current working context.                        |
+| **KB stubs**        | —               | Placeholder for Phase 5 knowledge-base references.                           |
 
-The three tiers are mutually exclusive (a fact appears in at most one tier). The consumer controls tier sizes and thresholds via `ResumeConfig`.
+The five tiers are mutually exclusive (a fact appears in at most one tier). The consumer controls tier sizes and thresholds via `ResumeConfig`.
 
 ## Scope Tree
 
@@ -186,13 +188,13 @@ The `ScopeQuery` enum controls scope resolution for searches:
 
 The engine has zero LLM or network dependencies. All intelligence is injected by the consumer:
 
-| Trait                    | Method                                | Phase                 |
-| ------------------------ | ------------------------------------- | --------------------- |
-| `EmbeddingProvider`      | `embed(text) -> Vec<f32>`             | Phase 1 (implemented) |
-| `SummaryGenerator`       | `summarize(facts) -> String`          | Phase 2 (implemented) |
-| `SummaryGenerator`       | `embed(text) -> Vec<f32>`             | Phase 2 (implemented) |
-| `ConflictArbiter`        | `arbitrate(old, new) -> CrudDecision` | Phase 2 (implemented) |
-| `PersistenceClassifier`  | `should_pin(fact) -> bool`            | Phase 3b (planned)    |
-| `KnowledgeBaseConnector` | `resolve(uri) -> KnowledgeChunk`      | Phase 5 (planned)     |
+| Trait                    | Method                                | Phase                  |
+| ------------------------ | ------------------------------------- | ---------------------- |
+| `EmbeddingProvider`      | `embed(text) -> Vec<f32>`             | Phase 1 (implemented)  |
+| `SummaryGenerator`       | `summarize(facts) -> String`          | Phase 2 (implemented)  |
+| `SummaryGenerator`       | `embed(text) -> Vec<f32>`             | Phase 2 (implemented)  |
+| `ConflictArbiter`        | `arbitrate(old, new) -> CrudDecision` | Phase 2 (implemented)  |
+| `PersistenceClassifier`  | `should_pin(fact) -> bool`            | Phase 3b (implemented) |
+| `KnowledgeBaseConnector` | `resolve(uri) -> KnowledgeChunk`      | Phase 5 (planned)      |
 
 This trait-based design means the engine can be tested with mock implementations (as the test suite demonstrates) and consumers can swap between local models, API-based models, or rule-based logic without touching the engine.

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -74,7 +74,30 @@ for operations that require external models:
 `ForgetPolicy`
 : Configuration struct (not a trait) controlling Ebbinghaus decay parameters.
 
+`PersistenceClassifier`
+: Decide whether a new fact should be pinned (unforgettable). Called during `add_fact()`. Optional.
+
 This design means the core crate compiles without any ML framework, HTTP client, or API key.
+
+## Pinned Facts
+
+Facts can be marked as **pinned** (unforgettable). Pinned facts:
+
+- Are never expired by the forgetting system (`forget()` skips them)
+- Are never deduplicated during consolidation
+- Appear in the top tier of `resume_context()` (tier 1: pinned)
+- Can be pinned explicitly via `pin_fact(id)` / `unpin_fact(id)`, through `AddFactOptions { pinned: Some(true), .. }`, or automatically via a `PersistenceClassifier`
+
+Pinned facts model agent identity, core beliefs, and critical knowledge that should persist indefinitely.
+
+## Future Memory & Scheduling
+
+Facts with `t_valid` set in the future are invisible to present-time queries but surface when their time arrives. The scheduling API supports this:
+
+- `list_due(now, scope)` — returns facts whose `t_valid <= now` (they have become valid)
+- `next_due_time(scope)` — returns the earliest future `t_valid`, so the consumer knows when to poll again
+
+This enables reminders, deferred knowledge, and time-triggered agent behavior.
 
 ## Scoping
 
@@ -96,15 +119,19 @@ Scope queries control visibility:
 - **Ancestors** — this scope and all parents up to root
 - **Inherited** — ancestors + subtree (full inherited context)
 
-## Five Primitives
+**Global summary invariant:** Global-level summaries (pass 3 of consolidation) are always placed at `scope_id=1` (root scope), regardless of the scopes of the underlying facts. Cluster-level summaries (pass 2) use majority-vote scope assignment from their source facts.
 
-| Primitive       | Method               | Purpose                                       |
-| --------------- | -------------------- | --------------------------------------------- |
-| **Ingest**      | `ingest()`           | Append event to the audit log                 |
-| **Query**       | `query()`            | Hybrid search with temporal and scope filters |
-| **Consolidate** | `consolidate()`      | Merge duplicates, cluster facts, summarize    |
-| **Forget**      | `forget()`           | Decay and prune low-importance facts          |
-| **Resolve**     | `resolve_conflict()` | Arbitrate contradicting facts                 |
+## Seven Primitives
+
+| Primitive       | Method                          | Purpose                                             |
+| --------------- | ------------------------------- | --------------------------------------------------- |
+| **Ingest**      | `ingest()`                      | Append event to the audit log                       |
+| **Query**       | `query()`                       | Hybrid search with temporal and scope filters       |
+| **Consolidate** | `consolidate()`                 | Merge duplicates, cluster facts, summarize          |
+| **Forget**      | `forget()`                      | Decay and prune low-importance facts (skips pinned) |
+| **Resolve**     | `resolve_conflict()`            | Arbitrate contradicting facts                       |
+| **Schedule**    | `list_due()`, `next_due_time()` | Surface future-memory facts and poll timing         |
+| **Resume**      | `resume_context()`              | 5-tier session bootstrapping                        |
 
 ## Threading
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -54,6 +54,9 @@ let event_id = engine.ingest(&NewEvent {
     source: "chat".into(),
     session_id: Some("session-1".into()),
     scope_id: 1, // root scope
+    origin_node_id: "local".into(),
+    sequence_id: 0,
+    created_at: None,
 })?;
 ```
 
@@ -72,6 +75,7 @@ let fact_id = engine.add_fact(
     &embedder,
     None,            // root scope
     None,            // default options (importance=0.5)
+    None,            // no auto-pin classifier
 )?;
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -135,7 +135,7 @@ This page summarizes the public API surface of the `memory-engine` crate.
 - `pinned: Vec<Fact>` -- tier 1: unforgettable facts, cross-scope, sorted by `importance_score` descending.
 - `high_importance: Vec<Fact>` -- tier 2: top facts by materialized `importance_score`.
 - `due: Vec<Fact>` -- tier 3: future-memory facts whose `t_valid` has arrived.
-- `recent: Vec<Fact>` -- tier 4: most recent facts from active scope.
+- `recent: Vec<Fact>` -- tier 4: most recent facts from scope ancestors.
 - `kb_stubs: Vec<String>` -- tier 5: placeholder for Phase 5 knowledge-base references.
 
 ### Config
@@ -151,7 +151,7 @@ The crate root (`lib.rs`) re-exports these items for convenience:
 
 - **Engine**: `MemoryEngine`, `EngineConfig`
 - **Error**: `MemoryError`, `Result`
-- **Traits**: `EmbeddingProvider`, `PersistenceClassifier`
+- **Traits**: `EmbeddingProvider` (note: `PersistenceClassifier` is available via `memory_engine::traits::PersistenceClassifier`, not re-exported at root)
 - **Types**: all public types from the `types` module (`Event`, `Fact`, `Edge`, `Summary`, `NewEvent`, `NewFact`, `NewEdge`, `NewSummary`, `EventType`, `FactType`, `ConsolidationLevel`, `ScopeQuery`, `ScopeNode`, `AddFactOptions`)
 - **Store utilities**: `serialize_embedding`, `deserialize_embedding`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -25,10 +25,10 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 ### Ingest
 
-| Method     | Signature                                                                            | Description                                                                                                              |
-| ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `ingest`   | `(&self, event: &NewEvent) -> Result<i64>`                                           | Append an event to the log. Returns the event ID.                                                                        |
-| `add_fact` | `(&self, content, fact_type, source_event_id, embedder, scope, opts) -> Result<i64>` | Compute embedding, blake3 hash, resolve scope, and insert a fact. Embedding is computed before acquiring the write lock. |
+| Method     | Signature                                                                                        | Description                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ingest`   | `(&self, event: &NewEvent) -> Result<i64>`                                                       | Append an event to the log. Returns the event ID.                                                                                                            |
+| `add_fact` | `(&self, content, fact_type, source_event_id, embedder, scope, opts, classifier) -> Result<i64>` | Compute embedding, blake3 hash, resolve scope, optionally auto-pin via classifier, and insert a fact. Embedding is computed before acquiring the write lock. |
 
 ### Facts
 
@@ -100,23 +100,43 @@ This page summarizes the public API surface of the `memory-engine` crate.
 | `graph_stats`     | `(&self) -> (usize, usize)`         | `(node_count, edge_count)`.                                   |
 | `graph_has_node`  | `(&self, fact_id: i64) -> bool`     | Whether a node exists in the graph.                           |
 
+### Pinning
+
+| Method       | Signature                        | Description                                                        |
+| ------------ | -------------------------------- | ------------------------------------------------------------------ |
+| `pin_fact`   | `(&self, id: i64) -> Result<()>` | Pin a fact (make it unforgettable). Bypasses forgetting and dedup. |
+| `unpin_fact` | `(&self, id: i64) -> Result<()>` | Unpin a fact (allow forgetting).                                   |
+
+### Scheduling
+
+| Method          | Signature                                                               | Description                                                                                                   |
+| --------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `list_due`      | `(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>>` | List active facts whose `t_valid <= now` (future memory that has surfaced). Scope-filterable.                 |
+| `next_due_time` | `(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>>`         | Scheduling hint: earliest `t_valid` among active future-dated facts. Returns `None` if no future facts exist. |
+
 ### Resume
 
 | Method           | Signature                                                 | Description                                                                                                     |
 | ---------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `resume_context` | `(&self, config: &ResumeConfig) -> Result<ResumeContext>` | 3-tier fact retrieval for session bootstrapping. Returns `NotFound` if the requested scope path does not exist. |
+| `resume_context` | `(&self, config: &ResumeConfig) -> Result<ResumeContext>` | 5-tier fact retrieval for session bootstrapping. Returns `NotFound` if the requested scope path does not exist. |
 
 `ResumeConfig` fields:
 
 - `scope_path: Option<String>` -- scope to resume from (ancestors are included).
-- `core_min_importance: f64` -- importance threshold for the core tier.
-- `identity_limit`, `core_limit`, `recent_limit` -- max facts per tier.
+- `now: DateTime<Utc>` -- current time for due-fact evaluation.
+- `pinned_cap: usize` -- max pinned facts (default: 50).
+- `high_importance_cap: usize` -- max high-importance facts (default: 20).
+- `high_importance_min: f64` -- minimum `importance_score` for tier 2 (default: 0.7).
+- `due_cap: usize` -- max due facts (default: 10).
+- `recent_cap: usize` -- max recent facts (default: 10).
 
-`ResumeContext` fields:
+`ResumeContext` fields (5 tiers, mutually exclusive):
 
-- `identity: Vec<Fact>` -- root-scope, highest-importance facts.
-- `core: Vec<Fact>` -- above-threshold facts from ancestors.
-- `recent: Vec<Fact>` -- most recent facts from ancestors.
+- `pinned: Vec<Fact>` -- tier 1: unforgettable facts, cross-scope, sorted by `importance_score` descending.
+- `high_importance: Vec<Fact>` -- tier 2: top facts by materialized `importance_score`.
+- `due: Vec<Fact>` -- tier 3: future-memory facts whose `t_valid` has arrived.
+- `recent: Vec<Fact>` -- tier 4: most recent facts from active scope.
+- `kb_stubs: Vec<String>` -- tier 5: placeholder for Phase 5 knowledge-base references.
 
 ### Config
 
@@ -131,7 +151,7 @@ The crate root (`lib.rs`) re-exports these items for convenience:
 
 - **Engine**: `MemoryEngine`, `EngineConfig`
 - **Error**: `MemoryError`, `Result`
-- **Traits**: `EmbeddingProvider`
+- **Traits**: `EmbeddingProvider`, `PersistenceClassifier`
 - **Types**: all public types from the `types` module (`Event`, `Fact`, `Edge`, `Summary`, `NewEvent`, `NewFact`, `NewEdge`, `NewSummary`, `EventType`, `FactType`, `ConsolidationLevel`, `ScopeQuery`, `ScopeNode`, `AddFactOptions`)
 - **Store utilities**: `serialize_embedding`, `deserialize_embedding`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -109,10 +109,10 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 ### Scheduling
 
-| Method          | Signature                                                               | Description                                                                                                   |
-| --------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `list_due`      | `(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>>` | List active facts whose `t_valid <= now` (future memory that has surfaced). Scope-filterable.                 |
-| `next_due_time` | `(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>>`         | Scheduling hint: earliest `t_valid` among active future-dated facts. Returns `None` if no future facts exist. |
+| Method          | Signature                                                               | Description                                                                                           |
+| --------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `list_due`      | `(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>>` | List active facts whose `t_valid <= now` (future memory that has surfaced). `None` scope = root only. |
+| `next_due_time` | `(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>>`         | Scheduling hint: earliest `t_valid` among active future-dated facts. `None` scope = root only.        |
 
 ### Resume
 

--- a/docs/reference/crate-layout.md
+++ b/docs/reference/crate-layout.md
@@ -16,7 +16,7 @@ memory_engine (lib.rs)
   +-- conflict      Bi-temporal conflict resolution
   +-- pool          Connection pool (N readers + 1 writer)
   +-- scope         Hierarchical scope tree cache
-  +-- resume        Session bootstrapping (3-tier retrieval)
+  +-- resume        Session bootstrapping (5-tier retrieval)
   +-- async_engine  Async wrapper (feature-gated)
 ```
 
@@ -37,6 +37,7 @@ memory_engine (lib.rs)
 - `EmbeddingProvider` -- compute text embeddings (local model or API).
 - `SummaryGenerator` -- generate summaries from fact clusters, plus embed the result.
 - `ConflictArbiter` -- decide how to resolve contradicting facts (returns `CrudDecision`).
+- `PersistenceClassifier` -- decide whether a new fact should be pinned (unforgettable). Optional, default returns `false`.
   Also defines `ForgetPolicy` (Ebbinghaus parameters and signal weights), `ConsolidationConfig`, `ConsolidationStats`, `PruneStats`, `ConflictResolution`, and `CrudDecision`.
 
 `search`
@@ -80,11 +81,13 @@ memory_engine (lib.rs)
 : `ScopeTree` -- in-memory cache of the hierarchical scope tree. Loaded from the `scopes` table on engine open. Resolves `ScopeQuery` variants (`Exact`, `Subtree`, `Ancestors`, `Inherited`) to sets of scope IDs without hitting the database.
 
 `resume`
-: Session bootstrapping via `ResumeConfig` and `ResumeContext`. Implements 3-tier retrieval:
+: Session bootstrapping via `ResumeConfig` and `ResumeContext`. Implements 5-tier retrieval:
 
-1. **Identity** -- root-scope, highest-importance facts.
-2. **Core** -- facts above an importance threshold from scope ancestors.
-3. **Recent** -- most recent facts from scope ancestors.
+1. **Pinned** -- unforgettable facts (`is_pinned = true`), cross-scope, sorted by `importance_score` descending.
+2. **High-importance** -- facts with materialized `importance_score` above a configurable threshold.
+3. **Due** -- future-memory facts whose `t_valid` has arrived (`t_valid <= now`).
+4. **Recent** -- most recent facts from scope ancestors.
+5. **KB stubs** -- placeholder for Phase 5 knowledge-base references.
    Tiers are mutually exclusive (a fact appears in at most one tier).
 
 `async_engine`

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -44,8 +44,26 @@ Embedding
 Importance
 : Computed score in the range [0, 1] that determines a fact's resistance to forgetting. Combines four weighted signals: recency decay, access frequency (`log(access_count + 1)`), graph degree (`log(edges + 1)`), and the fact's base importance value.
 
+Pinned fact
+: A fact marked as unforgettable (`is_pinned = true`). Pinned facts are never expired by forgetting and never deduplicated during consolidation. They appear in tier 1 of `resume_context()`. Facts can be pinned explicitly via `pin_fact()`, through `AddFactOptions { pinned: Some(true) }`, or automatically by a `PersistenceClassifier`.
+
+Future memory
+: A fact with `t_valid` set in the future. Invisible to present-time queries until `t_valid` arrives. Retrieved via `list_due(now)` when the time comes. Enables reminders, deferred knowledge, and scheduled agent behavior.
+
+Importance score (materialized)
+: A composite score in [0, 1] stored on each fact as `importance_score`. Computed during `forget()` as a weighted sum of recency, frequency, graph connectivity, and base importance. Used by `resume_context()` tier 2 (high-importance) to select facts without recomputation.
+
+PersistenceClassifier
+: Consumer-provided trait that decides whether a newly inserted fact should be pinned. Called during `add_fact()` with a pre-insert synthetic `Fact`. Default implementation returns `false` (opt-in). Classifiers should rely on `content`, `fact_type`, `importance`, and `metadata` only.
+
+Scheduling API
+: The `list_due(now, scope)` and `next_due_time(scope)` methods. `list_due` returns active facts whose `t_valid` has arrived. `next_due_time` returns the earliest future `t_valid` for poll scheduling.
+
+Global summary invariant
+: Global-level summaries (consolidation pass 3) are always placed at `scope_id=1` (root scope), regardless of the scopes of the underlying facts. Cluster-level summaries use majority-vote scope assignment.
+
 Resume context
-: Three-tier fact retrieval for bootstrapping a new agent session. Tier 1 (identity): root-scope, highest-importance facts. Tier 2 (core): facts above an importance threshold from scope ancestors. Tier 3 (recent): most recent facts from scope ancestors. Tiers are mutually exclusive.
+: Five-tier fact retrieval for bootstrapping a new agent session. Tier 1 (pinned): unforgettable facts, cross-scope. Tier 2 (high-importance): facts above a materialized `importance_score` threshold. Tier 3 (due): future-memory facts whose `t_valid` has arrived. Tier 4 (recent): most recent facts from scope ancestors. Tier 5 (kb_stubs): placeholder for Phase 5 knowledge-base references. Tiers are mutually exclusive.
 
 WAL (Write-Ahead Logging)
 : SQLite journaling mode used by the connection pool. Enables concurrent readers while a single writer commits. The engine opens all connections in WAL mode to maximize read throughput without blocking on writes.

--- a/docs/usage/adding-facts.md
+++ b/docs/usage/adding-facts.md
@@ -31,6 +31,7 @@ pub fn add_fact(
     embedder: &dyn EmbeddingProvider,
     scope: Option<&str>,
     opts: Option<&AddFactOptions>,
+    classifier: Option<&dyn PersistenceClassifier>,
 ) -> Result<i64>
 ```
 
@@ -41,7 +42,8 @@ pub fn add_fact(
 | `source_event_id` | Optional link back to the originating event for provenance.                                      |
 | `embedder`        | Implementation of `EmbeddingProvider` to compute the embedding vector.                           |
 | `scope`           | Optional hierarchical scope path (e.g., `"user:michael/project:demo"`). `None` means root scope. |
-| `opts`            | Optional overrides for importance, metadata, and temporal bounds.                                |
+| `opts`            | Optional overrides for importance, metadata, temporal bounds, and pinning.                       |
+| `classifier`      | Optional `PersistenceClassifier` for auto-pinning. Pass `None` to skip.                          |
 
 The method computes the embedding **before** acquiring the write lock. This means slow embedding calls (e.g., network API round-trips) do not block concurrent readers.
 
@@ -87,6 +89,7 @@ let fact_id = engine.add_fact(
     &embedder,
     None,       // root scope
     None,       // default options
+    None,       // no auto-pin classifier
 )?;
 ```
 
@@ -100,6 +103,7 @@ pub struct AddFactOptions {
     pub metadata: Option<serde_json::Value>,
     pub t_valid: Option<DateTime<Utc>>,
     pub t_invalid: Option<DateTime<Utc>>,
+    pub pinned: Option<bool>,
 }
 ```
 
@@ -108,6 +112,7 @@ All fields are `Option` and default to `None`. When `None`:
 - `importance` defaults to `0.5`
 - `metadata` defaults to `{}`
 - `t_valid` and `t_invalid` are unset (the fact is valid for all time)
+- `pinned` uses the classifier's decision (or `false` if no classifier is provided). Setting `pinned: Some(true)` overrides the classifier.
 
 Example with overrides:
 
@@ -133,6 +138,7 @@ let id = engine.add_fact(
     &embedder,
     Some("team:backend/service:api"),
     Some(&opts),
+    None,  // no auto-pin classifier
 )?;
 ```
 
@@ -164,11 +170,11 @@ When `scope` is `None`, the fact is placed at the root scope (ID 1), which is vi
 ```rust
 // Facts at different scopes
 engine.add_fact("Global preference", FactType::Semantic, None, &embedder,
-    None, None)?;  // root scope
+    None, None, None)?;  // root scope
 
 engine.add_fact("Michael's preference", FactType::Semantic, None, &embedder,
-    Some("user:michael"), None)?;
+    Some("user:michael"), None, None)?;
 
 engine.add_fact("Project-specific config", FactType::Procedural, None, &embedder,
-    Some("user:michael/project:demo"), None)?;
+    Some("user:michael/project:demo"), None, None)?;
 ```


### PR DESCRIPTION
## Summary

- Updates 11 doc files to reflect the shipped Phase 3b API surface
- Replaces all 3-tier resume references with the 5-tier model (pinned → high_importance → due → recent → kb_stubs)
- Documents 5 new public methods: `pin_fact`, `unpin_fact`, `list_due`, `next_due_time`, `resume_context` (updated)
- Adds `PersistenceClassifier` as the 4th consumer trait across extensibility, architecture, and crate-layout docs
- Updates `add_fact()` signature (7→8 args with `classifier`) and `AddFactOptions` (new `pinned` field) in all examples
- Documents pinned-fact bypass in forgetting and consolidation dedup
- Documents materialized `importance_score` (during prune + inheritance during dedup)
- Adds 7 glossary entries: pinned facts, future memory, importance_score, PersistenceClassifier, scheduling API, global summary invariant, updated resume context
- Adds `scope_id=1` global summary invariant to core-concepts
- Updates `NewEvent` examples with envelope fields (`origin_node_id`, `sequence_id`, `created_at`)
- Updates "Five Primitives" → "Seven Primitives" (adds Schedule + Resume)

## Acceptance criteria from #35

- [x] All 13 checklist items resolved (11 files + 2 folded-in items)
- [x] No documentation references to 3-tier resume (verified via grep)
- [x] No "planned" markers for shipped Phase 3b features
- [x] `add_fact()` signature correct in all examples and guides
- [x] `cargo test` passes (187 tests, 0 failures)

## Test plan

- [x] `cargo test` — 187 passed, 0 failed
- [x] Grep verification: no stale "3-tier" references in active docs
- [x] Grep verification: no stale "planned" markers for Phase 3b features

Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)