### PR TITLE
feat(store): schema evolution discipline (#18)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
 rand = { version = "0.8", features = ["small_rng"] }
 criterion = { version = "0.5", features = ["html_reports"] }
+insta = { version = "1", features = ["yaml"] }
+proptest = "1"
 
 [[bench]]
 name = "search_bench"

--- a/docs/schema-evolution-policy.md
+++ b/docs/schema-evolution-policy.md
@@ -1,0 +1,154 @@
+# Schema Evolution Policy
+
+This document defines the versioning, migration, and backwards-compatibility rules for memory-engine's SQLite schema. It covers four version axes, the migration framework, event envelope versioning, and testing requirements.
+
+## Version Axes
+
+memory-engine tracks four independent version numbers:
+
+| Axis             | Location       | Purpose                          | Example |
+| ---------------- | -------------- | -------------------------------- | ------- |
+| `schema_version` | `config` table | DDL version of the SQLite schema | `5`     |
+| `storage_epoch`  | `config` table | Coarse compatibility gate        | `1`     |
+| Crate semver     | `Cargo.toml`   | Rust API compatibility           | `0.1.0` |
+| MCP API version  | MCP server     | Wire protocol compatibility      | `1.0`   |
+
+**`schema_version`** is a monotonic integer incremented by each migration. It tracks which DDL changes have been applied. All migrations within the same epoch are forward-compatible.
+
+**`storage_epoch`** is a coarse-grained gate. All schema versions within the same epoch can be migrated forward. Bumping the epoch signals a breaking architectural change (e.g., dropping support for old migrations). The library rejects databases from future epochs with `MemoryError::UnsupportedEpoch`.
+
+## Forward-Only Migration Policy
+
+Migrations are forward-only. There is no rollback code.
+
+**Rationale:** For an embedded library where consumers control the upgrade timing, forward-only simplifies the migration framework and avoids the complexity of reversible DDL changes (which SQLite makes especially difficult since `ALTER TABLE` is limited). Pre-migration backup provides the safety net.
+
+### Pre-Migration Backup
+
+Before running migrations, a WAL-safe backup can be created via `VACUUM INTO`. This produces an atomic, consistent copy regardless of WAL state (no sidecar `-wal` or `-shm` files).
+
+- **Opt-in:** Pass `backup_dir` in `EngineConfig` to enable. `None` skips backup.
+- **File-backed only:** In-memory databases cannot be backed up (returns error).
+- **Naming:** `<db_name>.v<current_version>.bak` in the specified directory.
+
+To restore from backup, replace the database file with the backup file.
+
+### Backwards-Compatibility Window
+
+All schema versions within the current epoch are supported by the migration chain. The library:
+
+1. Reads `storage_epoch` from the config table (defaults to 1 for pre-epoch databases).
+2. Rejects future epochs with `UnsupportedEpoch`.
+3. Rejects future schema versions with a clear "consider upgrading" error.
+4. Runs the migration chain from the stored version to `CURRENT_SCHEMA_VERSION`.
+
+## Migration Framework
+
+Migrations are defined as `(MigrationFn, bool)` tuples in the `MIGRATIONS` array:
+
+```rust
+const MIGRATIONS: &[(MigrationFn, bool)] = &[
+    (migrate_v1_to_v2, false),   // Add scopes + scope_id
+    (migrate_v2_to_v3, true),    // Table rebuild for FK constraints
+    (migrate_v3_to_v4, false),   // Add is_pinned, importance_score, envelope
+    (migrate_v4_to_v5, false),   // Add event_revision
+];
+```
+
+The boolean flag indicates whether `PRAGMA foreign_keys` must be disabled during the migration (required for table-rebuild migrations that `DROP` and recreate tables).
+
+Each migration runs inside a transaction. On failure, the transaction rolls back and the version is NOT bumped.
+
+### How to Add a Migration
+
+1. Write a `migrate_vN_to_vM(conn: &Connection) -> Result<()>` function with frozen DDL (do not reference live DDL constants).
+2. Append `(migrate_vN_to_vM, needs_fk_disable)` to `MIGRATIONS`.
+3. Bump `CURRENT_SCHEMA_VERSION` to `M`.
+4. Update `TABLES_DDL` (and other live DDL constants) to reflect the new schema.
+5. Add a frozen DDL snapshot (`TABLES_VM_DDL`, `init_schema_vM()`) in the test module.
+6. Update version assertions in existing tests (e.g., `"N"` to `"M"`).
+7. Add specific migration tests: `migrate_vN_to_vM_adds_...`, `fresh_db_creates_vM_schema`.
+8. Run `cargo test` — the insta snapshot test will fail with a pending snapshot. Review and accept the new snapshot.
+9. Verify all property-based migration tests still pass (they exercise the full chain).
+
+## Event Envelope Versioning
+
+Events in the append-only log carry a per-event-type revision via the `event_revision` column.
+
+### How It Works
+
+- **`Event` struct** (read side): Has `event_revision: u16` with `#[serde(default = 1)]`.
+- **`NewEvent` struct** (write side): Does NOT have `event_revision`. The store stamps it internally from the `UpcasterRegistry`.
+- **On insert:** `EventStore::insert()` writes `registry.latest_revision(event_type)`.
+- **On read:** `get()`/`list()` return raw stored data (audit-log semantics). `get_upcasted()`/`list_upcasted()` apply the upcaster chain.
+
+### Raw vs Upcasted Reads
+
+| Method                  | Applies upcasters | Use case                     |
+| ----------------------- | ----------------- | ---------------------------- |
+| `get(id)`               | No                | Audit log, debugging, replay |
+| `list(filter)`          | No                | Audit log, batch export      |
+| `get_upcasted(id)`      | Yes               | Application logic            |
+| `list_upcasted(filter)` | Yes               | Application logic            |
+
+Raw reads preserve the exact payload that was stored. This is critical for event-sourced systems where the event log is the source of truth.
+
+### UpcasterRegistry
+
+The registry maps `(event_type, from_revision)` to a transformation function:
+
+```rust
+let mut registry = UpcasterRegistry::new();
+registry.register("Interaction", 1, |mut payload| {
+    // Transform v1 payload to v2 format
+    payload["schema_version"] = json!("v2");
+    Ok(payload)
+});
+```
+
+Chains are applied sequentially. If an event is at revision 1 and the latest is 3, upcasters `(1->2)` then `(2->3)` run in order. A gap in the chain (e.g., `2->3` registered but `1->2` missing) returns `MemoryError::Migration`.
+
+### How to Add an Upcaster
+
+1. Identify the event type and the payload change.
+2. Register the upcaster in the `UpcasterRegistry` before constructing `EngineConfig`:
+   ```rust
+   let mut registry = UpcasterRegistry::new();
+   registry.register("EventType", current_revision, |payload| {
+       // Transform payload
+       Ok(transformed)
+   });
+   config.upcaster_registry = registry;
+   ```
+3. Add tests in `events.rs`: insert at old revision (via empty registry), read with new registry, verify transformation.
+4. The next schema migration should update the `event_revision` DEFAULT if the new revision should be the baseline for fresh databases.
+
+### Replay Contract
+
+Upcasting must produce **semantically equivalent** results — the upcasted payload should be interpretable by application logic the same way as a natively-written payload at the target revision. Exact byte-level equality is not required (field ordering may differ), but the semantic content must be identical.
+
+## Testing Requirements
+
+### Schema Snapshot (insta)
+
+The `schema_v5_snapshot` test captures the complete DDL of a fresh database via a deterministic projection (sorted by type+name, whitespace-normalized). This snapshot:
+
+- Breaks when any DDL constant changes (catches unintentional schema drift).
+- Is version-controlled alongside the code.
+- Must be reviewed and accepted after any schema change.
+
+### Property-Based Tests (proptest)
+
+Three property-based tests verify migration invariants across random inputs:
+
+| Test                                      | Property                                                   |
+| ----------------------------------------- | ---------------------------------------------------------- |
+| `migration_preserves_event_count`         | Event count is identical before and after v1->v5 migration |
+| `migration_preserves_fact_content_hashes` | Content hashes survive the full migration chain unchanged  |
+| `migration_v1_to_v5_fk_integrity`         | `PRAGMA foreign_key_check` is clean after migration        |
+
+### Frozen DDL Snapshots
+
+Each major schema version has a complete, standalone DDL snapshot in the test module (`init_schema_v1`, `init_schema_v2`, `init_schema_v4`). These depend on NO live DDL constants, preventing fixture drift when tables evolve.
+
+This allows migration tests to start from any historical version and verify the migration chain produces the correct result.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -16,6 +16,7 @@ use crate::store::facts::FactStore;
 use crate::store::schema::{get_config, set_config};
 use crate::store::scopes::ScopeStore;
 use crate::store::summaries::SummaryStore;
+use crate::store::upcaster::UpcasterRegistry;
 use crate::traits::{
     ConflictArbiter, ConflictResolution, ConsolidationConfig, ConsolidationStats,
     EmbeddingProvider, ForgetPolicy, PersistenceClassifier, PruneStats, SummaryGenerator,
@@ -31,6 +32,12 @@ pub struct EngineConfig {
     pub read_pool_size: usize,
     /// Optional search configuration for ANN strategy dispatch.
     pub search_config: Option<SearchConfig>,
+    /// Optional directory for WAL-safe pre-migration backups.
+    /// When set, `VACUUM INTO` creates a backup before running migrations.
+    pub backup_dir: Option<PathBuf>,
+    /// Upcaster registry for event payload versioning.
+    /// Defaults to empty (all event types at revision 1).
+    pub upcaster_registry: UpcasterRegistry,
 }
 
 impl EngineConfig {
@@ -42,6 +49,8 @@ impl EngineConfig {
             embed_dim,
             read_pool_size: 4,
             search_config: None,
+            backup_dir: None,
+            upcaster_registry: UpcasterRegistry::new(),
         }
     }
 }
@@ -64,6 +73,7 @@ pub struct MemoryEngine {
     hnsw_strategy: Option<crate::search::ann::HnswStrategy>,
     #[cfg_attr(not(feature = "ann"), allow(dead_code))]
     search_config: Option<SearchConfig>,
+    upcaster_registry: UpcasterRegistry,
 }
 
 impl std::fmt::Debug for MemoryEngine {
@@ -86,8 +96,18 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::Migration` if the stored `embed_dim` doesn't match.
     pub fn open(config: &EngineConfig) -> Result<Self> {
-        let pool = ConnectionPool::open(&config.path, config.embed_dim, config.read_pool_size)?;
-        Self::init_from_pool(pool, config.embed_dim, config.search_config.clone())
+        let pool = ConnectionPool::open(
+            &config.path,
+            config.embed_dim,
+            config.read_pool_size,
+            config.backup_dir.as_deref(),
+        )?;
+        Self::init_from_pool(
+            pool,
+            config.embed_dim,
+            config.search_config.clone(),
+            config.upcaster_registry.clone(),
+        )
     }
 
     /// Open an in-memory engine for testing.
@@ -97,7 +117,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::Database` if the connection or schema setup fails.
     pub fn open_memory(embed_dim: usize) -> Result<Self> {
         let pool = ConnectionPool::open_memory(embed_dim)?;
-        Self::init_from_pool(pool, embed_dim, None)
+        Self::init_from_pool(pool, embed_dim, None, UpcasterRegistry::new())
     }
 
     /// Open an in-memory engine with optional search config for testing.
@@ -110,7 +130,7 @@ impl MemoryEngine {
         search_config: Option<SearchConfig>,
     ) -> Result<Self> {
         let pool = ConnectionPool::open_memory(embed_dim)?;
-        Self::init_from_pool(pool, embed_dim, search_config)
+        Self::init_from_pool(pool, embed_dim, search_config, UpcasterRegistry::new())
     }
 
     /// Shared constructor logic: validate embed_dim, load graph and scope tree.
@@ -118,6 +138,7 @@ impl MemoryEngine {
         pool: ConnectionPool,
         embed_dim: usize,
         search_config: Option<SearchConfig>,
+        upcaster_registry: UpcasterRegistry,
     ) -> Result<Self> {
         // Scope the MutexGuard so it drops before we move `pool` into the struct.
         let (graph, scope_tree) = {
@@ -152,6 +173,7 @@ impl MemoryEngine {
             #[cfg(feature = "ann")]
             hnsw_strategy,
             search_config,
+            upcaster_registry,
         })
     }
 
@@ -224,7 +246,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::Database` on insert failure.
     pub fn ingest(&self, event: &NewEvent) -> Result<i64> {
         let conn = self.write_conn();
-        EventStore::new(&conn).insert(event)
+        EventStore::new(&conn, &self.upcaster_registry).insert(event)
     }
 
     /// Add a fact: compute embedding via `embedder`, compute blake3 content hash,

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum MemoryError {
 
     #[error("connection pool error: {0}")]
     Pool(String),
+
+    #[error("unsupported storage epoch: database is epoch {db_epoch}, this library supports epoch {supported_epoch}")]
+    UnsupportedEpoch { db_epoch: u16, supported_epoch: u16 },
 }
 
 /// Convenience alias for `Result<T, MemoryError>`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,6 @@ pub mod types;
 
 pub use engine::{EngineConfig, MemoryEngine};
 pub use error::*;
-pub use store::{deserialize_embedding, serialize_embedding};
+pub use store::{deserialize_embedding, serialize_embedding, UpcasterRegistry};
 pub use traits::EmbeddingProvider;
 pub use types::*;

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -82,10 +82,15 @@ impl ConnectionPool {
     /// # Errors
     ///
     /// Returns `MemoryError::Database` if any connection or schema setup fails.
-    pub fn open(path: &Path, embed_dim: usize, read_pool_size: usize) -> Result<Self> {
+    pub fn open(
+        path: &Path,
+        embed_dim: usize,
+        read_pool_size: usize,
+        backup_dir: Option<&Path>,
+    ) -> Result<Self> {
         let write_conn = open_connection(&path.to_string_lossy())?;
         init_schema(&write_conn)?;
-        migrate(&write_conn)?;
+        migrate(&write_conn, backup_dir)?;
 
         let mut read_conns = Vec::with_capacity(read_pool_size);
         for _ in 0..read_pool_size {
@@ -113,7 +118,7 @@ impl ConnectionPool {
     pub fn open_memory(embed_dim: usize) -> Result<Self> {
         let conn = open_memory_conn()?;
         init_schema(&conn)?;
-        migrate(&conn)?;
+        migrate(&conn, None)?;
         Ok(Self {
             write_conn: Mutex::new(conn),
             read_conns: Mutex::new(Vec::new()),
@@ -189,7 +194,7 @@ mod tests {
     fn pool_file_backed_concurrent_reads() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.db");
-        let pool = ConnectionPool::open(&db_path, 4, 2).unwrap();
+        let pool = ConnectionPool::open(&db_path, 4, 2, None).unwrap();
 
         // Write something
         {
@@ -210,7 +215,7 @@ mod tests {
     fn pool_read_guard_returns_connection() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.db");
-        let pool = ConnectionPool::open(&db_path, 4, 1).unwrap();
+        let pool = ConnectionPool::open(&db_path, 4, 1, None).unwrap();
 
         // Checkout and return
         {
@@ -232,7 +237,7 @@ mod tests {
     fn pool_file_backed_is_file_backed() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.db");
-        let pool = ConnectionPool::open(&db_path, 4, 2).unwrap();
+        let pool = ConnectionPool::open(&db_path, 4, 2, None).unwrap();
         assert!(pool.is_file_backed());
 
         let mem_pool = ConnectionPool::open_memory(4).unwrap();

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -126,7 +126,7 @@ mod tests {
     fn setup() -> Connection {
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
         conn
     }
 

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -133,7 +133,7 @@ mod tests {
     fn setup_tree() -> ScopeTree {
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
 
         // Create: root -> user:michael -> project:demo
         //                              -> project:other

--- a/src/store/edges.rs
+++ b/src/store/edges.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
 use crate::store::{parse_optional_timestamp, parse_timestamp};

--- a/src/store/events.rs
+++ b/src/store/events.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
+use crate::store::upcaster::UpcasterRegistry;
 use crate::types::{Event, EventType, NewEvent};
 
 /// Filter for querying events.
@@ -16,6 +17,7 @@ pub struct EventFilter {
 /// Store for the append-only event log.
 pub struct EventStore<'a> {
     conn: &'a Connection,
+    registry: &'a UpcasterRegistry,
 }
 
 const fn event_type_to_str(et: &EventType) -> &'static str {
@@ -74,6 +76,8 @@ fn row_to_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
         })
         .transpose()?;
 
+    let event_revision: i64 = row.get("event_revision")?;
+
     Ok(Event {
         id: row.get("id")?,
         timestamp,
@@ -85,14 +89,15 @@ fn row_to_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
         origin_node_id: row.get("origin_node_id")?,
         sequence_id: row.get("sequence_id")?,
         created_at,
+        event_revision: u16::try_from(event_revision).unwrap_or(1),
     })
 }
 
 impl<'a> EventStore<'a> {
-    /// Create a new `EventStore` borrowing the given connection.
+    /// Create a new `EventStore` borrowing the given connection and upcaster registry.
     #[must_use]
-    pub const fn new(conn: &'a Connection) -> Self {
-        Self { conn }
+    pub const fn new(conn: &'a Connection, registry: &'a UpcasterRegistry) -> Self {
+        Self { conn, registry }
     }
 
     /// Insert a new event, returning its auto-assigned id.
@@ -109,8 +114,8 @@ impl<'a> EventStore<'a> {
 
         self.conn.execute(
             "INSERT INTO events (timestamp, event_type, payload, source, session_id, scope_id,
-                origin_node_id, sequence_id, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                origin_node_id, sequence_id, created_at, event_revision)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 timestamp_str,
                 event_type_str,
@@ -121,6 +126,7 @@ impl<'a> EventStore<'a> {
                 event.origin_node_id,
                 event.sequence_id,
                 created_at_str,
+                i64::from(self.registry.latest_revision(event_type_str)),
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
@@ -134,7 +140,7 @@ impl<'a> EventStore<'a> {
     pub fn get(&self, id: i64) -> Result<Event> {
         let mut stmt = self.conn.prepare(
             "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
-                    origin_node_id, sequence_id, created_at
+                    origin_node_id, sequence_id, created_at, event_revision
              FROM events WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], row_to_event)?;
@@ -153,7 +159,7 @@ impl<'a> EventStore<'a> {
     pub fn list(&self, filter: &EventFilter) -> Result<Vec<Event>> {
         let (sql, values) = build_filter_query(
             "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
-                    origin_node_id, sequence_id, created_at FROM events",
+                    origin_node_id, sequence_id, created_at, event_revision FROM events",
             filter,
         );
         let mut stmt = self.conn.prepare(&sql)?;
@@ -175,6 +181,48 @@ impl<'a> EventStore<'a> {
         let mut stmt = self.conn.prepare(&sql)?;
         let count = stmt.query_row(rusqlite::params_from_iter(values), |row| row.get(0))?;
         Ok(count)
+    }
+
+    /// Get an event by id with upcasted payload.
+    ///
+    /// Unlike [`Self::get`], this applies the upcaster chain to transform
+    /// the payload from its stored revision to the latest revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if the id doesn't exist.
+    /// Returns `MemoryError::Migration` if upcasting fails.
+    pub fn get_upcasted(&self, id: i64) -> Result<Event> {
+        let event = self.get(id)?;
+        self.apply_upcasting(event)
+    }
+
+    /// List events matching the filter with upcasted payloads.
+    ///
+    /// Unlike [`Self::list`], this applies the upcaster chain to transform
+    /// each event's payload from its stored revision to the latest revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Migration` if upcasting fails.
+    pub fn list_upcasted(&self, filter: &EventFilter) -> Result<Vec<Event>> {
+        let events = self.list(filter)?;
+        events
+            .into_iter()
+            .map(|e| self.apply_upcasting(e))
+            .collect()
+    }
+
+    /// Apply the upcaster chain to an event's payload.
+    fn apply_upcasting(&self, mut event: Event) -> Result<Event> {
+        let event_type_str = event_type_to_str(&event.event_type);
+        let (new_payload, new_rev) =
+            self.registry
+                .upcast(event_type_str, event.event_revision, event.payload)?;
+        event.payload = new_payload;
+        event.event_revision = new_rev;
+        Ok(event)
     }
 }
 
@@ -248,7 +296,8 @@ mod tests {
     #[test]
     fn insert_returns_id() {
         let conn = setup();
-        let store = EventStore::new(&conn);
+        let registry = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &registry);
         let id = store.insert(&make_event("test", None)).unwrap();
         assert_eq!(id, 1);
         let id2 = store.insert(&make_event("test", None)).unwrap();
@@ -258,7 +307,8 @@ mod tests {
     #[test]
     fn get_round_trip() {
         let conn = setup();
-        let store = EventStore::new(&conn);
+        let registry = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &registry);
         let event = make_event("src1", Some("sess-1"));
         let id = store.insert(&event).unwrap();
         let retrieved = store.get(id).unwrap();
@@ -271,7 +321,8 @@ mod tests {
     #[test]
     fn get_not_found() {
         let conn = setup();
-        let store = EventStore::new(&conn);
+        let registry = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &registry);
         let err = store.get(999).unwrap_err();
         assert!(matches!(err, MemoryError::NotFound(_)));
     }
@@ -279,7 +330,8 @@ mod tests {
     #[test]
     fn list_with_session_id_filter() {
         let conn = setup();
-        let store = EventStore::new(&conn);
+        let registry = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &registry);
         store.insert(&make_event("a", Some("sess-1"))).unwrap();
         store.insert(&make_event("b", Some("sess-2"))).unwrap();
         store.insert(&make_event("c", Some("sess-1"))).unwrap();
@@ -290,17 +342,16 @@ mod tests {
         };
         let results = store.list(&filter).unwrap();
         assert_eq!(results.len(), 2);
-        assert!(
-            results
-                .iter()
-                .all(|e| e.session_id == Some("sess-1".into()))
-        );
+        assert!(results
+            .iter()
+            .all(|e| e.session_id == Some("sess-1".into())));
     }
 
     #[test]
     fn count_matches_list() {
         let conn = setup();
-        let store = EventStore::new(&conn);
+        let registry = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &registry);
         store.insert(&make_event("a", Some("sess-1"))).unwrap();
         store.insert(&make_event("b", Some("sess-2"))).unwrap();
         store.insert(&make_event("c", Some("sess-1"))).unwrap();
@@ -316,7 +367,8 @@ mod tests {
     #[test]
     fn json_payload_round_trip() {
         let conn = setup();
-        let store = EventStore::new(&conn);
+        let registry = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &registry);
         let payload = serde_json::json!({
             "nested": {"array": [1, 2, 3]},
             "bool": true,
@@ -337,5 +389,125 @@ mod tests {
         let retrieved = store.get(id).unwrap();
         assert_eq!(retrieved.payload, payload);
         assert_eq!(retrieved.event_type, EventType::ToolCall);
+    }
+
+    #[test]
+    fn get_returns_raw_event() {
+        let conn = setup();
+        // Insert with empty registry → stamped at revision 1
+        let empty_reg = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &empty_reg);
+        let id = store.insert(&make_event("test", None)).unwrap();
+
+        // Now read with a registry that has upcasters
+        let mut registry = UpcasterRegistry::new();
+        registry.register("Interaction", 1, |mut v| {
+            v["upcasted"] = serde_json::json!(true);
+            Ok(v)
+        });
+        let store2 = EventStore::new(&conn, &registry);
+
+        // Raw get() does NOT apply upcasting — returns stored payload
+        let raw = store2.get(id).unwrap();
+        assert!(raw.payload.get("upcasted").is_none());
+        assert_eq!(raw.event_revision, 1); // stored at revision 1
+    }
+
+    #[test]
+    fn get_upcasted_transforms_payload() {
+        let conn = setup();
+        // Insert with empty registry → stored at revision 1
+        let empty_reg = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &empty_reg);
+        let id = store.insert(&make_event("test", None)).unwrap();
+
+        // Read with upcaster registry
+        let mut registry = UpcasterRegistry::new();
+        registry.register("Interaction", 1, |mut v| {
+            v["upcasted"] = serde_json::json!(true);
+            Ok(v)
+        });
+        let store2 = EventStore::new(&conn, &registry);
+
+        // get_upcasted() applies the chain: revision 1 → 2
+        let upcasted = store2.get_upcasted(id).unwrap();
+        assert_eq!(upcasted.payload["upcasted"], true);
+        assert_eq!(upcasted.event_revision, 2);
+    }
+
+    #[test]
+    fn list_upcasted_transforms_all() {
+        let conn = setup();
+        // Insert with empty registry → stored at revision 1
+        let empty_reg = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &empty_reg);
+        store.insert(&make_event("a", None)).unwrap();
+        store.insert(&make_event("b", None)).unwrap();
+
+        // Read with upcaster registry
+        let mut registry = UpcasterRegistry::new();
+        registry.register("Interaction", 1, |mut v| {
+            v["version"] = serde_json::json!("v2");
+            Ok(v)
+        });
+        let store2 = EventStore::new(&conn, &registry);
+
+        let raw = store2.list(&EventFilter::default()).unwrap();
+        assert!(raw.iter().all(|e| e.payload.get("version").is_none()));
+
+        let upcasted = store2.list_upcasted(&EventFilter::default()).unwrap();
+        assert_eq!(upcasted.len(), 2);
+        assert!(upcasted.iter().all(|e| e.payload["version"] == "v2"));
+        assert!(upcasted.iter().all(|e| e.event_revision == 2));
+    }
+
+    #[test]
+    fn insert_stamps_latest_revision() {
+        let conn = setup();
+        let mut registry = UpcasterRegistry::new();
+        // Interaction has upcasters 1→2 and 2→3, so latest = 3
+        registry.register("Interaction", 1, |v| Ok(v));
+        registry.register("Interaction", 2, |v| Ok(v));
+        let store = EventStore::new(&conn, &registry);
+
+        let id = store.insert(&make_event("test", None)).unwrap();
+        let event = store.get(id).unwrap();
+        assert_eq!(event.event_revision, 3); // stamped at latest
+    }
+
+    #[test]
+    fn serde_event_revision_compat() {
+        // Event JSON without event_revision deserializes with default 1
+        let json = r#"{
+            "id": 1,
+            "timestamp": "2024-01-01T00:00:00Z",
+            "event_type": "Interaction",
+            "payload": {},
+            "source": "test",
+            "session_id": null,
+            "scope_id": 1,
+            "origin_node_id": "local",
+            "sequence_id": 0,
+            "created_at": null
+        }"#;
+        let event: crate::types::Event = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_revision, 1);
+
+        // With explicit event_revision
+        let json_v3 = r#"{
+            "id": 1,
+            "timestamp": "2024-01-01T00:00:00Z",
+            "event_type": "Interaction",
+            "payload": {},
+            "source": "test",
+            "session_id": null,
+            "scope_id": 1,
+            "origin_node_id": "local",
+            "sequence_id": 0,
+            "created_at": null,
+            "event_revision": 3
+        }"#;
+        let event_v3: crate::types::Event = serde_json::from_str(json_v3).unwrap();
+        assert_eq!(event_v3.event_revision, 3);
     }
 }

