### PR TITLE
refactor: scope-aware session lookup in link_session_facts

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -123,7 +123,7 @@ This page summarizes the public API surface of the `memory-engine` crate.
 | `graph_component`    | `(&self, fact_id: i64) -> Vec<i64>`          | All fact IDs in the connected component containing `fact_id`.                                                                            |
 | `graph_stats`        | `(&self) -> (usize, usize)`                  | `(node_count, edge_count)`.                                                                                                              |
 | `graph_has_node`     | `(&self, fact_id: i64) -> bool`              | Whether a node exists in the graph.                                                                                                      |
-| `link_session_facts` | `(&self, session_id: &str) -> Result<usize>` | Create bidirectional `co_session` edges between all active facts sharing a session. Idempotent. Returns the number of new edges created. |
+| `link_session_facts` | `(&self, session_id: &str, scope: Option<&str>) -> Result<usize>` | Create bidirectional `co_session` edges between all active facts sharing a session. When `scope` is `Some`, only facts within that scope subtree are considered. Idempotent. Returns the number of new edges created. |
 
 ### Pinning
 

--- a/docs/usage/graph-relationships.md
+++ b/docs/usage/graph-relationships.md
@@ -19,13 +19,18 @@ Edges are produced by three processes -- two internal and one consumer-triggered
 
 **Consolidation** -- During three-pass consolidation, when duplicate facts are identified and merged, edges may be created to track the dedup lineage.
 
