### PR TITLE
refactor(search): validate reranker output is subset of input

### DIFF
--- a/docs/advanced/extensibility.md
+++ b/docs/advanced/extensibility.md
@@ -231,6 +231,8 @@ let engine = MemoryEngine::open_memory_with(dim, None, Some(Box::new(my_reranker
 assert_eq!(engine.reranker_name(), Some("cross_encoder"));
 ```
 
+**Contract enforcement:** The engine validates reranker output at runtime (defense-in-depth). After each `rerank()` call, `query()` checks that: (1) every output fact ID was present in the input candidates, (2) no duplicate IDs appear, and (3) output length does not exceed input length. Violations produce `MemoryError::Reranker` with a diagnostic message. This guards against buggy reranker implementations while preserving the trusted-consumer model for well-behaved code.
+
 **Lock semantics:** Reranking runs _outside_ the database read lock. This is critical because cross-encoder inference (local model or API call) can take 10-100ms per candidate. The read lock is held only for `hybrid_search()`, then released before reranking begins.
 
 **Research rationale:** Four-layer cognitive architecture research shows cross-encoder reranking on top-20 candidates improves nDCG@10 by 5-15%. The engine is positioned at layer 2 (retrieval + reranking), while layers 3-4 (semantic extraction, context adaptation) are consumer responsibilities.

--- a/docs/advanced/hybrid-search.md
+++ b/docs/advanced/hybrid-search.md
@@ -182,6 +182,10 @@ This means reranking applies to FTS, Hybrid, and Vector+text queries. Pure vecto
 
 The `Reranker::rerank()` method is failable (`-> Result<Vec<SearchResult>>`). Errors propagate as `MemoryError::Reranker`. This allows consumers to handle inference failures, timeouts, or API errors gracefully.
 
+### Contract Enforcement
+
+After each `rerank()` call, the engine validates that the output is a valid subset of the input candidates — no fabricated fact IDs, no duplicates, and output length <= input length. Violations produce `MemoryError::Reranker` with a diagnostic message identifying the specific breach. See the [Reranker trait documentation](../../src/traits.rs) for the full contract.
+
 See [Extensibility](extensibility.md) for trait definition, implementation example, and engine wiring.
 
 ## Content Hashing

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -459,7 +459,10 @@ impl MemoryEngine {
         // Apply reranker if present and query has text (cross-encoder needs query text).
         // Runs OUTSIDE the read lock — reranking may involve slow inference/API calls.
         if let (Some(reranker), Some(text)) = (&self.reranker, &query.text) {
+            // Snapshot input IDs before reranking for subset validation (#85).
+            let input_snapshot: Vec<_> = results.iter().map(|r| r.fact.id).collect();
             results = reranker.rerank(text, results)?;
+            Self::validate_reranker_output(&input_snapshot, &results)?;
         }
 
         // Always truncate to limit — rerank_depth may have over-fetched from hybrid_search.
@@ -1481,6 +1484,44 @@ impl MemoryEngine {
     }
 
     // --- Private helpers ---
+
+    /// Validate that reranker output is a subset of input candidates.
+    ///
+    /// Checks three invariants:
+    /// 1. Every output fact ID was present in the input candidates
+    /// 2. No duplicate fact IDs in the output
+    /// 3. Output length does not exceed input length (implied by 1+2, checked for clarity)
+    fn validate_reranker_output(input_ids: &[i64], output: &[SearchResult]) -> Result<()> {
+        use std::collections::HashSet;
+
+        if output.len() > input_ids.len() {
+            return Err(MemoryError::Reranker(format!(
+                "reranker violated subset contract: output length ({}) exceeds input length ({})",
+                output.len(),
+                input_ids.len(),
+            )));
+        }
+
+        let input_set: HashSet<i64> = input_ids.iter().copied().collect();
+        let mut seen = HashSet::with_capacity(output.len());
+
+        for result in output {
+            let id = result.fact.id;
+            if !input_set.contains(&id) {
+                return Err(MemoryError::Reranker(format!(
+                    "reranker violated subset contract: output contains fact id {id} \
+                     not present in input candidates",
+                )));
+            }
+            if !seen.insert(id) {
+                return Err(MemoryError::Reranker(format!(
+                    "reranker violated subset contract: duplicate fact id {id} in output",
+                )));
+            }
+        }
+
+        Ok(())
+    }
 
     /// Resolve scope IDs from an optional scope path.
     /// Returns [root_id] when scope is None, or ancestor IDs when scope exists.
@@ -3684,5 +3725,267 @@ mod tests {
         assert!(
             matches!(result.unwrap_err(), MemoryError::NotFound(msg) if msg.contains("scope path"))
         );
+    }
+
+    // --- Reranker subset/permutation guard (issue #85) ---
+
+    /// Returns all candidates plus a fabricated fact with a bogus ID.
+    struct FabricatingReranker;
+    impl Reranker for FabricatingReranker {
+        fn rerank(
+            &self,
+            _query: &str,
+            mut candidates: Vec<SearchResult>,
+        ) -> Result<Vec<SearchResult>> {
+            // Inject a fact that was NOT in the input candidates
+            candidates.push(SearchResult {
+                fact: Fact {
+                    id: 999_999,
+                    content: "fabricated".into(),
+                    content_hash: "fake_hash".into(),
+                    embedding: vec![0.0; DIM],
+                    fact_type: FactType::Episodic,
+                    t_created: Utc::now(),
+                    t_expired: None,
+                    t_valid: None,
+                    t_invalid: None,
+                    source_event_id: None,
+                    importance: 0.0,
+                    access_count: 0,
+                    last_accessed: Utc::now(),
+                    metadata: serde_json::Value::Null,
+                    scope_id: 0,
+                    is_pinned: false,
+                    importance_score: 0.0,
+                    surfaced_at: None,
+                },
+                score: 1.0,
+                match_type: MatchType::Fts,
+            });
+            Ok(candidates)
+        }
+        fn name(&self) -> &str {
+            "fabricating"
+        }
+    }
+
+    /// Replaces the last candidate with a clone of the first (same length, duplicate ID).
+    struct DuplicatingReranker;
+    impl Reranker for DuplicatingReranker {
+        fn rerank(
+            &self,
+            _query: &str,
+            mut candidates: Vec<SearchResult>,
+        ) -> Result<Vec<SearchResult>> {
+            if candidates.len() >= 2 {
+                candidates[1] = candidates[0].clone();
+            }
+            Ok(candidates)
+        }
+        fn name(&self) -> &str {
+            "duplicating"
+        }
+    }
+
+    #[test]
+    fn reranker_rejects_fabricated_facts() {
+        let engine =
+            MemoryEngine::open_memory_with(DIM, None, Some(Box::new(FabricatingReranker))).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        engine
+            .add_fact(
+                "real fact",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let result = engine.query(&SearchQuery {
+            text: Some("real".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        });
+
+        assert!(result.is_err(), "should reject fabricated facts");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Reranker(_)),
+            "should be a Reranker error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("subset"),
+            "error message should mention subset violation, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reranker_rejects_duplicates() {
+        let engine =
+            MemoryEngine::open_memory_with(DIM, None, Some(Box::new(DuplicatingReranker))).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        engine
+            .add_fact(
+                "dup fact alpha",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        engine
+            .add_fact(
+                "dup fact beta",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let result = engine.query(&SearchQuery {
+            text: Some("dup".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        });
+
+        assert!(result.is_err(), "should reject duplicates");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Reranker(_)),
+            "should be a Reranker error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("duplicate"),
+            "error message should mention duplicate, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reranker_allows_valid_subset() {
+        // A well-behaved reranker (ReverseReranker) should still work fine
+        let engine =
+            MemoryEngine::open_memory_with(DIM, None, Some(Box::new(ReverseReranker))).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        engine
+            .add_fact(
+                "guard alpha",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        engine
+            .add_fact(
+                "guard beta",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let result = engine.query(&SearchQuery {
+            text: Some("guard".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        });
+
+        assert!(
+            result.is_ok(),
+            "valid subset should pass: {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn reranker_allows_filtering_subset() {
+        /// Returns only the first candidate, discarding the rest.
+        struct FilteringReranker;
+        impl Reranker for FilteringReranker {
+            fn rerank(
+                &self,
+                _query: &str,
+                mut candidates: Vec<SearchResult>,
+            ) -> Result<Vec<SearchResult>> {
+                candidates.truncate(1);
+                Ok(candidates)
+            }
+            fn name(&self) -> &str {
+                "filtering"
+            }
+        }
+
+        let engine =
+            MemoryEngine::open_memory_with(DIM, None, Some(Box::new(FilteringReranker))).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        engine
+            .add_fact(
+                "filterable first",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        engine
+            .add_fact(
+                "filterable second",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let result = engine.query(&SearchQuery {
+            text: Some("filterable".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        });
+
+        assert!(
+            result.is_ok(),
+            "filtering subset should pass: {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap().len(), 1);
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -94,6 +94,11 @@ pub trait PersistenceClassifier {
 /// - Input: query text + candidates from hybrid search (FTS + vector + RRF)
 /// - Output: reordered/rescored candidates (may filter, must not add new facts)
 /// - The returned vec length must be <= input length
+/// - Every returned fact ID must be present in the input candidates (no fabrication)
+/// - No duplicate fact IDs in the output
+///
+/// These invariants are enforced at runtime by `MemoryEngine::query()`.
+/// Violations produce `MemoryError::Reranker`.
 pub trait Reranker: Send + Sync {
     /// Rerank candidates for the given query text.
     ///


### PR DESCRIPTION
## Summary

- Adds defense-in-depth validation after `Reranker::rerank()` calls in `query()`, enforcing the documented trait contract: output must be a subset of input candidates with no duplicates
- Validates three invariants: subset membership (no fabricated fact IDs), no duplicates, output length <= input length
- Violations produce `MemoryError::Reranker` with diagnostic messages identifying the specific breach

## Implementation

- `validate_reranker_output()` private method on `MemoryEngine` — O(n) via `HashSet` for both ID membership and dedup tracking
- Input fact IDs are snapshotted before the reranker call (the reranker takes ownership of the `Vec<SearchResult>`)
- Hard-fail on violation (consistent with existing `MemoryError::Reranker` for reranker errors)

## Test plan

- [x] `reranker_rejects_fabricated_facts` — `FabricatingReranker` injects a bogus fact ID → caught by subset check
- [x] `reranker_rejects_duplicates` — `DuplicatingReranker` replaces second candidate with clone of first → caught by dedup check  
- [x] `reranker_allows_valid_subset` — `ReverseReranker` (well-behaved) passes validation
- [x] `reranker_allows_filtering_subset` — `FilteringReranker` returns strict subset → passes validation
- [x] Pre-existing reranker tests still pass (reversal, error propagation, rerank_depth, skipping)

Fixes #85