--- a/src/store/events.rs
+++ b/src/store/events.rs
@@ -89,7 +89,13 @@ fn row_to_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
         origin_node_id: row.get("origin_node_id")?,
         sequence_id: row.get("sequence_id")?,
         created_at,
-        event_revision: u16::try_from(event_revision).unwrap_or(1),
+        event_revision: u16::try_from(event_revision).map_err(|_| {
+            rusqlite::Error::FromSqlConversionFailure(
+                10, // event_revision column index
+                rusqlite::types::Type::Integer,
+                format!("event_revision {event_revision} out of u16 range").into(),
+            )
+        })?,
     })
 }
 

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
 use crate::store::{

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,13 +8,18 @@ pub mod facts;
 pub mod schema;
 pub mod scopes;
 pub mod summaries;
+pub mod upcaster;
 
 pub use edges::EdgeStore;
 pub use events::{EventFilter, EventStore};
 pub use facts::FactStore;
-pub use schema::{get_config, init_schema, migrate, open_connection, open_memory, set_config};
+pub use schema::{
+    backup_before_migration, get_config, init_schema, migrate, open_connection, open_memory,
+    set_config,
+};
 pub use scopes::ScopeStore;
 pub use summaries::SummaryStore;
+pub use upcaster::UpcasterRegistry;
 
 use chrono::{DateTime, Utc};
 

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -150,11 +150,10 @@ pub fn migrate(conn: &Connection, backup_dir: Option<&Path>) -> Result<()> {
 
     // --- Epoch gate ---
     let epoch_str = get_config(conn, "storage_epoch")?;
-    let db_epoch: u16 = epoch_str
-        .as_deref()
-        .unwrap_or("1") // pre-epoch DBs are implicitly epoch 1
+    let epoch_raw = epoch_str.as_deref().unwrap_or("1"); // pre-epoch DBs are implicitly epoch 1
+    let db_epoch: u16 = epoch_raw
         .parse()
-        .unwrap_or(1);
+        .map_err(|_| MemoryError::Migration(format!("invalid storage_epoch: {epoch_raw}")))?;
     if db_epoch > STORAGE_EPOCH {
         return Err(MemoryError::UnsupportedEpoch {
             db_epoch,
@@ -252,8 +251,21 @@ pub fn backup_before_migration(
         .to_string_lossy();
     let backup_path = backup_dir.join(format!("{db_name}.v{current_version}.bak"));
 
-    // VACUUM INTO creates a standalone, defragmented copy — WAL-safe
-    let sql = format!("VACUUM INTO '{}'", backup_path.to_string_lossy());
+    // Remove existing backup to avoid VACUUM INTO failure on re-run
+    if backup_path.exists() {
+        std::fs::remove_file(&backup_path).map_err(|e| {
+            MemoryError::Migration(format!(
+                "cannot remove existing backup {}: {e}",
+                backup_path.display()
+            ))
+        })?;
+    }
+
+    // VACUUM INTO creates a standalone, defragmented copy — WAL-safe.
+    // SQLite VACUUM INTO does not support parameterized paths, so we escape
+    // single quotes manually (SQLite string literal escaping: ' → '').
+    let escaped = backup_path.to_string_lossy().replace('\'', "''");
+    let sql = format!("VACUUM INTO '{escaped}'");
     conn.execute_batch(&sql)
         .map_err(|e| MemoryError::Migration(format!("backup failed: {e}")))?;
 

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -1,9 +1,19 @@
+use std::path::{Path, PathBuf};
+
 use rusqlite::Connection;
 
 use crate::error::{MemoryError, Result};
 
 /// Current schema version. Bump when adding migrations.
-const CURRENT_SCHEMA_VERSION: u32 = 4;
+const CURRENT_SCHEMA_VERSION: u32 = 5;
+
+/// Storage epoch — coarse-grained compatibility gate.
+///
+/// All schema versions within the same epoch are forwards-compatible via
+/// the migration chain. Bumping the epoch signals a breaking architectural
+/// change (e.g., dropping old migration support). Libraries reject DBs
+/// from future epochs with [`MemoryError::UnsupportedEpoch`].
+const STORAGE_EPOCH: u16 = 1;
 
 /// Open a `SQLite` connection to a file, with pragmas set.
 ///
@@ -64,13 +74,14 @@ pub fn init_schema(conn: &Connection) -> Result<()> {
     if !is_fresh {
         return Ok(()); // existing DB — let migrate() handle evolution
     }
-    // Fresh DB: create full latest (v3) schema
+    // Fresh DB: create full latest schema
     conn.execute_batch(TABLES_DDL)?;
     conn.execute_batch(SCOPES_DDL)?;
     conn.execute_batch(FTS5_DDL)?;
     conn.execute_batch(TRIGGERS_DDL)?;
     conn.execute_batch(INDEXES_DDL)?;
     set_config(conn, "schema_version", &CURRENT_SCHEMA_VERSION.to_string())?;
+    set_config(conn, "storage_epoch", &STORAGE_EPOCH.to_string())?;
     Ok(())
 }
 
@@ -113,6 +124,7 @@ const MIGRATIONS: &[(MigrationFn, bool)] = &[
     (migrate_v1_to_v2, false),
     (migrate_v2_to_v3, true),
     (migrate_v3_to_v4, false),
+    (migrate_v4_to_v5, false),
 ];
 
 /// Run forward-only migrations from the current schema version to
@@ -121,20 +133,54 @@ const MIGRATIONS: &[(MigrationFn, bool)] = &[
 /// Each migration runs inside a transaction. On failure, the migration rolls
 /// back and the version is NOT bumped.
 ///
+/// When `backup_dir` is `Some`, a WAL-safe backup is created via `VACUUM INTO`
+/// before running any migration functions. Pass `None` for in-memory databases
+/// or when backup is not desired.
+///
 /// # Errors
 ///
+/// Returns `MemoryError::UnsupportedEpoch` if the DB is from a future epoch.
 /// Returns `MemoryError::Migration` if the stored version is newer than
 /// supported, or if any migration step fails.
-pub fn migrate(conn: &Connection) -> Result<()> {
+pub fn migrate(conn: &Connection, backup_dir: Option<&Path>) -> Result<()> {
     let version_str = get_config(conn, "schema_version")?.unwrap_or_else(|| "1".to_string());
     let version: u32 = version_str
         .parse()
         .map_err(|_| MemoryError::Migration(format!("invalid schema_version: {version_str}")))?;
 
+    // --- Epoch gate ---
+    let epoch_str = get_config(conn, "storage_epoch")?;
+    let db_epoch: u16 = epoch_str
+        .as_deref()
+        .unwrap_or("1") // pre-epoch DBs are implicitly epoch 1
+        .parse()
+        .unwrap_or(1);
+    if db_epoch > STORAGE_EPOCH {
+        return Err(MemoryError::UnsupportedEpoch {
+            db_epoch,
+            supported_epoch: STORAGE_EPOCH,
+        });
+    }
+
     if version > CURRENT_SCHEMA_VERSION {
         return Err(MemoryError::Migration(format!(
-            "schema_version {version} is newer than supported {CURRENT_SCHEMA_VERSION}"
+            "schema_version {version} is newer than supported {CURRENT_SCHEMA_VERSION}; \
+             consider upgrading the memory-engine crate"
         )));
+    }
+
+    // Nothing to migrate
+    if version == CURRENT_SCHEMA_VERSION {
+        // Ensure epoch is set for pre-epoch DBs that are already at latest version
+        if epoch_str.is_none() {
+            set_config(conn, "storage_epoch", &STORAGE_EPOCH.to_string())?;
+        }
+        return Ok(());
+    }
+
+    // --- WAL-safe backup before migration ---
+    if let Some(dir) = backup_dir {
+        backup_before_migration(conn, dir, version)?;
     }
 
     for (i, (migration, disable_fk)) in MIGRATIONS.iter().enumerate() {
@@ -166,7 +212,52 @@ pub fn migrate(conn: &Connection) -> Result<()> {
             result?;
         }
     }
+
+    // Stamp epoch for pre-epoch migrated DBs
+    if epoch_str.is_none() {
+        set_config(conn, "storage_epoch", &STORAGE_EPOCH.to_string())?;
+    }
+
     Ok(())
+}
+
+/// Create a WAL-safe backup of the database before running migrations.
+///
+/// Uses `VACUUM INTO` which produces an atomic, consistent copy regardless
+/// of WAL state (no sidecar files to worry about).
+///
+/// # Errors
+///
+/// Returns `MemoryError::Migration` if the connection is in-memory or the
+/// backup path cannot be written to.
+pub fn backup_before_migration(
+    conn: &Connection,
+    backup_dir: &Path,
+    current_version: u32,
+) -> Result<PathBuf> {
+    // Extract the source database file path via PRAGMA database_list
+    let db_path: String = conn
+        .query_row("PRAGMA database_list", [], |row| row.get::<_, String>(2))
+        .map_err(|e| MemoryError::Migration(format!("cannot read database path: {e}")))?;
+
+    if db_path.is_empty() || db_path == ":memory:" {
+        return Err(MemoryError::Migration(
+            "cannot backup in-memory database".to_string(),
+        ));
+    }
+
+    let db_name = Path::new(&db_path)
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy();
+    let backup_path = backup_dir.join(format!("{db_name}.v{current_version}.bak"));
+
+    // VACUUM INTO creates a standalone, defragmented copy — WAL-safe
+    let sql = format!("VACUUM INTO '{}'", backup_path.to_string_lossy());
+    conn.execute_batch(&sql)
+        .map_err(|e| MemoryError::Migration(format!("backup failed: {e}")))?;
+
+    Ok(backup_path)
 }
 
 fn set_foreign_keys(conn: &Connection, enabled: bool) -> Result<()> {
@@ -390,6 +481,12 @@ fn migrate_v3_to_v4(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Add `event_revision` column for per-event-type envelope versioning.
+fn migrate_v4_to_v5(conn: &Connection) -> Result<()> {
+    conn.execute_batch("ALTER TABLE events ADD COLUMN event_revision INTEGER NOT NULL DEFAULT 1;")?;
+    Ok(())
+}
+
 // --- DDL constants ---
 
 const TABLES_DDL: &str = "
@@ -403,7 +500,8 @@ CREATE TABLE IF NOT EXISTS events (
     scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
     origin_node_id TEXT NOT NULL DEFAULT 'local',
     sequence_id INTEGER NOT NULL DEFAULT 0,
-    created_at TEXT
+    created_at TEXT,
+    event_revision INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE TABLE IF NOT EXISTS facts (
@@ -678,6 +776,141 @@ CREATE INDEX IF NOT EXISTS idx_events_scope ON events(scope_id);
 CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
 ";
 
+    // --- Frozen V4 DDL snapshot ---
+    // Complete standalone DDL for v4 schema. Depends on NO live DDL constants
+    // to prevent fixture drift when tables evolve in future versions.
+
+    /// Test helper: creates v4 schema (v3 + is_pinned, importance_score, event envelope).
+    fn init_schema_v4(conn: &Connection) -> Result<()> {
+        conn.execute_batch(TABLES_V4_DDL)?;
+        conn.execute_batch(SCOPES_DDL_V4)?;
+        conn.execute_batch(FTS5_DDL_V4)?;
+        conn.execute_batch(TRIGGERS_DDL_V4)?;
+        conn.execute_batch(INDEXES_V4_DDL)?;
+        set_config(conn, "schema_version", "4")?;
+        Ok(())
+    }
+
+    const TABLES_V4_DDL: &str = "
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    source TEXT NOT NULL,
+    session_id TEXT,
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
+    origin_node_id TEXT NOT NULL DEFAULT 'local',
+    sequence_id INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS facts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    embedding BLOB NOT NULL,
+    fact_type TEXT NOT NULL CHECK(fact_type IN ('episodic', 'semantic', 'procedural')),
+    t_created TEXT NOT NULL,
+    t_expired TEXT,
+    t_valid TEXT,
+    t_invalid TEXT,
+    source_event_id INTEGER REFERENCES events(id),
+    importance REAL NOT NULL DEFAULT 0.5,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)),
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
+    is_pinned INTEGER NOT NULL DEFAULT 0,
+    importance_score REAL NOT NULL DEFAULT 0.5
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    target_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    relation_type TEXT NOT NULL,
+    weight REAL NOT NULL DEFAULT 1.0,
+    t_created TEXT NOT NULL,
+    t_expired TEXT,
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id)
+);
+
+CREATE TABLE IF NOT EXISTS summaries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    embedding BLOB NOT NULL,
+    level TEXT NOT NULL CHECK(level IN ('local', 'cluster', 'global')),
+    source_fact_ids TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id)
+);
+
+CREATE TABLE IF NOT EXISTS config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+";
+
+    const SCOPES_DDL_V4: &str = "
+CREATE TABLE IF NOT EXISTS scopes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    parent_id INTEGER REFERENCES scopes(id),
+    label TEXT NOT NULL,
+    depth INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_scopes_parent ON scopes(parent_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scopes_parent_label
+    ON scopes(parent_id, label);
+
+INSERT OR IGNORE INTO scopes (id, parent_id, label, depth) VALUES (1, NULL, 'root', 0);
+";
+
+    const FTS5_DDL_V4: &str = "
+CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
+    content,
+    content='facts',
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+";
+
+    const TRIGGERS_DDL_V4: &str = "
+CREATE TRIGGER IF NOT EXISTS facts_fts_ai AFTER INSERT ON facts BEGIN
+    INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS facts_fts_ad AFTER DELETE ON facts BEGIN
+    INSERT INTO facts_fts(facts_fts, rowid, content) VALUES ('delete', old.id, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS facts_fts_au AFTER UPDATE ON facts BEGIN
+    INSERT INTO facts_fts(facts_fts, rowid, content) VALUES ('delete', old.id, old.content);
+    INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content);
+END;
+";
+
+    const INDEXES_V4_DDL: &str = "
+CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_facts_expired ON facts(t_expired);
+CREATE INDEX IF NOT EXISTS idx_facts_type ON facts(fact_type);
+CREATE INDEX IF NOT EXISTS idx_facts_valid ON facts(t_valid, t_invalid);
+CREATE INDEX IF NOT EXISTS idx_facts_hash ON facts(content_hash);
+CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_fact_id);
+CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_fact_id);
+CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
+CREATE INDEX IF NOT EXISTS idx_facts_scope ON facts(scope_id);
+CREATE INDEX IF NOT EXISTS idx_edges_scope ON edges(scope_id);
+CREATE INDEX IF NOT EXISTS idx_events_scope ON events(scope_id);
+CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
+CREATE INDEX IF NOT EXISTS idx_facts_pinned ON facts(is_pinned) WHERE is_pinned = 1;
+CREATE INDEX IF NOT EXISTS idx_facts_importance_score ON facts(importance_score);
+CREATE INDEX IF NOT EXISTS idx_facts_t_valid_due ON facts(t_valid) WHERE t_valid IS NOT NULL AND t_expired IS NULL;
+CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, sequence_id);
+";
+
     #[test]
     fn init_schema_creates_all_tables() {
         let conn = open_memory().unwrap();
@@ -772,28 +1005,28 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
         init_schema(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("4".to_string())
+            Some("5".to_string())
         );
         // migrate is a no-op on fresh DB
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("4".to_string())
+            Some("5".to_string())
         );
     }
 
     #[test]
-    fn migrate_v1_through_v4_runs_without_error() {
+    fn migrate_v1_through_v5_runs_without_error() {
         let conn = open_memory().unwrap();
         init_schema_v1(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
             Some("1".to_string())
         );
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("4".to_string())
+            Some("5".to_string())
         );
     }
 
@@ -801,11 +1034,11 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
     fn migrate_skips_if_current() {
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
-        migrate(&conn).unwrap();
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
+        migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("4".to_string())
+            Some("5".to_string())
         );
     }
 
@@ -814,7 +1047,7 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
         set_config(&conn, "schema_version", "99").unwrap();
-        let err = migrate(&conn).unwrap_err();
+        let err = migrate(&conn, None).unwrap_err();
         assert!(matches!(err, MemoryError::Migration(_)));
     }
 
@@ -836,10 +1069,10 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
         )
         .unwrap();
 
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("4".to_string())
+            Some("5".to_string())
         );
 
         // Data survived both migrations
