### PR TITLE
feat(cli): add memory-engine-cli inspector tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ Companion repos:
 
 ```bash
 cargo build                           # debug build
+cargo build -p memory-engine-cli      # CLI inspector binary
 cargo test                            # all tests
+cargo test -p memory-engine-cli       # CLI integration tests
 cargo test --all-features             # with async + HNSW + compression
 cargo clippy --all-targets            # lint (pedantic + nursery)
 cargo fmt --check                     # format check
@@ -54,6 +56,7 @@ Read these docs when working on the relevant area:
 | Bi-temporal semantics          | `docs/advanced/bi-temporal-semantics.md` |
 | Consolidation pipeline         | `docs/advanced/consolidation.md`         |
 | Hybrid search tuning           | `docs/advanced/hybrid-search.md`         |
+| CLI inspector usage            | `docs/reference/cli-inspector.md`        |
 
 ## Key Design Decisions
 
@@ -65,4 +68,4 @@ Read these docs when working on the relevant area:
 
 ## Status
 
-Phase 4a ✅ (inspection APIs, import/export, bootstrap, reranker). Next: Phase 4b (CLI + MCP server), then Phase 5 (cognitive pipelines — DreamCycle, outcome tracking, provenance). See `docs/ROADMAP.md` for open issues and dependency graph.
+Phase 4a ✅ (inspection APIs, import/export, bootstrap, reranker). Phase 4b in progress: CLI inspector ✅ (`memory-engine-cli`), MCP server next. Then Phase 5 (cognitive pipelines — DreamCycle, outcome tracking, provenance). See `docs/ROADMAP.md` for open issues and dependency graph.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["memory-engine-cli"]
+
 [package]
 name = "memory-engine"
 version = "0.1.0"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -219,7 +219,7 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 | Feature                                                                           | Description                                                                                                 |
 | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Read-only open path ([#103](https://github.com/dutiona/memory-engine/issues/103)) | `MemoryEngine::open_readonly()` — prerequisite for CLI/MCP operator tools to avoid write-lock contention    |
-| CLI inspector ([#44](https://github.com/dutiona/memory-engine/issues/44))         | `memory-engine-cli` — operator tool (subcommands: inspect, dump, query, explain, stats, import, export)     |
+| CLI inspector ([#44](https://github.com/dutiona/memory-engine/issues/44))         | `memory-engine-cli` — operator tool (subcommands: inspect, dump, query, explain, stats, import, export) ✅  |
 | MCP server ([#45](https://github.com/dutiona/memory-engine/issues/45))            | `memory-engine-mcp` — maps 1:1 to engine API. Includes pre-compaction flush endpoint for push-based capture |
 | ↳ MCP P1 tools ([#95](https://github.com/dutiona/memory-engine/issues/95))        | consolidate, forget, dump_state, pin/unpin                                                                  |
 | ↳ MCP P2 tools ([#96](https://github.com/dutiona/memory-engine/issues/96))        | replay_events, fact_history, bootstrap                                                                      |

--- a/docs/reference/cli-inspector.md
+++ b/docs/reference/cli-inspector.md
@@ -1,0 +1,127 @@
+# CLI Inspector (`memory-engine-cli`)
+
+## What
+
+`memory-engine-cli` is an operator tool for inspecting, querying, and managing memory-engine databases from the command line. It provides read-only access to facts, events, statistics, and provenance — plus import/export for data portability.
+
+## Why
+
+The engine library is designed for in-process use by AI agents. But operators (humans debugging agent behavior, migrating data, or monitoring memory health) need a way to inspect the database without writing Rust code. The CLI fills this gap — it's the `sqlite3` equivalent for memory-engine databases.
+
+The CLI also enables scriptable workflows: pipe `--format json` output into `jq`, use `--format plain` in shell scripts, or export snapshots for offline analysis.
+
+**Research context:** The CLI implements the "operator observability" requirement identified in the context adaptation survey (ACE, DC, Reflexion). Agents that can't be inspected can't be debugged — and undebuggable agents can't be trusted in production.
+
+## How
+
+### Installation
+
+```bash
+cargo install --path memory-engine-cli
+# or build from workspace
+cargo build -p memory-engine-cli --release
+```
+
+### Usage
+
+Every command requires `--db <path>` (or set `MEMORY_ENGINE_DB` env var):
+
+```bash
+export MEMORY_ENGINE_DB=/path/to/agent.db
+```
+
+### Subcommands
+
+#### `stats` — Engine Statistics
+
+```bash
+memory-engine-cli stats
+memory-engine-cli --format json stats
+memory-engine-cli --format plain stats   # scriptable: facts.active=42
+```
+
+Shows fact counts (total, active, expired, pinned, due), edge counts, event count, scope depth, and storage size.
+
+#### `inspect <id>` — Fact Details
+
+```bash
+memory-engine-cli inspect 42
+memory-engine-cli --format json inspect 42
+```
+
+Shows all 17 fields of a fact: content, type, importance scores, bi-temporal timestamps (`t_created`, `t_expired`, `t_valid`, `t_invalid`), access count, scope, metadata, content hash, source event, and surfaced_at.
+
+#### `explain <id>` — Fact Provenance
+
+```bash
+memory-engine-cli explain 42
+```
+
+Shows why a fact is in its current state: active/expired/pinned/due, scope path, importance breakdown (base vs composite), access count, source event ID, and graph context (degree, component size, neighbor IDs).
+
+#### `query <text>` — Full-Text Search
+
+```bash
+memory-engine-cli query "database migration"
+memory-engine-cli query "auth" --scope "project/backend" --limit 5
+memory-engine-cli query "pattern" --fact-type semantic --min-importance 0.5
+memory-engine-cli query "critical" --pinned-only
+```
+
+FTS5-based text search. No embeddings required (the CLI has no `EmbeddingProvider`). Filters: `--scope`, `--limit`, `--fact-type` (episodic/semantic/procedural), `--min-importance`, `--pinned-only`.
+
+#### `export -o <path>` — Export State
+
+```bash
+memory-engine-cli export -o backup.json
+memory-engine-cli export -o backup.db --export-format sqlite
+memory-engine-cli export -o backup.json.gz --export-format json-gz
+memory-engine-cli export -o backup.json.zst --export-format json-zst
+```
+
+Exports the full engine state. JSON is human-readable; SQLite is a WAL-safe binary copy; compressed formats save space.
+
+#### `import <snapshot>` — Restore from Snapshot
+
+```bash
+memory-engine-cli --db new-agent.db import backup.json
+memory-engine-cli --db new-agent.db import backup.json.gz --embed-dim 384
+```
+
+Restores a JSON snapshot into a **new** database (refuses to overwrite existing). Auto-detects `embed_dim` from plain JSON; use `--embed-dim` for compressed snapshots.
+
+**Note:** Import currently has a known issue with schema version mismatch (v6 vs v5 in restore path, tracked in #80). The test is `#[ignore]` pending library fix.
+
+#### `dump [facts|events|all]` — Debug Listing
+
+```bash
+memory-engine-cli dump facts --limit 20
+memory-engine-cli dump events --limit 50
+memory-engine-cli --format json dump all    # single JSON object: {"facts": [...], "events": [...]}
+```
+
+Lists active facts and/or events to stdout. Useful for quick debugging. `--format json dump all` emits a single valid JSON document.
+
+### Output Formats
+
+| Format  | Flag             | Use Case                              |
+| ------- | ---------------- | ------------------------------------- |
+| `table` | `--format table` | Default. Human-readable aligned table |
+| `json`  | `--format json`  | Machine-readable, pipe to `jq`        |
+| `plain` | `--format plain` | One value per line, scriptable        |
+
+### Architecture
+
+The CLI is a workspace member crate (`memory-engine-cli/`) with no LLM dependencies. Each subcommand is a thin module in `src/commands/` that:
+
+1. Opens the engine via `db::open_engine()` (probes `embed_dim` from config table)
+2. Calls the library's inspection API
+3. Formats output according to `--format`
+
+The `open_engine()` function sets `backup_dir` adjacent to the database as a safety measure — `MemoryEngine::open()` may run schema migrations. A true read-only open path is tracked in #103.
+
+### Known Limitations
+
+- **No vector search in `query`**: The CLI doesn't implement `EmbeddingProvider`, so only FTS5 text matching works. Vector/hybrid search requires embeddings.
+- **`dump --limit` is post-hoc**: `list_active_facts()` loads all facts before truncating. Fine for operator use but won't scale to very large databases. Tracked in #104.
+- **Import schema version**: Export/import roundtrip fails due to schema v6 vs restore v5 mismatch. Tracked in #80.

