### PR TITLE
feat(engine): add read-only open path for CLI/operator tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Read these docs when working on the relevant area:
 3. **Soft deletion** — facts are expired (`t_expired` set), never hard-deleted. Full audit trail for temporal reasoning.
 4. **Bi-temporal** — 4 timestamps per fact: `t_created`/`t_expired` (system), `t_valid`/`t_invalid` (real-world). From Graphiti.
 5. **`unsafe_code = "forbid"`** — no unsafe code anywhere.
+6. **Read-only open path** — `EngineConfig::read_only` opens without write capability. Defense in depth: file existence check + `validate_schema_version()` (read-only) + SQLite `query_only` pragma + Rust-level `try_write()` guard.
 
 ## Status
 

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -94,7 +94,7 @@ The crate is organized into modules with clear responsibilities:
 | `consolidation/` | Three-pass memory compression: local dedup, cluster fusion, global integration.                                                          |
 | `forgetting/`    | Ebbinghaus decay with multi-signal importance scoring.                                                                                   |
 | `conflict/`      | Bi-temporal conflict resolution delegated to `ConflictArbiter`.                                                                          |
-| `pool/`          | `ConnectionPool`: N reader connections + 1 writer connection.                                                                            |
+| `pool/`          | `ConnectionPool`: N reader connections + 1 writer connection. Supports read-only mode for operator tools.                                |
 | `traits`         | Consumer-provided trait definitions. Zero LLM/network dependencies in core.                                                              |
 | `types`          | All data types: `Event`, `Fact`, `Edge`, `Summary`, `ScopeNode`, `ScopeQuery`, enums.                                                    |
 | `error`          | `MemoryError` enum with `thiserror` derivations.                                                                                         |
@@ -106,7 +106,7 @@ The crate is organized into modules with clear responsibilities:
 
 Thread safety is provided by three mechanisms:
 
-1. **ConnectionPool** -- Bounded pool of N SQLite reader connections (default 4) protected by a semaphore, plus 1 exclusive writer connection behind a `parking_lot::Mutex`. Readers use SQLite WAL mode for concurrent access without blocking writes.
+1. **ConnectionPool** -- Bounded pool of N SQLite reader connections (default 4) protected by a semaphore, plus 1 exclusive writer connection behind a `parking_lot::Mutex`. Readers use SQLite WAL mode for concurrent access without blocking writes. In read-only mode (`EngineConfig::read_only`), the writer slot holds a read-only connection and `try_write()` returns `MemoryError::ReadOnly`.
 
 2. **RwLock\<MemoryGraph\>** -- The in-memory petgraph is behind a `parking_lot::RwLock`. Read operations (`graph_degree`, `graph_neighbors`, etc.) take a shared read lock. Mutations (conflict resolution, forgetting, consolidation) take an exclusive write lock.
 

--- a/docs/design/design-choices.md
+++ b/docs/design/design-choices.md
@@ -133,3 +133,32 @@ A `KnowledgeBaseConnector` trait that lets the engine reference external knowled
 **Rationale:** Memory and knowledge are distinct (see [Research Basis](research-basis.md)). The engine stores what the agent has internalized; knowledge bases store raw content. But facts should be able to cite their sources. The connector trait keeps the boundary clean: the engine never fetches content directly, but it can tell the consumer where to look.
 
 **Degradation:** When the KB is unreachable, the engine returns a "memory lapse" marker. The consumer retries later.