@@ -926,10 +1159,10 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
         conn.execute("DELETE FROM events WHERE scope_id = 999", [])
             .unwrap();
 
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("4".to_string())
+            Some("5".to_string())
         );
 
         // After migration: orphan scope_id fails (FK enforced)
@@ -955,7 +1188,7 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
             [],
         ).unwrap();
 
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
 
         // FTS index was rebuilt and repopulated
         let count: i64 = conn
@@ -996,7 +1229,7 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
         .unwrap();
 
         // Migration must fail — orphan scope_id violates FK check
-        let err = migrate(&conn).unwrap_err();
+        let err = migrate(&conn, None).unwrap_err();
         assert!(
             matches!(err, MemoryError::Migration(_)),
             "expected Migration error for orphan scope_id, got: {err:?}"
@@ -1030,7 +1263,7 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
         )
         .unwrap();
 
-        migrate(&conn).unwrap();
+        migrate(&conn, None).unwrap();
 
         // Verify new columns with defaults
         let (is_pinned, importance_score): (i64, f64) = conn
@@ -1057,17 +1290,17 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("4".to_string())
+            Some("5".to_string())
         );
     }
 
     #[test]
-    fn fresh_db_creates_v4_schema() {
+    fn fresh_db_creates_v5_schema() {
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("4".to_string())
+            Some("5".to_string())
         );
         conn.execute(
             "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed, is_pinned, importance_score)
@@ -1099,5 +1332,384 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
             get_config(&conn, "schema_version").unwrap(),
             Some("1".to_string())
         );
+    }
+
+    // --- Storage epoch tests ---
+
+    #[test]
+    fn init_schema_sets_storage_epoch() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        assert_eq!(
+            get_config(&conn, "storage_epoch").unwrap(),
+            Some("1".to_string())
+        );
+    }
+
+    #[test]
+    fn migrate_rejects_future_epoch() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        set_config(&conn, "storage_epoch", "99").unwrap();
+        let err = migrate(&conn, None).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                MemoryError::UnsupportedEpoch {
+                    db_epoch: 99,
+                    supported_epoch: 1
+                }
+            ),
+            "expected UnsupportedEpoch, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn migrate_sets_epoch_for_pre_epoch_db() {
+        let conn = open_memory().unwrap();
+        init_schema_v1(&conn).unwrap();
+        // Pre-epoch DB has no storage_epoch config
+        assert!(get_config(&conn, "storage_epoch").unwrap().is_none());
+        migrate(&conn, None).unwrap();
+        // After migration, epoch is stamped
+        assert_eq!(
+            get_config(&conn, "storage_epoch").unwrap(),
+            Some("1".to_string())
+        );
+    }
+
+    #[test]
+    fn migrate_sets_epoch_for_current_version_db() {
+        let conn = open_memory().unwrap();
+        init_schema_v1(&conn).unwrap();
+        // Manually set to current version but no epoch
+        set_config(&conn, "schema_version", &CURRENT_SCHEMA_VERSION.to_string()).unwrap();
+        assert!(get_config(&conn, "storage_epoch").unwrap().is_none());
+        migrate(&conn, None).unwrap();
+        assert_eq!(
+            get_config(&conn, "storage_epoch").unwrap(),
+            Some("1".to_string())
+        );
+    }
+
+    // --- WAL-safe backup tests ---
+
+    #[test]
+    fn backup_returns_error_for_memory_db() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let err = backup_before_migration(&conn, dir.path(), 4).unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Migration(ref msg) if msg.contains("in-memory")),
+            "expected in-memory error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn backup_creates_wal_safe_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let backup_dir = dir.path().join("backups");
+        std::fs::create_dir(&backup_dir).unwrap();
+
+        // Create a real file-backed DB
+        let conn = open_connection(&db_path.to_string_lossy()).unwrap();
+        init_schema(&conn).unwrap();
+        // Insert some data
+        conn.execute(
+            "INSERT INTO events (timestamp, event_type, payload, source, scope_id)
+             VALUES (datetime('now'), 'Interaction', '{}', 'test', 1)",
+            [],
+        )
+        .unwrap();
+
+        let backup_path = backup_before_migration(&conn, &backup_dir, 4).unwrap();
+        assert!(backup_path.exists(), "backup file should exist");
+        assert!(
+            backup_path.to_string_lossy().contains("test.db.v4.bak"),
+            "backup should be named test.db.v4.bak, got: {backup_path:?}"
+        );
+
+        // Verify backup is a valid SQLite database with data
+        let backup_conn = Connection::open(&backup_path).unwrap();
+        let count: i64 = backup_conn
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "backup should contain the event");
+    }
+
+    #[test]
+    fn backup_nonexistent_dir_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let conn = open_connection(&db_path.to_string_lossy()).unwrap();
+        init_schema(&conn).unwrap();
+
+        let bad_dir = dir.path().join("nonexistent");
+        let err = backup_before_migration(&conn, &bad_dir, 4).unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Migration(ref msg) if msg.contains("backup failed")),
+            "expected backup failed error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn migrate_without_backup_dir_skips_backup() {
+        let conn = open_memory().unwrap();
+        init_schema_v1(&conn).unwrap();
+        // Should work fine with None — no backup attempted on in-memory
+        migrate(&conn, None).unwrap();
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap(),
+            Some("5".to_string())
+        );
+    }
+
+    // --- v4→v5 migration tests ---
+
+    #[test]
+    fn migrate_v4_to_v5_adds_event_revision() {
+        let conn = open_memory().unwrap();
+        init_schema_v4(&conn).unwrap();
+
+        // Insert an event at v4 (no event_revision column yet)
+        conn.execute(
+            "INSERT INTO events (timestamp, event_type, payload, source, scope_id)
+             VALUES (datetime('now'), 'Interaction', '{}', 'test', 1)",
+            [],
+        )
+        .unwrap();
+
+        migrate(&conn, None).unwrap();
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap(),
+            Some("5".to_string())
+        );
+
+        // Existing events get default revision = 1
+        let revision: i64 = conn
+            .query_row(
+                "SELECT event_revision FROM events WHERE source = 'test'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(revision, 1);
+
+        // New events can specify revision
+        conn.execute(
+            "INSERT INTO events (timestamp, event_type, payload, source, scope_id, event_revision)
+             VALUES (datetime('now'), 'ToolCall', '{}', 'test2', 1, 3)",
+            [],
+        )
+        .unwrap();
+        let rev2: i64 = conn
+            .query_row(
+                "SELECT event_revision FROM events WHERE source = 'test2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(rev2, 3);
+    }
+
+    #[test]
+    fn fresh_db_has_event_revision_column() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        // Insert with explicit event_revision
+        conn.execute(
+            "INSERT INTO events (timestamp, event_type, payload, source, scope_id, event_revision)
+             VALUES (datetime('now'), 'Interaction', '{}', 'test', 1, 2)",
+            [],
+        )
+        .unwrap();
+        let rev: i64 = conn
+            .query_row(
+                "SELECT event_revision FROM events WHERE source = 'test'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(rev, 2);
+
+        // Default is 1
+        conn.execute(
+            "INSERT INTO events (timestamp, event_type, payload, source, scope_id)
+             VALUES (datetime('now'), 'ToolCall', '{}', 'test2', 1)",
+            [],
+        )
+        .unwrap();
+        let rev_default: i64 = conn
+            .query_row(
+                "SELECT event_revision FROM events WHERE source = 'test2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(rev_default, 1);
+    }
+
+    #[test]
+    fn migrate_v1_through_v5_preserves_events() {
+        let conn = open_memory().unwrap();
+        init_schema_v1(&conn).unwrap();
+
+        // Insert event at v1
+        conn.execute(
+            "INSERT INTO events (timestamp, event_type, payload, source)
+             VALUES (datetime('now'), 'Interaction', '{\"key\":\"val\"}', 'v1-src')",
+            [],
+        )
+        .unwrap();
+
+        migrate(&conn, None).unwrap();
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap(),
+            Some("5".to_string())
+        );
+
+        // Event survived all migrations, got default revision
+        let (source, revision): (String, i64) = conn
+            .query_row(
+                "SELECT source, event_revision FROM events WHERE source = 'v1-src'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(source, "v1-src");
+        assert_eq!(revision, 1);
+    }
+
+    // --- Schema snapshot test (insta) ---
+
+    /// Deterministic projection of the schema: sorted by (type, name), SQL normalized.
+    /// This avoids SQLite formatting variance across versions.
+    fn deterministic_schema_dump(conn: &Connection) -> String {
+        let mut stmt = conn
+            .prepare(
+                "SELECT type, name, sql FROM sqlite_master
+                 WHERE sql IS NOT NULL
+                 ORDER BY type, name",
+            )
+            .unwrap();
+        let rows: Vec<String> = stmt
+            .query_map([], |row| {
+                let obj_type: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let sql: String = row.get(2)?;
+                // Normalize whitespace for determinism
+                let normalized = sql.split_whitespace().collect::<Vec<_>>().join(" ");
+                Ok(format!("-- {obj_type}: {name}\n{normalized};"))
+            })
+            .unwrap()
+            .collect::<std::result::Result<_, _>>()
+            .unwrap();
+        rows.join("\n\n")
+    }
+
+    #[test]
+    fn schema_v5_snapshot() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let schema = deterministic_schema_dump(&conn);
+        insta::assert_snapshot!("schema_v5", schema);
+    }
+
+    // --- Property-based migration tests (proptest) ---
+
+    proptest::proptest! {
+        #[test]
+        fn migration_preserves_event_count(n_events in 1_usize..20) {
+            let conn = open_memory().unwrap();
+            init_schema_v1(&conn).unwrap();
+
+            for i in 0..n_events {
+                conn.execute(
+                    "INSERT INTO events (timestamp, event_type, payload, source)
+                     VALUES (datetime('now'), 'Interaction', '{}', ?1)",
+                    rusqlite::params![format!("src-{i}")],
+                ).unwrap();
+            }
+
+            let count_before: i64 = conn
+                .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(count_before, n_events as i64);
+
+            migrate(&conn, None).unwrap();
+
+            let count_after: i64 = conn
+                .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(count_after, n_events as i64);
+        }
+
+        #[test]
+        fn migration_preserves_fact_content_hashes(n_facts in 1_usize..10) {
+            let conn = open_memory().unwrap();
+            init_schema_v1(&conn).unwrap();
+
+            let mut expected_hashes = Vec::new();
+            for i in 0..n_facts {
+                let hash = format!("hash-{i}");
+                conn.execute(
+                    "INSERT INTO facts (content, content_hash, embedding, fact_type,
+                     t_created, importance, access_count, last_accessed, metadata)
+                     VALUES (?1, ?2, X'00', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}')",
+                    rusqlite::params![format!("fact-{i}"), &hash],
+                ).unwrap();
+                expected_hashes.push(hash);
+            }
+
+            migrate(&conn, None).unwrap();
+
+            let mut stmt = conn
+                .prepare("SELECT content_hash FROM facts ORDER BY id")
+                .unwrap();
+            let actual_hashes: Vec<String> = stmt
+                .query_map([], |r| r.get(0))
+                .unwrap()
+                .collect::<std::result::Result<_, _>>()
+                .unwrap();
+            assert_eq!(actual_hashes, expected_hashes);
+        }
+
+        #[test]
+        fn migration_v1_to_v5_fk_integrity(n_events in 1_usize..5) {
+            let conn = open_memory().unwrap();
+            init_schema_v1(&conn).unwrap();
+
+            for i in 0..n_events {
+                conn.execute(
+                    "INSERT INTO events (timestamp, event_type, payload, source)
+                     VALUES (datetime('now'), 'Interaction', '{}', ?1)",
+                    rusqlite::params![format!("src-{i}")],
+                ).unwrap();
+            }
+
+            // Insert a fact referencing event 1
+            if n_events > 0 {
+                conn.execute(
+                    "INSERT INTO facts (content, content_hash, embedding, fact_type,
+                     t_created, source_event_id, importance, access_count, last_accessed, metadata)
+                     VALUES ('test', 'h1', X'00', 'episodic', datetime('now'), 1, 0.5, 0, datetime('now'), '{}')",
+                    [],
+                ).unwrap();
+            }
+
+            migrate(&conn, None).unwrap();
+
+            // PRAGMA foreign_key_check returns rows for violations — empty = clean
+            let mut stmt = conn.prepare("PRAGMA foreign_key_check").unwrap();
+            let violations: Vec<String> = stmt
+                .query_map([], |r| r.get::<_, String>(0))
+                .unwrap()
+                .collect::<std::result::Result<_, _>>()
+                .unwrap();
+            assert!(violations.is_empty(), "FK violations: {violations:?}");
+        }
     }
 }

