### PR TITLE
feat(inspect): dedicated surfaced_at column for due facts

### DIFF
--- a/docs/advanced/bi-temporal-semantics.md
+++ b/docs/advanced/bi-temporal-semantics.md
@@ -135,7 +135,7 @@ if let Some(next) = engine.next_due_time(None)? {
 }
 ```
 
-`list_due(now, scope)` returns active facts where `t_valid <= now` and `t_valid IS NOT NULL`, excluding bi-temporally invalidated facts (`t_invalid <= now`). `next_due_time(scope)` returns the earliest `t_valid` among facts where `t_valid > now`, allowing the consumer to schedule its next poll without busy-waiting. Both methods resolve `None` to the root scope only — pass an explicit scope path to include child scopes.
+`list_due(now, scope)` returns active facts where `t_valid <= now` and `t_valid IS NOT NULL`, excluding bi-temporally invalidated facts (`t_invalid <= now`). On first return, each fact's `surfaced_at` column is stamped with the current time so callers can distinguish newly-due facts from previously-surfaced ones. `next_due_time(scope)` returns the earliest `t_valid` among facts where `t_valid > now`, allowing the consumer to schedule its next poll without busy-waiting. Both methods resolve `None` to the root scope only — pass an explicit scope path to include child scopes.
 
 **Historical queries**. Query what the agent knew at a past point in time by setting `valid_at` to a historical timestamp.
 

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -94,10 +94,10 @@ Pinned facts model agent identity, core beliefs, and critical knowledge that sho
 
 Facts with `t_valid` set in the future are invisible to present-time queries but surface when their time arrives. The scheduling API supports this:
 
-- `list_due(now, scope)` — returns facts whose `t_valid <= now` (they have become valid)
+- `list_due(now, scope)` — returns facts whose `t_valid <= now` (they have become valid). Stamps `surfaced_at` on first return.
 - `next_due_time(scope)` — returns the earliest future `t_valid`, so the consumer knows when to poll again
 
-This enables reminders, deferred knowledge, and time-triggered agent behavior.
+The `surfaced_at` timestamp lets callers distinguish newly-due facts from previously-surfaced ones. This enables reminders, deferred knowledge, and time-triggered agent behavior.
 
 ## Scoping
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -32,10 +32,10 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 ### Bootstrap
 
-| Method                | Signature                                                                                                    | Description                                                                                                             |
-| --------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `bootstrap_session`   | `(&self, reader, embedder, extractor, config, classifier) -> Result<BootstrapReport>`                        | Bootstrap a single JSONL session log. Savepoint-wrapped for crash safety. Uses marker event for idempotency.            |
-| `bootstrap_directory` | `(&self, dir: &Path, embedder, extractor, config, classifier) -> Result<BootstrapReport>`                    | Bootstrap all top-level `*.jsonl` files in a directory. Aggregates reports. Individual failures are logged and skipped.  |
+| Method                | Signature                                                                                 | Description                                                                                                             |
+| --------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `bootstrap_session`   | `(&self, reader, embedder, extractor, config, classifier) -> Result<BootstrapReport>`     | Bootstrap a single JSONL session log. Savepoint-wrapped for crash safety. Uses marker event for idempotency.            |
+| `bootstrap_directory` | `(&self, dir: &Path, embedder, extractor, config, classifier) -> Result<BootstrapReport>` | Bootstrap all top-level `*.jsonl` files in a directory. Aggregates reports. Individual failures are logged and skipped. |
 
 ### Facts
 
@@ -141,10 +141,10 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 ### Scheduling
 
-| Method          | Signature                                                               | Description                                                                                           |
-| --------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `list_due`      | `(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>>` | List active facts whose `t_valid <= now` (future memory that has surfaced). `None` scope = root only. |
-| `next_due_time` | `(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>>`         | Scheduling hint: earliest `t_valid` among active future-dated facts. `None` scope = root only.        |
+| Method          | Signature                                                               | Description                                                                                                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_due`      | `(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>>` | List active facts whose `t_valid <= now` (future memory that has surfaced). Stamps `surfaced_at` on first return so callers can distinguish newly-due from previously-seen facts. `None` scope = root only. |
+| `next_due_time` | `(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>>`         | Scheduling hint: earliest `t_valid` among active future-dated facts. `None` scope = root only.                                                                                                              |
 
 ### Resume
 
@@ -172,10 +172,10 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 ### Bootstrap
 
-| Method                | Signature                                                                                                                   | Description                                                                                                                                                      |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bootstrap_session`   | `(&self, reader, embedder, extractor, config, classifier) -> Result<BootstrapReport>`                                       | Parse a single JSONL session log and import noteworthy episodes as historical facts. Uses savepoint transactions for crash safety and event-based idempotency.   |
-| `bootstrap_directory` | `(&self, dir: &Path, embedder, extractor, config, classifier) -> Result<BootstrapReport>`                                   | Discover and bootstrap all top-level `*.jsonl` files in a directory. Individual session failures are logged and skipped. Returns an aggregated report.            |
+| Method                | Signature                                                                                 | Description                                                                                                                                                    |
+| --------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bootstrap_session`   | `(&self, reader, embedder, extractor, config, classifier) -> Result<BootstrapReport>`     | Parse a single JSONL session log and import noteworthy episodes as historical facts. Uses savepoint transactions for crash safety and event-based idempotency. |
+| `bootstrap_directory` | `(&self, dir: &Path, embedder, extractor, config, classifier) -> Result<BootstrapReport>` | Discover and bootstrap all top-level `*.jsonl` files in a directory. Individual session failures are logged and skipped. Returns an aggregated report.         |
 
 `BootstrapConfig` fields:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -143,7 +143,7 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 | Method          | Signature                                                               | Description                                                                                                                                                                                                 |
 | --------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `list_due`      | `(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>>` | List active facts whose `t_valid <= now` (future memory that has surfaced). Stamps `surfaced_at` on first return so callers can distinguish newly-due from previously-seen facts. `None` scope = root only. |
+| `list_due`      | `(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>>` | List active facts whose `t_valid <= now` (future memory that has surfaced). Stamps `surfaced_at` on first return so callers can distinguish newly-due from previously-surfaced facts — the old heuristic (`access_count > 0 && last_accessed > t_valid`) was unreliable for bootstrap/past-dated facts. `None` scope = root only. |
 | `next_due_time` | `(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>>`         | Scheduling hint: earliest `t_valid` among active future-dated facts. `None` scope = root only.                                                                                                              |
 
 ### Resume

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -48,7 +48,7 @@ Pinned fact
 : A fact marked as unforgettable (`is_pinned = true`). Pinned facts are never expired by forgetting and never deduplicated during consolidation. They appear in tier 1 of `resume_context()`. Facts can be pinned explicitly via `pin_fact()`, through `AddFactOptions { pinned: Some(true) }`, or automatically by a `PersistenceClassifier`.
 
 Future memory
-: A fact with `t_valid` set in the future. Invisible to present-time queries until `t_valid` arrives. Retrieved via `list_due(now)` when the time comes. Enables reminders, deferred knowledge, and scheduled agent behavior.
+: A fact with `t_valid` set in the future. Invisible to present-time queries until `t_valid` arrives. Retrieved via `list_due(now)` when the time comes — the first call stamps `surfaced_at` so callers can distinguish newly-due facts from previously-surfaced ones. Enables reminders, deferred knowledge, and scheduled agent behavior.
 
 Importance score (materialized)
 : A composite score in [0, 1] stored on each fact as `importance_score`. Computed during `forget()` as a weighted sum of recency, frequency, graph connectivity, and base importance. Used by `resume_context()` tier 2 (high-importance) to select facts without recomputation.
@@ -57,7 +57,7 @@ PersistenceClassifier
 : Consumer-provided trait that decides whether a newly inserted fact should be pinned. Called during `add_fact()` with a pre-insert synthetic `Fact`. Default implementation returns `false` (opt-in). Classifiers should rely on `content`, `fact_type`, `importance`, and `metadata` only.
 
 Scheduling API
-: The `list_due(now, scope)` and `next_due_time(scope)` methods. `list_due` returns active facts whose `t_valid` has arrived. `next_due_time` returns the earliest future `t_valid` for poll scheduling.
+: The `list_due(now, scope)` and `next_due_time(scope)` methods. `list_due` returns active facts whose `t_valid` has arrived and stamps `surfaced_at` on first return. `next_due_time` returns the earliest future `t_valid` for poll scheduling.
 
 Global summary invariant
 : Global-level summaries (consolidation pass 3) are always placed at `scope_id=1` (root scope), regardless of the scopes of the underlying facts. Cluster-level summaries use majority-vote scope assignment.

--- a/docs/usage/inspection.md
+++ b/docs/usage/inspection.md
@@ -58,8 +58,8 @@ match &explanation.state {
     FactState::Active => println!("Alive and well"),
     FactState::Expired { reason } => println!("Expired: {reason:?}"),
     FactState::Pinned => println!("Pinned (unforgettable)"),
-    FactState::Due { t_valid, surfaced } => {
-        println!("Due since {t_valid}, surfaced={surfaced}")
+    FactState::Due { t_valid, surfaced_at } => {
+        println!("Due since {t_valid}, surfaced_at={surfaced_at:?}")
     }
     FactState::Invalidated { t_invalid } => {
         println!("Invalidated at {t_invalid}")

--- a/docs/usage/inspection.md
+++ b/docs/usage/inspection.md
@@ -50,7 +50,9 @@ println!("DB size:      {} bytes", stats.storage.main_db_bytes);
 ## Explain Fact
 
 Answers "why is this fact in its current state?" Returns provenance, graph context,
-and the resolved scope path.
+and the resolved scope path. For due facts, the `surfaced_at` timestamp records
+when `list_due()` or `resume_context()` first returned the fact — `None` means it
+has not yet been surfaced to any consumer.
 
 ```rust
 let explanation = engine.explain_fact(fact_id)?;

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -222,6 +222,7 @@ fn bootstrap_within_savepoint(
                     scope_id,
                     is_pinned: false,
                     importance_score: fact.importance,
+                    surfaced_at: None,
                 };
                 c.should_pin(&temp)
             });

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
 use crate::graph::{EdgeData, MemoryGraph};
@@ -63,6 +63,7 @@ pub fn resolve_conflict(
         metadata: new_fact.metadata.clone(),
         is_pinned: new_fact.is_pinned,
         importance_score: 0.5,
+        surfaced_at: None,
     };
 
     let decision = arbiter.arbitrate(&old_fact, &new_as_fact)?;

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -52,6 +52,7 @@ pub fn global_integration(
             metadata: serde_json::json!({}),
             is_pinned: false,
             importance_score: 0.5,
+            surfaced_at: None,
         })
         .collect();
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -369,6 +369,7 @@ impl MemoryEngine {
                     scope_id: 0,
                     is_pinned: false,
                     importance_score: base_importance,
+                    surfaced_at: None,
                 };
                 c.should_pin(&temp)
             }),
@@ -1126,15 +1127,38 @@ impl MemoryEngine {
 
     // --- Public API: Scheduling ---
 
-    /// List facts whose scheduled time has arrived.
     /// Returns active facts where `t_valid <= now` and `t_valid IS NOT NULL`.
     ///
-    /// This is a read-only query — facts are not consumed or marked as delivered.
-    /// Consumers should track delivery state externally if incremental delivery
-    /// is needed, or use `pin_fact()`/`forget()` to manage fact lifecycle.
+    /// On first return, stamps `surfaced_at` for facts that have not yet been
+    /// surfaced. Subsequent calls return the original timestamp. The returned
+    /// facts always carry the DB-authoritative `surfaced_at` value.
     pub fn list_due(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>> {
         let scope_ids = self.resolve_scope_ids(scope)?;
-        self.with_read(|conn| FactStore::new(conn, self.embed_dim).list_due(now, &scope_ids))
+        let mut facts =
+            self.with_read(|conn| FactStore::new(conn, self.embed_dim).list_due(now, &scope_ids))?;
+
+        // Stamp surfaced_at for newly-surfaced facts
+        let unsurfaced_ids: Vec<i64> = facts
+            .iter()
+            .filter(|f| f.surfaced_at.is_none())
+            .map(|f| f.id)
+            .collect();
+
+        if !unsurfaced_ids.is_empty() {
+            let conn = self.write_conn();
+            let stamped =
+                FactStore::new(&conn, self.embed_dim).stamp_surfaced(&unsurfaced_ids, now)?;
+            // Update in-place with DB-authoritative timestamps
+            let stamped_map: std::collections::HashMap<i64, chrono::DateTime<chrono::Utc>> =
+                stamped.into_iter().collect();
+            for fact in &mut facts {
+                if let Some(&ts) = stamped_map.get(&fact.id) {
+                    fact.surfaced_at = Some(ts);
+                }
+            }
+        }
+
+        Ok(facts)
     }
 
     /// Scheduling hint: when should the consumer next call `list_due()`?
@@ -1303,10 +1327,34 @@ impl MemoryEngine {
             }
         }; // scope_tree read lock dropped here
 
-        // Step 2: Query DB (no locks held)
-        self.with_read(|conn| {
+        // Step 2: Query DB on read connection
+        let mut ctx = self.with_read(|conn| {
             crate::resume::resume_context(conn, &scope_ids, self.embed_dim, config)
-        })
+        })?;
+
+        // Step 3: Stamp surfaced_at on the final due facts (post-filter, post-cap).
+        // Must use write_conn — read connections have query_only = ON.
+        let unsurfaced_ids: Vec<i64> = ctx
+            .due
+            .iter()
+            .filter(|f| f.surfaced_at.is_none())
+            .map(|f| f.id)
+            .collect();
+
+        if !unsurfaced_ids.is_empty() {
+            let conn = self.write_conn();
+            let stamped = FactStore::new(&conn, self.embed_dim)
+                .stamp_surfaced(&unsurfaced_ids, config.now)?;
+            let stamped_map: std::collections::HashMap<i64, DateTime<Utc>> =
+                stamped.into_iter().collect();
+            for fact in &mut ctx.due {
+                if let Some(&ts) = stamped_map.get(&fact.id) {
+                    fact.surfaced_at = Some(ts);
+                }
+            }
+        }
+
+        Ok(ctx)
     }
 }
 

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -188,6 +188,7 @@ mod tests {
             metadata: serde_json::json!({}),
             is_pinned: false,
             importance_score: 0.5,
+            surfaced_at: None,
         };
 
         // Fact B: old, rarely accessed, isolated, low importance
@@ -209,6 +210,7 @@ mod tests {
             metadata: serde_json::json!({}),
             is_pinned: false,
             importance_score: 0.5,
+            surfaced_at: None,
         };
 
         let importance_a = compute_importance(&fact_a, 5, now, &policy);
@@ -249,6 +251,7 @@ mod tests {
             metadata: serde_json::json!({}),
             is_pinned: false,
             importance_score: 0.5,
+            surfaced_at: None,
         };
 
         let mut procedural_fact = base_fact.clone();

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -62,13 +62,10 @@ fn determine_state(fact: &Fact, now: DateTime<Utc>) -> FactState {
     }
     if let Some(t_valid) = fact.t_valid {
         if t_valid <= now && (fact.t_invalid.is_none() || fact.t_invalid.unwrap() > now) {
-            // Heuristic: `surfaced` checks whether the fact was accessed after it
-            // became valid. This is unreliable when `last_accessed` equals insertion
-            // time (no explicit access yet) — a past-dated fact will appear surfaced
-            // even if the scheduler never returned it. A dedicated `surfaced_at`
-            // column would fix this; for now, treat the flag as best-effort.
-            let surfaced = fact.access_count > 0 && fact.last_accessed > t_valid;
-            return FactState::Due { t_valid, surfaced };
+            return FactState::Due {
+                t_valid,
+                surfaced_at: fact.surfaced_at,
+            };
         }
     }
     FactState::Active

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -33,7 +33,7 @@ pub enum FactState {
     },
     Due {
         t_valid: DateTime<Utc>,
-        surfaced: bool,
+        surfaced_at: Option<DateTime<Utc>>,
     },
 }
 

--- a/src/search/ann.rs
+++ b/src/search/ann.rs
@@ -425,6 +425,7 @@ mod tests {
                     access_count: 0,
                     last_accessed: Utc::now(),
                     metadata: serde_json::json!({}),
+                    is_pinned: false,
                 };
                 let id = store.insert(&fact).unwrap();
                 ids.push(id);
@@ -467,6 +468,7 @@ mod tests {
                 access_count: 0,
                 last_accessed: Utc::now(),
                 metadata: serde_json::json!({}),
+                is_pinned: false,
             };
             let new_id = store.insert(&new_fact).unwrap();
             strategy.notify_insert(new_id, &new_emb);

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -73,8 +73,8 @@ impl<'a> FactStore<'a> {
             "INSERT INTO facts (content, content_hash, embedding, fact_type,
                 t_created, t_expired, t_valid, t_invalid,
                 source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                is_pinned, importance_score)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                is_pinned, importance_score, surfaced_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, NULL)",
             params![
                 fact.content,
                 hash,
@@ -107,7 +107,7 @@ impl<'a> FactStore<'a> {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts WHERE id = ?1",
         )?;
         let dim = self.embed_dim;
@@ -129,7 +129,7 @@ impl<'a> FactStore<'a> {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts WHERE t_expired IS NULL",
         )?;
         let dim = self.embed_dim;
@@ -155,7 +155,7 @@ impl<'a> FactStore<'a> {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts
              WHERE t_expired IS NULL
                AND (t_valid IS NULL OR t_valid <= ?1)
@@ -234,7 +234,7 @@ impl<'a> FactStore<'a> {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts
              WHERE t_expired IS NULL AND scope_id = ?1
              ORDER BY importance DESC
@@ -267,7 +267,7 @@ impl<'a> FactStore<'a> {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
@@ -290,7 +290,7 @@ impl<'a> FactStore<'a> {
         let base = "SELECT id, content, content_hash, embedding, fact_type,
                         t_created, t_expired, t_valid, t_invalid,
                         source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                        is_pinned, importance_score
+                        is_pinned, importance_score, surfaced_at
                  FROM facts WHERE t_expired IS NULL AND is_pinned = 1";
         let dim = self.embed_dim;
         if scope_ids.is_empty() {
@@ -319,7 +319,7 @@ impl<'a> FactStore<'a> {
         let base = "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts
              WHERE t_expired IS NULL AND t_valid IS NOT NULL AND t_valid <= ?1
              AND (t_invalid IS NULL OR t_invalid > ?1)";
@@ -387,6 +387,38 @@ impl<'a> FactStore<'a> {
         }
     }
 
+    /// Stamp `surfaced_at` for facts that have not yet been surfaced.
+    /// Returns the persisted `(fact_id, surfaced_at)` pairs for ALL requested IDs
+    /// (including those already stamped by a prior caller).
+    pub fn stamp_surfaced(
+        &self,
+        fact_ids: &[i64],
+        now: DateTime<Utc>,
+    ) -> Result<Vec<(i64, DateTime<Utc>)>> {
+        if fact_ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let now_str = now.to_rfc3339();
+        let ids_json = serde_json::to_string(fact_ids)?;
+        // Stamp only unsurfaced facts (idempotent for already-stamped ones)
+        self.conn.execute(
+            "UPDATE facts SET surfaced_at = ?1 WHERE id IN (SELECT value FROM json_each(?2)) AND surfaced_at IS NULL",
+            params![now_str, ids_json],
+        )?;
+        // Re-read persisted values for ALL requested IDs (handles concurrent races)
+        let mut stmt = self.conn.prepare(
+            "SELECT id, surfaced_at FROM facts WHERE id IN (SELECT value FROM json_each(?1)) AND surfaced_at IS NOT NULL",
+        )?;
+        let rows = stmt.query_map(params![ids_json], |row| {
+            let id: i64 = row.get(0)?;
+            let ts_str: String = row.get(1)?;
+            let ts = parse_timestamp(&ts_str)?;
+            Ok((id, ts))
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
     /// Set the pinned flag on a fact.
     pub fn set_pinned(&self, id: i64, pinned: bool) -> Result<()> {
         let rows = self.conn.execute(
@@ -409,7 +441,7 @@ impl<'a> FactStore<'a> {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts ORDER BY id ASC",
         )?;
         let dim = self.embed_dim;
@@ -444,7 +476,7 @@ impl<'a> FactStore<'a> {
         let base = "SELECT id, content, content_hash, embedding, fact_type,
                         t_created, t_expired, t_valid, t_invalid,
                         source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                        is_pinned, importance_score
+                        is_pinned, importance_score, surfaced_at
                  FROM facts
                  WHERE t_expired IS NULL AND importance_score >= ?1
                    AND id NOT IN (SELECT value FROM json_each(?2))";
@@ -521,7 +553,7 @@ impl<'a> FactStore<'a> {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
@@ -588,7 +620,7 @@ impl<'a> FactStore<'a> {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score
+                    is_pinned, importance_score, surfaced_at
              FROM facts
              WHERE {where_clause}
              ORDER BY importance_score DESC"
@@ -634,6 +666,8 @@ fn row_to_fact(row: &rusqlite::Row<'_>, embed_dim: usize) -> rusqlite::Result<Fa
     let t_valid = parse_optional_timestamp(t_valid_str.as_deref())?;
     let t_invalid = parse_optional_timestamp(t_invalid_str.as_deref())?;
     let last_accessed = parse_timestamp(&last_accessed_str)?;
+    let surfaced_at_str: Option<String> = row.get("surfaced_at")?;
+    let surfaced_at = parse_optional_timestamp(surfaced_at_str.as_deref())?;
 
     let fact_type = str_to_fact_type(&fact_type_str).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
@@ -667,6 +701,7 @@ fn row_to_fact(row: &rusqlite::Row<'_>, embed_dim: usize) -> rusqlite::Result<Fa
         scope_id: row.get("scope_id")?,
         is_pinned: is_pinned_i64 != 0,
         importance_score: row.get("importance_score")?,
+        surfaced_at,
     })
 }
 

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use crate::error::{MemoryError, Result};
 
 /// Current schema version. Bump when adding migrations.
-const CURRENT_SCHEMA_VERSION: u32 = 5;
+const CURRENT_SCHEMA_VERSION: u32 = 6;
 
 /// Storage epoch — coarse-grained compatibility gate.
 ///
@@ -146,6 +146,7 @@ const MIGRATIONS: &[(MigrationFn, bool)] = &[
     (migrate_v2_to_v3, true),
     (migrate_v3_to_v4, false),
     (migrate_v4_to_v5, false),
+    (migrate_v5_to_v6, false),
 ];
 
 /// Run forward-only migrations from the current schema version to
@@ -520,6 +521,12 @@ fn migrate_v4_to_v5(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Add `surfaced_at` column for tracking when due facts are first returned to consumers.
+fn migrate_v5_to_v6(conn: &Connection) -> Result<()> {
+    conn.execute_batch("ALTER TABLE facts ADD COLUMN surfaced_at TEXT;")?;
+    Ok(())
+}
+
 // --- DDL constants ---
 
 const TABLES_DDL: &str = "
@@ -554,7 +561,8 @@ CREATE TABLE IF NOT EXISTS facts (
     metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)),
     scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
     is_pinned INTEGER NOT NULL DEFAULT 0,
-    importance_score REAL NOT NULL DEFAULT 0.5
+    importance_score REAL NOT NULL DEFAULT 0.5,
+    surfaced_at TEXT
 );
 
 CREATE TABLE IF NOT EXISTS edges (
@@ -944,6 +952,80 @@ CREATE INDEX IF NOT EXISTS idx_facts_t_valid_due ON facts(t_valid) WHERE t_valid
 CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, sequence_id);
 ";
 
+    /// Frozen v5 schema for testing v5→v6 migration.
+    /// Identical to v4 but with `event_revision` on events table.
+    fn init_schema_v5(conn: &Connection) -> Result<()> {
+        conn.execute_batch(TABLES_V5_DDL)?;
+        conn.execute_batch(SCOPES_DDL_V4)?;
+        conn.execute_batch(FTS5_DDL_V4)?;
+        conn.execute_batch(TRIGGERS_DDL_V4)?;
+        conn.execute_batch(INDEXES_V4_DDL)?;
+        set_config(conn, "schema_version", "5")?;
+        Ok(())
+    }
+
+    const TABLES_V5_DDL: &str = "
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    source TEXT NOT NULL,
+    session_id TEXT,
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
+    origin_node_id TEXT NOT NULL DEFAULT 'local',
+    sequence_id INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT,
+    event_revision INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS facts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    embedding BLOB NOT NULL,
+    fact_type TEXT NOT NULL CHECK(fact_type IN ('episodic', 'semantic', 'procedural')),
+    t_created TEXT NOT NULL,
+    t_expired TEXT,
+    t_valid TEXT,
+    t_invalid TEXT,
+    source_event_id INTEGER REFERENCES events(id),
+    importance REAL NOT NULL DEFAULT 0.5,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)),
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
+    is_pinned INTEGER NOT NULL DEFAULT 0,
+    importance_score REAL NOT NULL DEFAULT 0.5
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    target_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    relation_type TEXT NOT NULL,
+    weight REAL NOT NULL DEFAULT 1.0,
+    t_created TEXT NOT NULL,
+    t_expired TEXT,
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id)
+);
+
+CREATE TABLE IF NOT EXISTS summaries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    embedding BLOB NOT NULL,
+    level TEXT NOT NULL CHECK(level IN ('local', 'cluster', 'global')),
+    source_fact_ids TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id)
+);
+
+CREATE TABLE IF NOT EXISTS config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+";
+
     #[test]
     fn init_schema_creates_all_tables() {
         let conn = open_memory().unwrap();
@@ -1038,13 +1120,13 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
         init_schema(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
         // migrate is a no-op on fresh DB
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
     }
 
@@ -1059,7 +1141,7 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
     }
 
@@ -1071,7 +1153,7 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
     }
 
@@ -1105,7 +1187,7 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
 
         // Data survived both migrations
@@ -1195,7 +1277,7 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
 
         // After migration: orphan scope_id fails (FK enforced)
@@ -1323,17 +1405,17 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
     }
 
     #[test]
-    fn fresh_db_creates_v5_schema() {
+    fn fresh_db_creates_v6_schema() {
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
         conn.execute(
             "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed, is_pinned, importance_score)
@@ -1495,7 +1577,7 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
     }
 
@@ -1517,7 +1599,7 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
 
         // Existing events get default revision = 1
@@ -1601,7 +1683,7 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("5".to_string())
+            Some("6".to_string())
         );
 
         // Event survived all migrations, got default revision
@@ -1614,6 +1696,95 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
             .unwrap();
         assert_eq!(source, "v1-src");
         assert_eq!(revision, 1);
+    }
+
+    // --- v5→v6 migration tests ---
+
+    #[test]
+    fn migrate_v5_to_v6_adds_surfaced_at() {
+        let conn = open_memory().unwrap();
+        init_schema_v5(&conn).unwrap();
+
+        // Insert a fact at v5 (no surfaced_at column yet)
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed)
+             VALUES ('test fact', 'h', X'00', 'episodic', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+
+        migrate(&conn, None).unwrap();
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap(),
+            Some("6".to_string())
+        );
+
+        // Existing facts have surfaced_at = NULL
+        let surfaced_at: Option<String> = conn
+            .query_row(
+                "SELECT surfaced_at FROM facts WHERE content = 'test fact'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            surfaced_at.is_none(),
+            "pre-existing facts should have NULL surfaced_at"
+        );
+
+        // New facts can have surfaced_at set
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed, surfaced_at)
+             VALUES ('new fact', 'h2', X'00', 'episodic', datetime('now'), datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        let surfaced: Option<String> = conn
+            .query_row(
+                "SELECT surfaced_at FROM facts WHERE content = 'new fact'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(surfaced.is_some(), "new facts can have surfaced_at set");
+    }
+
+    #[test]
+    fn fresh_db_has_surfaced_at_column() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        // Insert with explicit surfaced_at
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed, surfaced_at)
+             VALUES ('test', 'h', X'00', 'episodic', datetime('now'), datetime('now'), '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        let ts: Option<String> = conn
+            .query_row(
+                "SELECT surfaced_at FROM facts WHERE content = 'test'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(ts, Some("2026-01-01T00:00:00Z".to_string()));
+
+        // Default is NULL
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed)
+             VALUES ('test2', 'h2', X'00', 'episodic', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        let ts_default: Option<String> = conn
+            .query_row(
+                "SELECT surfaced_at FROM facts WHERE content = 'test2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(ts_default.is_none());
     }
 
     // --- Schema snapshot test (insta) ---
@@ -1644,11 +1815,11 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
     }
 
     #[test]
-    fn schema_v5_snapshot() {
+    fn schema_v6_snapshot() {
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
         let schema = deterministic_schema_dump(&conn);
-        insta::assert_snapshot!("schema_v5", schema);
+        insta::assert_snapshot!("schema_v6", schema);
     }
 
     // --- Property-based migration tests (proptest) ---

--- a/src/store/snapshots/memory_engine__store__schema__tests__schema_v6.snap
+++ b/src/store/snapshots/memory_engine__store__schema__tests__schema_v6.snap
@@ -1,6 +1,6 @@
 ---
 source: src/store/schema.rs
-assertion_line: 1618
+assertion_line: 1822
 expression: schema
 ---
 -- index: idx_edges_expired
@@ -70,7 +70,7 @@ CREATE TABLE edges ( id INTEGER PRIMARY KEY AUTOINCREMENT, source_fact_id INTEGE
 CREATE TABLE events ( id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL, event_type TEXT NOT NULL, payload TEXT NOT NULL DEFAULT '{}', source TEXT NOT NULL, session_id TEXT, scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id), origin_node_id TEXT NOT NULL DEFAULT 'local', sequence_id INTEGER NOT NULL DEFAULT 0, created_at TEXT, event_revision INTEGER NOT NULL DEFAULT 1 );
 
 -- table: facts
-CREATE TABLE facts ( id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT NOT NULL, content_hash TEXT NOT NULL, -- blake3 hex[:16] for dedup embedding BLOB NOT NULL, fact_type TEXT NOT NULL CHECK(fact_type IN ('episodic', 'semantic', 'procedural')), t_created TEXT NOT NULL, t_expired TEXT, t_valid TEXT, t_invalid TEXT, source_event_id INTEGER REFERENCES events(id), importance REAL NOT NULL DEFAULT 0.5, access_count INTEGER NOT NULL DEFAULT 0, last_accessed TEXT NOT NULL, metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)), scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id), is_pinned INTEGER NOT NULL DEFAULT 0, importance_score REAL NOT NULL DEFAULT 0.5 );
+CREATE TABLE facts ( id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT NOT NULL, content_hash TEXT NOT NULL, -- blake3 hex[:16] for dedup embedding BLOB NOT NULL, fact_type TEXT NOT NULL CHECK(fact_type IN ('episodic', 'semantic', 'procedural')), t_created TEXT NOT NULL, t_expired TEXT, t_valid TEXT, t_invalid TEXT, source_event_id INTEGER REFERENCES events(id), importance REAL NOT NULL DEFAULT 0.5, access_count INTEGER NOT NULL DEFAULT 0, last_accessed TEXT NOT NULL, metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)), scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id), is_pinned INTEGER NOT NULL DEFAULT 0, importance_score REAL NOT NULL DEFAULT 0.5, surfaced_at TEXT );
 
 -- table: facts_fts
 CREATE VIRTUAL TABLE facts_fts USING fts5( content, content='facts', content_rowid='id', tokenize='porter unicode61' );

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,6 +97,8 @@ pub struct Fact {
     pub scope_id: i64,
     pub is_pinned: bool,
     pub importance_score: f64,
+    #[serde(default)]
+    pub surfaced_at: Option<DateTime<Utc>>,
 }
 
 /// A graph edge between two facts.
@@ -279,8 +281,65 @@ mod tests {
             scope_id: 1,
             is_pinned: false,
             importance_score: 0.5,
+            surfaced_at: None,
         };
         assert!(fact.t_expired.is_none());
         assert!(fact.t_valid.is_none());
+    }
+
+    #[test]
+    fn serde_fact_without_surfaced_at() {
+        // JSON without the surfaced_at field — serde(default) should yield None.
+        let json = r#"{
+            "id": 1,
+            "content": "hello",
+            "content_hash": "abc123",
+            "embedding": [0.1, 0.2],
+            "fact_type": "Semantic",
+            "t_created": "2026-01-01T00:00:00Z",
+            "t_expired": null,
+            "t_valid": null,
+            "t_invalid": null,
+            "source_event_id": null,
+            "importance": 0.5,
+            "access_count": 0,
+            "last_accessed": "2026-01-01T00:00:00Z",
+            "metadata": {},
+            "scope_id": 1,
+            "is_pinned": false,
+            "importance_score": 0.5
+        }"#;
+        let fact: Fact = serde_json::from_str(json).unwrap();
+        assert!(
+            fact.surfaced_at.is_none(),
+            "missing surfaced_at should deserialize as None"
+        );
+
+        // JSON with surfaced_at present — should round-trip correctly.
+        let json_with = r#"{
+            "id": 2,
+            "content": "world",
+            "content_hash": "def456",
+            "embedding": [0.3],
+            "fact_type": "Episodic",
+            "t_created": "2026-01-01T00:00:00Z",
+            "t_expired": null,
+            "t_valid": null,
+            "t_invalid": null,
+            "source_event_id": null,
+            "importance": 0.7,
+            "access_count": 1,
+            "last_accessed": "2026-01-01T00:00:00Z",
+            "metadata": {},
+            "scope_id": 1,
+            "is_pinned": false,
+            "importance_score": 0.7,
+            "surfaced_at": "2026-03-15T12:00:00Z"
+        }"#;
+        let fact2: Fact = serde_json::from_str(json_with).unwrap();
+        let ts = fact2
+            .surfaced_at
+            .expect("surfaced_at should deserialize when present");
+        assert_eq!(ts.to_rfc3339(), "2026-03-15T12:00:00+00:00");
     }
 }

--- a/tests/inspect_test.rs
+++ b/tests/inspect_test.rs
@@ -156,3 +156,43 @@ fn fact_history_not_found() {
     let err = engine.fact_history(999);
     assert!(err.is_err());
 }
+
+/// `list_due` stamps `surfaced_at` on first return, and subsequent calls
+/// preserve the original timestamp (idempotent stamping).
+#[test]
+fn stamp_surfaced_on_list_due() {
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    let now = Utc::now();
+
+    // Add a fact with t_valid in the past so it is immediately due.
+    let opts = AddFactOptions {
+        t_valid: Some(now - Duration::hours(1)),
+        ..Default::default()
+    };
+    engine
+        .add_fact(
+            "due reminder",
+            FactType::Episodic,
+            None,
+            &TestEmbed,
+            None,
+            Some(&opts),
+            None,
+        )
+        .unwrap();
+
+    // First call: surfaced_at should be stamped.
+    let due1 = engine.list_due(now, None).unwrap();
+    assert_eq!(due1.len(), 1);
+    let ts1 = due1[0]
+        .surfaced_at
+        .expect("surfaced_at should be Some after first list_due");
+
+    // Second call: surfaced_at must be identical (not re-stamped).
+    let due2 = engine.list_due(now + Duration::seconds(5), None).unwrap();
+    assert_eq!(due2.len(), 1);
+    let ts2 = due2[0]
+        .surfaced_at
+        .expect("surfaced_at should still be Some on second call");
+    assert_eq!(ts1, ts2, "surfaced_at must not change across calls");
+}


### PR DESCRIPTION
## Summary

- Add `surfaced_at: Option<DateTime<Utc>>` column to facts table (schema migration v5→v6)
- Replace unreliable `surfaced` heuristic (`access_count > 0 && last_accessed > t_valid`) with direct timestamp
- `MemoryEngine::list_due()` and `resume_context()` stamp `surfaced_at` on first return
- Race-safe: re-reads persisted timestamp from DB, concurrent callers get same value
- `FactState::Due` changes from `{ surfaced: bool }` to `{ surfaced_at: Option<DateTime<Utc>> }`
- Backward-compatible serde via `#[serde(default)]`

## Changes

- **Schema**: Migration v5→v6, `surfaced_at TEXT` nullable column
- **Types**: `Fact.surfaced_at` with `#[serde(default)]`, `FactState::Due.surfaced_at`
- **Store**: `stamp_surfaced()` method using UPDATE+SELECT with `json_each` pattern
- **Engine**: `list_due()` and `resume_context()` stamp after read/filter
- **Inspect**: `determine_state()` uses `fact.surfaced_at` directly
- **Tests**: stamp idempotency, serde backward compat, schema migration v5→v6
- **Docs**: Updated 5 doc files + engine doc-comment

Fixes #78
Plan: #91

## Test plan

- [x] `stamp_surfaced_on_list_due` — stamps on first call, unchanged on second
- [x] `serde_fact_without_surfaced_at` — older JSON deserializes with `surfaced_at: None`
- [x] `migrate_v5_to_v6_adds_surfaced_at` — pre-existing rows get NULL, new rows can set it
- [x] `fresh_db_has_surfaced_at_column` — fresh DB DDL includes column
- [x] All 325 existing tests pass
- [ ] Multi-model review via `/super-review`