+
+---
+
+## Read-Only Open Path **{Implemented}**
+
+`MemoryEngine::open()` with `EngineConfig::read_only = true` opens a database without write capability — no `init_schema()`, no `migrate()`, no writable connection pool.
+
+**What:** A `read_only: bool` flag on `EngineConfig` that, when set:
+
+1. Validates schema version and epoch compatibility without writing
+2. Opens all connections with `PRAGMA query_only = ON` (including the internal slot used for cache loading)
+3. Guards all write methods with `MemoryError::ReadOnly` at the Rust level
+
+**Why:** Identified during PR #99 (CLI inspector) code review. The standard `open()` path always creates a writable connection pool and may run schema migrations. For operator tools (CLI inspect, MCP read-only queries, monitoring dashboards) that only need to read facts and statistics, this is undesirable:
+
+- An accidental schema upgrade on a live database could corrupt data if the migration has bugs, or conflict with a concurrent agent writing to the same DB
+- Migration creates WAL-safe backups, which consumes disk space and I/O on production databases that the operator only intended to inspect
+- The Principle of Least Privilege: inspection tools should not require write access to the database they are inspecting
+
+This mirrors a common pattern in database tooling: `psql` vs `pg_dump --read-only`, SQLite's `PRAGMA query_only`, and Redis's `--readonly` flag for replicas. The motivation is both operational safety and defense against accidental mutation.
+
+**How — defense in depth:**
+
+1. **File existence guard:** `open_read_only` rejects nonexistent paths before SQLite can create an empty file (which would be a write side effect)
+2. **Schema validation without mutation:** `validate_schema_version()` checks epoch and version compatibility using only SELECT queries — no DDL, no config writes
+3. **SQLite-level enforcement:** All connections have `PRAGMA query_only = ON`, so even if a code path bypasses the Rust guard, SQLite rejects the write
+4. **Rust-level enforcement:** `pool.try_write()` checks the `read_only` flag and returns `MemoryError::ReadOnly` before acquiring the mutex
+
+**Trade-off:** `list_due()` and `resume_context()` have write side effects (stamping `surfaced_at`). In read-only mode, these return `ReadOnly` if unsurfaced facts exist. CLI tools should use `list_active_facts()` for inspection. A future follow-up (#93) may add a read-only variant that skips stamping.

--- a/docs/reference/crate-layout.md
+++ b/docs/reference/crate-layout.md
@@ -31,7 +31,7 @@ memory_engine (lib.rs)
 : Core data types returned by and passed into the engine. Includes full structs (`Event`, `Fact`, `Edge`, `Summary`, `ScopeNode`), insertion structs (`NewEvent`, `NewFact`, `NewEdge`, `NewSummary`), enums (`EventType`, `FactType`, `ConsolidationLevel`, `ScopeQuery`), and option structs (`AddFactOptions`).
 
 `error`
-: `MemoryError` enum with `thiserror` derivation. Variants: `NotFound`, `Database` (from `rusqlite`), `Serialization` (from `serde_json`), `EmbeddingDimension`, `Conflict`, `Migration`, `NotImplemented`, `Pool`. Also exports `Result<T>` as an alias for `std::result::Result<T, MemoryError>`.
+: `MemoryError` enum with `thiserror` derivation. Variants: `NotFound`, `Database` (from `rusqlite`), `Serialization` (from `serde_json`), `EmbeddingDimension`, `Conflict`, `Migration`, `NotImplemented`, `Pool`, `UnsupportedEpoch`, `Internal`, `Io`, `Bootstrap`, `Reranker`, `ReadOnly`. Also exports `Result<T>` as an alias for `std::result::Result<T, MemoryError>`.
 
 `traits`
 : Consumer-implemented traits that the engine delegates to for domain-specific behavior:
@@ -77,7 +77,7 @@ memory_engine (lib.rs)
 : Bi-temporal conflict resolution. Given an existing fact and a candidate, delegates to a `ConflictArbiter` for the decision (`Add`, `Update`, `Delete`, `Noop`). On `Update`, the old fact is expired and a `superseded_by` edge is created in the graph. All mutations run in a single transaction.
 
 `pool`
-: `ConnectionPool` wrapping SQLite connections. Uses `parking_lot::Mutex` for the single write connection and a bounded pool of read connections. Supports both file-backed and in-memory modes. Configurable read pool size (default: 4).
+: `ConnectionPool` wrapping SQLite connections. Uses `parking_lot::Mutex` for the single write connection and a bounded pool of read connections. Supports both file-backed and in-memory modes. Configurable read pool size (default: 4). Read-only mode (`open_read_only`) validates schema version without init/migrate and guards all writes with `MemoryError::ReadOnly`.
 
 `scope`
 : `ScopeTree` -- in-memory cache of the hierarchical scope tree. Loaded from the `scopes` table on engine open. Resolves `ScopeQuery` variants (`Exact`, `Subtree`, `Ancestors`, `Inherited`) to sets of scope IDs without hitting the database.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -41,6 +41,8 @@ pub struct EngineConfig {
     /// Upcaster registry for event payload versioning.
     /// Defaults to empty (all event types at revision 1).
     pub upcaster_registry: UpcasterRegistry,
+    /// Open in read-only mode: skip init/migration, reject writes.
+    pub read_only: bool,
 }
 
 impl EngineConfig {
@@ -54,6 +56,7 @@ impl EngineConfig {
             search_config: None,
             backup_dir: None,
             upcaster_registry: UpcasterRegistry::new(),
+            read_only: false,
         }
     }
 }