--- a/src/store/scopes.rs
+++ b/src/store/scopes.rs
@@ -161,7 +161,7 @@ mod tests {
     fn setup() -> Connection {
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
-        crate::store::schema::migrate(&conn).unwrap();
+        crate::store::schema::migrate(&conn, None).unwrap();
         conn
     }
 

--- a/src/store/snapshots/memory_engine__store__schema__tests__schema_v5.snap
+++ b/src/store/snapshots/memory_engine__store__schema__tests__schema_v5.snap
@@ -1,0 +1,106 @@
+---
+source: src/store/schema.rs
+assertion_line: 1618
+expression: schema
+---
+-- index: idx_edges_expired
+CREATE INDEX idx_edges_expired ON edges(t_expired);
+
+-- index: idx_edges_scope
+CREATE INDEX idx_edges_scope ON edges(scope_id);
+
+-- index: idx_edges_source
+CREATE INDEX idx_edges_source ON edges(source_fact_id);
+
+-- index: idx_edges_target
+CREATE INDEX idx_edges_target ON edges(target_fact_id);
+
+-- index: idx_events_origin_seq
+CREATE INDEX idx_events_origin_seq ON events(origin_node_id, sequence_id);
+
+-- index: idx_events_scope
+CREATE INDEX idx_events_scope ON events(scope_id);
+
+-- index: idx_events_session
+CREATE INDEX idx_events_session ON events(session_id) WHERE session_id IS NOT NULL;
+
+-- index: idx_events_timestamp
+CREATE INDEX idx_events_timestamp ON events(timestamp);
+
+-- index: idx_facts_expired
+CREATE INDEX idx_facts_expired ON facts(t_expired);
+
+-- index: idx_facts_hash
+CREATE INDEX idx_facts_hash ON facts(content_hash);
+
+-- index: idx_facts_importance_score
+CREATE INDEX idx_facts_importance_score ON facts(importance_score);
+
+-- index: idx_facts_pinned
+CREATE INDEX idx_facts_pinned ON facts(is_pinned) WHERE is_pinned = 1;
+
+-- index: idx_facts_scope
+CREATE INDEX idx_facts_scope ON facts(scope_id);
+
+-- index: idx_facts_t_valid_due
+CREATE INDEX idx_facts_t_valid_due ON facts(t_valid) WHERE t_valid IS NOT NULL AND t_expired IS NULL;
+
+-- index: idx_facts_type
+CREATE INDEX idx_facts_type ON facts(fact_type);
+
+-- index: idx_facts_valid
+CREATE INDEX idx_facts_valid ON facts(t_valid, t_invalid);
+
+-- index: idx_scopes_parent
+CREATE INDEX idx_scopes_parent ON scopes(parent_id);
+
+-- index: idx_scopes_parent_label
+CREATE UNIQUE INDEX idx_scopes_parent_label ON scopes(parent_id, label);
+
+-- index: idx_summaries_scope
+CREATE INDEX idx_summaries_scope ON summaries(scope_id);
+
+-- table: config
+CREATE TABLE config ( key TEXT PRIMARY KEY, value TEXT NOT NULL );
+
+-- table: edges
+CREATE TABLE edges ( id INTEGER PRIMARY KEY AUTOINCREMENT, source_fact_id INTEGER NOT NULL REFERENCES facts(id), target_fact_id INTEGER NOT NULL REFERENCES facts(id), relation_type TEXT NOT NULL, weight REAL NOT NULL DEFAULT 1.0, t_created TEXT NOT NULL, t_expired TEXT, scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id) );
+
+-- table: events
+CREATE TABLE events ( id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL, event_type TEXT NOT NULL, payload TEXT NOT NULL DEFAULT '{}', source TEXT NOT NULL, session_id TEXT, scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id), origin_node_id TEXT NOT NULL DEFAULT 'local', sequence_id INTEGER NOT NULL DEFAULT 0, created_at TEXT, event_revision INTEGER NOT NULL DEFAULT 1 );
+
+-- table: facts
+CREATE TABLE facts ( id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT NOT NULL, content_hash TEXT NOT NULL, -- blake3 hex[:16] for dedup embedding BLOB NOT NULL, fact_type TEXT NOT NULL CHECK(fact_type IN ('episodic', 'semantic', 'procedural')), t_created TEXT NOT NULL, t_expired TEXT, t_valid TEXT, t_invalid TEXT, source_event_id INTEGER REFERENCES events(id), importance REAL NOT NULL DEFAULT 0.5, access_count INTEGER NOT NULL DEFAULT 0, last_accessed TEXT NOT NULL, metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)), scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id), is_pinned INTEGER NOT NULL DEFAULT 0, importance_score REAL NOT NULL DEFAULT 0.5 );
+
+-- table: facts_fts
+CREATE VIRTUAL TABLE facts_fts USING fts5( content, content='facts', content_rowid='id', tokenize='porter unicode61' );
+
+-- table: facts_fts_config
+CREATE TABLE 'facts_fts_config'(k PRIMARY KEY, v) WITHOUT ROWID;
+
+-- table: facts_fts_data
+CREATE TABLE 'facts_fts_data'(id INTEGER PRIMARY KEY, block BLOB);
+
+-- table: facts_fts_docsize
+CREATE TABLE 'facts_fts_docsize'(id INTEGER PRIMARY KEY, sz BLOB);
+
+-- table: facts_fts_idx
+CREATE TABLE 'facts_fts_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID;
+
+-- table: scopes
+CREATE TABLE scopes ( id INTEGER PRIMARY KEY AUTOINCREMENT, parent_id INTEGER REFERENCES scopes(id), label TEXT NOT NULL, depth INTEGER NOT NULL DEFAULT 0 );
+
+-- table: sqlite_sequence
+CREATE TABLE sqlite_sequence(name,seq);
+
+-- table: summaries
+CREATE TABLE summaries ( id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT NOT NULL, embedding BLOB NOT NULL, level TEXT NOT NULL CHECK(level IN ('local', 'cluster', 'global')), source_fact_ids TEXT NOT NULL DEFAULT '[]', created_at TEXT NOT NULL, scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id) );
+
+-- trigger: facts_fts_ad
+CREATE TRIGGER facts_fts_ad AFTER DELETE ON facts BEGIN INSERT INTO facts_fts(facts_fts, rowid, content) VALUES ('delete', old.id, old.content); END;
+
+-- trigger: facts_fts_ai
+CREATE TRIGGER facts_fts_ai AFTER INSERT ON facts BEGIN INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content); END;
+
+-- trigger: facts_fts_au
+CREATE TRIGGER facts_fts_au AFTER UPDATE ON facts BEGIN INSERT INTO facts_fts(facts_fts, rowid, content) VALUES ('delete', old.id, old.content); INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content); END;

