### PR TITLE
feat(inspect): populate source_event in FactProvenance

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -134,13 +134,13 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 ### Inspection
 
-| Method          | Signature                                              | Description                                                                                      |
-| --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| `statistics`    | `(&self) -> Result<EngineStatistics>`                  | Aggregate counts of facts, edges, summaries, scopes, events, and storage metrics.                |
-| `explain_fact`  | `(&self, id: i64) -> Result<FactExplanation>`          | Why a fact is in its current state: provenance, graph context, scope path.                       |
-| `fact_history`  | `(&self, id: i64) -> Result<FactHistory>`              | Bi-temporal timeline of a fact's lifecycle from its temporal stamps.                             |
-| `replay_events` | `(&self, filter: &ReplayFilter) -> Result<Vec<Event>>` | Replay a filtered segment of the event log. Supports ID range, time window, session, and upcast. |
-| `dump_state`    | `(&self, format: &DumpFormat) -> Result<()>`           | Export full engine state to JSON or SQLite backup.                                               |
+| Method          | Signature                                              | Description                                                                                                   |
+| --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `statistics`    | `(&self) -> Result<EngineStatistics>`                  | Aggregate counts of facts, edges, summaries, scopes, events, and storage metrics.                             |
+| `explain_fact`  | `(&self, id: i64) -> Result<FactExplanation>`          | Why a fact is in its current state: provenance (with source event when available), graph context, scope path. |
+| `fact_history`  | `(&self, id: i64) -> Result<FactHistory>`              | Bi-temporal timeline of a fact's lifecycle from its temporal stamps.                                          |
+| `replay_events` | `(&self, filter: &ReplayFilter) -> Result<Vec<Event>>` | Replay a filtered segment of the event log. Supports ID range, time window, session, and upcast.              |
+| `dump_state`    | `(&self, format: &DumpFormat) -> Result<()>`           | Export full engine state to JSON or SQLite backup.                                                            |
 
 ### Scheduling
 

--- a/docs/usage/inspection.md
+++ b/docs/usage/inspection.md
@@ -79,6 +79,29 @@ The state is determined by the **first matching** rule:
 4. `t_valid <= now` and not invalidated → `Due`
 5. Otherwise → `Active`
 
+### Provenance and source event
+
+`FactProvenance` includes the originating event when the fact has a `source_event_id`:
+
+```rust
+let explanation = engine.explain_fact(fact_id)?;
+if let Some(event) = &explanation.provenance.source_event {
+    println!("Created from event {}: {:?}", event.id, event.event_type);
+    println!("Payload: {}", event.payload);
+}
+```
+
+- **What:** `FactProvenance.source_event` contains the full `Event` that produced this
+  fact, fetched via upcasted read so the payload is always at the latest schema revision.
+- **Why:** Enables full provenance tracing — from fact to originating event — without
+  a separate event lookup. Useful for debugging, auditing, and tooling integration.
+- **How:** Automatically populated when the fact has a `source_event_id` (set during
+  `add_fact()` when extracting from an ingested event). `None` for facts created
+  without a source event.
+
+Note: the full `Event` envelope is exposed (payload, source, session_id, origin_node_id,
+sequence_id). This is intentional for inspection/debugging use cases.
+
 ### Limitations
 
 - **`ExpiredReason`** is best-effort. Most expired facts return `Unknown` because

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1215,7 +1215,14 @@ impl MemoryEngine {
         let graph = self.graph.read();
         let scope_tree = self.scope_tree.read();
         self.with_read(|conn| {
-            crate::inspect::explain::explain_fact(conn, &graph, &scope_tree, self.embed_dim, id)
+            crate::inspect::explain::explain_fact(
+                conn,
+                &graph,
+                &scope_tree,
+                self.embed_dim,
+                id,
+                &self.upcaster_registry,
+            )
         })
     }
 

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -4,7 +4,9 @@ use rusqlite::Connection;
 use crate::error::Result;
 use crate::graph::MemoryGraph;
 use crate::scope::tree::ScopeTree;