@@ -101,12 +104,16 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::Migration` if the stored `embed_dim` doesn't match.
     pub fn open(config: &EngineConfig) -> Result<Self> {
-        let pool = ConnectionPool::open(
-            &config.path,
-            config.embed_dim,
-            config.read_pool_size,
-            config.backup_dir.as_deref(),
-        )?;
+        let pool = if config.read_only {
+            ConnectionPool::open_read_only(&config.path, config.embed_dim, config.read_pool_size)?
+        } else {
+            ConnectionPool::open(
+                &config.path,
+                config.embed_dim,
+                config.read_pool_size,
+                config.backup_dir.as_deref(),
+            )?
+        };
         Self::init_from_pool(
             pool,
             config.embed_dim,
@@ -199,8 +206,15 @@ impl MemoryEngine {
         upcaster_registry: UpcasterRegistry,
         reranker: Option<Box<dyn Reranker>>,
     ) -> Result<Self> {
-        // Scope the MutexGuard so it drops before we move `pool` into the struct.
-        let (graph, scope_tree) = {
+        // Scope the guard so it drops before we move `pool` into the struct.
+        let (graph, scope_tree) = if pool.is_read_only() {
+            // Read-only: use read connection, validate only (no set)
+            let conn = pool.read();
+            Self::validate_embed_dim(&conn, embed_dim)?;
+            let graph = MemoryGraph::load_from_db(&conn)?;
+            let scope_tree = ScopeTree::load(&conn)?;
+            (graph, scope_tree)
+        } else {
             let conn = pool.write();
             Self::validate_or_set_embed_dim(&conn, embed_dim)?;
             let graph = MemoryGraph::load_from_db(&conn)?;
@@ -208,11 +222,11 @@ impl MemoryEngine {
             (graph, scope_tree)
         };
 
+        // HNSW build is read-only — always use a read connection.
         #[cfg(feature = "ann")]
         let hnsw_strategy = if let Some(ref cfg) = search_config {
-            // Skip building the index if the threshold is unreachable.
             if cfg.ann_threshold < usize::MAX {
-                let conn = pool.write();
+                let conn = pool.read();
                 Some(crate::search::ann::HnswStrategy::build_from_db(
                     &conn, embed_dim,
                 )?)
@@ -285,6 +299,31 @@ impl MemoryEngine {
         Ok(())
     }
 
+    /// Validate stored embed_dim matches requested — read-only, never writes.
+    fn validate_embed_dim(conn: &Connection, embed_dim: usize) -> Result<()> {
+        if let Some(stored) = get_config(conn, "embed_dim")? {
+            let stored_dim: usize = stored.parse().map_err(|_| {
+                MemoryError::Migration(format!("invalid stored embed_dim: {stored}"))
+            })?;
+            if stored_dim != embed_dim {
+                return Err(MemoryError::Migration(format!(
+                    "embed_dim mismatch: stored {stored_dim} vs requested {embed_dim}"
+                )));
+            }
+            Ok(())
+        } else {
+            Err(MemoryError::Migration(
+                "embed_dim not set in database; open in read-write mode first".to_string(),
+            ))
+        }
+    }
+
+    /// Whether this engine was opened in read-only mode.
+    #[must_use]
+    pub fn is_read_only(&self) -> bool {
+        self.pool.is_read_only()
+    }
+
     // --- Private connection dispatch helpers ---
 
     /// Execute a read operation on a connection from the read pool.
@@ -299,8 +338,10 @@ impl MemoryEngine {
     /// Lock the write connection and return the guard directly.
     /// Callers use this when they need to hold the write lock across
     /// multiple operations (e.g., DB mutation + cache update).
-    fn write_conn(&self) -> MutexGuard<'_, Connection> {
-        self.pool.write()
+    ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
+    fn write_conn(&self) -> Result<MutexGuard<'_, Connection>> {
+        self.pool.try_write()
     }
 
     // --- Public API: Ingest ---
@@ -311,7 +352,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::Database` on insert failure.
     pub fn ingest(&self, event: &NewEvent) -> Result<i64> {
-        let conn = self.write_conn();
+        let conn = self.write_conn()?;
         EventStore::new(&conn, &self.upcaster_registry).insert(event)
     }
 