--- a/src/store/summaries.rs
+++ b/src/store/summaries.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
 use crate::store::{deserialize_embedding, parse_timestamp, serialize_embedding};
@@ -282,12 +282,10 @@ mod tests {
 
         let deleted = store.delete_by_level(&ConsolidationLevel::Cluster).unwrap();
         assert_eq!(deleted, 2);
-        assert!(
-            store
-                .list_by_level(&ConsolidationLevel::Cluster)
-                .unwrap()
-                .is_empty()
-        );
+        assert!(store
+            .list_by_level(&ConsolidationLevel::Cluster)
+            .unwrap()
+            .is_empty());
         assert_eq!(
             store
                 .list_by_level(&ConsolidationLevel::Global)

--- a/src/store/upcaster.rs
+++ b/src/store/upcaster.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+
+use crate::error::{MemoryError, Result};
+
+/// Function that transforms an event payload from revision N to N+1.
+pub type UpcasterFn = fn(serde_json::Value) -> Result<serde_json::Value>;
+
+/// Registry of per-event-type upcaster functions.
+///
+/// Each upcaster transforms a payload from revision `N` to `N+1`.
+/// Chains are applied sequentially: if an event is at revision 1 and
+/// the latest is 3, upcasters `(1→2)` then `(2→3)` run in order.
+///
+/// Raw reads (`EventStore::get`/`list`) bypass this entirely — audit-log
+/// semantics are preserved. Only `get_upcasted`/`list_upcasted` apply the chain.
+#[derive(Clone)]
+pub struct UpcasterRegistry {
+    /// `(event_type, from_revision)` → upcaster function
+    upcasters: HashMap<(String, u16), UpcasterFn>,
+    /// `event_type` → latest known revision
+    latest: HashMap<String, u16>,
+}
+
+impl std::fmt::Debug for UpcasterRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpcasterRegistry")
+            .field("registered_upcasters", &self.upcasters.len())
+            .field("latest_revisions", &self.latest)
+            .finish()
+    }
+}
+
+impl Default for UpcasterRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UpcasterRegistry {
+    /// Create an empty registry. All event types default to revision 1.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            upcasters: HashMap::new(),
+            latest: HashMap::new(),
+        }
+    }
+
+    /// Register an upcaster that transforms `event_type` payloads from
+    /// `from_revision` to `from_revision + 1`.
+    ///
+    /// The latest revision for this event type is automatically tracked as
+    /// `max(current_latest, from_revision + 1)`.
+    pub fn register(&mut self, event_type: &str, from_revision: u16, func: UpcasterFn) {
+        let target = from_revision + 1;
+        self.upcasters
+            .insert((event_type.to_string(), from_revision), func);
+        let current = self.latest.entry(event_type.to_string()).or_insert(1);
+        if target > *current {
+            *current = target;
+        }
+    }
+
+    /// Get the latest known revision for an event type.
+    /// Returns 1 if no upcasters are registered for this type.
+    #[must_use]
+    pub fn latest_revision(&self, event_type: &str) -> u16 {
+        self.latest.get(event_type).copied().unwrap_or(1)
+    }
+
+    /// Apply the upcaster chain to transform a payload from `current_revision`
+    /// to the latest revision for `event_type`.
+    ///
+    /// Returns `(transformed_payload, final_revision)`.
+    ///
+    /// If no upcasters are registered or the payload is already at latest,
+    /// returns the payload unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Migration` if there's a gap in the upcaster chain
+    /// (e.g., revision 2→3 is registered but 1→2 is missing).
+    pub fn upcast(
+        &self,
+        event_type: &str,
+        current_revision: u16,
+        payload: serde_json::Value,
+    ) -> Result<(serde_json::Value, u16)> {
+        let latest = self.latest_revision(event_type);
+        if current_revision >= latest {
+            return Ok((payload, current_revision));
+        }
+
+        let mut value = payload;
+        let mut rev = current_revision;
+
+        while rev < latest {
+            let key = (event_type.to_string(), rev);
+            let func = self.upcasters.get(&key).ok_or_else(|| {
+                MemoryError::Migration(format!(
+                    "missing upcaster for event type '{event_type}' from revision {rev} to {}",
+                    rev + 1
+                ))
+            })?;
+            value = func(value)?;
+            rev += 1;
+        }
+
+        Ok((value, rev))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_returns_unchanged() {
+        let registry = UpcasterRegistry::new();
+        let payload = serde_json::json!({"key": "value"});
+        let (result, rev) = registry.upcast("Interaction", 1, payload.clone()).unwrap();
+        assert_eq!(result, payload);
+        assert_eq!(rev, 1);
+    }
+
+    #[test]
+    fn latest_revision_defaults_to_1() {
+        let registry = UpcasterRegistry::new();
+        assert_eq!(registry.latest_revision("Interaction"), 1);
+        assert_eq!(registry.latest_revision("NonExistent"), 1);
+    }
+
+    #[test]
+    fn single_upcaster_transforms() {
+        let mut registry = UpcasterRegistry::new();
+        registry.register("Interaction", 1, |mut v| {
+            v["version"] = serde_json::json!("v2");
+            Ok(v)
+        });
+
+        assert_eq!(registry.latest_revision("Interaction"), 2);
+
+        let payload = serde_json::json!({"msg": "hello"});
+        let (result, rev) = registry.upcast("Interaction", 1, payload).unwrap();
+        assert_eq!(rev, 2);
+        assert_eq!(result["version"], "v2");
+        assert_eq!(result["msg"], "hello");
+    }
+
+    #[test]
+    fn chain_transforms_sequentially() {
+        let mut registry = UpcasterRegistry::new();
+        // 1→2: add field
+        registry.register("ToolCall", 1, |mut v| {
+            v["step1"] = serde_json::json!(true);
+            Ok(v)
+        });
+        // 2→3: rename field
+        registry.register("ToolCall", 2, |mut v| {
+            v["step2"] = serde_json::json!(true);
+            Ok(v)
+        });
+
+        assert_eq!(registry.latest_revision("ToolCall"), 3);
+
+        let payload = serde_json::json!({"original": true});
+        let (result, rev) = registry.upcast("ToolCall", 1, payload).unwrap();
+        assert_eq!(rev, 3);
+        assert!(result["original"].as_bool().unwrap());
+        assert!(result["step1"].as_bool().unwrap());
+        assert!(result["step2"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn missing_in_chain_errors() {
+        let mut registry = UpcasterRegistry::new();
+        // Register 2→3 but NOT 1→2 — creates a gap
+        registry.register("ToolCall", 2, |v| Ok(v));
+
+        let payload = serde_json::json!({});
+        let err = registry.upcast("ToolCall", 1, payload).unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Migration(ref msg) if msg.contains("missing upcaster")),
+            "expected missing upcaster error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn noop_at_latest() {
+        let mut registry = UpcasterRegistry::new();
+        registry.register("Interaction", 1, |mut v| {
+            v["transformed"] = serde_json::json!(true);
+            Ok(v)
+        });
+
+        // Already at latest revision 2
+        let payload = serde_json::json!({"data": 42});
+        let (result, rev) = registry.upcast("Interaction", 2, payload.clone()).unwrap();
+        assert_eq!(result, payload); // unchanged
+        assert_eq!(rev, 2);
+    }
+
+    #[test]
+    fn independent_event_types() {
+        let mut registry = UpcasterRegistry::new();
+        registry.register("Interaction", 1, |mut v| {
+            v["interaction_v2"] = serde_json::json!(true);
+            Ok(v)
+        });
+        registry.register("ToolCall", 1, |mut v| {
+            v["toolcall_v2"] = serde_json::json!(true);
+            Ok(v)
+        });
+
+        assert_eq!(registry.latest_revision("Interaction"), 2);
+        assert_eq!(registry.latest_revision("ToolCall"), 2);
+        assert_eq!(registry.latest_revision("MemoryOp"), 1); // no upcasters
+
+        let (r1, _) = registry
+            .upcast("Interaction", 1, serde_json::json!({}))
+            .unwrap();
+        assert!(r1["interaction_v2"].as_bool().unwrap());
+        assert!(r1.get("toolcall_v2").is_none());
+    }
+}

--- a/src/store/upcaster.rs
+++ b/src/store/upcaster.rs
@@ -93,9 +93,10 @@ impl UpcasterRegistry {
 
         let mut value = payload;
         let mut rev = current_revision;
+        let type_key = event_type.to_string();
 
         while rev < latest {
-            let key = (event_type.to_string(), rev);
+            let key = (type_key.clone(), rev);
             let func = self.upcasters.get(&key).ok_or_else(|| {
                 MemoryError::Migration(format!(
                     "missing upcaster for event type '{event_type}' from revision {rev} to {}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -68,6 +68,13 @@ pub struct Event {
     pub sequence_id: i64,
     /// When the event was ingested into this node's store (ingest-time).
     pub created_at: Option<DateTime<Utc>>,
+    /// Schema revision of the event payload (for upcasting at read time).
+    #[serde(default = "default_event_revision")]
+    pub event_revision: u16,
+}
+
+const fn default_event_revision() -> u16 {
+    1
 }
 
 /// A bi-temporal fact derived from events.
@@ -239,6 +246,7 @@ mod tests {
             origin_node_id: "local".into(),
             sequence_id: 0,
             created_at: None,
+            event_revision: 1,
         };
         let json = serde_json::to_string(&event).unwrap();
         let back: Event = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary

- **Storage epoch versioning**: coarse-grained compatibility gate (`STORAGE_EPOCH=1`) stored in config table. Rejects databases from future epochs with `MemoryError::UnsupportedEpoch`
- **WAL-safe pre-migration backup**: `VACUUM INTO` creates atomic, consistent backup before migrations. Opt-in via `EngineConfig::backup_dir`
- **Event envelope versioning**: migration v4→v5 adds `event_revision INTEGER NOT NULL DEFAULT 1` to events table. Per-event-type revision tracking via `UpcasterRegistry`
- **Raw vs upcasted reads**: `get()`/`list()` unchanged (audit-log semantics). New `get_upcasted()`/`list_upcasted()` apply upcaster chains at read time
- **UpcasterRegistry**: `fn(Value) -> Result<Value>` functions keyed by `(event_type, from_revision)`, chained sequentially for multi-step upgrades
- **Migration testing infrastructure**: insta snapshot test (deterministic DDL projection), 3 proptest property-based tests (row count, content hashes, FK integrity), frozen V4 DDL snapshot
- **Schema evolution policy**: formal document covering version axes, forward-only policy, backup, envelope versioning, and testing requirements

## Stats

- 18 files changed, 1381 insertions, 69 deletions
- 214 tests pass (187 original + 27 new)
- 3 new files: `src/store/upcaster.rs`, `docs/schema-evolution-policy.md`, insta snapshot

## Design decisions

Based on 3-way AI research consensus (Claude/Codex/Gemini) documented in issue #18:
1. Forward-only migrations with pre-migration backup (no rollback code)
2. `event_revision` on `Event` only (read side) — `NewEvent` unchanged, store stamps internally
3. Explicit raw/upcasted read separation preserves audit-log integrity
4. Storage epoch as coarse-grained break-glass for architectural changes

## Test plan

- [x] All 214 tests pass (`cargo test`)
- [x] No new clippy warnings from changed code
- [x] Migration chain v1→v2→v3→v4→v5 verified
- [x] Property-based tests: row count preserved, content hashes survive, FK integrity clean
- [x] Insta snapshot accepted for v5 schema
- [x] Upcaster chain: single, sequential, gap detection, noop at latest
- [x] Raw reads return stored data unchanged; upcasted reads apply transforms

Closes #18