### PR TITLE
fix(bootstrap): propagate interrupted flag through filter.rs

### DIFF
--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -32,6 +32,7 @@ pub struct ToolCallRecord {
     pub stdout: Option<String>,
     pub stderr: Option<String>,
     pub is_error: bool,
+    pub interrupted: bool,
 }
 
 /// Category of a noteworthy episode detected by keyword pre-filter.
@@ -283,6 +284,7 @@ fn extract_tool_calls(
                 stdout: None,
                 stderr: None,
                 is_error: false,
+                interrupted: false,
             });
         }
     }
@@ -297,6 +299,7 @@ fn extract_tool_calls(
             calls[i].stdout.clone_from(&result.stdout);
             calls[i].stderr.clone_from(&result.stderr);
             calls[i].is_error = result.is_error.unwrap_or(false);
+            calls[i].interrupted = result.interrupted.unwrap_or(false);
         }
     }
 
@@ -566,6 +569,29 @@ mod tests {
         }
     }
 
+    fn user_with_interrupted_tool_result(uuid: &str, parent: &str, secs: i64) -> SessionEntry {
+        SessionEntry {
+            entry_type: EntryType::User,
+            session_id: Some("sess-1".into()),
+            timestamp: ts(secs).map(|t| t.to_rfc3339()),
+            uuid: opt(uuid),
+            parent_uuid: opt(parent),
+            cwd: None,
+            git_branch: None,
+            message: Some(MessagePayload {
+                role: Some("user".into()),
+                content: Some(json!([{"type": "text", "text": ""}])),
+            }),
+            tool_use_result: Some(ToolUseResult {
+                stdout: None,
+                stderr: Some("interrupted".into()),
+                interrupted: Some(true),
+                is_error: Some(false),
+            }),
+            data: None,
+        }
+    }
+
     // -- reconstruct_turns tests --
 
     #[test]
@@ -616,6 +642,32 @@ mod tests {
         assert!(!turns[0].tool_calls[0].is_error);
     }
 
+    #[test]
+    fn reconstruct_propagates_interrupted_flag() {
+        let entries = vec![
+            user_entry("u1", "", "run ls", 100),
+            assistant_with_tool("a1", "u1", "Sure", "Bash", 101),
+            user_with_interrupted_tool_result("u2", "a1", 102),
+        ];
+        let turns = reconstruct_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        assert!(turns[0].tool_calls[0].interrupted);
+        assert!(!turns[0].tool_calls[0].is_error);
+    }
+
+    #[test]
+    fn reconstruct_interrupted_false_by_default() {
+        let entries = vec![
+            user_entry("u1", "", "run ls", 100),
+            assistant_with_tool("a1", "u1", "Sure", "Bash", 101),
+            user_with_tool_result("u2", "a1", "", Some("ok"), None, false, 102),
+        ];
+        let turns = reconstruct_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert!(!turns[0].tool_calls[0].interrupted);
+    }
+
     // -- keyword_prefilter tests --
 
     fn make_turn(user: &str, assistant: &str) -> ConversationTurn {
@@ -639,6 +691,7 @@ mod tests {
                 stdout: None,
                 stderr: Some(stderr.into()),
                 is_error: true,
+                interrupted: false,
             }],
             uuid: "t1".into(),
         }

--- a/src/bootstrap/outcome.rs
+++ b/src/bootstrap/outcome.rs
@@ -443,17 +443,20 @@ mod tests {
     }
 
     #[test]