--- a/memory-engine-cli/Cargo.toml
+++ b/memory-engine-cli/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "memory-engine-cli"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "CLI inspector for memory-engine — operator tool for querying, inspecting, and managing agent memory"
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "memory-engine-cli"
+path = "src/main.rs"
+
+[dependencies]
+memory-engine = { path = "..", features = ["compress-gzip", "compress-zstd"] }
+clap = { version = "4", features = ["derive", "env"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1"
+tabled = "0.20"
+chrono = { version = "0.4", features = ["serde"] }
+rusqlite = { version = "0.34", features = ["bundled-full"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }

--- a/memory-engine-cli/examples/create_smoke_db.rs
+++ b/memory-engine-cli/examples/create_smoke_db.rs
@@ -1,0 +1,77 @@
+use memory_engine::{EmbeddingProvider, EngineConfig, FactType, MemoryEngine};
+
+struct FakeEmbed;
+impl EmbeddingProvider for FakeEmbed {
+    fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
+        Ok(vec![0.1, 0.2, 0.3, 0.4])
+    }
+}
+
+fn main() {
+    let path = std::path::PathBuf::from("/tmp/smoke-test-agent.db");
+    if path.exists() {
+        std::fs::remove_file(&path).unwrap();
+    }
+    let config = EngineConfig::new(path, 4);
+    let engine = MemoryEngine::open(&config).unwrap();
+    let e = FakeEmbed;
+
+    engine
+        .add_fact(
+            "User prefers concise responses without filler words",
+            FactType::Semantic,
+            None,
+            &e,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Project uses Rust 2024 edition with clap for CLI parsing",
+            FactType::Procedural,
+            None,
+            &e,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Meeting discussed Q2 roadmap: Phase 4b CLI inspector then MCP server",
+            FactType::Episodic,
+            None,
+            &e,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "The database schema migrated from v5 to v6 on 2026-03-15",
+            FactType::Semantic,
+            None,
+            &e,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Agent successfully resolved 3 merge conflicts in the auth module",
+            FactType::Episodic,
+            None,
+            &e,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine.pin_fact(1).unwrap();
+
+    println!("Created /tmp/smoke-test-agent.db with 5 facts (fact 1 pinned)");
+}

--- a/memory-engine-cli/src/commands/dump.rs
+++ b/memory-engine-cli/src/commands/dump.rs
@@ -53,13 +53,35 @@ pub fn run(db: &Path, args: &DumpArgs, format: OutputFormat) -> anyhow::Result<(
     match args.target.as_str() {
         "facts" => dump_facts(&engine, args.limit, format),
         "events" => dump_events(&engine, args.limit, format),
-        "all" => {
-            dump_facts(&engine, args.limit, format)?;
-            println!();
-            dump_events(&engine, args.limit, format)
-        }
+        "all" => dump_all(&engine, args.limit, format),
         _ => unreachable!(),
     }
+}
+
+fn dump_all(
+    engine: &memory_engine::MemoryEngine,
+    limit: usize,
+    format: OutputFormat,
+) -> anyhow::Result<()> {
+    if format == OutputFormat::Json {
+        let mut facts = engine.list_active_facts()?;
+        facts.truncate(limit);
+        let filter = ReplayFilter {
+            limit: Some(limit),
+            ..ReplayFilter::default()
+        };
+        let events = engine.replay_events(&filter)?;
+        let combined = serde_json::json!({
+            "facts": facts,
+            "events": events,
+        });
+        output::print_json(&combined)?;
+    } else {
+        dump_facts(engine, limit, format)?;
+        println!();
+        dump_events(engine, limit, format)?;
+    }
+    Ok(())
 }
 
 fn dump_facts(

--- a/memory-engine-cli/src/commands/dump.rs
+++ b/memory-engine-cli/src/commands/dump.rs
@@ -1,0 +1,136 @@
+use std::path::Path;
+
+use memory_engine::inspect_types::ReplayFilter;
+use tabled::{Table, Tabled};
+
+use crate::db::open_engine;
+use crate::output::{self, truncate_str, OutputFormat};
+
+#[derive(clap::Args)]
+pub struct DumpArgs {
+    /// What to dump
+    #[arg(value_parser = ["facts", "events", "all"], default_value = "facts")]
+    target: String,
+
+    /// Maximum items
+    #[arg(long, default_value = "100")]
+    limit: usize,
+}
+
+#[derive(Tabled)]
+struct FactRow {
+    #[tabled(rename = "ID")]
+    id: i64,
+    #[tabled(rename = "Type")]
+    fact_type: String,
+    #[tabled(rename = "Pinned")]
+    pinned: &'static str,
+    #[tabled(rename = "Score")]
+    importance: String,
+    #[tabled(rename = "Created")]
+    created: String,
+    #[tabled(rename = "Content")]
+    content: String,
+}
+
+#[derive(Tabled)]
+struct EventRow {
+    #[tabled(rename = "ID")]
+    id: i64,
+    #[tabled(rename = "Type")]
+    event_type: String,
+    #[tabled(rename = "Source")]
+    source: String,
+    #[tabled(rename = "Timestamp")]
+    timestamp: String,
+    #[tabled(rename = "Session")]
+    session: String,
+}
+
+pub fn run(db: &Path, args: &DumpArgs, format: OutputFormat) -> anyhow::Result<()> {
+    let engine = open_engine(db)?;
+
+    match args.target.as_str() {
+        "facts" => dump_facts(&engine, args.limit, format),
+        "events" => dump_events(&engine, args.limit, format),
+        "all" => {
+            dump_facts(&engine, args.limit, format)?;
+            println!();
+            dump_events(&engine, args.limit, format)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn dump_facts(
+    engine: &memory_engine::MemoryEngine,
+    limit: usize,
+    format: OutputFormat,
+) -> anyhow::Result<()> {
+    let mut facts = engine.list_active_facts()?;
+    facts.truncate(limit);
+
+    match format {
+        OutputFormat::Json => output::print_json(&facts)?,
+        OutputFormat::Table => {
+            let rows: Vec<FactRow> = facts
+                .iter()
+                .map(|f| FactRow {
+                    id: f.id,
+                    fact_type: format!("{:?}", f.fact_type),
+                    pinned: if f.is_pinned { "yes" } else { "" },
+                    importance: format!("{:.2}", f.importance_score),
+                    created: f.t_created.format("%Y-%m-%d %H:%M").to_string(),
+                    content: truncate_str(&f.content, 60),
+                })
+                .collect();
+            println!("=== Active Facts ({}) ===", facts.len());
+            println!("{}", Table::new(rows));
+        }
+        OutputFormat::Plain => {
+            for f in &facts {
+                println!("{}\t{:?}\t{}", f.id, f.fact_type, f.content);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn dump_events(
+    engine: &memory_engine::MemoryEngine,
+    limit: usize,
+    format: OutputFormat,
+) -> anyhow::Result<()> {
+    let filter = ReplayFilter {
+        limit: Some(limit),
+        ..ReplayFilter::default()
+    };
+    let events = engine.replay_events(&filter)?;
+
+    match format {
+        OutputFormat::Json => output::print_json(&events)?,
+        OutputFormat::Table => {
+            let rows: Vec<EventRow> = events
+                .iter()
+                .map(|e| EventRow {
+                    id: e.id,
+                    event_type: format!("{:?}", e.event_type),
+                    source: e.source.clone(),
+                    timestamp: e.timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
+                    session: e.session_id.clone().unwrap_or_default(),
+                })
+                .collect();
+            println!("=== Events ({}) ===", events.len());
+            println!("{}", Table::new(rows));
+        }
+        OutputFormat::Plain => {
+            for e in &events {
+                println!(
+                    "{}\t{:?}\t{}\t{}",
+                    e.id, e.event_type, e.source, e.timestamp
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/memory-engine-cli/src/commands/explain.rs
+++ b/memory-engine-cli/src/commands/explain.rs
@@ -1,0 +1,80 @@
+use std::path::Path;
+
+use tabled::{Table, Tabled};
+
+use crate::db::open_engine;
+use crate::output::{self, OutputFormat};
+
+#[derive(Tabled)]
+struct ExplainRow {
+    #[tabled(rename = "Aspect")]
+    aspect: &'static str,
+    #[tabled(rename = "Detail")]
+    detail: String,
+}
+
+pub fn run(db: &Path, fact_id: i64, format: OutputFormat) -> anyhow::Result<()> {
+    let engine = open_engine(db)?;
+    let explanation = engine.explain_fact(fact_id)?;
+
+    match format {
+        OutputFormat::Json => output::print_json(&explanation)?,
+        OutputFormat::Table => {
+            let rows = vec![
+                ExplainRow {
+                    aspect: "fact_id",
+                    detail: explanation.fact_id.to_string(),
+                },
+                ExplainRow {
+                    aspect: "state",
+                    detail: format!("{:?}", explanation.state),
+                },
+                ExplainRow {
+                    aspect: "scope_path",
+                    detail: explanation.scope_path.clone(),
+                },
+                ExplainRow {
+                    aspect: "importance",
+                    detail: format!(
+                        "base={:.4}  composite={:.4}",
+                        explanation.provenance.importance, explanation.provenance.importance_score,
+                    ),
+                },
+                ExplainRow {
+                    aspect: "is_pinned",
+                    detail: explanation.provenance.is_pinned.to_string(),
+                },
+                ExplainRow {
+                    aspect: "access_count",
+                    detail: explanation.provenance.access_count.to_string(),
+                },
+                ExplainRow {
+                    aspect: "source_event",
+                    detail: explanation
+                        .provenance
+                        .source_event_id
+                        .map_or_else(|| "\u{2014}".into(), |id| id.to_string()),
+                },
+                ExplainRow {
+                    aspect: "graph",
+                    detail: format!(
+                        "degree={} component_size={} neighbors={:?}",
+                        explanation.graph_context.degree,
+                        explanation.graph_context.component_size,
+                        explanation.graph_context.neighbor_ids,
+                    ),
+                },
+            ];
+            println!("{}", Table::new(rows));
+        }
+        OutputFormat::Plain => {
+            println!("state: {:?}", explanation.state);
+            println!("scope: {}", explanation.scope_path);
+            println!("pinned: {}", explanation.provenance.is_pinned);
+            println!("importance: {:.4}", explanation.provenance.importance_score);
+            println!("degree: {}", explanation.graph_context.degree);
+        }
+    }
+
+    Ok(())
+}

--- a/memory-engine-cli/src/commands/export.rs
+++ b/memory-engine-cli/src/commands/export.rs
@@ -23,7 +23,7 @@ pub fn run(db: &Path, args: &ExportArgs) -> anyhow::Result<()> {
         "sqlite" => DumpFormat::Sqlite(args.output.clone()),
         "json-gz" => DumpFormat::JsonGzip(args.output.clone()),
         "json-zst" => DumpFormat::JsonZstd(args.output.clone()),
-        other => anyhow::bail!("unknown export format: {other}"),
+        _ => unreachable!("clap value_parser prevents unknown formats"),
     };
 
     engine.dump_state(&format)?;

--- a/memory-engine-cli/src/commands/export.rs
+++ b/memory-engine-cli/src/commands/export.rs
@@ -1,0 +1,32 @@
+use std::path::{Path, PathBuf};
+
+use memory_engine::inspect_types::DumpFormat;
+
+use crate::db::open_engine;
+
+#[derive(clap::Args)]
+pub struct ExportArgs {
+    /// Output file path
+    #[arg(short, long)]
+    output: PathBuf,
+
+    /// Export format
+    #[arg(long, default_value = "json", value_parser = ["json", "sqlite", "json-gz", "json-zst"])]
+    export_format: String,
+}
+
+pub fn run(db: &Path, args: &ExportArgs) -> anyhow::Result<()> {
+    let engine = open_engine(db)?;
+
+    let format = match args.export_format.as_str() {
+        "json" => DumpFormat::Json(args.output.clone()),
+        "sqlite" => DumpFormat::Sqlite(args.output.clone()),
+        "json-gz" => DumpFormat::JsonGzip(args.output.clone()),
+        "json-zst" => DumpFormat::JsonZstd(args.output.clone()),
+        other => anyhow::bail!("unknown export format: {other}"),
+    };
+
+    engine.dump_state(&format)?;
+    eprintln!("Exported to {}", args.output.display());
+    Ok(())
+}

--- a/memory-engine-cli/src/commands/import.rs
+++ b/memory-engine-cli/src/commands/import.rs
@@ -1,0 +1,56 @@
+use std::path::{Path, PathBuf};
+
+use memory_engine::{EngineConfig, MemoryEngine};
+
+#[derive(clap::Args)]
+pub struct ImportArgs {
+    /// Path to JSON snapshot file (plain, .gz, or .zst — auto-detected)
+    snapshot: PathBuf,
+
+    /// Embedding dimension (required for compressed snapshots, auto-detected for plain JSON)
+    #[arg(long)]
+    embed_dim: Option<usize>,
+}
+
+pub fn run(db: &Path, args: &ImportArgs) -> anyhow::Result<()> {
+    if db.exists() {
+        anyhow::bail!(
+            "target database {} already exists — import requires a fresh path",
+            db.display()
+        );
+    }
+
+    let embed_dim = match args.embed_dim {
+        Some(dim) => dim,
+        None => peek_embed_dim(&args.snapshot).map_err(|e| {
+            anyhow::anyhow!("{e}\n\nHint: for compressed snapshots, pass --embed-dim explicitly")
+        })?,
+    };
+
+    let config = EngineConfig::new(db.to_path_buf(), embed_dim);
+    let _engine = MemoryEngine::restore_json(&args.snapshot, &config)?;
+
+    eprintln!(
+        "Imported {} into {} (embed_dim={})",
+        args.snapshot.display(),
+        db.display(),
+        embed_dim,
+    );
+    Ok(())
+}
+
+/// Peek at a JSON snapshot file to extract `embed_dim` without loading everything.
+fn peek_embed_dim(path: &Path) -> anyhow::Result<usize> {
+    #[derive(serde::Deserialize)]
+    struct SnapshotHeader {
+        embed_dim: usize,
+    }
+
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+
+    let header: SnapshotHeader = serde_json::from_reader(reader)
+        .map_err(|e| anyhow::anyhow!("failed to read snapshot header: {e}"))?;
+
+    Ok(header.embed_dim)
+}

--- a/memory-engine-cli/src/commands/inspect.rs
+++ b/memory-engine-cli/src/commands/inspect.rs
@@ -1,0 +1,111 @@
+use std::path::Path;
+
+use tabled::{Table, Tabled};
+
+use crate::db::open_engine;
+use crate::output::{self, OutputFormat};
+
+#[derive(Tabled)]
+struct FactField {
+    #[tabled(rename = "Field")]
+    field: &'static str,
+    #[tabled(rename = "Value")]
+    value: String,
+}
+
+pub fn run(db: &Path, fact_id: i64, format: OutputFormat) -> anyhow::Result<()> {
+    let engine = open_engine(db)?;
+    let fact = engine.get_fact(fact_id)?;
+
+    match format {
+        OutputFormat::Json => output::print_json(&fact)?,
+        OutputFormat::Table => {
+            let rows = vec![
+                FactField {
+                    field: "id",
+                    value: fact.id.to_string(),
+                },
+                FactField {
+                    field: "content",
+                    value: fact.content.clone(),
+                },
+                FactField {
+                    field: "fact_type",
+                    value: format!("{:?}", fact.fact_type),
+                },
+                FactField {
+                    field: "importance",
+                    value: format!("{:.4}", fact.importance),
+                },
+                FactField {
+                    field: "importance_score",
+                    value: format!("{:.4}", fact.importance_score),
+                },
+                FactField {
+                    field: "is_pinned",
+                    value: fact.is_pinned.to_string(),
+                },
+                FactField {
+                    field: "access_count",
+                    value: fact.access_count.to_string(),
+                },
+                FactField {
+                    field: "scope_id",
+                    value: fact.scope_id.to_string(),
+                },
+                FactField {
+                    field: "t_created",
+                    value: fact.t_created.to_rfc3339(),
+                },
+                FactField {
+                    field: "t_expired",
+                    value: fact
+                        .t_expired
+                        .map_or_else(|| "\u{2014}".into(), |t| t.to_rfc3339()),
+                },
+                FactField {
+                    field: "t_valid",
+                    value: fact
+                        .t_valid
+                        .map_or_else(|| "\u{2014}".into(), |t| t.to_rfc3339()),
+                },
+                FactField {
+                    field: "t_invalid",
+                    value: fact
+                        .t_invalid
+                        .map_or_else(|| "\u{2014}".into(), |t| t.to_rfc3339()),
+                },
+                FactField {
+                    field: "surfaced_at",
+                    value: fact
+                        .surfaced_at
+                        .map_or_else(|| "\u{2014}".into(), |t| t.to_rfc3339()),
+                },
+                FactField {
+                    field: "source_event_id",
+                    value: fact
+                        .source_event_id
+                        .map_or_else(|| "\u{2014}".into(), |id| id.to_string()),
+                },
+                FactField {
+                    field: "last_accessed",
+                    value: fact.last_accessed.to_rfc3339(),
+                },
+                FactField {
+                    field: "content_hash",
+                    value: fact.content_hash.clone(),
+                },
+                FactField {
+                    field: "metadata",
+                    value: fact.metadata.to_string(),
+                },
+            ];
+            println!("{}", Table::new(rows));
+        }
+        OutputFormat::Plain => {
+            println!("{}", fact.content);
+        }
+    }
+
+    Ok(())
+}

--- a/memory-engine-cli/src/commands/mod.rs
+++ b/memory-engine-cli/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod stats;

--- a/memory-engine-cli/src/commands/mod.rs
+++ b/memory-engine-cli/src/commands/mod.rs
@@ -1,1 +1,7 @@
+pub mod dump;
+pub mod explain;
+pub mod export;
+pub mod import;
+pub mod inspect;
+pub mod query;
 pub mod stats;

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -1,0 +1,117 @@
+use std::path::Path;
+
+use memory_engine::search::hybrid::MatchType;
+use memory_engine::MemoryQuery;
+use tabled::{Table, Tabled};
+
+use crate::db::open_engine;
+use crate::output::{self, truncate_str, OutputFormat};
+
+#[derive(clap::Args)]
+pub struct QueryArgs {
+    /// Search text (FTS5 full-text search)
+    text: String,
+
+    /// Maximum results
+    #[arg(long, default_value = "10")]
+    limit: usize,
+
+    /// Scope path filter (subtree match)
+    #[arg(long)]
+    scope: Option<String>,
+
+    /// Filter by fact type (episodic, semantic, procedural)
+    #[arg(long)]
+    fact_type: Option<String>,
+
+    /// Minimum importance score
+    #[arg(long)]
+    min_importance: Option<f64>,
+
+    /// Show only pinned facts
+    #[arg(long)]
+    pinned_only: bool,
+}
+
+#[derive(Tabled)]
+struct ResultRow {
+    #[tabled(rename = "ID")]
+    id: i64,
+    #[tabled(rename = "Score")]
+    score: String,
+    #[tabled(rename = "Match")]
+    match_type: String,
+    #[tabled(rename = "Type")]
+    fact_type: String,
+    #[tabled(rename = "Pinned")]
+    pinned: &'static str,
+    #[tabled(rename = "Content")]
+    content: String,
+}
+
+pub fn run(db: &Path, args: &QueryArgs, format: OutputFormat) -> anyhow::Result<()> {
+    let engine = open_engine(db)?;
+
+    let mut query = MemoryQuery::new().text(&args.text).limit(args.limit);
+
+    if let Some(scope) = &args.scope {
+        query = query.scope_subtree(scope);
+    }
+
+    if let Some(score) = args.min_importance {
+        query = query.min_importance_score(score);
+    }
+
+    if let Some(ft) = &args.fact_type {
+        let fact_type = match ft.to_lowercase().as_str() {
+            "episodic" => memory_engine::FactType::Episodic,
+            "semantic" => memory_engine::FactType::Semantic,
+            "procedural" => memory_engine::FactType::Procedural,
+            other => anyhow::bail!(
+                "unknown fact type: {other} (expected: episodic, semantic, procedural)"
+            ),
+        };
+        query = query.fact_type(fact_type);
+    }
+
+    if args.pinned_only {
+        query = query.pinned_only();
+    }
+
+    let results = engine.execute_query(&query)?;
+
+    match format {
+        OutputFormat::Json => output::print_json(&results)?,
+        OutputFormat::Table => {
+            if results.is_empty() {
+                println!("No results.");
+                return Ok(());
+            }
+            let rows: Vec<ResultRow> = results
+                .iter()
+                .map(|r| ResultRow {
+                    id: r.fact.id,
+                    score: format!("{:.4}", r.score),
+                    match_type: match r.match_type {
+                        MatchType::Fts => "FTS".into(),
+                        MatchType::Vector => "VEC".into(),
+                        MatchType::Both => "BOTH".into(),
+                        MatchType::ImportanceRank => "RANK".into(),
+                        _ => "?".into(),
+                    },
+                    fact_type: format!("{:?}", r.fact.fact_type),
+                    pinned: if r.fact.is_pinned { "yes" } else { "" },
+                    content: truncate_str(&r.fact.content, 80),
+                })
+                .collect();
+            println!("{}", Table::new(rows));
+        }
+        OutputFormat::Plain => {
+            for r in &results {
+                println!("{}\t{:.4}\t{}", r.fact.id, r.score, r.fact.content);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/memory-engine-cli/src/commands/stats.rs
+++ b/memory-engine-cli/src/commands/stats.rs
@@ -1,7 +1,110 @@
 use std::path::Path;
 
-use crate::output::OutputFormat;
+use tabled::{Table, Tabled};
 
-pub fn run(_db: &Path, _format: OutputFormat) -> anyhow::Result<()> {
-    todo!("stats subcommand — implemented in Task 3")
+use crate::db::open_engine;
+use crate::output::{self, OutputFormat};
+
+#[derive(Tabled)]
+struct StatRow {
+    #[tabled(rename = "Category")]
+    category: &'static str,
+    #[tabled(rename = "Metric")]
+    metric: &'static str,
+    #[tabled(rename = "Value")]
+    value: String,
+}
+
+pub fn run(db: &Path, format: OutputFormat) -> anyhow::Result<()> {
+    let engine = open_engine(db)?;
+    let stats = engine.statistics()?;
+
+    match format {
+        OutputFormat::Json => output::print_json(&stats)?,
+        OutputFormat::Table => {
+            let rows = vec![
+                StatRow {
+                    category: "Facts",
+                    metric: "total",
+                    value: stats.facts.total.to_string(),
+                },
+                StatRow {
+                    category: "Facts",
+                    metric: "active",
+                    value: stats.facts.active.to_string(),
+                },
+                StatRow {
+                    category: "Facts",
+                    metric: "expired",
+                    value: stats.facts.expired.to_string(),
+                },
+                StatRow {
+                    category: "Facts",
+                    metric: "pinned",
+                    value: stats.facts.pinned.to_string(),
+                },
+                StatRow {
+                    category: "Facts",
+                    metric: "due",
+                    value: stats.facts.due.to_string(),
+                },
+                StatRow {
+                    category: "Edges",
+                    metric: "total",
+                    value: stats.edges.total.to_string(),
+                },
+                StatRow {
+                    category: "Edges",
+                    metric: "active",
+                    value: stats.edges.active.to_string(),
+                },
+                StatRow {
+                    category: "Events",
+                    metric: "total",
+                    value: stats.events.total.to_string(),
+                },
+                StatRow {
+                    category: "Scopes",
+                    metric: "total",
+                    value: stats.scopes.total.to_string(),
+                },
+                StatRow {
+                    category: "Scopes",
+                    metric: "max_depth",
+                    value: stats.scopes.max_depth.to_string(),
+                },
+                StatRow {
+                    category: "Summaries",
+                    metric: "total",
+                    value: stats.summaries.total.to_string(),
+                },
+                StatRow {
+                    category: "Storage",
+                    metric: "size_bytes",
+                    value: stats.storage.main_db_bytes.to_string(),
+                },
+                StatRow {
+                    category: "Storage",
+                    metric: "page_count",
+                    value: stats.storage.page_count.to_string(),
+                },
+            ];
+            println!("{}", Table::new(rows));
+        }
+        OutputFormat::Plain => {
+            println!("facts.total={}", stats.facts.total);
+            println!("facts.active={}", stats.facts.active);
+            println!("facts.expired={}", stats.facts.expired);
+            println!("facts.pinned={}", stats.facts.pinned);
+            println!("facts.due={}", stats.facts.due);
+            println!("edges.total={}", stats.edges.total);
+            println!("edges.active={}", stats.edges.active);
+            println!("events.total={}", stats.events.total);
+            println!("scopes.total={}", stats.scopes.total);
+            println!("summaries.total={}", stats.summaries.total);
+            println!("storage.size_bytes={}", stats.storage.main_db_bytes);
+        }
+    }
+
+    Ok(())
 }

--- a/memory-engine-cli/src/commands/stats.rs
+++ b/memory-engine-cli/src/commands/stats.rs
@@ -1,0 +1,7 @@
+use std::path::Path;
+
+use crate::output::OutputFormat;
+
+pub fn run(_db: &Path, _format: OutputFormat) -> anyhow::Result<()> {
+    todo!("stats subcommand — implemented in Task 3")
+}

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -26,9 +26,9 @@ pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
             [],
             |row| row.get::<_, String>(0),
         )
-        .map_err(|_| {
+        .map_err(|e| {
             anyhow::anyhow!(
-                "database has no embed_dim in config table — is this a memory-engine database?"
+                "database has no embed_dim in config table — is this a memory-engine database? ({e})"
             )
         })?
         .parse()

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use memory_engine::{EngineConfig, MemoryEngine};
+
+/// Open a `MemoryEngine` from an existing database file.
+///
+/// Reads `embed_dim` from the database config table so the user
+/// doesn't have to specify it manually.
+pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
+    let conn = rusqlite::Connection::open_with_flags(
+        path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let embed_dim: usize = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'embed_dim'",
+            [],
+            |row| {
+                let s: String = row.get(0)?;
+                Ok(s)
+            },
+        )
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "database has no embed_dim in config table — is this a memory-engine database?"
+            )
+        })?
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid embed_dim value in config table"))?;
+    drop(conn);
+
+    let config = EngineConfig::new(path.to_path_buf(), embed_dim);
+    let engine = MemoryEngine::open(&config)?;
+    Ok(engine)
+}

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -6,7 +6,16 @@ use memory_engine::{EngineConfig, MemoryEngine};
 ///
 /// Reads `embed_dim` from the database config table so the user
 /// doesn't have to specify it manually.
+///
+/// # Caveat
+///
+/// `MemoryEngine::open()` may run schema migrations on the writable pool.
+/// We mitigate this by setting `backup_dir` next to the database so any
+/// migration creates a WAL-safe backup first. A true read-only open path
+/// requires library support (tracked as a follow-up issue).
 pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
+    anyhow::ensure!(path.exists(), "database not found: {}", path.display());
+
     let conn = rusqlite::Connection::open_with_flags(
         path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -15,10 +24,7 @@ pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
         .query_row(
             "SELECT value FROM config WHERE key = 'embed_dim'",
             [],
-            |row| {
-                let s: String = row.get(0)?;
-                Ok(s)
-            },
+            |row| row.get::<_, String>(0),
         )
         .map_err(|_| {
             anyhow::anyhow!(
@@ -29,7 +35,9 @@ pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
         .map_err(|_| anyhow::anyhow!("invalid embed_dim value in config table"))?;
     drop(conn);
 
-    let config = EngineConfig::new(path.to_path_buf(), embed_dim);
+    let backup_dir = path.parent().map(Path::to_path_buf);
+    let mut config = EngineConfig::new(path.to_path_buf(), embed_dim);
+    config.backup_dir = backup_dir;
     let engine = MemoryEngine::open(&config)?;
     Ok(engine)
 }

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -22,11 +22,11 @@ use output::OutputFormat;
 )]
 struct Cli {
     /// Path to the memory-engine SQLite database
-    #[arg(long, global = true, env = "MEMORY_ENGINE_DB")]
+    #[arg(long, env = "MEMORY_ENGINE_DB")]
     db: PathBuf,
 
     /// Output format
-    #[arg(long, global = true, default_value = "table")]
+    #[arg(long, default_value = "table")]
     format: OutputFormat,
 
     #[command(subcommand)]

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -11,7 +11,15 @@ use output::OutputFormat;
 
 /// memory-engine-cli — operator tool for agent memory databases
 #[derive(Parser)]
-#[command(name = "memory-engine-cli", version, about)]
+#[command(
+    name = "memory-engine-cli",
+    version,
+    about = "Operator tool for agent memory databases",
+    long_about = "memory-engine-cli is a command-line inspector for memory-engine databases.\n\n\
+        It provides read-only access to facts, events, statistics, and provenance.\n\
+        For data portability, use export/import for JSON snapshots or SQLite backups.",
+    after_help = "Set MEMORY_ENGINE_DB to avoid passing --db on every invocation."
+)]
 struct Cli {
     /// Path to the memory-engine SQLite database
     #[arg(long, global = true, env = "MEMORY_ENGINE_DB")]
@@ -29,6 +37,24 @@ struct Cli {
 enum Commands {
     /// Show engine statistics
     Stats,
+    /// View fact details
+    Inspect {
+        /// Fact ID
+        id: i64,
+    },
+    /// Explain why a fact is active, forgotten, pinned, or due
+    Explain {
+        /// Fact ID
+        id: i64,
+    },
+    /// Search facts by text (FTS5 full-text search)
+    Query(commands::query::QueryArgs),
+    /// Export engine state to file (JSON, SQLite, compressed)
+    Export(commands::export::ExportArgs),
+    /// Import a JSON snapshot into a new database
+    Import(commands::import::ImportArgs),
+    /// Dump facts or events to stdout (debug/inspection)
+    Dump(commands::dump::DumpArgs),
 }
 
 fn main() -> ExitCode {
@@ -36,6 +62,12 @@ fn main() -> ExitCode {
 
     let result = match cli.command {
         Commands::Stats => commands::stats::run(&cli.db, cli.format),
+        Commands::Inspect { id } => commands::inspect::run(&cli.db, id, cli.format),
+        Commands::Explain { id } => commands::explain::run(&cli.db, id, cli.format),
+        Commands::Query(ref args) => commands::query::run(&cli.db, args, cli.format),
+        Commands::Export(ref args) => commands::export::run(&cli.db, args),
+        Commands::Import(ref args) => commands::import::run(&cli.db, args),
+        Commands::Dump(ref args) => commands::dump::run(&cli.db, args, cli.format),
     };
 
     match result {

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -1,0 +1,16 @@
+use clap::Parser;
+
+/// memory-engine-cli — operator tool for agent memory databases
+#[derive(Parser)]
+#[command(name = "memory-engine-cli", version, about)]
+struct Cli {
+    /// Path to the memory-engine SQLite database
+    #[arg(long, env = "MEMORY_ENGINE_DB")]
+    db: std::path::PathBuf,
+}
+
+fn main() {
+    let _cli = Cli::parse();
+    eprintln!("memory-engine-cli: not yet implemented");
+    std::process::exit(1);
+}

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -1,16 +1,48 @@
-use clap::Parser;
+mod commands;
+mod db;
+mod output;
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+use output::OutputFormat;
 
 /// memory-engine-cli — operator tool for agent memory databases
 #[derive(Parser)]
 #[command(name = "memory-engine-cli", version, about)]
 struct Cli {
     /// Path to the memory-engine SQLite database
-    #[arg(long, env = "MEMORY_ENGINE_DB")]
-    db: std::path::PathBuf,
+    #[arg(long, global = true, env = "MEMORY_ENGINE_DB")]
+    db: PathBuf,
+
+    /// Output format
+    #[arg(long, global = true, default_value = "table")]
+    format: OutputFormat,
+
+    #[command(subcommand)]
+    command: Commands,
 }
 
-fn main() {
-    let _cli = Cli::parse();
-    eprintln!("memory-engine-cli: not yet implemented");
-    std::process::exit(1);
+#[derive(Subcommand)]
+enum Commands {
+    /// Show engine statistics
+    Stats,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Commands::Stats => commands::stats::run(&cli.db, cli.format),
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -17,11 +17,11 @@ use output::OutputFormat;
     about = "Operator tool for agent memory databases",
     long_about = "memory-engine-cli is a command-line inspector for memory-engine databases.\n\n\
         It provides read-only access to facts, events, statistics, and provenance.\n\
-        For data portability, use export/import for JSON snapshots or SQLite backups.",
+        For data portability, use export/import for JSON snapshots or `SQLite` backups.",
     after_help = "Set MEMORY_ENGINE_DB to avoid passing --db on every invocation."
 )]
 struct Cli {
-    /// Path to the memory-engine SQLite database
+    /// Path to the memory-engine `SQLite` database
     #[arg(long, env = "MEMORY_ENGINE_DB")]
     db: PathBuf,
 
@@ -49,7 +49,7 @@ enum Commands {
     },
     /// Search facts by text (FTS5 full-text search)
     Query(commands::query::QueryArgs),
-    /// Export engine state to file (JSON, SQLite, compressed)
+    /// Export engine state to file (JSON, `SQLite`, compressed)
     Export(commands::export::ExportArgs),
     /// Import a JSON snapshot into a new database
     Import(commands::import::ImportArgs),

--- a/memory-engine-cli/src/output.rs
+++ b/memory-engine-cli/src/output.rs
@@ -1,0 +1,32 @@
+use clap::ValueEnum;
+
+/// Output format for CLI commands.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable table (default)
+    #[default]
+    Table,
+    /// Machine-readable JSON
+    Json,
+    /// Minimal plain text (one value per line, scriptable)
+    Plain,
+}
+
+/// Truncate a string to `max_chars` characters, appending "..." if truncated.
+/// Safe for multi-byte UTF-8 — never slices mid-character.
+pub fn truncate_str(s: &str, max_chars: usize) -> String {
+    let mut chars = s.chars();
+    let truncated: String = chars.by_ref().take(max_chars.saturating_sub(3)).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        s.to_string()
+    }
+}
+
+/// Print a value as JSON to stdout.
+pub fn print_json<T: serde::Serialize>(value: &T) -> anyhow::Result<()> {
+    serde_json::to_writer_pretty(std::io::stdout(), value)?;
+    println!();
+    Ok(())
+}

--- a/memory-engine-cli/src/output.rs
+++ b/memory-engine-cli/src/output.rs
@@ -1,7 +1,7 @@
 use clap::ValueEnum;
 
 /// Output format for CLI commands.
-#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
     /// Human-readable table (default)
     #[default]
@@ -15,13 +15,11 @@ pub enum OutputFormat {
 /// Truncate a string to `max_chars` characters, appending "..." if truncated.
 /// Safe for multi-byte UTF-8 — never slices mid-character.
 pub fn truncate_str(s: &str, max_chars: usize) -> String {
-    let mut chars = s.chars();
-    let truncated: String = chars.by_ref().take(max_chars.saturating_sub(3)).collect();
-    if chars.next().is_some() {
-        format!("{truncated}...")
-    } else {
-        s.to_string()
+    if s.chars().count() <= max_chars {
+        return s.to_string();
     }
+    let truncated: String = s.chars().take(max_chars.saturating_sub(3)).collect();
+    format!("{truncated}...")
 }
 
 /// Print a value as JSON to stdout.

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -1,0 +1,274 @@
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// Create a test database with sample data and return (tempdir, db_path).
+fn create_test_db() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    let config = memory_engine::EngineConfig::new(db_path.clone(), 4);
+    let engine = memory_engine::MemoryEngine::open(&config).unwrap();
+
+    struct FakeEmbed;
+    impl memory_engine::EmbeddingProvider for FakeEmbed {
+        fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
+            Ok(vec![0.1, 0.2, 0.3, 0.4])
+        }
+    }
+
+    engine
+        .add_fact(
+            "The sky is blue",
+            memory_engine::FactType::Semantic,
+            None,
+            &FakeEmbed,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Rust is fast",
+            memory_engine::FactType::Procedural,
+            None,
+            &FakeEmbed,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Memory engines consolidate facts",
+            memory_engine::FactType::Episodic,
+            None,
+            &FakeEmbed,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    drop(engine);
+    (dir, db_path)
+}
+
+fn cli() -> Command {
+    Command::cargo_bin("memory-engine-cli").unwrap()
+}
+
+// --- stats ---
+
+#[test]
+fn stats_table_output() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "stats"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Facts"))
+        .stdout(predicate::str::contains("3"));
+}
+
+#[test]
+fn stats_json_output() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "stats",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"active\""));
+}
+
+#[test]
+fn stats_plain_output() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "plain",
+            "stats",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("facts.active=3"));
+}
+
+// --- inspect ---
+
+#[test]
+fn inspect_existing_fact() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "inspect", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("The sky is blue"));
+}
+
+#[test]
+fn inspect_nonexistent_fact() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "inspect", "999"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+// --- explain ---
+
+#[test]
+fn explain_fact() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "explain", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fact_id"))
+        .stdout(predicate::str::contains("scope"));
+}
+
+// --- query ---
+
+#[test]
+fn query_fts() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "query", "blue sky"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sky"));
+}
+
+#[test]
+fn query_no_results() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "query", "xyznonexistent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results"));
+}
+
+// --- export + import roundtrip ---
+
+// NOTE: Skipped due to pre-existing library bug — restore.rs has
+// CURRENT_SCHEMA_VERSION=5 but running schema is v6 after #78/#92.
+// Re-enable once the library's restore tests are fixed.
+#[test]
+#[ignore]
+fn export_import_roundtrip() {
+    let (dir, db_path) = create_test_db();
+
+    // Export
+    let export_path = dir.path().join("export.json");
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "export",
+            "-o",
+            export_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(export_path.exists());
+
+    // Import into new DB
+    let new_db = dir.path().join("imported.db");
+    cli()
+        .args([
+            "--db",
+            new_db.to_str().unwrap(),
+            "import",
+            export_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Verify imported DB has same data
+    cli()
+        .args([
+            "--db",
+            new_db.to_str().unwrap(),
+            "--format",
+            "plain",
+            "stats",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("facts.active=3"));
+}
+
+// --- dump ---
+
+#[test]
+fn dump_facts() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "dump", "facts"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Active Facts"));
+}
+
+#[test]
+fn dump_events() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "dump", "events"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Events"));
+}
+
+// --- error handling ---
+
+#[test]
+fn missing_db_flag() {
+    cli()
+        .args(["stats"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--db"));
+}
+
+#[test]
+fn nonexistent_db() {
+    cli()
+        .args(["--db", "/tmp/nonexistent_memory_engine.db", "stats"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn import_rejects_existing_db() {
+    let (dir, db_path) = create_test_db();
+    let fake_snapshot = dir.path().join("fake.json");
+    std::fs::write(&fake_snapshot, "{}").unwrap();
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "import",
+            fake_snapshot.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -45,7 +45,7 @@ pub struct SearchQuery {
 }
 
 /// A search result with the full fact, combined score, and match source.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SearchResult {
     pub fact: Fact,
     pub score: f64,


### PR DESCRIPTION
## Summary

Implements the CLI inspector tool for memory-engine databases (#44 — Phase 4b).

New crate `memory-engine-cli` as a workspace member with 7 subcommands: stats, inspect, explain, query, export, import, dump. Three output formats: table/json/plain. Documentation at `docs/reference/cli-inspector.md`.

## Related

- Implementation plan: #143
- Follow-up (read-only engine open): #103
- Follow-up (LIMIT pushdown): #104

## Test plan

- [x] `cargo test -p memory-engine-cli` — 13 pass, 1 ignored
- [x] `cargo clippy -p memory-engine-cli --no-deps -- -D warnings` — clean
- [x] Library baseline unchanged (319 pass, 3 pre-existing failures)
- [ ] Manual smoke test with a real agent database

Closes #44