+use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
+use crate::store::upcaster::UpcasterRegistry;
 use crate::types::Fact;
 
 use super::types::{
@@ -14,23 +16,28 @@ use super::types::{
 
 /// Explain why a fact is in its current state.
 ///
+/// When the fact has a `source_event_id`, the originating event is fetched via
+/// [`EventStore::get_upcasted`] and included in the provenance output.
+///
 /// # Errors
 ///
-/// Returns [`MemoryError::NotFound`] if the fact does not exist, or
-/// [`MemoryError::Database`] on SQL failure.
+/// Returns [`MemoryError::NotFound`] if the fact (or its source event) does not exist.
+/// Returns [`MemoryError::Migration`] if the source event cannot be upcasted.
+/// Returns [`MemoryError::Database`] on SQL failure.
 pub fn explain_fact(
     conn: &Connection,
     graph: &MemoryGraph,
     scope_tree: &ScopeTree,
     embed_dim: usize,
     fact_id: i64,
+    registry: &UpcasterRegistry,
 ) -> Result<FactExplanation> {
     let store = FactStore::new(conn, embed_dim);
     let fact = store.get(fact_id)?;
     let now = Utc::now();
 
     let state = determine_state(&fact, now);
-    let provenance = build_provenance(&fact);
+    let provenance = build_provenance(conn, registry, &fact)?;
     let graph_context = build_graph_context(graph, fact_id);
     let scope_path = scope_tree
         .path_for_id(fact.scope_id)
@@ -74,15 +81,27 @@ fn determine_state(fact: &Fact, now: DateTime<Utc>) -> FactState {
     FactState::Active
 }
 
-const fn build_provenance(fact: &Fact) -> FactProvenance {
-    FactProvenance {
+fn build_provenance(
+    conn: &Connection,
+    registry: &UpcasterRegistry,
+    fact: &Fact,
+) -> Result<FactProvenance> {
+    let source_event = match fact.source_event_id {
+        Some(event_id) => {
+            let event_store = EventStore::new(conn, registry);
+            Some(event_store.get_upcasted(event_id)?)
+        }
+        None => None,
+    };
+
+    Ok(FactProvenance {
         source_event_id: fact.source_event_id,
-        source_event: None,
+        source_event,
         importance: fact.importance,
         importance_score: fact.importance_score,
         is_pinned: fact.is_pinned,
         access_count: fact.access_count,
-    }
+    })
 }
 
 fn build_graph_context(graph: &MemoryGraph, fact_id: i64) -> GraphContext {
@@ -150,7 +169,7 @@ mod tests {
     use super::*;
     use crate::engine::MemoryEngine;
     use crate::traits::EmbeddingProvider;
-    use crate::types::{AddFactOptions, FactType};
+    use crate::types::{AddFactOptions, EventType, FactType, NewEvent};
     use chrono::Duration;
 
     const DIM: usize = 4;
@@ -291,5 +310,67 @@ mod tests {
             history.timeline[0].kind,
             HistoryEventKind::Created
         ));
+    }
+
+    #[test]
+    fn explain_fact_with_source_event() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+
+        // Ingest an event to get an event_id
+        let event = NewEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::json!({"role": "user", "content": "hello"}),
+            source: "test".to_string(),
+            session_id: Some("sess-1".to_string()),
+            scope_id: 1,
+            origin_node_id: "node-1".to_string(),
+            sequence_id: 1,
+            created_at: None,
+        };
+        let event_id = engine.ingest(&event).unwrap();
+
+        // Create a fact linked to that event
+        let fact_id = engine
+            .add_fact(
+                "fact from event",
+                FactType::Semantic,
+                Some(event_id),
+                &FakeEmbed,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let explanation = engine.explain_fact(fact_id).unwrap();
+        assert_eq!(explanation.provenance.source_event_id, Some(event_id));
+
+        let source_event = explanation
+            .provenance
+            .source_event
+            .expect("source_event should be populated");
+        assert_eq!(source_event.id, event_id);
+        assert!(matches!(source_event.event_type, EventType::Interaction));
+    }
+
+    #[test]
+    fn explain_fact_without_source_event() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let fact_id = engine
+            .add_fact(
+                "standalone fact",
+                FactType::Semantic,
+                None,
+                &FakeEmbed,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let explanation = engine.explain_fact(fact_id).unwrap();
+        assert_eq!(explanation.provenance.source_event_id, None);
+        assert!(explanation.provenance.source_event.is_none());
     }
 }

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -54,8 +54,8 @@ pub enum ExpiredReason {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FactProvenance {
     pub source_event_id: Option<i64>,
-    /// The source event, if available. Currently always `None` — populating this
-    /// requires an `EventStore` lookup that is deferred to a future version.
+    /// The originating event, fetched via upcasted read when `source_event_id`
+    /// is `Some`. `None` for facts created without a `source_event_id`.
     pub source_event: Option<Event>,
     pub importance: f64,
     pub importance_score: f64,


### PR DESCRIPTION
## Summary

- Thread `UpcasterRegistry` into `explain_fact()` so `FactProvenance.source_event` is populated when `source_event_id` is `Some`
- Uses `get_upcasted()` per schema-evolution policy (application-facing API)
- Errors propagate — FK constraints guarantee event exists; no graceful degradation needed
- Updates rustdoc, usage docs (`inspection.md`), and API reference

## Changes

| File | Change |
|------|--------|
| `src/inspect/explain.rs` | Add `registry` param, fetch upcasted event in `build_provenance()` |
| `src/engine.rs` | Pass `&self.upcaster_registry` to inner call |
| `src/inspect/types.rs` | Update rustdoc on `source_event` field |
| `docs/usage/inspection.md` | Document `source_event` field (what/why/how) |
| `docs/reference/api.md` | Update `explain_fact` description |

## Test plan

- [x] `explain_fact_with_source_event` — verifies source event is populated when `source_event_id` is `Some`
- [x] `explain_fact_without_source_event` — verifies `None` when no source event
- [x] Full test suite passes (323 tests, 0 failures)
- [x] Clippy clean on changed files (101 pre-existing warnings on main unchanged)

Fixes #77