-    fn interrupted_flag_drives_was_interrupted() {
+    fn interrupted_flag_true_triggers_was_interrupted() {
         let mut tc = make_tool_call(Some("output"), None, false);
         tc.interrupted = true;
         let turns = vec![make_turn("do thing", "ok", vec![tc])];
         let (_, signals) = classify_outcome(&turns);
         assert!(signals.was_interrupted);
-        // is_error alone no longer triggers was_interrupted
+    }
+
+    #[test]
+    fn is_error_alone_does_not_trigger_was_interrupted() {
         let tc_err = make_tool_call(None, Some("fail"), true);
-        let turns2 = vec![make_turn("do thing", "ok", vec![tc_err])];
-        let (_, signals2) = classify_outcome(&turns2);
-        assert!(!signals2.was_interrupted);
+        let turns = vec![make_turn("do thing", "ok", vec![tc_err])];
+        let (_, signals) = classify_outcome(&turns);
+        assert!(!signals.was_interrupted);
     }
 
     #[test]

--- a/src/bootstrap/outcome.rs
+++ b/src/bootstrap/outcome.rs
@@ -24,10 +24,8 @@ pub struct OutcomeSignals {
     pub has_commit: bool,
     pub tests_passed: bool,
     pub has_error_loops: bool,
-    /// Approximated via `is_error` on the last tool call — the underlying
-    /// `ToolCallRecord` does not carry the raw `interrupted` flag from the
-    /// session log.  This is a known limitation; a future refinement can
-    /// propagate `ToolUseResult::interrupted` through filter.rs.
+    /// True when the last tool call in the session was interrupted, as reported
+    /// by `ToolUseResult::interrupted` propagated through `filter.rs`.
     pub was_interrupted: bool,
     pub final_user_sentiment: Option<Sentiment>,
 }
@@ -53,7 +51,7 @@ pub enum Sentiment {
 /// | `has_commit` | `"git commit"` in tool input **or** commit-like patterns (`[main`, `[master`, 7+ hex chars) in stdout |
 /// | `tests_passed` | `"test result: ok"` / `"passed"` with test-runner patterns in stdout |
 /// | `has_error_loops` | Same stderr prefix (first 100 chars) in 3+ consecutive tool calls |
-/// | `was_interrupted` | Last `ToolCallRecord` has `is_error == true` (proxy — see [`OutcomeSignals::was_interrupted`]) |
+/// | `was_interrupted` | Last `ToolCallRecord` has `interrupted == true` (from `ToolUseResult::interrupted`) |
 /// | `final_user_sentiment` | Keyword match on the last user message |
 ///
 /// # Classification
@@ -198,14 +196,14 @@ fn detect_error_loops(turns: &[super::filter::ConversationTurn]) -> bool {
     false
 }
 
-/// Proxy for interruption: the very last tool call's `is_error` flag.
+/// True when the very last tool call was interrupted.
 fn detect_interrupted(turns: &[super::filter::ConversationTurn]) -> bool {
     turns
         .iter()
         .rev()
         .flat_map(|t| t.tool_calls.iter().rev())
         .next()
-        .is_some_and(|tc| tc.is_error)
+        .is_some_and(|tc| tc.interrupted)
 }
 
 /// Keyword-based sentiment of the final user message.
@@ -270,6 +268,7 @@ mod tests {
             stdout: stdout.map(Into::into),
             stderr: stderr.map(Into::into),
             is_error,
+            interrupted: false,
         }
     }
 
@@ -306,7 +305,31 @@ mod tests {
     }
 
     #[test]
-    fn classify_failure_error_loop() {
+    fn classify_failure_error_loop_with_interruption() {
+        let err = "error[E0308]: mismatched types";
+        let mut last_call = make_tool_call(None, Some(err), true);
+        last_call.interrupted = true;
+        let turns = vec![
+            make_turn(
+                "fix it",
+                "trying",
+                vec![make_tool_call(None, Some(err), true)],
+            ),
+            make_turn(
+                "fix it",
+                "trying",
+                vec![make_tool_call(None, Some(err), true)],
+            ),
+            make_turn("fix it", "trying", vec![last_call]),
+        ];
+        let (outcome, signals) = classify_outcome(&turns);
+        assert_eq!(outcome, SessionOutcome::Failure);
+        assert!(signals.has_error_loops);
+        assert!(signals.was_interrupted);
+    }
+
+    #[test]
+    fn error_loop_without_interruption_is_indeterminate() {
         let err = "error[E0308]: mismatched types";
         let turns = vec![
             make_turn(
@@ -326,9 +349,10 @@ mod tests {
             ),
         ];
         let (outcome, signals) = classify_outcome(&turns);
-        assert_eq!(outcome, SessionOutcome::Failure);
+        // Error loops without interruption no longer classified as Failure
+        assert_eq!(outcome, SessionOutcome::Indeterminate);
         assert!(signals.has_error_loops);
-        assert!(signals.was_interrupted); // last tool call has is_error=true
+        assert!(!signals.was_interrupted);
     }
 
     #[test]
@@ -388,6 +412,7 @@ mod tests {
             stdout: None,
             stderr: None,
             is_error: false,
+            interrupted: false,
         };
         let turns = vec![make_turn("commit", "ok", vec![tc])];
         let (_, signals) = classify_outcome(&turns);
@@ -415,6 +440,20 @@ mod tests {
         ];
         let (_, signals) = classify_outcome(&turns);
         assert!(!signals.has_error_loops);
+    }
+
+    #[test]
+    fn interrupted_flag_drives_was_interrupted() {
+        let mut tc = make_tool_call(Some("output"), None, false);
+        tc.interrupted = true;
+        let turns = vec![make_turn("do thing", "ok", vec![tc])];
+        let (_, signals) = classify_outcome(&turns);
+        assert!(signals.was_interrupted);
+        // is_error alone no longer triggers was_interrupted
+        let tc_err = make_tool_call(None, Some("fail"), true);
+        let turns2 = vec![make_turn("do thing", "ok", vec![tc_err])];
+        let (_, signals2) = classify_outcome(&turns2);
+        assert!(!signals2.was_interrupted);
     }
 
     #[test]

--- a/src/bootstrap/outcome.rs
+++ b/src/bootstrap/outcome.rs
@@ -57,7 +57,7 @@ pub enum Sentiment {
 /// # Classification
 ///
 /// - **Success**: `(has_commit && !has_error_loops) || (tests_passed && !was_interrupted)`
-/// - **Failure**: `(has_error_loops && was_interrupted) || (negative sentiment && !has_commit)`
+/// - **Failure**: `has_error_loops || was_interrupted || (negative sentiment && !has_commit)`
 /// - **Indeterminate**: everything else
 pub fn classify_outcome(
     turns: &[super::filter::ConversationTurn],
@@ -78,7 +78,8 @@ pub fn classify_outcome(
 
     let outcome = if (has_commit && !has_error_loops) || (tests_passed && !was_interrupted) {
         SessionOutcome::Success
-    } else if (has_error_loops && was_interrupted)
+    } else if has_error_loops
+        || was_interrupted
         || (final_user_sentiment == Sentiment::Negative && !has_commit)
     {
         SessionOutcome::Failure
@@ -329,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn error_loop_without_interruption_is_indeterminate() {
+    fn error_loop_without_interruption_is_failure() {
         let err = "error[E0308]: mismatched types";
         let turns = vec![
             make_turn(
@@ -349,8 +350,8 @@ mod tests {
             ),
         ];
         let (outcome, signals) = classify_outcome(&turns);
-        // Error loops without interruption no longer classified as Failure
-        assert_eq!(outcome, SessionOutcome::Indeterminate);
+        // Error loops alone are sufficient for Failure classification
+        assert_eq!(outcome, SessionOutcome::Failure);
         assert!(signals.has_error_loops);
         assert!(!signals.was_interrupted);
     }


### PR DESCRIPTION
## Summary

- Added `interrupted: bool` field to `ToolCallRecord`, populated from `ToolUseResult::interrupted` during enrichment in `extract_tool_calls()`
- Updated `detect_interrupted()` to use the real `interrupted` flag instead of `is_error` proxy, eliminating false positives
- Relaxed `Failure` classification: error loops, interruption, and negative sentiment are now independent failure signals
- Updated doc comments on `OutcomeSignals::was_interrupted` and `classify_outcome`

## Test plan

- [x] `reconstruct_propagates_interrupted_flag`
- [x] `reconstruct_interrupted_false_by_default`
- [x] `interrupted_flag_true_triggers_was_interrupted`
- [x] `is_error_alone_does_not_trigger_was_interrupted`
- [x] `error_loop_without_interruption_is_failure`
- [x] `classify_failure_error_loop_with_interruption`
- [x] `bootstrap_failure_session` integration test
- [x] All 46 bootstrap unit tests pass
- [x] All 8 bootstrap integration tests pass

## Review

- Gemini Code Assist: split combined test into two (addressed)
- Gemini CLI: MEDIUM on behavioral shift (intentional)
- Codex CLI: HIGH on classification regression (fixed in b00270f)

Fixes #83