### PR TITLE
refactor(inspect): drop graph RwLock before DB read in explain_fact

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1302,9 +1302,20 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::NotFound` if the fact doesn't exist.
     /// Returns `MemoryError::Database` on SQL failure.
+    ///
+    /// # Lock strategy
+    ///
+    /// The graph `RwLock` is acquired and released *before* the database read
+    /// to reduce lock contention — connected-component traversal is the expensive
+    /// part and does not need to be held across the DB call. The `scope_tree`
+    /// lock is kept across `with_read` because scope-path resolution depends on
+    /// `fact.scope_id` fetched from the database.
+    ///
+    /// This means the graph context may reflect a slightly older snapshot than the
+    /// database state under concurrent writes. This trade-off is intentional for
+    /// an informational API — see [`inspect::explain::explain_fact_with_graph_context`].
     pub fn explain_fact(&self, id: i64) -> Result<crate::inspect::FactExplanation> {
-        // Snapshot graph context before the DB call to release the graph lock
-        // early — connected-component traversal is the expensive part.
+        // Snapshot graph context under the graph lock, then release it.
         let graph_context = {
             let graph = self.graph.read();
             crate::inspect::explain::build_graph_context(&graph, id)
@@ -1313,13 +1324,13 @@ impl MemoryEngine {
         // resolution requires fact.scope_id, which comes from the DB.
         let scope_tree = self.scope_tree.read();
         self.with_read(|conn| {
-            crate::inspect::explain::explain_fact(
+            crate::inspect::explain::explain_fact_with_graph_context(
                 conn,
                 &scope_tree,
                 self.embed_dim,
                 id,
                 &self.upcaster_registry,
-                graph_context.clone(),
+                graph_context,
             )
         })
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1303,16 +1303,23 @@ impl MemoryEngine {
     /// Returns `MemoryError::NotFound` if the fact doesn't exist.
     /// Returns `MemoryError::Database` on SQL failure.
     pub fn explain_fact(&self, id: i64) -> Result<crate::inspect::FactExplanation> {
-        let graph = self.graph.read();
+        // Snapshot graph context before the DB call to release the graph lock
+        // early — connected-component traversal is the expensive part.
+        let graph_context = {
+            let graph = self.graph.read();
+            crate::inspect::explain::build_graph_context(&graph, id)
+        };
+        // scope_tree lock is still held across with_read because scope_path
+        // resolution requires fact.scope_id, which comes from the DB.
         let scope_tree = self.scope_tree.read();
         self.with_read(|conn| {
             crate::inspect::explain::explain_fact(
                 conn,
-                &graph,
                 &scope_tree,
                 self.embed_dim,
                 id,
                 &self.upcaster_registry,
+                graph_context.clone(),
             )
         })
     }

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
 use crate::error::Result;
-use crate::graph::MemoryGraph;
 use crate::scope::tree::ScopeTree;
 use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
@@ -26,11 +25,11 @@ use super::types::{
 /// Returns [`MemoryError::Database`] on SQL failure.
 pub fn explain_fact(
     conn: &Connection,
-    graph: &MemoryGraph,
     scope_tree: &ScopeTree,
     embed_dim: usize,
     fact_id: i64,
     registry: &UpcasterRegistry,
+    graph_context: GraphContext,
 ) -> Result<FactExplanation> {
     let store = FactStore::new(conn, embed_dim);
     let fact = store.get(fact_id)?;
@@ -38,7 +37,6 @@ pub fn explain_fact(
 
     let state = determine_state(&fact, now);
     let provenance = build_provenance(conn, registry, &fact)?;
-    let graph_context = build_graph_context(graph, fact_id);
     let scope_path = scope_tree
         .path_for_id(fact.scope_id)
         .unwrap_or_else(|| format!("scope:{}", fact.scope_id));
@@ -101,7 +99,7 @@ fn build_provenance(
     })
 }
 
-fn build_graph_context(graph: &MemoryGraph, fact_id: i64) -> GraphContext {
+pub(crate) fn build_graph_context(graph: &crate::graph::MemoryGraph, fact_id: i64) -> GraphContext {
     let degree = graph.degree(fact_id);
     // Use connected_component to get ALL neighbors (in + out), consistent with degree.
     // `neighbors()` only returns outgoing, which would be inconsistent with degree.

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
 use crate::error::Result;
+use crate::graph::MemoryGraph;
 use crate::scope::tree::ScopeTree;
 use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
@@ -15,8 +16,9 @@ use super::types::{
 
 /// Explain why a fact is in its current state.
 ///
-/// When the fact has a `source_event_id`, the originating event is fetched via
-/// [`EventStore::get_upcasted`] and included in the provenance output.
+/// Computes graph context, temporal state, provenance, and scope path for the
+/// given fact. When the fact has a `source_event_id`, the originating event is
+/// fetched via [`EventStore::get_upcasted`] and included in the provenance.
 ///
 /// # Errors
 ///
@@ -24,6 +26,36 @@ use super::types::{
 /// Returns [`MemoryError::Migration`] if the source event cannot be upcasted.
 /// Returns [`MemoryError::Database`] on SQL failure.
 pub fn explain_fact(
+    conn: &Connection,
+    graph: &MemoryGraph,
+    scope_tree: &ScopeTree,
+    embed_dim: usize,
+    fact_id: i64,
+    registry: &UpcasterRegistry,
+) -> Result<FactExplanation> {
+    let graph_context = build_graph_context(graph, fact_id);
+    explain_fact_with_graph_context(
+        conn,
+        scope_tree,
+        embed_dim,
+        fact_id,
+        registry,
+        graph_context,
+    )
+}
+
+/// Like [`explain_fact`], but accepts a pre-computed [`GraphContext`].
+///
+/// Used by [`MemoryEngine::explain_fact`] to release the graph `RwLock` before
+/// acquiring the database connection, reducing lock contention.
+///
+/// # Consistency note
+///
+/// The graph context may reflect a slightly older graph state than the database
+/// snapshot if a concurrent writer commits between the graph traversal and the
+/// DB read. This is acceptable for an informational/debugging API — the
+/// explanation is best-effort, not transactionally consistent.
+pub(crate) fn explain_fact_with_graph_context(
     conn: &Connection,
     scope_tree: &ScopeTree,
     embed_dim: usize,


### PR DESCRIPTION
## Summary
- Snapshots `GraphContext` (connected-component traversal) under the graph read lock, then releases it before acquiring the DB connection via `with_read()`
- Reduces unnecessary lock contention between `explain_fact` readers and concurrent graph mutations
- `scope_tree` lock intentionally kept across `with_read` because scope path resolution depends on `fact.scope_id` from the DB

## Notes
The original issue proposed dropping *both* `graph` and `scope_tree` locks before the DB call. However, `scope_path` resolution requires `fact.scope_id` which only becomes available after the DB fetch. The `graph` lock is the meaningful one to release early since `build_graph_context` performs connected-component traversal — the heavier operation.

## Test plan
- [x] `cargo test` — 319 passing (3 pre-existing failures unchanged)
- [x] `cargo check` — no warnings
- [x] Pre-existing clippy error confirmed identical to main

Fixes #79