@@ -380,7 +421,7 @@ impl MemoryEngine {
         let emb_copy = embedding.clone();
 
         let fact_id = {
-            let conn = self.write_conn();
+            let conn = self.write_conn()?;
             let scope_id = match scope {
                 Some(path) => {
                     let scope_store = ScopeStore::new(&conn);
@@ -747,7 +788,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::Database` on write failure.
     pub fn set_config(&self, key: &str, value: &str) -> Result<()> {
-        let conn = self.write_conn();
+        let conn = self.write_conn()?;
         set_config(&conn, key, value)
     }
 
@@ -774,7 +815,7 @@ impl MemoryEngine {
         config: &crate::bootstrap::BootstrapConfig,
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
-        let conn = self.write_conn();
+        let conn = self.write_conn()?;
         let scope_id = match &config.scope {
             Some(path) => {
                 let scope_store = ScopeStore::new(&conn);
@@ -814,7 +855,7 @@ impl MemoryEngine {
         config: &crate::bootstrap::BootstrapConfig,
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
-        let conn = self.write_conn();
+        let conn = self.write_conn()?;
         let scope_id = match &config.scope {
             Some(path) => {
                 let scope_store = ScopeStore::new(&conn);
@@ -851,7 +892,7 @@ impl MemoryEngine {
         config: &ConsolidationConfig,
     ) -> Result<ConsolidationStats> {
         let (stats, expired_ids) = {
-            let conn = self.write_conn();
+            let conn = self.write_conn()?;
             let (stats, expired_ids) =
                 crate::consolidation::consolidate(&conn, generator, self.embed_dim, config)?;
 
@@ -889,7 +930,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::Database` on SQL failure.
     pub fn forget(&self, policy: &ForgetPolicy) -> Result<PruneStats> {
         let (stats, pruned_ids) = {
-            let conn = self.write_conn();
+            let conn = self.write_conn()?;
             let mut graph = self.graph.write();
             crate::forgetting::prune(&conn, &mut graph, policy, self.embed_dim, Utc::now())?
         };
@@ -925,7 +966,7 @@ impl MemoryEngine {
         #[cfg(feature = "ann")]
         let embedding = new_fact.embedding.clone();
         let resolution = {
-            let conn = self.write_conn();
+            let conn = self.write_conn()?;
             let mut graph = self.graph.write();
             crate::conflict::resolve_conflict(
                 &conn,
@@ -1007,7 +1048,7 @@ impl MemoryEngine {
             None => Vec::new(),
         };
 
-        let conn = self.write_conn();
+        let conn = self.write_conn()?;
         let facts =
             FactStore::new(&conn, self.embed_dim).list_active_by_session(session_id, &scope_ids)?;
 
@@ -1167,7 +1208,7 @@ impl MemoryEngine {
             .collect();
 
         if !unsurfaced_ids.is_empty() {
-            let conn = self.write_conn();
+            let conn = self.write_conn()?;
             let stamped =
                 FactStore::new(&conn, self.embed_dim).stamp_surfaced(&unsurfaced_ids, now)?;
             // Update in-place with DB-authoritative timestamps
@@ -1196,13 +1237,13 @@ impl MemoryEngine {
 
     /// Pin a fact (make it unforgettable).
     pub fn pin_fact(&self, id: i64) -> Result<()> {
-        let conn = self.write_conn();
+        let conn = self.write_conn()?;
         FactStore::new(&conn, self.embed_dim).set_pinned(id, true)
     }
 
     /// Unpin a fact (allow forgetting).
     pub fn unpin_fact(&self, id: i64) -> Result<()> {
-        let conn = self.write_conn();
+        let conn = self.write_conn()?;
         FactStore::new(&conn, self.embed_dim).set_pinned(id, false)
     }
 
@@ -1325,7 +1366,7 @@ impl MemoryEngine {
                 "zstd compression requires the `compress-zstd` feature".into(),
             )),
             crate::inspect::DumpFormat::Sqlite(path) => {
-                let conn = self.write_conn();
+                let conn = self.write_conn()?;
                 crate::inspect::dump::dump_sqlite(&conn, path)
             }
             _ => Err(MemoryError::NotImplemented(
@@ -1583,7 +1624,7 @@ impl MemoryEngine {
             .collect();
 
         if !unsurfaced_ids.is_empty() {
-            let conn = self.write_conn();
+            let conn = self.write_conn()?;
             let stamped = FactStore::new(&conn, self.embed_dim)
                 .stamp_surfaced(&unsurfaced_ids, config.now)?;
             let stamped_map: std::collections::HashMap<i64, DateTime<Utc>> =

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -161,12 +161,16 @@ impl MemoryEngine {
         config: &EngineConfig,
         reranker: Option<Box<dyn Reranker>>,
     ) -> Result<Self> {
-        let pool = ConnectionPool::open(
-            &config.path,
-            config.embed_dim,
-            config.read_pool_size,
-            config.backup_dir.as_deref(),
-        )?;
+        let pool = if config.read_only {
+            ConnectionPool::open_read_only(&config.path, config.embed_dim, config.read_pool_size)?
+        } else {
+            ConnectionPool::open(
+                &config.path,
+                config.embed_dim,
+                config.read_pool_size,
+                config.backup_dir.as_deref(),
+            )?
+        };
         Self::init_from_pool(
             pool,
             config.embed_dim,

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,10 @@ pub enum MemoryError {
 
     #[error("reranker error: {0}")]
     Reranker(String),
+
+    /// Attempted a write operation on a read-only engine.
+    #[error("operation requires write access, but engine was opened read-only")]
+    ReadOnly,
 }
 
 /// Convenience alias for `Result<T, MemoryError>`.
@@ -72,6 +76,15 @@ mod tests {
     fn reranker_error_display() {
         let err = MemoryError::Reranker("cross-encoder timeout".into());
         assert_eq!(err.to_string(), "reranker error: cross-encoder timeout");
+    }
+
+    #[test]
+    fn read_only_error_display() {
+        let err = MemoryError::ReadOnly;
+        assert_eq!(
+            err.to_string(),
+            "operation requires write access, but engine was opened read-only"
+        );
     }
 
     #[test]

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -21,6 +21,7 @@ pub struct ConnectionPool {
     path: Option<PathBuf>,
     embed_dim: usize,
     read_pool_size: usize,
+    read_only: bool,
 }
 
 /// RAII guard that returns a read connection to the pool on drop.
@@ -107,6 +108,7 @@ impl ConnectionPool {
             path: Some(path.to_path_buf()),
             embed_dim,
             read_pool_size,
+            read_only: false,
         })
     }
 
@@ -126,6 +128,57 @@ impl ConnectionPool {
             path: None,
             embed_dim,
             read_pool_size: 0,
+            read_only: false,
+        })
+    }
+
+    /// Open a file-backed pool in read-only mode.
+    ///
+    /// The database file must already exist and have been initialized by a prior
+    /// read-write open. This constructor validates schema compatibility without
+    /// running `init_schema()` or `migrate()`.
+    ///
+    /// All connections have `PRAGMA query_only = ON`, including the internal slot
+    /// used for cache loading during initialization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Migration` if the file does not exist, the schema
+    /// is uninitialized, or the schema needs migration.
+    /// Returns `MemoryError::UnsupportedEpoch` if the DB epoch is from the future.
+    pub fn open_read_only(path: &Path, embed_dim: usize, read_pool_size: usize) -> Result<Self> {
+        use crate::store::schema::validate_schema_version;
+
+        // Reject nonexistent files — don't let SQLite create an empty DB
+        if !path.exists() {
+            return Err(MemoryError::Migration(format!(
+                "database file does not exist: {}; cannot open read-only",
+                path.display()
+            )));
+        }
+
+        // Open a connection to validate schema — then reuse as internal read slot
+        let conn = open_connection(&path.to_string_lossy())?;
+        validate_schema_version(&conn)?;
+        conn.execute_batch("PRAGMA query_only = ON")
+            .map_err(MemoryError::Database)?;
+
+        let mut read_conns = Vec::with_capacity(read_pool_size);
+        for _ in 0..read_pool_size {
+            let c = open_connection(&path.to_string_lossy())?;
+            c.execute_batch("PRAGMA query_only = ON")
+                .map_err(MemoryError::Database)?;
+            read_conns.push(c);
+        }
+
+        Ok(Self {
+            write_conn: Mutex::new(conn),
+            read_conns: Mutex::new(read_conns),
+            read_available: Condvar::new(),
+            path: Some(path.to_path_buf()),
+            embed_dim,
+            read_pool_size,
+            read_only: true,
         })
     }
 
@@ -154,6 +207,22 @@ impl ConnectionPool {
     /// Lock the write connection.
     pub fn write(&self) -> MutexGuard<'_, Connection> {
         self.write_conn.lock()
+    }
+
+    /// Attempt to lock the write connection.
+    ///
+    /// Returns `MemoryError::ReadOnly` if the pool was opened read-only.
+    pub fn try_write(&self) -> Result<MutexGuard<'_, Connection>> {
+        if self.read_only {
+            return Err(MemoryError::ReadOnly);
+        }
+        Ok(self.write_conn.lock())
+    }
+
+    /// Whether this pool was opened in read-only mode.
+    #[must_use]
+    pub const fn is_read_only(&self) -> bool {
+        self.read_only
     }
 
     /// Embedding dimension configured for this pool.
@@ -248,5 +317,50 @@ mod tests {
 
         let mem_pool = ConnectionPool::open_memory(4).unwrap();
         assert!(!mem_pool.is_file_backed());
+    }
+
+    #[test]
+    fn pool_open_read_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        // First create a valid DB
+        let _pool = ConnectionPool::open(&db_path, 4, 2, None).unwrap();
+        drop(_pool);
+
+        // Now open read-only
+        let pool = ConnectionPool::open_read_only(&db_path, 4, 2).unwrap();
+        assert!(pool.is_file_backed());
+        assert!(pool.is_read_only());
+
+        // Read should work
+        let r = pool.read();
+        let v = get_config(&r, "schema_version").unwrap();
+        assert!(v.is_some());
+    }
+
+    #[test]
+    fn pool_read_only_write_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let _pool = ConnectionPool::open(&db_path, 4, 2, None).unwrap();
+        drop(_pool);
+
+        let pool = ConnectionPool::open_read_only(&db_path, 4, 2).unwrap();
+        let err = pool.try_write().unwrap_err();
+        assert!(matches!(err, MemoryError::ReadOnly));
+    }
+
+    #[test]
+    fn pool_open_read_only_nonexistent_file_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("nonexistent.db");
+        let result = ConnectionPool::open_read_only(&db_path, 4, 2);
+        assert!(matches!(result, Err(MemoryError::Migration(_))));
+    }
+
+    #[test]
+    fn pool_not_read_only_by_default() {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        assert!(!pool.is_read_only());
     }
 }

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -5,7 +5,8 @@ use rusqlite::Connection;
 
 use crate::error::{MemoryError, Result};
 use crate::store::schema::{
-    init_schema, migrate, open_connection, open_memory as open_memory_conn,
+    init_schema, migrate, open_connection, open_connection_read_only,
+    open_memory as open_memory_conn,
 };
 
 /// A connection pool with N read connections and 1 write connection.
@@ -149,25 +150,21 @@ impl ConnectionPool {
     pub fn open_read_only(path: &Path, embed_dim: usize, read_pool_size: usize) -> Result<Self> {
         use crate::store::schema::validate_schema_version;
 
-        // Reject nonexistent files — don't let SQLite create an empty DB
-        if !path.exists() {
+        // Reject nonexistent or non-file paths before SQLite can act
+        if !path.is_file() {
             return Err(MemoryError::Migration(format!(
-                "database file does not exist: {}; cannot open read-only",
+                "database path is not a regular file: {}; cannot open read-only",
                 path.display()
             )));
         }
 
-        // Open a connection to validate schema — then reuse as internal read slot
-        let conn = open_connection(&path.to_string_lossy())?;
+        // Open with SQLITE_OPEN_READ_ONLY — no file creation, no WAL mutation
+        let conn = open_connection_read_only(&path.to_string_lossy())?;
         validate_schema_version(&conn)?;
-        conn.execute_batch("PRAGMA query_only = ON")
-            .map_err(MemoryError::Database)?;
 
         let mut read_conns = Vec::with_capacity(read_pool_size);
         for _ in 0..read_pool_size {
-            let c = open_connection(&path.to_string_lossy())?;
-            c.execute_batch("PRAGMA query_only = ON")
-                .map_err(MemoryError::Database)?;
+            let c = open_connection_read_only(&path.to_string_lossy())?;
             read_conns.push(c);
         }
 

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -26,6 +26,25 @@ pub fn open_connection(path: &str) -> Result<Connection> {
     Ok(conn)
 }
 
+/// Open a read-only `SQLite` connection to a file, with safe pragmas.
+///
+/// Uses `SQLITE_OPEN_READ_ONLY` flags — no file creation, no WAL mutation.
+/// Skips `journal_mode` and `synchronous` pragmas (read-only connections
+/// cannot set them and don't need to).
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` if the connection or pragma setup fails.
+pub fn open_connection_read_only(path: &str) -> Result<Connection> {
+    use rusqlite::OpenFlags;
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    set_pragmas_read_only(&conn)?;
+    Ok(conn)
+}
+
 /// Open an in-memory `SQLite` connection, with pragmas set.
 ///
 /// # Errors
@@ -35,6 +54,15 @@ pub fn open_memory() -> Result<Connection> {
     let conn = Connection::open_in_memory()?;
     set_pragmas(&conn)?;
     Ok(conn)
+}
+
+/// Pragmas safe for read-only connections — skip WAL and synchronous.
+fn set_pragmas_read_only(conn: &Connection) -> Result<()> {
+    for pragma in &["PRAGMA foreign_keys = ON", "PRAGMA busy_timeout = 5000"] {
+        let mut stmt = conn.prepare(pragma)?;
+        let _ = stmt.query([])?;
+    }
+    Ok(())
 }
 
 fn set_pragmas(conn: &Connection) -> Result<()> {

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -242,6 +242,70 @@ pub fn migrate(conn: &Connection, backup_dir: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
+/// Validate that the database schema is compatible with this library version
+/// without attempting any writes (no migrations, no init).
+///
+/// Returns `Ok(())` if the schema version matches [`CURRENT_SCHEMA_VERSION`]
+/// and the epoch is compatible. Returns an error if:
+/// - The database has no config table (fresh/uninitialized)
+/// - The schema version is newer than supported
+/// - The schema version is older and needs migration
+/// - The storage epoch is from the future
+///
+/// This is the read-only counterpart of [`init_schema`] + [`migrate`].
+pub fn validate_schema_version(conn: &Connection) -> Result<()> {
+    // Check if config table exists
+    let has_config: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='config'",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(MemoryError::Database)?;
+
+    if !has_config {
+        return Err(MemoryError::Migration(
+            "database has no config table; cannot open read-only on an uninitialized database"
+                .to_string(),
+        ));
+    }
+
+    // Check epoch
+    let epoch_str = get_config(conn, "storage_epoch")?;
+    let epoch_raw = epoch_str.as_deref().unwrap_or("1");
+    let db_epoch: u16 = epoch_raw
+        .parse()
+        .map_err(|_| MemoryError::Migration(format!("invalid storage_epoch: {epoch_raw}")))?;
+    if db_epoch > STORAGE_EPOCH {
+        return Err(MemoryError::UnsupportedEpoch {
+            db_epoch,
+            supported_epoch: STORAGE_EPOCH,
+        });
+    }
+
+    // Check schema version
+    let version_str = get_config(conn, "schema_version")?.unwrap_or_else(|| "1".to_string());
+    let version: u32 = version_str
+        .parse()
+        .map_err(|_| MemoryError::Migration(format!("invalid schema_version: {version_str}")))?;
+
+    if version > CURRENT_SCHEMA_VERSION {
+        return Err(MemoryError::Migration(format!(
+            "schema_version {version} is newer than supported {CURRENT_SCHEMA_VERSION}; \
+             consider upgrading the memory-engine crate"
+        )));
+    }
+
+    if version < CURRENT_SCHEMA_VERSION {
+        return Err(MemoryError::Migration(format!(
+            "schema_version {version} needs migration to {CURRENT_SCHEMA_VERSION}; \
+             open in read-write mode first to run migrations"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Create a WAL-safe backup of the database before running migrations.
 ///
 /// Uses `VACUUM INTO` which produces an atomic, consistent copy regardless
@@ -1915,5 +1979,51 @@ CREATE TABLE IF NOT EXISTS config (
                 .unwrap();
             assert!(violations.is_empty(), "FK violations: {violations:?}");
         }
+    }
+
+    #[test]
+    fn validate_schema_version_current_ok() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        migrate(&conn, None).unwrap();
+        validate_schema_version(&conn).unwrap();
+    }
+
+    #[test]
+    fn validate_schema_version_future_version_err() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        migrate(&conn, None).unwrap();
+        set_config(&conn, "schema_version", "999").unwrap();
+        let err = validate_schema_version(&conn).unwrap_err();
+        assert!(matches!(err, MemoryError::Migration(_)));
+    }
+
+    #[test]
+    fn validate_schema_version_future_epoch_err() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        migrate(&conn, None).unwrap();
+        set_config(&conn, "storage_epoch", "999").unwrap();
+        let err = validate_schema_version(&conn).unwrap_err();
+        assert!(matches!(err, MemoryError::UnsupportedEpoch { .. }));
+    }
+
+    #[test]
+    fn validate_schema_version_fresh_db_err() {
+        let conn = open_memory().unwrap();
+        let err = validate_schema_version(&conn).unwrap_err();
+        assert!(matches!(err, MemoryError::Migration(_)));
+    }
+
+    #[test]
+    fn validate_schema_version_old_version_err() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        migrate(&conn, None).unwrap();
+        let old = (CURRENT_SCHEMA_VERSION - 1).to_string();
+        set_config(&conn, "schema_version", &old).unwrap();
+        let err = validate_schema_version(&conn).unwrap_err();
+        assert!(matches!(err, MemoryError::Migration(_)));
     }
 }

--- a/tests/read_only_test.rs
+++ b/tests/read_only_test.rs
@@ -84,3 +84,19 @@ fn read_only_engine_query_works() {
     let val = engine.get_config("test_key").unwrap();
     assert_eq!(val, Some("test_value".to_string()));
 }
+
+#[test]
+fn open_read_only_with_reranker() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    {
+        let config = EngineConfig::new(db_path.clone(), DIM);
+        let _engine = MemoryEngine::open(&config).unwrap();
+    }
+
+    let mut config = EngineConfig::new(db_path, DIM);
+    config.read_only = true;
+    let engine = MemoryEngine::open_with_reranker(&config, None).unwrap();
+    assert!(engine.is_read_only());
+}

--- a/tests/read_only_test.rs
+++ b/tests/read_only_test.rs
@@ -1,0 +1,86 @@
+use memory_engine::{EngineConfig, MemoryEngine, MemoryError};
+use tempfile::tempdir;
+
+const DIM: usize = 4;
+
+#[test]
+fn open_read_only_on_initialized_db() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // First, create and initialize the DB normally
+    {
+        let config = EngineConfig::new(db_path.clone(), DIM);
+        let _engine = MemoryEngine::open(&config).unwrap();
+    }
+
+    // Now open read-only
+    let mut config = EngineConfig::new(db_path, DIM);
+    config.read_only = true;
+    let engine = MemoryEngine::open(&config).unwrap();
+    assert!(engine.is_read_only());
+
+    // Read operations should work
+    let stats = engine.statistics().unwrap();
+    assert_eq!(stats.facts.active, 0);
+}
+
+#[test]
+fn open_read_only_on_nonexistent_db_fails() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("nonexistent.db");
+
+    let mut config = EngineConfig::new(db_path, DIM);
+    config.read_only = true;
+    // File doesn't exist — rejected before SQLite can create empty file
+    let result = MemoryEngine::open(&config);
+    assert!(matches!(result, Err(MemoryError::Migration(_))));
+}
+
+#[test]
+fn read_only_engine_rejects_writes() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Initialize
+    {
+        let config = EngineConfig::new(db_path.clone(), DIM);
+        let _engine = MemoryEngine::open(&config).unwrap();
+    }
+
+    // Open read-only
+    let mut config = EngineConfig::new(db_path, DIM);
+    config.read_only = true;
+    let engine = MemoryEngine::open(&config).unwrap();
+
+    // set_config is the simplest write method — no mock providers needed
+    let err = engine.set_config("test_key", "test_value").unwrap_err();
+    assert!(matches!(err, MemoryError::ReadOnly));
+}
+
+#[test]
+fn engine_not_read_only_by_default() {
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    assert!(!engine.is_read_only());
+}
+
+#[test]
+fn read_only_engine_query_works() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Initialize and add a fact
+    {
+        let config = EngineConfig::new(db_path.clone(), DIM);
+        let engine = MemoryEngine::open(&config).unwrap();
+        engine.set_config("test_key", "test_value").unwrap();
+    }
+
+    // Open read-only and verify read access
+    let mut config = EngineConfig::new(db_path, DIM);
+    config.read_only = true;
+    let engine = MemoryEngine::open(&config).unwrap();
+
+    let val = engine.get_config("test_key").unwrap();
+    assert_eq!(val, Some("test_value".to_string()));
+}


### PR DESCRIPTION
## Summary

- Add `EngineConfig::read_only` flag that opens a `MemoryEngine` without write capability — no `init_schema()`, no `migrate()`, all connections `query_only = ON`
- Defense-in-depth: file existence guard → `validate_schema_version()` (read-only) → SQLite `PRAGMA query_only` → Rust-level `try_write()` guard
- All 14 write methods return `MemoryError::ReadOnly` when engine is opened read-only
- HNSW index build now always uses a read connection (was unnecessarily holding write lock)
- Documentation: design rationale in design-choices.md, architecture overview, crate layout, CLAUDE.md

## Files Changed

| File | Change |
|------|--------|
| `src/error.rs` | `MemoryError::ReadOnly` variant |
| `src/store/schema.rs` | `validate_schema_version()` — read-only schema check |
| `src/pool/connection_pool.rs` | `open_read_only()`, `is_read_only()`, `try_write()` |
| `src/engine.rs` | `EngineConfig::read_only`, branched `open()`/`open_with_reranker()`, `validate_embed_dim()`, `is_read_only()`, `write_conn()` → `Result` |
| `tests/read_only_test.rs` | 6 integration tests |
| `docs/design/design-choices.md` | New section: Read-Only Open Path |
| `docs/design/architecture-overview.md` | Threading model update |
| `docs/reference/crate-layout.md` | Module description updates |
| `CLAUDE.md` | Design decision #6 |

## Test plan

- [x] `cargo test` — 363 tests pass, 0 failures
- [x] `cargo clippy --all-targets` — no new warnings
- [x] Read-only engine rejects writes (`set_config` returns `ReadOnly`)
- [x] Read-only engine allows reads (`statistics()`, `get_config()`)
- [x] Opening nonexistent file in read-only mode fails with `Migration` error
- [x] `open_with_reranker` respects `read_only` flag

Fixes #103.