-**Co-session linking** -- `link_session_facts(session_id)` creates bidirectional `co_session` edges between all active facts that share a `session_id` (via the `events` table). This captures write-time co-occurrence: facts mentioned in the same conversation session are contextually related even when their content is semantically dissimilar. Inspired by [DiffMem](https://github.com/Growth-Kinetics/DiffMem), where files modified in the same commit are implicitly linked.
+**Co-session linking** -- `link_session_facts(session_id, scope)` creates bidirectional `co_session` edges between all active facts that share a `session_id` (via the `events` table). This captures write-time co-occurrence: facts mentioned in the same conversation session are contextually related even when their content is semantically dissimilar. Inspired by [DiffMem](https://github.com/Growth-Kinetics/DiffMem), where files modified in the same commit are implicitly linked.
 
 Co-session edges have weight `0.5` (strong enough to influence importance scoring, weaker than explicit semantic relationships) and `scope_id = 1` (root scope, since co-session is cross-scope by nature). The method is idempotent -- calling it twice for the same session does not create duplicate edges.
 
+The optional `scope` parameter restricts the lookup to facts within a scope subtree. When `None`, all scopes are included (global lookup). In multi-tenant deployments where different scopes might reuse session IDs, passing `Some("user:alice")` prevents cross-scope edge creation between unrelated tenants.
+
 ```rust
-// After ingesting all facts for a session:
-let new_edges = engine.link_session_facts("session-abc-123")?;
+// Global lookup (backward-compatible):
+let new_edges = engine.link_session_facts("session-abc-123", None)?;
+
+// Scope-aware lookup (multi-tenant safe):
+let new_edges = engine.link_session_facts("session-abc-123", Some("user:alice"))?;
 println!("Created {new_edges} co-session edges");
 ```
 

--- a/docs/usage/graph-relationships.md
+++ b/docs/usage/graph-relationships.md
@@ -23,7 +23,7 @@ Edges are produced by three processes -- two internal and one consumer-triggered
 
 Co-session edges have weight `0.5` (strong enough to influence importance scoring, weaker than explicit semantic relationships) and `scope_id = 1` (root scope, since co-session is cross-scope by nature). The method is idempotent -- calling it twice for the same session does not create duplicate edges.
 
-The optional `scope` parameter restricts the lookup to facts within a scope subtree. When `None`, all scopes are included (global lookup). In multi-tenant deployments where different scopes might reuse session IDs, passing `Some("user:alice")` prevents cross-scope edge creation between unrelated tenants.
+The optional `scope` parameter restricts the lookup to facts within a scope subtree. When `None`, all scopes are included (global lookup). This matters in multi-tenant deployments where different scopes might reuse session IDs (e.g., `user:alice/session:1` and `user:bob/session:1`): without scope filtering, unrelated facts could be linked, and those edges influence `graph_degree` in importance scoring (`forget()`), meaning one tenant's session could change pruning decisions for another. Passing `Some("user:alice")` prevents this cross-scope contamination. (See [issue #73](https://github.com/dutiona/memory-engine/issues/73), identified during [PR #67 review](https://github.com/dutiona/memory-engine/pull/67#discussion_r2957128940).)
 
 ```rust
 // Global lookup (backward-compatible):

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -258,6 +258,20 @@ impl AsyncMemoryEngine {
             .map_err(join_err)?
     }
 
+    /// Create co-session edges between facts sharing a session.
+    pub async fn link_session_facts(
+        &self,
+        session_id: String,
+        scope: Option<String>,
+    ) -> Result<usize> {
+        let engine = self.inner.clone();
+        tokio::task::spawn_blocking(move || {
+            engine.link_session_facts(&session_id, scope.as_deref())
+        })
+        .await
+        .map_err(join_err)?
+    }
+
     /// Async wrapper for [`MemoryEngine::statistics`].
     ///
     /// # Errors
@@ -292,10 +306,7 @@ impl AsyncMemoryEngine {
     ///
     /// Returns [`MemoryError::NotFound`] if the fact does not exist, or
     /// [`MemoryError::Database`] on SQL failure.
-    pub async fn explain_fact(
-        &self,
-        id: i64,
-    ) -> Result<crate::inspect::FactExplanation> {
+    pub async fn explain_fact(&self, id: i64) -> Result<crate::inspect::FactExplanation> {
         let engine = self.inner.clone();
         tokio::task::spawn_blocking(move || engine.explain_fact(id))
             .await
@@ -308,10 +319,7 @@ impl AsyncMemoryEngine {
     ///
     /// Returns [`MemoryError::NotFound`] if the fact does not exist, or
     /// [`MemoryError::Database`] on SQL failure.
-    pub async fn fact_history(
-        &self,
-        id: i64,
-    ) -> Result<crate::inspect::FactHistory> {
+    pub async fn fact_history(&self, id: i64) -> Result<crate::inspect::FactHistory> {
         let engine = self.inner.clone();
         tokio::task::spawn_blocking(move || engine.fact_history(id))
             .await
@@ -324,10 +332,7 @@ impl AsyncMemoryEngine {
     ///
     /// Returns [`MemoryError::Internal`] on I/O or serialization failure,
     /// or [`MemoryError::Database`] on SQL failure.
-    pub async fn dump_state(
-        &self,
-        format: &crate::inspect::DumpFormat,
-    ) -> Result<()> {
+    pub async fn dump_state(&self, format: &crate::inspect::DumpFormat) -> Result<()> {
         let engine = self.inner.clone();
         let format = format.clone();
         tokio::task::spawn_blocking(move || engine.dump_state(&format))
@@ -394,11 +399,10 @@ impl AsyncMemoryEngine {
 
     /// Async wrapper for [`MemoryEngine::restore_json_memory`].
     pub async fn restore_json_memory(snapshot_path: std::path::PathBuf) -> Result<Self> {
-        let engine = tokio::task::spawn_blocking(move || {
-            MemoryEngine::restore_json_memory(&snapshot_path)
-        })
-        .await
-        .map_err(join_err)??;
+        let engine =
+            tokio::task::spawn_blocking(move || MemoryEngine::restore_json_memory(&snapshot_path))
+                .await
+                .map_err(join_err)??;
         Ok(Self::new(engine))
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -977,17 +977,36 @@ impl MemoryEngine {
     /// (root — cross-scope by nature). Idempotent: calling twice for the same
     /// session does not create duplicate edges.
     ///
+    /// When `scope` is `Some`, only facts within that scope subtree are
+    /// considered. When `None`, all scopes are included (global lookup,
+    /// backward-compatible).
+    ///
     /// Returns the number of new edges created.
     ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on SQL failure.
-    pub fn link_session_facts(&self, session_id: &str) -> Result<usize> {
+    /// Returns `MemoryError::NotFound` if `scope` is `Some` but the path
+    /// does not exist.
+    pub fn link_session_facts(&self, session_id: &str, scope: Option<&str>) -> Result<usize> {
         use crate::graph::EdgeData;
         use crate::store::edges::EdgeStore;
 
+        // Resolve scope path → subtree IDs (short-lived read lock)
+        let scope_ids: Vec<i64> = match scope {
+            Some(path) => {
+                let tree = self.scope_tree.read();
+                let id = tree
+                    .resolve_path(path)
+                    .ok_or_else(|| MemoryError::NotFound(format!("scope path: {path}")))?;
+                tree.subtree(id)
+            }
+            None => Vec::new(),
+        };
+
         let conn = self.write_conn();
-        let facts = FactStore::new(&conn, self.embed_dim).list_active_by_session(session_id)?;
+        let facts =
+            FactStore::new(&conn, self.embed_dim).list_active_by_session(session_id, &scope_ids)?;
 
         if facts.len() < 2 {
             drop(conn);
@@ -3458,7 +3477,7 @@ mod tests {
         let (_, f1) = add_session_fact(&engine, "fact a", "s1");
         let (_, f2) = add_session_fact(&engine, "fact b", "s1");
 
-        let created = engine.link_session_facts("s1").unwrap();
+        let created = engine.link_session_facts("s1", None).unwrap();
         assert_eq!(created, 2); // A→B and B→A
 
         // Verify edges in DB
@@ -3495,7 +3514,7 @@ mod tests {
         add_session_fact(&engine, "b", "s1");
         add_session_fact(&engine, "c", "s1");
 
-        let created = engine.link_session_facts("s1").unwrap();
+        let created = engine.link_session_facts("s1", None).unwrap();
         assert_eq!(created, 6); // 3 pairs × 2 directions
     }
 
@@ -3504,14 +3523,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         add_session_fact(&engine, "lonely", "s1");
 
-        let created = engine.link_session_facts("s1").unwrap();
+        let created = engine.link_session_facts("s1", None).unwrap();
         assert_eq!(created, 0);
     }
 
     #[test]
     fn link_session_facts_empty_session_noop() {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
-        let created = engine.link_session_facts("nonexistent").unwrap();
+        let created = engine.link_session_facts("nonexistent", None).unwrap();
         assert_eq!(created, 0);
     }
 
@@ -3521,10 +3540,10 @@ mod tests {
         add_session_fact(&engine, "a", "s1");
         add_session_fact(&engine, "b", "s1");
 
-        let first = engine.link_session_facts("s1").unwrap();
+        let first = engine.link_session_facts("s1", None).unwrap();
         assert_eq!(first, 2);
 
-        let second = engine.link_session_facts("s1").unwrap();
+        let second = engine.link_session_facts("s1", None).unwrap();
         assert_eq!(second, 0); // no new edges
 
         // Total edge count unchanged
@@ -3542,7 +3561,7 @@ mod tests {
         // Before linking — no edges
         assert_eq!(engine.graph_degree(f1), 0);
 
-        engine.link_session_facts("s1").unwrap();
+        engine.link_session_facts("s1", None).unwrap();
 
         // After: each fact has 2 outgoing + 2 incoming = degree 4
         assert_eq!(engine.graph_degree(f1), 4);
@@ -3563,11 +3582,107 @@ mod tests {
             FactStore::new(&conn, DIM).expire(f3, Utc::now()).unwrap();
         }
 
-        let created = engine.link_session_facts("s1").unwrap();
+        let created = engine.link_session_facts("s1", None).unwrap();
         assert_eq!(created, 2); // Only f1↔active2, not f3
 
         // f3 should have no edges
         assert_eq!(engine.graph_degree(f3), 0);
         assert_eq!(engine.graph_degree(f1), 2); // 1 out + 1 in
+    }
+
+    // --- Scope-aware session linking tests ---
+
+    /// Helper: add a fact in a specific scope, linked to a session.
+    fn add_scoped_session_fact(
+        engine: &MemoryEngine,
+        content: &str,
+        session_id: &str,
+        scope_path: &str,
+    ) -> (i64, i64) {
+        let embedder = MockEmbedder { dim: DIM };
+        let event = NewEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::json!({"msg": content}),
+            source: "test".into(),
+            session_id: Some(session_id.into()),
+            scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
+        };
+        let event_id = engine.ingest(&event).unwrap();
+        let fact_id = engine
+            .add_fact(
+                content,
+                FactType::Semantic,
+                Some(event_id),
+                &embedder,
+                Some(scope_path),
+                None,
+                None,
+            )
+            .unwrap();
+        (event_id, fact_id)
+    }
+
+    #[test]
+    fn link_session_facts_scope_filters_cross_scope() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+
+        // Two facts in user:alice, one in user:bob — same session_id
+        let (_, f1) = add_scoped_session_fact(&engine, "alice a", "s1", "user:alice");
+        let (_, f2) = add_scoped_session_fact(&engine, "alice b", "s1", "user:alice");
+        let (_, f3) = add_scoped_session_fact(&engine, "bob c", "s1", "user:bob");
+
+        // Scope-filtered: only link alice's facts
+        let created = engine.link_session_facts("s1", Some("user:alice")).unwrap();
+        assert_eq!(created, 2); // f1↔f2
+
+        assert_eq!(engine.graph_degree(f1), 2); // 1 out + 1 in
+        assert_eq!(engine.graph_degree(f2), 2);
+        assert_eq!(engine.graph_degree(f3), 0); // bob excluded
+    }
+
+    #[test]
+    fn link_session_facts_scope_none_links_all() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+
+        add_scoped_session_fact(&engine, "alice a", "s1", "user:alice");
+        add_scoped_session_fact(&engine, "bob b", "s1", "user:bob");
+        add_scoped_session_fact(&engine, "root c", "s1", "user:charlie");
+
+        // None = global lookup (backward-compatible)
+        let created = engine.link_session_facts("s1", None).unwrap();
+        assert_eq!(created, 6); // 3 facts × 2 directions
+    }
+
+    #[test]
+    fn link_session_facts_scope_subtree() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+
+        // Create facts at different depths under user:alice
+        let (_, f1) = add_scoped_session_fact(&engine, "top", "s1", "user:alice");
+        let (_, f2) = add_scoped_session_fact(&engine, "nested", "s1", "user:alice/project:x");
+        let (_, f3) = add_scoped_session_fact(&engine, "other", "s1", "user:bob");
+
+        // Subtree from user:alice should include both alice and alice/project:x
+        let created = engine.link_session_facts("s1", Some("user:alice")).unwrap();
+        assert_eq!(created, 2); // f1↔f2
+        assert_eq!(engine.graph_degree(f1), 2);
+        assert_eq!(engine.graph_degree(f2), 2);
+        assert_eq!(engine.graph_degree(f3), 0);
+    }
+
+    #[test]
+    fn link_session_facts_scope_not_found() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        add_session_fact(&engine, "a", "s1");
+
+        let result = engine.link_session_facts("s1", Some("user:nonexistent"));
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), MemoryError::NotFound(msg) if msg.contains("scope path"))
+        );
     }
 }

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -513,23 +513,49 @@ impl<'a> FactStore<'a> {
     /// Returns lightweight [`SessionFact`] structs (no embeddings) sorted by id.
     /// Facts without `source_event_id` are excluded by the INNER JOIN.
     ///
+    /// When `scope_ids` is non-empty, only facts whose `scope_id` is in the
+    /// provided set are returned. When empty, all scopes are included
+    /// (backward-compatible global lookup).
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on query failure.
-    pub fn list_active_by_session(&self, session_id: &str) -> Result<Vec<SessionFact>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT f.id
-             FROM facts f
-             INNER JOIN events e ON f.source_event_id = e.id
-             WHERE e.session_id = ?1
-               AND f.t_expired IS NULL
-             ORDER BY f.id",
-        )?;
-        let rows = stmt.query_map(params![session_id], |row| {
-            Ok(SessionFact { id: row.get(0)? })
-        })?;
-        rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(MemoryError::Database)
+    pub fn list_active_by_session(
+        &self,
+        session_id: &str,
+        scope_ids: &[i64],
+    ) -> Result<Vec<SessionFact>> {
+        if scope_ids.is_empty() {
+            let mut stmt = self.conn.prepare(
+                "SELECT f.id
+                 FROM facts f
+                 INNER JOIN events e ON f.source_event_id = e.id
+                 WHERE e.session_id = ?1
+                   AND f.t_expired IS NULL
+                 ORDER BY f.id",
+            )?;
+            let rows = stmt.query_map(params![session_id], |row| {
+                Ok(SessionFact { id: row.get(0)? })
+            })?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(MemoryError::Database)
+        } else {
+            let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
+            let mut stmt = self.conn.prepare(
+                "SELECT f.id
+                 FROM facts f
+                 INNER JOIN events e ON f.source_event_id = e.id
+                 WHERE e.session_id = ?1
+                   AND f.t_expired IS NULL
+                   AND f.scope_id IN (SELECT value FROM json_each(?2))
+                 ORDER BY f.id",
+            )?;
+            let rows = stmt.query_map(params![session_id, scope_json], |row| {
+                Ok(SessionFact { id: row.get(0)? })
+            })?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(MemoryError::Database)
+        }
     }
 
     /// List active facts in a set of scopes, excluding specific fact IDs,
@@ -967,7 +993,7 @@ mod tests {
         let _f3 = insert_fact_with_event(&conn, "fact c", e3);
 
         let store = FactStore::new(&conn, DIM);
-        let session_facts = store.list_active_by_session("s1").unwrap();
+        let session_facts = store.list_active_by_session("s1", &[]).unwrap();
         assert_eq!(session_facts.len(), 2);
         assert_eq!(session_facts[0].id, f1);
         assert_eq!(session_facts[1].id, f2);
@@ -985,7 +1011,7 @@ mod tests {
         let store = FactStore::new(&conn, DIM);
         store.expire(f2, Utc::now()).unwrap();
 
-        let session_facts = store.list_active_by_session("s1").unwrap();
+        let session_facts = store.list_active_by_session("s1", &[]).unwrap();
         assert_eq!(session_facts.len(), 1);
         assert_eq!(session_facts[0].id, f1);
     }
@@ -994,8 +1020,66 @@ mod tests {
     fn list_active_by_session_empty_for_unknown() {
         let conn = setup();
         let store = FactStore::new(&conn, DIM);
-        let result = store.list_active_by_session("nonexistent").unwrap();
+        let result = store.list_active_by_session("nonexistent", &[]).unwrap();
         assert!(result.is_empty());
+    }
+
+    fn insert_scoped_fact_with_event(
+        conn: &Connection,
+        content: &str,
+        event_id: i64,
+        scope_id: i64,
+    ) -> i64 {
+        let store = FactStore::new(conn, DIM);
+        let mut fact = make_fact(content, vec![0.1; DIM]);
+        fact.source_event_id = Some(event_id);
+        fact.scope_id = scope_id;
+        store.insert(&fact).unwrap()
+    }
+
+    #[test]
+    fn list_active_by_session_filters_by_scope() {
+        let conn = setup();
+
+        // Create child scopes under root (id=1)
+        conn.execute(
+            "INSERT INTO scopes (id, parent_id, label, depth) VALUES (2, 1, 'alice', 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO scopes (id, parent_id, label, depth) VALUES (3, 1, 'bob', 1)",
+            [],
+        )
+        .unwrap();
+
+        let e1 = insert_event(&conn, Some("s1"));
+        let e2 = insert_event(&conn, Some("s1"));
+        let e3 = insert_event(&conn, Some("s1"));
+
+        let f1 = insert_scoped_fact_with_event(&conn, "alice fact", e1, 2);
+        let f2 = insert_scoped_fact_with_event(&conn, "alice fact 2", e2, 2);
+        let _f3 = insert_scoped_fact_with_event(&conn, "bob fact", e3, 3);
+
+        let store = FactStore::new(&conn, DIM);
+
+        // Filter by alice's scope
+        let alice_facts = store.list_active_by_session("s1", &[2]).unwrap();
+        assert_eq!(alice_facts.len(), 2);
+        assert_eq!(alice_facts[0].id, f1);
+        assert_eq!(alice_facts[1].id, f2);
+
+        // Filter by bob's scope
+        let bob_facts = store.list_active_by_session("s1", &[3]).unwrap();
+        assert_eq!(bob_facts.len(), 1);
+
+        // No filter (empty slice) returns all
+        let all_facts = store.list_active_by_session("s1", &[]).unwrap();
+        assert_eq!(all_facts.len(), 3);
+
+        // Multiple scopes
+        let both = store.list_active_by_session("s1", &[2, 3]).unwrap();
+        assert_eq!(both.len(), 3);
     }
 
     #[test]

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -540,7 +540,7 @@ impl<'a> FactStore<'a> {
             rows.collect::<std::result::Result<Vec<_>, _>>()
                 .map_err(MemoryError::Database)
         } else {
-            let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
+            let scope_json = serde_json::to_string(scope_ids)?;
             let mut stmt = self.conn.prepare(
                 "SELECT f.id
                  FROM facts f


### PR DESCRIPTION
## Summary

- Add optional `scope: Option<&str>` parameter to `link_session_facts` for multi-tenant safety
- When `scope` is `Some`, resolves scope path to subtree IDs and restricts fact lookup to that subtree
- When `None`, behavior is unchanged (global lookup, backward-compatible)
- Store layer: `list_active_by_session` accepts `scope_ids: &[i64]` with `json_each` filter

## Test plan

- [x] Existing 7 `link_session_facts` tests pass with `None` (backward compat)
- [x] New `link_session_facts_scope_filters_cross_scope` — verifies cross-scope exclusion
- [x] New `link_session_facts_scope_none_links_all` — verifies global fallback
- [x] New `link_session_facts_scope_subtree` — verifies subtree semantics (nested scopes)
- [x] New `link_session_facts_scope_not_found` — verifies error on invalid scope path
- [x] New `list_active_by_session_filters_by_scope` — store-level scope filtering
- [x] All 324 tests pass (3 pre-existing failures in restore tests unrelated to this change)
- [x] No new clippy warnings

Fixes #73