### PR TITLE
feat(mcp): memory-engine-mcp server (#45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,10 @@ Companion repos:
 ```bash
 cargo build                           # debug build
 cargo build -p memory-engine-cli      # CLI inspector binary
+cargo build -p memory-engine-mcp      # MCP server binary
 cargo test                            # all tests
 cargo test -p memory-engine-cli       # CLI integration tests
+cargo test -p memory-engine-mcp       # MCP server tests
 cargo test --all-features             # with async + HNSW + compression
 cargo clippy --all-targets            # lint (pedantic + nursery)
 cargo fmt --check                     # format check
@@ -57,6 +59,7 @@ Read these docs when working on the relevant area:
 | Consolidation pipeline         | `docs/advanced/consolidation.md`         |
 | Hybrid search tuning           | `docs/advanced/hybrid-search.md`         |
 | CLI inspector usage            | `docs/reference/cli-inspector.md`        |
+| MCP server usage               | `docs/reference/mcp-server.md`           |
 
 ## Key Design Decisions
 
@@ -69,4 +72,4 @@ Read these docs when working on the relevant area:
 
 ## Status
 
-Phase 4a ✅ (inspection APIs, import/export, bootstrap, reranker). Phase 4b in progress: CLI inspector ✅ (`memory-engine-cli`), MCP server next. Then Phase 5 (cognitive pipelines — DreamCycle, outcome tracking, provenance). See `docs/ROADMAP.md` for open issues and dependency graph.
+Phase 4a ✅ (inspection APIs, import/export, bootstrap, reranker). Phase 4b in progress: CLI inspector ✅ (`memory-engine-cli`), MCP server ✅ (`memory-engine-mcp`, 10 P0 tools + tiered depth). P1 tools (#95) and P2 tools (#96) pending. Then Phase 5 (cognitive pipelines — DreamCycle, outcome tracking, provenance). See `docs/ROADMAP.md` for open issues and dependency graph.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["memory-engine-cli"]
+members = ["memory-engine-cli", "memory-engine-mcp"]
 exclude = [".worktrees"]
 
 [package]

--- a/benches/search_bench.rs
+++ b/benches/search_bench.rs
@@ -20,7 +20,7 @@
 //! - SQLite WAL mode + OS page cache → warm-cache after first iteration.
 //!   This is realistic for interactive use where the DB is already open.
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use memory_engine::engine::{EngineConfig, MemoryEngine};
 use memory_engine::search::cosine_similarity;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -1,0 +1,124 @@
+# MCP Server (`memory-engine-mcp`)
+
+## What
+
+A stdio-based MCP server binary that exposes memory-engine as 10 tools for autonomous AI agents. Part of the four-layer cognitive architecture (Knowledge → Memory → Wisdom → Intelligence) — this crate bridges Memory to Intelligence via the Model Context Protocol.
+
+## Why
+
+Autonomous agents need a standard protocol to interact with their memory. Raw library calls aren't accessible from agent runtimes (Claude Code, etc.). The MCP server provides a thin, validated adapter layer that:
+
+- Exposes the 5 memory primitives (ingest, query, consolidate, forget, resolve) as MCP tools
+- Shapes responses via tiered depth (sparse/standard/full) to respect agent context window budgets
+- Provides a pre-compaction flush endpoint for capturing insights before context compression
+- Validates inputs at the transport boundary (the engine trusts its callers; the MCP server doesn't)
+
+**Research basis:** NeuroStack's auto-escalating retrieval pattern (sparse → medium → full), ACC's bounded compressed cognitive state, MCP ecosystem analysis (5 memory servers evaluated).
+
+## How
+
+### Installation
+
+```bash
+cargo build -p memory-engine-mcp --release
+```
+
+### Usage
+
+```bash
+# With TOML config
+memory-engine-mcp --config /path/to/mcp.toml
+
+# With CLI args
+memory-engine-mcp --db-path /path/to/memory.db --embed-url http://localhost:11434/v1/embeddings --embed-model nomic-embed-text
+
+# With env vars
+MEMORY_MCP_DB_PATH=/path/to/memory.db MEMORY_MCP_EMBED_URL=... memory-engine-mcp
+```
+
+### Configuration
+
+```toml
+[engine]
+db_path = "/path/to/memory.db"
+embed_dim = 384  # Optional — probed from existing DB if omitted
+
+[embedding]
+endpoint = "http://localhost:11434/v1/embeddings"
+model = "nomic-embed-text"
+api_key = "sk-..."  # Optional — for authenticated endpoints
+dimensions = 384
+timeout_secs = 30
+```
+
+CLI flags override TOML values field-by-field (e.g., `--embed-api-key` overrides `api_key` in TOML while keeping `endpoint` and `model` from TOML).
+
+### Claude Code Integration
+
+Add to `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "memory-engine": {
+      "command": "/path/to/memory-engine-mcp",
+      "args": ["--config", "/path/to/mcp.toml"]
+    }
+  }
+}
+```
+
+### Tools
+
+| Tool                    | Purpose                      | Depth                |
+| ----------------------- | ---------------------------- | -------------------- |
+| `memory_ingest`         | Append event to log          | —                    |
+| `memory_add_fact`       | Add fact with embedding      | —                    |
+| `memory_query`          | Hybrid FTS + vector search   | sparse/standard/full |
+| `memory_resume_context` | 5-tier cognitive boot        | sparse/standard/full |
+| `memory_list_due`       | Scheduled fact surfacing     | sparse/standard/full |
+| `memory_next_due_time`  | Next scheduled time          | —                    |
+| `memory_explain_fact`   | Fact provenance              | sparse/standard/full |
+| `memory_get_fact`       | Single fact by ID            | sparse/standard/full |
+| `memory_statistics`     | Aggregate stats              | —                    |
+| `memory_flush_insights` | Batch pre-compaction capture | —                    |
+
+### Tiered Depth
+
+Controls response verbosity to manage token budget:
+
+| Depth      | ~Tokens/fact | Includes                                                    |
+| ---------- | ------------ | ----------------------------------------------------------- |
+| `sparse`   | ~15          | id, truncated content (200 chars), importance_score, scope  |
+| `standard` | ~75          | All fields except embedding and content_hash                |
+| `full`     | ~300+        | Everything: provenance, graph context, embedding dimensions |
+
+Usage: pass `"depth": "sparse"` (or `"standard"`, `"full"`) as a tool parameter.
+
+### Embedding
+
+The server requires an OpenAI-compatible embedding endpoint for `memory_add_fact` and vector/hybrid queries. Compatible with:
+
+- **ollama**: `http://localhost:11434/v1/embeddings`
+- **OpenAI**: `https://api.openai.com/v1/embeddings`
+- Any endpoint returning `{ "data": [{ "embedding": [...] }] }` or `{ "embeddings": [[...]] }`
+
+For `memory_add_fact`, callers can bypass server-side embedding by passing a pre-computed `embedding` array.
+
+### Pre-Compaction Flush
+
+`memory_flush_insights` accepts a batch of insights for agents to capture before context window compaction. Each insight becomes a fact with `metadata.source = "pre_compaction_flush"`. Supports partial success — individual failures are reported without aborting the batch.
+
+### Architecture
+
+```
+Agent (Claude, etc.) → stdio JSON-RPC → memory-engine-mcp → MemoryEngine (SQLite)
+                                         ├── config.rs (TOML + env + CLI)
+                                         ├── server.rs (ServerHandler, spawn_blocking)
+                                         ├── tools/   (10 handlers + dispatch)
+                                         ├── depth.rs (response shaping)
+                                         ├── embedding.rs (HTTP provider)
+                                         └── error.rs (MemoryError → MCP)
+```
+
+Tool calls run on tokio's blocking thread pool (`spawn_blocking`) since the engine is sync (SQLite). Protocol version pinned to `2025-06-18`.

--- a/examples/basic_roundtrip.rs
+++ b/examples/basic_roundtrip.rs
@@ -2,11 +2,11 @@
 //!
 //! Run with: `cargo run --example basic_roundtrip`
 
+use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{EventType, FactType, NewEvent};
-use memory_engine::MemoryEngine;
 
 /// Zero-vector embedder for examples (no external model needed).
 struct DummyEmbedder;

--- a/examples/bi_temporal_query.rs
+++ b/examples/bi_temporal_query.rs
@@ -5,11 +5,11 @@
 //! Run with: `cargo run --example bi_temporal_query`
 
 use chrono::{Duration, Utc};
+use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactOptions, FactType};
-use memory_engine::MemoryEngine;
 
 struct DummyEmbedder;
 

--- a/examples/custom_traits.rs
+++ b/examples/custom_traits.rs
@@ -2,13 +2,13 @@
 //!
 //! Run with: `cargo run --example custom_traits`
 
+use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::traits::{
     ConflictArbiter, ConsolidationConfig, CrudDecision, EmbeddingProvider, ForgetPolicy,
     SummaryGenerator,
 };
 use memory_engine::types::{Fact, FactType, NewFact};
-use memory_engine::MemoryEngine;
 
 // --- EmbeddingProvider: consumers bring their own embedding model ---
 

--- a/memory-engine-cli/src/commands/dump.rs
+++ b/memory-engine-cli/src/commands/dump.rs
@@ -4,7 +4,7 @@ use memory_engine::inspect_types::ReplayFilter;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, truncate_str, OutputFormat};
+use crate::output::{self, OutputFormat, truncate_str};
 
 #[derive(clap::Args)]
 pub struct DumpArgs {

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
-use memory_engine::search::hybrid::MatchType;
 use memory_engine::MemoryQuery;
+use memory_engine::search::hybrid::MatchType;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, truncate_str, OutputFormat};
+use crate::output::{self, OutputFormat, truncate_str};
 
 #[derive(clap::Args)]
 pub struct QueryArgs {

--- a/memory-engine-mcp/Cargo.toml
+++ b/memory-engine-mcp/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "memory-engine-mcp"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "MCP server for memory-engine — exposes agent memory as MCP tools over stdio"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/dutiona/memory-engine"
+
+[dependencies]
+memory-engine = { path = "..", features = ["async"] }
+rmcp = { version = "1", features = ["server", "transport-io"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive", "env"] }
+toml = "0.8"
+reqwest = { version = "0.12", features = ["blocking", "json"] }
+rusqlite = { version = "0.34", features = ["bundled-full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+thiserror = "2"
+
+[dev-dependencies]
+wiremock = "0.6"
+tempfile = "3"
+insta = { version = "1", features = ["yaml"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }

--- a/memory-engine-mcp/Cargo.toml
+++ b/memory-engine-mcp/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/dutiona/memory-engine"
 [dependencies]
 memory-engine = { path = "..", features = ["async"] }
 rmcp = { version = "1", features = ["server", "transport-io"] }
+schemars = { version = "1", features = ["chrono04"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/memory-engine-mcp/src/config.rs
+++ b/memory-engine-mcp/src/config.rs
@@ -1,0 +1,1 @@
+// Phase B1: TOML + env + CLI config loading.

--- a/memory-engine-mcp/src/config.rs
+++ b/memory-engine-mcp/src/config.rs
@@ -1,1 +1,121 @@
-// Phase B1: TOML + env + CLI config loading.
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Top-level MCP server configuration.
+///
+/// Loaded from TOML file, with CLI args and env vars as overrides.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpConfig {
+    /// Engine database configuration.
+    pub engine: EngineSection,
+
+    /// Embedding provider configuration (optional — needed for add_fact + vector queries).
+    pub embedding: Option<EmbeddingSection>,
+}
+
+/// Engine / database configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EngineSection {
+    /// Path to the memory-engine SQLite database.
+    pub db_path: PathBuf,
+
+    /// Embedding dimension. If omitted, probed from existing database.
+    pub embed_dim: Option<usize>,
+}
+
+/// Embedding provider configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EmbeddingSection {
+    /// OpenAI-compatible embedding endpoint URL (e.g. `http://localhost:11434/v1/embeddings`).
+    pub endpoint: String,
+
+    /// Model name to request (e.g. `nomic-embed-text`).
+    pub model: String,
+
+    /// API key (optional — for authenticated endpoints).
+    pub api_key: Option<String>,
+
+    /// Expected embedding dimensions. Used to validate responses.
+    pub dimensions: usize,
+
+    /// HTTP timeout in seconds. Default: 30.
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+}
+
+const fn default_timeout() -> u64 {
+    30
+}
+
+/// Probe `embed_dim` from an existing database by reading the config table.
+///
+/// Mirrors the pattern from `memory-engine-cli/src/db.rs`.
+///
+/// # Errors
+///
+/// Returns an error if the database doesn't exist or has no `embed_dim` config.
+pub fn probe_embed_dim(db_path: &Path) -> Result<usize, String> {
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| format!("cannot open database: {e}"))?;
+
+    let dim_str: String = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'embed_dim'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|_| "database has no embed_dim in config table".to_owned())?;
+
+    dim_str
+        .parse::<usize>()
+        .map_err(|e| format!("invalid embed_dim value '{dim_str}': {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_full_config() {
+        let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+embed_dim = 384
+
+[embedding]
+endpoint = "http://localhost:11434/v1/embeddings"
+model = "nomic-embed-text"
+dimensions = 384
+"#;
+        let config: McpConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.engine.embed_dim, Some(384));
+        assert!(config.embedding.is_some());
+        let emb = config.embedding.unwrap();
+        assert_eq!(emb.model, "nomic-embed-text");
+        assert_eq!(emb.timeout_secs, 30); // default
+    }
+
+    #[test]
+    fn deserialize_minimal_config() {
+        let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+"#;
+        let config: McpConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.engine.embed_dim, None);
+        assert!(config.embedding.is_none());
+    }
+
+    #[test]
+    fn probe_nonexistent_db() {
+        let result = probe_embed_dim(Path::new("/tmp/nonexistent_memory_engine_test.db"));
+        assert!(result.is_err());
+    }
+}

--- a/memory-engine-mcp/src/config.rs
+++ b/memory-engine-mcp/src/config.rs
@@ -59,6 +59,12 @@ const fn default_timeout() -> u64 {
 ///
 /// Returns an error if the database doesn't exist or has no `embed_dim` config.
 pub fn probe_embed_dim(db_path: &Path) -> Result<usize, String> {
+    if !db_path.is_file() {
+        return Err(format!(
+            "database path is not a file or does not exist: {}",
+            db_path.display()
+        ));
+    }
     let conn = rusqlite::Connection::open_with_flags(
         db_path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -61,6 +61,7 @@ pub fn shape_fact(fact: &Fact, depth: Depth, scope_path: Option<&str>) -> Value 
             "source_event_id": fact.source_event_id,
             "access_count": fact.access_count,
             "last_accessed": fact.last_accessed,
+            "surfaced_at": fact.surfaced_at,
             "metadata": fact.metadata,
         }),
         Depth::Full => {

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -1,1 +1,242 @@
-// Phase B4: Tiered response shaping (sparse/standard/full).
+use memory_engine::inspect_types::FactExplanation;
+use memory_engine::resume::ResumeContext;
+use memory_engine::search::hybrid::SearchResult;
+use memory_engine::types::Fact;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+/// Tiered retrieval depth for MCP responses.
+///
+/// Controls how much detail is included in tool results to manage token budget.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Depth {
+    /// ~15 tokens/fact: id, truncated content, importance_score, scope_path.
+    Sparse,
+    /// ~75 tokens/fact: all fields except embedding and content_hash. Default.
+    #[default]
+    Standard,
+    /// ~300+ tokens/fact: everything including provenance, event history, graph context.
+    Full,
+}
+
+/// Maximum content length for sparse depth truncation.
+const SPARSE_CONTENT_MAX: usize = 200;
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    // Find a valid UTF-8 boundary near max.
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Shape a [`Fact`] according to the requested depth.
+pub fn shape_fact(fact: &Fact, depth: Depth, scope_path: Option<&str>) -> Value {
+    match depth {
+        Depth::Sparse => json!({
+            "id": fact.id,
+            "content": truncate(&fact.content, SPARSE_CONTENT_MAX),
+            "importance_score": fact.importance_score,
+            "scope": scope_path.unwrap_or(""),
+        }),
+        Depth::Standard => json!({
+            "id": fact.id,
+            "content": fact.content,
+            "fact_type": fact.fact_type,
+            "importance": fact.importance,
+            "importance_score": fact.importance_score,
+            "is_pinned": fact.is_pinned,
+            "scope_id": fact.scope_id,
+            "scope": scope_path.unwrap_or(""),
+            "t_created": fact.t_created,
+            "t_expired": fact.t_expired,
+            "t_valid": fact.t_valid,
+            "t_invalid": fact.t_invalid,
+            "source_event_id": fact.source_event_id,
+            "access_count": fact.access_count,
+            "last_accessed": fact.last_accessed,
+            "metadata": fact.metadata,
+        }),
+        Depth::Full => {
+            // Full includes everything standard has, plus embedding dimensions.
+            json!({
+                "id": fact.id,
+                "content": fact.content,
+                "content_hash": fact.content_hash,
+                "fact_type": fact.fact_type,
+                "importance": fact.importance,
+                "importance_score": fact.importance_score,
+                "is_pinned": fact.is_pinned,
+                "scope_id": fact.scope_id,
+                "scope": scope_path.unwrap_or(""),
+                "t_created": fact.t_created,
+                "t_expired": fact.t_expired,
+                "t_valid": fact.t_valid,
+                "t_invalid": fact.t_invalid,
+                "source_event_id": fact.source_event_id,
+                "access_count": fact.access_count,
+                "last_accessed": fact.last_accessed,
+                "surfaced_at": fact.surfaced_at,
+                "metadata": fact.metadata,
+                "embedding_dim": fact.embedding.len(),
+            })
+        }
+    }
+}
+
+/// Shape a [`SearchResult`] according to the requested depth.
+pub fn shape_search_result(result: &SearchResult, depth: Depth, scope_path: Option<&str>) -> Value {
+    let mut shaped = shape_fact(&result.fact, depth, scope_path);
+    if let Value::Object(ref mut map) = shaped {
+        map.insert("score".to_owned(), json!(result.score));
+        map.insert(
+            "match_type".to_owned(),
+            json!(format!("{:?}", result.match_type)),
+        );
+    }
+    shaped
+}
+
+/// Shape a [`FactExplanation`] according to the requested depth.
+pub fn shape_explanation(explanation: &FactExplanation, depth: Depth) -> Value {
+    match depth {
+        Depth::Sparse => json!({
+            "fact_id": explanation.fact_id,
+            "state": format!("{:?}", explanation.state),
+            "scope_path": explanation.scope_path,
+        }),
+        Depth::Standard => json!({
+            "fact_id": explanation.fact_id,
+            "state": explanation.state,
+            "scope_path": explanation.scope_path,
+            "provenance": {
+                "source_event_id": explanation.provenance.source_event_id,
+                "importance": explanation.provenance.importance,
+                "importance_score": explanation.provenance.importance_score,
+                "is_pinned": explanation.provenance.is_pinned,
+                "access_count": explanation.provenance.access_count,
+            },
+            "graph": {
+                "degree": explanation.graph_context.degree,
+                "component_size": explanation.graph_context.component_size,
+            },
+        }),
+        Depth::Full => {
+            // Full: serialize the entire explanation including source_event.
+            serde_json::to_value(explanation).unwrap_or(json!(null))
+        }
+    }
+}
+
+/// Shape a [`ResumeContext`] according to the requested depth.
+///
+/// Each tier's facts are shaped independently.
+pub fn shape_resume_context(ctx: &ResumeContext, depth: Depth) -> Value {
+    let shape_vec = |facts: &[Fact]| -> Vec<Value> {
+        facts.iter().map(|f| shape_fact(f, depth, None)).collect()
+    };
+
+    json!({
+        "pinned": shape_vec(&ctx.pinned),
+        "high_importance": shape_vec(&ctx.high_importance),
+        "due": shape_vec(&ctx.due),
+        "recent": shape_vec(&ctx.recent),
+        "kb_stubs": ctx.kb_stubs,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use memory_engine::types::FactType;
+
+    fn make_test_fact() -> Fact {
+        Fact {
+            id: 42,
+            content:
+                "This is a test fact with enough content to test truncation behavior in sparse mode"
+                    .into(),
+            content_hash: "abc123".into(),
+            embedding: vec![0.1; 384],
+            fact_type: FactType::Semantic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: Some(10),
+            importance: 0.8,
+            access_count: 5,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({"topic": "test"}),
+            scope_id: 1,
+            is_pinned: false,
+            importance_score: 0.85,
+            surfaced_at: None,
+        }
+    }
+
+    #[test]
+    fn sparse_truncates_and_minimal_fields() {
+        let fact = make_test_fact();
+        let shaped = shape_fact(&fact, Depth::Sparse, Some("/test"));
+        let obj = shaped.as_object().unwrap();
+        assert_eq!(obj.len(), 4); // id, content, importance_score, scope
+        assert!(obj.contains_key("id"));
+        assert!(obj.contains_key("content"));
+        assert!(obj.contains_key("importance_score"));
+        assert!(obj.contains_key("scope"));
+    }
+
+    #[test]
+    fn standard_excludes_embedding_and_hash() {
+        let fact = make_test_fact();
+        let shaped = shape_fact(&fact, Depth::Standard, None);
+        let obj = shaped.as_object().unwrap();
+        assert!(!obj.contains_key("embedding"));
+        assert!(!obj.contains_key("content_hash"));
+        assert!(!obj.contains_key("embedding_dim"));
+        assert!(obj.contains_key("content"));
+        assert!(obj.contains_key("fact_type"));
+        assert!(obj.contains_key("metadata"));
+    }
+
+    #[test]
+    fn full_includes_embedding_dim_and_hash() {
+        let fact = make_test_fact();
+        let shaped = shape_fact(&fact, Depth::Full, None);
+        let obj = shaped.as_object().unwrap();
+        assert!(obj.contains_key("content_hash"));
+        assert!(obj.contains_key("embedding_dim"));
+        assert_eq!(obj["embedding_dim"], 384);
+    }
+
+    #[test]
+    fn search_result_adds_score_and_match_type() {
+        use memory_engine::search::hybrid::MatchType;
+        let result = SearchResult {
+            fact: make_test_fact(),
+            score: 0.95,
+            match_type: MatchType::Fts,
+        };
+        let shaped = shape_search_result(&result, Depth::Sparse, None);
+        let obj = shaped.as_object().unwrap();
+        assert!(obj.contains_key("score"));
+        assert!(obj.contains_key("match_type"));
+    }
+
+    #[test]
+    fn truncate_respects_char_boundary() {
+        let s = "hello 🌍 world";
+        let truncated = truncate(s, 8);
+        // Should not split the emoji
+        assert!(truncated.len() <= 8);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+}

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -1,0 +1,1 @@
+// Phase B4: Tiered response shaping (sparse/standard/full).

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -130,7 +130,10 @@ pub fn shape_explanation(explanation: &FactExplanation, depth: Depth) -> Value {
         }),
         Depth::Full => {
             // Full: serialize the entire explanation including source_event.
-            serde_json::to_value(explanation).unwrap_or(json!(null))
+            serde_json::to_value(explanation).unwrap_or_else(|e| {
+                tracing::error!("failed to serialize FactExplanation: {e}");
+                json!(null)
+            })
         }
     }
 }

--- a/memory-engine-mcp/src/embedding.rs
+++ b/memory-engine-mcp/src/embedding.rs
@@ -14,24 +14,27 @@ pub struct HttpEmbeddingProvider {
 }
 
 impl HttpEmbeddingProvider {
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be constructed (e.g., TLS init failure).
     pub fn new(
         endpoint: String,
         model: String,
         api_key: Option<String>,
         expected_dim: usize,
         timeout_secs: u64,
-    ) -> Self {
+    ) -> Result<Self, String> {
         let client = reqwest::blocking::ClientBuilder::new()
             .timeout(std::time::Duration::from_secs(timeout_secs))
             .build()
-            .expect("failed to build HTTP client");
-        Self {
+            .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+        Ok(Self {
             client,
             endpoint,
             model,
             api_key,
             expected_dim,
-        }
+        })
     }
 }
 

--- a/memory-engine-mcp/src/embedding.rs
+++ b/memory-engine-mcp/src/embedding.rs
@@ -1,1 +1,131 @@
-// Phase B3: HttpEmbeddingProvider + PassthroughEmbedder.
+use memory_engine::error::MemoryError;
+use memory_engine::traits::EmbeddingProvider;
+
+/// HTTP-based embedding provider calling an OpenAI-compatible `/v1/embeddings` endpoint.
+///
+/// Uses `reqwest::blocking::Client` because the engine's `EmbeddingProvider` trait is sync.
+/// This runs inside `tokio::task::spawn_blocking` via the engine's connection pool.
+pub struct HttpEmbeddingProvider {
+    client: reqwest::blocking::Client,
+    endpoint: String,
+    model: String,
+    api_key: Option<String>,
+    expected_dim: usize,
+}
+
+impl HttpEmbeddingProvider {
+    pub fn new(
+        endpoint: String,
+        model: String,
+        api_key: Option<String>,
+        expected_dim: usize,
+        timeout_secs: u64,
+    ) -> Self {
+        let client = reqwest::blocking::ClientBuilder::new()
+            .timeout(std::time::Duration::from_secs(timeout_secs))
+            .build()
+            .expect("failed to build HTTP client");
+        Self {
+            client,
+            endpoint,
+            model,
+            api_key,
+            expected_dim,
+        }
+    }
+}
+
+impl EmbeddingProvider for HttpEmbeddingProvider {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+        let mut req = self.client.post(&self.endpoint).json(&serde_json::json!({
+            "model": &self.model,
+            "input": text,
+        }));
+
+        if let Some(key) = &self.api_key {
+            req = req.bearer_auth(key);
+        }
+
+        let resp = req
+            .send()
+            .map_err(|e| MemoryError::Internal(format!("embedding HTTP request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            return Err(MemoryError::Internal(format!(
+                "embedding endpoint returned {status}: {body}"
+            )));
+        }
+
+        let body: serde_json::Value = resp
+            .json()
+            .map_err(|e| MemoryError::Internal(format!("embedding response parse error: {e}")))?;
+
+        // Auto-detect response format:
+        // OpenAI: { "data": [{ "embedding": [...] }] }
+        // Ollama: { "embeddings": [[...]] }
+        let embedding = if let Some(data) = body.get("data") {
+            data.get(0)
+                .and_then(|d| d.get("embedding"))
+                .and_then(|e| serde_json::from_value::<Vec<f32>>(e.clone()).ok())
+        } else if let Some(embeddings) = body.get("embeddings") {
+            embeddings
+                .get(0)
+                .and_then(|e| serde_json::from_value::<Vec<f32>>(e.clone()).ok())
+        } else if let Some(embedding) = body.get("embedding") {
+            // Single embedding format
+            serde_json::from_value::<Vec<f32>>(embedding.clone()).ok()
+        } else {
+            None
+        };
+
+        let embedding = embedding.ok_or_else(|| {
+            MemoryError::Internal(format!(
+                "cannot extract embedding from response: {}",
+                serde_json::to_string(&body).unwrap_or_default()
+            ))
+        })?;
+
+        if embedding.len() != self.expected_dim {
+            return Err(MemoryError::EmbeddingDimension {
+                expected: self.expected_dim,
+                actual: embedding.len(),
+            });
+        }
+
+        Ok(embedding)
+    }
+}
+
+/// Pass-through embedder for pre-computed embeddings supplied by the caller.
+///
+/// Used when `memory_add_fact` receives an `embedding` parameter directly.
+pub struct PassthroughEmbedder {
+    embedding: Vec<f32>,
+}
+
+impl PassthroughEmbedder {
+    pub fn new(embedding: Vec<f32>) -> Self {
+        Self { embedding }
+    }
+}
+
+impl EmbeddingProvider for PassthroughEmbedder {
+    fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
+        Ok(self.embedding.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_returns_stored_embedding() {
+        let emb = vec![0.1, 0.2, 0.3];
+        let provider = PassthroughEmbedder::new(emb.clone());
+        let result = provider.embed("anything").unwrap();
+        assert_eq!(result, emb);
+    }
+}

--- a/memory-engine-mcp/src/embedding.rs
+++ b/memory-engine-mcp/src/embedding.rs
@@ -1,0 +1,1 @@
+// Phase B3: HttpEmbeddingProvider + PassthroughEmbedder.

--- a/memory-engine-mcp/src/error.rs
+++ b/memory-engine-mcp/src/error.rs
@@ -50,6 +50,11 @@ pub fn to_mcp_error(err: MemoryError) -> ErrorData {
         MemoryError::NotImplemented(msg) => {
             ErrorData::internal_error(format!("not implemented: {msg}"), None)
         }
+
+        MemoryError::ReadOnly => ErrorData::invalid_request(
+            "engine opened in read-only mode — write operations are not available",
+            None,
+        ),
     }
 }
 

--- a/memory-engine-mcp/src/error.rs
+++ b/memory-engine-mcp/src/error.rs
@@ -1,0 +1,1 @@
+// Phase B2: MemoryError → MCP ErrorData mapping.

--- a/memory-engine-mcp/src/error.rs
+++ b/memory-engine-mcp/src/error.rs
@@ -1,1 +1,122 @@
-// Phase B2: MemoryError → MCP ErrorData mapping.
+use memory_engine::error::MemoryError;
+use rmcp::model::ErrorData;
+
+/// Map a [`MemoryError`] to an MCP [`ErrorData`] with appropriate JSON-RPC error codes.
+pub fn to_mcp_error(err: MemoryError) -> ErrorData {
+    match err {
+        MemoryError::NotFound(msg) => ErrorData::resource_not_found(msg, None),
+
+        MemoryError::EmbeddingDimension { expected, actual } => ErrorData::invalid_params(
+            format!("embedding dimension mismatch: expected {expected}, got {actual}"),
+            None,
+        ),
+
+        MemoryError::Conflict(msg) => ErrorData::invalid_params(format!("conflict: {msg}"), None),
+
+        MemoryError::Database(e) => ErrorData::internal_error(format!("database error: {e}"), None),
+
+        MemoryError::Serialization(e) => {
+            ErrorData::internal_error(format!("serialization error: {e}"), None)
+        }
+
+        MemoryError::Migration(msg) => {
+            ErrorData::internal_error(format!("migration error: {msg}"), None)
+        }
+
+        MemoryError::Pool(msg) => ErrorData::internal_error(format!("pool error: {msg}"), None),
+
+        MemoryError::UnsupportedEpoch {
+            db_epoch,
+            supported_epoch,
+        } => ErrorData::internal_error(
+            format!("unsupported storage epoch: db={db_epoch}, supported={supported_epoch}"),
+            None,
+        ),
+
+        MemoryError::Internal(msg) => {
+            ErrorData::internal_error(format!("internal error: {msg}"), None)
+        }
+
+        MemoryError::Io(e) => ErrorData::internal_error(format!("I/O error: {e}"), None),
+
+        MemoryError::Bootstrap(msg) => {
+            ErrorData::internal_error(format!("bootstrap error: {msg}"), None)
+        }
+
+        MemoryError::Reranker(msg) => {
+            ErrorData::internal_error(format!("reranker error: {msg}"), None)
+        }
+
+        MemoryError::NotImplemented(msg) => {
+            ErrorData::internal_error(format!("not implemented: {msg}"), None)
+        }
+    }
+}
+
+/// MCP-layer validation errors (before reaching the engine).
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    #[error("importance must be in [0.0, 1.0], got {0}")]
+    ImportanceOutOfRange(f64),
+
+    #[error("t_valid must be before t_invalid")]
+    TemporalInconsistency,
+
+    #[error("unknown event_type: {0}")]
+    UnknownEventType(String),
+
+    #[error("unknown fact_type: {0}")]
+    UnknownFactType(String),
+
+    #[error("embedding dimensions mismatch: expected {expected}, got {actual}")]
+    EmbeddingDimension { expected: usize, actual: usize },
+
+    #[error("embedding provider not configured — required for this operation")]
+    NoEmbeddingProvider,
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<ValidationError> for ErrorData {
+    fn from(err: ValidationError) -> Self {
+        ErrorData::invalid_params(err.to_string(), None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_found_maps_to_resource_not_found() {
+        let err = MemoryError::NotFound("fact 42".into());
+        let mcp = to_mcp_error(err);
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::RESOURCE_NOT_FOUND);
+    }
+
+    #[test]
+    fn embedding_dim_maps_to_invalid_params() {
+        let err = MemoryError::EmbeddingDimension {
+            expected: 768,
+            actual: 384,
+        };
+        let mcp = to_mcp_error(err);
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn database_maps_to_internal() {
+        let err = MemoryError::Database(rusqlite::Error::QueryReturnedNoRows);
+        let mcp = to_mcp_error(err);
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn validation_error_maps_to_invalid_params() {
+        let err = ValidationError::ImportanceOutOfRange(1.5);
+        let mcp: ErrorData = err.into();
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(mcp.message.contains("1.5"));
+    }
+}

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -5,7 +5,11 @@ mod error;
 mod server;
 mod tools;
 
+use std::sync::Arc;
+
 use clap::Parser;
+use memory_engine::engine::{EngineConfig, MemoryEngine};
+use rmcp::ServiceExt;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -43,17 +47,86 @@ async fn main() -> Result<(), BoxError> {
         .with(EnvFilter::from_default_env().add_directive(tracing::Level::WARN.into()))
         .init();
 
-    let _cli = Cli::parse();
+    let cli = Cli::parse();
 
-    // TODO: Phase B-D implementation
-    // 1. Load config (TOML + env + CLI layering)
-    // 2. Probe embed_dim from existing DB if needed
+    // 1. Load config (TOML file, with CLI overrides)
+    let mcp_config = load_config(&cli)?;
+
+    // 2. Resolve embed_dim: explicit config > DB probe
+    let embed_dim = match mcp_config.engine.embed_dim {
+        Some(dim) => dim,
+        None => config::probe_embed_dim(&mcp_config.engine.db_path)
+            .map_err(|e| format!("cannot determine embed_dim: {e}"))?,
+    };
+
     // 3. Open MemoryEngine
-    // 4. Initialize HttpEmbeddingProvider
-    // 5. Construct MemoryMcpServer
-    // 6. Serve over stdio
+    let engine_config = EngineConfig::new(mcp_config.engine.db_path.clone(), embed_dim);
+    let engine =
+        MemoryEngine::open(&engine_config).map_err(|e| format!("failed to open engine: {e}"))?;
+    let engine = Arc::new(engine);
 
-    tracing::info!("memory-engine-mcp starting");
-    eprintln!("memory-engine-mcp: not yet implemented — scaffold only");
-    std::process::exit(1);
+    // 4. Initialize embedding provider (optional)
+    let embedder = mcp_config.embedding.map(|emb_config| {
+        Arc::new(embedding::HttpEmbeddingProvider::new(
+            emb_config.endpoint,
+            emb_config.model,
+            emb_config.api_key,
+            emb_config.dimensions,
+            emb_config.timeout_secs,
+        ))
+    });
+
+    // 5. Construct and serve
+    let mcp_server = server::MemoryMcpServer::new(engine, embedder, embed_dim);
+
+    tracing::info!("memory-engine-mcp starting on stdio");
+    let transport = rmcp::transport::io::stdio();
+    let service = mcp_server.serve(transport).await?;
+    service.waiting().await?;
+
+    Ok(())
+}
+
+/// Load configuration from TOML file with CLI overrides.
+fn load_config(cli: &Cli) -> Result<config::McpConfig, BoxError> {
+    // Start with TOML file if provided
+    let mut mcp_config = if let Some(config_path) = &cli.config {
+        let content = std::fs::read_to_string(config_path)
+            .map_err(|e| format!("cannot read config file {}: {e}", config_path.display()))?;
+        toml::from_str::<config::McpConfig>(&content)
+            .map_err(|e| format!("invalid config file: {e}"))?
+    } else {
+        // Minimal config — db_path must come from CLI
+        let db_path = cli
+            .db_path
+            .clone()
+            .ok_or("either --config or --db-path is required")?;
+        config::McpConfig {
+            engine: config::EngineSection {
+                db_path,
+                embed_dim: None,
+            },
+            embedding: None,
+        }
+    };
+
+    // CLI overrides
+    if let Some(db_path) = &cli.db_path {
+        mcp_config.engine.db_path = db_path.clone();
+    }
+
+    // Build embedding config from CLI if not in TOML
+    if mcp_config.embedding.is_none() {
+        if let (Some(url), Some(model)) = (&cli.embed_url, &cli.embed_model) {
+            mcp_config.embedding = Some(config::EmbeddingSection {
+                endpoint: url.clone(),
+                model: model.clone(),
+                api_key: cli.embed_api_key.clone(),
+                dimensions: mcp_config.engine.embed_dim.unwrap_or(384),
+                timeout_secs: 30,
+            });
+        }
+    }
+
+    Ok(mcp_config)
 }

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -1,0 +1,59 @@
+mod config;
+mod depth;
+mod embedding;
+mod error;
+mod server;
+mod tools;
+
+use clap::Parser;
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// MCP server for memory-engine — exposes agent memory as MCP tools over stdio.
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+    /// Path to TOML configuration file.
+    #[arg(long, env = "MEMORY_MCP_CONFIG")]
+    config: Option<std::path::PathBuf>,
+
+    /// Path to the memory-engine SQLite database.
+    #[arg(long, env = "MEMORY_MCP_DB_PATH")]
+    db_path: Option<std::path::PathBuf>,
+
+    /// Embedding endpoint URL (OpenAI-compatible).
+    #[arg(long, env = "MEMORY_MCP_EMBED_URL")]
+    embed_url: Option<String>,
+
+    /// Embedding model name.
+    #[arg(long, env = "MEMORY_MCP_EMBED_MODEL")]
+    embed_model: Option<String>,
+
+    /// Embedding API key (optional, for authenticated endpoints).
+    #[arg(long, env = "MEMORY_MCP_EMBED_API_KEY")]
+    embed_api_key: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    // MCP uses stdout for JSON-RPC — all logging goes to stderr.
+    tracing_subscriber::registry()
+        .with(fmt::layer().with_writer(std::io::stderr).with_ansi(false))
+        .with(EnvFilter::from_default_env().add_directive(tracing::Level::WARN.into()))
+        .init();
+
+    let _cli = Cli::parse();
+
+    // TODO: Phase B-D implementation
+    // 1. Load config (TOML + env + CLI layering)
+    // 2. Probe embed_dim from existing DB if needed
+    // 3. Open MemoryEngine
+    // 4. Initialize HttpEmbeddingProvider
+    // 5. Construct MemoryMcpServer
+    // 6. Serve over stdio
+
+    tracing::info!("memory-engine-mcp starting");
+    eprintln!("memory-engine-mcp: not yet implemented — scaffold only");
+    std::process::exit(1);
+}

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -66,15 +66,8 @@ async fn main() -> Result<(), BoxError> {
     let engine = Arc::new(engine);
 
     // 4. Initialize embedding provider (optional)
-    let embedder = mcp_config.embedding.map(|emb_config| {
-        Arc::new(embedding::HttpEmbeddingProvider::new(
-            emb_config.endpoint,
-            emb_config.model,
-            emb_config.api_key,
-            emb_config.dimensions,
-            emb_config.timeout_secs,
-        ))
-    });
+    // Use the resolved embed_dim (from DB probe or config), not the TOML value.
+    let embedder = build_embedder(&cli, &mcp_config, embed_dim)?;
 
     // 5. Construct and serve
     let mcp_server = server::MemoryMcpServer::new(engine, embedder, embed_dim);
@@ -85,6 +78,43 @@ async fn main() -> Result<(), BoxError> {
     service.waiting().await?;
 
     Ok(())
+}
+
+/// Build the embedding provider from config + CLI, using the probed embed_dim.
+fn build_embedder(
+    cli: &Cli,
+    mcp_config: &config::McpConfig,
+    embed_dim: usize,
+) -> Result<Option<Arc<embedding::HttpEmbeddingProvider>>, BoxError> {
+    // Priority: TOML [embedding] section > CLI flags
+    if let Some(ref emb_config) = mcp_config.embedding {
+        return Ok(Some(Arc::new(
+            embedding::HttpEmbeddingProvider::new(
+                emb_config.endpoint.clone(),
+                emb_config.model.clone(),
+                emb_config.api_key.clone(),
+                embed_dim, // Use probed dim, not config dim
+                emb_config.timeout_secs,
+            )
+            .map_err(|e| format!("failed to create embedding provider: {e}"))?,
+        )));
+    }
+
+    // Build from CLI flags if available
+    if let (Some(url), Some(model)) = (&cli.embed_url, &cli.embed_model) {
+        return Ok(Some(Arc::new(
+            embedding::HttpEmbeddingProvider::new(
+                url.clone(),
+                model.clone(),
+                cli.embed_api_key.clone(),
+                embed_dim,
+                30,
+            )
+            .map_err(|e| format!("failed to create embedding provider: {e}"))?,
+        )));
+    }
+
+    Ok(None)
 }
 
 /// Load configuration from TOML file with CLI overrides.
@@ -115,18 +145,8 @@ fn load_config(cli: &Cli) -> Result<config::McpConfig, BoxError> {
         mcp_config.engine.db_path = db_path.clone();
     }
 
-    // Build embedding config from CLI if not in TOML
-    if mcp_config.embedding.is_none() {
-        if let (Some(url), Some(model)) = (&cli.embed_url, &cli.embed_model) {
-            mcp_config.embedding = Some(config::EmbeddingSection {
-                endpoint: url.clone(),
-                model: model.clone(),
-                api_key: cli.embed_api_key.clone(),
-                dimensions: mcp_config.engine.embed_dim.unwrap_or(384),
-                timeout_secs: 30,
-            });
-        }
-    }
+    // NOTE: Embedding config from CLI is handled in build_embedder(),
+    // which runs after embed_dim probe to avoid dimension mismatch.
 
     Ok(mcp_config)
 }

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -81,40 +81,38 @@ async fn main() -> Result<(), BoxError> {
 }
 
 /// Build the embedding provider from config + CLI, using the probed embed_dim.
+///
+/// CLI flags override TOML values (endpoint, model, api_key) when provided,
+/// enabling operators to inject runtime secrets via env/CLI.
 fn build_embedder(
     cli: &Cli,
     mcp_config: &config::McpConfig,
     embed_dim: usize,
 ) -> Result<Option<Arc<embedding::HttpEmbeddingProvider>>, BoxError> {
-    // Priority: TOML [embedding] section > CLI flags
-    if let Some(ref emb_config) = mcp_config.embedding {
-        return Ok(Some(Arc::new(
-            embedding::HttpEmbeddingProvider::new(
-                emb_config.endpoint.clone(),
-                emb_config.model.clone(),
-                emb_config.api_key.clone(),
-                embed_dim, // Use probed dim, not config dim
-                emb_config.timeout_secs,
-            )
-            .map_err(|e| format!("failed to create embedding provider: {e}"))?,
-        )));
-    }
+    // Merge TOML + CLI: CLI overrides individual fields
+    let base = mcp_config.embedding.as_ref();
 
-    // Build from CLI flags if available
-    if let (Some(url), Some(model)) = (&cli.embed_url, &cli.embed_model) {
-        return Ok(Some(Arc::new(
-            embedding::HttpEmbeddingProvider::new(
-                url.clone(),
-                model.clone(),
-                cli.embed_api_key.clone(),
-                embed_dim,
-                30,
-            )
-            .map_err(|e| format!("failed to create embedding provider: {e}"))?,
-        )));
-    }
+    let endpoint = cli
+        .embed_url
+        .clone()
+        .or_else(|| base.map(|b| b.endpoint.clone()));
+    let model = cli
+        .embed_model
+        .clone()
+        .or_else(|| base.map(|b| b.model.clone()));
+    let api_key = cli
+        .embed_api_key
+        .clone()
+        .or_else(|| base.and_then(|b| b.api_key.clone()));
+    let timeout = base.map_or(30, |b| b.timeout_secs);
 
-    Ok(None)
+    match (endpoint, model) {
+        (Some(url), Some(mdl)) => Ok(Some(Arc::new(
+            embedding::HttpEmbeddingProvider::new(url, mdl, api_key, embed_dim, timeout)
+                .map_err(|e| format!("failed to create embedding provider: {e}"))?,
+        ))),
+        _ => Ok(None),
+    }
 }
 
 /// Load configuration from TOML file with CLI overrides.

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -119,6 +119,9 @@ fn build_embedder(
 fn load_config(cli: &Cli) -> Result<config::McpConfig, BoxError> {
     // Start with TOML file if provided
     let mut mcp_config = if let Some(config_path) = &cli.config {
+        if !config_path.is_file() {
+            return Err(format!("config path is not a file: {}", config_path.display()).into());
+        }
         let content = std::fs::read_to_string(config_path)
             .map_err(|e| format!("cannot read config file {}: {e}", config_path.display()))?;
         toml::from_str::<config::McpConfig>(&content)

--- a/memory-engine-mcp/src/server.rs
+++ b/memory-engine-mcp/src/server.rs
@@ -1,1 +1,101 @@
-// Phase C1: MemoryMcpServer struct + ServerHandler impl.
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use memory_engine::engine::MemoryEngine;
+use rmcp::RoleServer;
+use rmcp::handler::server::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Implementation, InitializeResult, ListToolsResult,
+    PaginatedRequestParams, ProtocolVersion, ServerCapabilities, Tool, ToolsCapability,
+};
+use rmcp::service::RequestContext;
+
+use crate::embedding::HttpEmbeddingProvider;
+use crate::tools;
+
+/// MCP server wrapping a [`MemoryEngine`] instance.
+///
+/// All tool calls are dispatched to `tokio::task::spawn_blocking` via the engine's
+/// internal connection pool. The server holds an `Arc<MemoryEngine>` for thread-safe sharing.
+pub struct MemoryMcpServer {
+    pub engine: Arc<MemoryEngine>,
+    pub embedder: Option<Arc<HttpEmbeddingProvider>>,
+    pub embed_dim: usize,
+}
+
+impl MemoryMcpServer {
+    pub fn new(
+        engine: Arc<MemoryEngine>,
+        embedder: Option<Arc<HttpEmbeddingProvider>>,
+        embed_dim: usize,
+    ) -> Self {
+        Self {
+            engine,
+            embedder,
+            embed_dim,
+        }
+    }
+
+    fn tool_definitions() -> Vec<Tool> {
+        tools::all_tool_definitions()
+    }
+}
+
+impl ServerHandler for MemoryMcpServer {
+    fn get_info(&self) -> InitializeResult {
+        let mut capabilities = ServerCapabilities::default();
+        capabilities.tools = Some(ToolsCapability {
+            list_changed: Some(false),
+        });
+        InitializeResult::new(capabilities)
+            .with_server_info(
+                Implementation::new("memory-engine-mcp", env!("CARGO_PKG_VERSION"))
+                    .with_description(
+                        "MCP server for memory-engine — durable long-term memory for AI agents",
+                    ),
+            )
+            .with_protocol_version(ProtocolVersion::V_2025_06_18)
+            .with_instructions(
+                "Memory engine MCP server. Tools: memory_ingest, memory_add_fact, memory_query, \
+             memory_resume_context, memory_list_due, memory_next_due_time, memory_explain_fact, \
+             memory_get_fact, memory_statistics, memory_flush_insights. \
+             Use depth=sparse|standard|full on query tools to control response verbosity.",
+            )
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, rmcp::model::ErrorData> {
+        Ok(ListToolsResult::with_all_items(Self::tool_definitions()))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::model::ErrorData> {
+        let name = request.name.clone();
+        let args = request.arguments.unwrap_or_default();
+
+        let engine = Arc::clone(&self.engine);
+        let embedder = self.embedder.clone();
+        let embed_dim = self.embed_dim;
+
+        // Dispatch to tool handlers on the blocking thread pool.
+        // Engine operations are sync (SQLite) — must not run on the async runtime.
+        let result = tokio::task::spawn_blocking(move || {
+            tools::dispatch(&name, args, &engine, embedder.as_deref(), embed_dim)
+        })
+        .await
+        .map_err(|e| {
+            rmcp::model::ErrorData::internal_error(
+                Cow::Owned(format!("task join error: {e}")),
+                None,
+            )
+        })??;
+
+        Ok(result)
+    }
+}

--- a/memory-engine-mcp/src/server.rs
+++ b/memory-engine-mcp/src/server.rs
@@ -1,0 +1,1 @@
+// Phase C1: MemoryMcpServer struct + ServerHandler impl.

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -438,10 +438,10 @@ fn handle_query(
 
     let mut query = memory_engine::MemoryQuery::new();
 
-    // Parse and validate search mode
-    let mode = match get_str(&args, "mode") {
-        Some(s) => parse_search_mode(&s)?,
-        None => SearchMode::Hybrid,
+    // Parse and validate search mode (if explicit)
+    let explicit_mode = match get_str(&args, "mode") {
+        Some(s) => Some(parse_search_mode(&s)?),
+        None => None,
     };
 
     // Parse embedding (with proper error on malformed input)
@@ -450,28 +450,40 @@ fn handle_query(
     if let Some(text) = get_str(&args, "text") {
         query = query.text(text.clone());
 
-        // For hybrid/vector mode, compute embedding from text
-        if mode != SearchMode::Fts {
+        // Determine effective mode for embedding decision
+        let needs_embedding = match explicit_mode {
+            Some(SearchMode::Fts) => false,
+            Some(SearchMode::Vector | SearchMode::Hybrid) => true,
+            None => true, // Default: try to provide embedding for hybrid if possible
+        };
+
+        if needs_embedding {
             if let Some(emb) = pre_emb {
                 query = query.embedding(emb);
             } else if let Some(emb_provider) = embedder {
                 let emb = emb_provider.embed(&text).map_err(to_mcp_error)?;
                 query = query.embedding(emb);
-            } else {
+            } else if explicit_mode.is_some() {
+                // User explicitly asked for vector/hybrid but no embedder available
                 return Err(ErrorData::invalid_params(
                     format!(
-                        "mode '{mode:?}' requires an embedding provider or pre-computed embedding"
+                        "mode '{:?}' requires an embedding provider or pre-computed embedding",
+                        explicit_mode.unwrap()
                     ),
                     None,
                 ));
             }
+            // If no explicit mode and no embedder, let engine infer FTS-only
         }
     } else if let Some(emb) = pre_emb {
         query = query.embedding(emb);
     }
 
-    // Explicitly set search mode — don't rely on engine inference
-    query = query.search_mode(mode);
+    // Only set search_mode when user explicitly requested one.
+    // Otherwise let the engine infer from available data (text, embedding, both).
+    if let Some(mode) = explicit_mode {
+        query = query.search_mode(mode);
+    }
 
     // Scope
     if let Some(scope) = get_str(&args, "scope") {

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1,0 +1,1 @@
+// Phase C2-C8: Tool handler modules.

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1,1 +1,658 @@
-// Phase C2-C8: Tool handler modules.
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use memory_engine::engine::MemoryEngine;
+use memory_engine::inspect_types::FactExplanation;
+use memory_engine::resume::ResumeConfig;
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine::types::{AddFactOptions, EventType, FactType, NewEvent};
+use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
+use serde_json::{Map, Value, json};
+
+use crate::depth::{self, Depth};
+use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
+use crate::error::{ValidationError, to_mcp_error};
+
+// ---------------------------------------------------------------------------
+// Tool definitions (JSON schemas)
+// ---------------------------------------------------------------------------
+
+/// Returns all P0 tool definitions with JSON schemas.
+pub fn all_tool_definitions() -> Vec<Tool> {
+    vec![
+        tool_def(
+            "memory_ingest",
+            "Append an event to the memory engine event log.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "event_type": { "type": "string", "enum": ["Interaction", "ToolCall", "MemoryOp", "SystemEvent"], "description": "Type of event" },
+                    "payload": { "description": "Event payload (arbitrary JSON)" },
+                    "source": { "type": "string", "description": "Event source identifier" },
+                    "session_id": { "type": "string", "description": "Session identifier (optional)" },
+                    "scope": { "type": "string", "description": "Scope path (e.g. '/project/x'). Created if missing." },
+                    "timestamp": { "type": "string", "format": "date-time", "description": "ISO 8601 timestamp. Defaults to now." }
+                },
+                "required": ["event_type", "payload", "source"]
+            }),
+        ),
+        tool_def(
+            "memory_add_fact",
+            "Add a fact to memory with server-side embedding.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": { "type": "string", "description": "Fact content text" },
+                    "fact_type": { "type": "string", "enum": ["Episodic", "Semantic", "Procedural"], "default": "Semantic" },
+                    "source_event_id": { "type": "integer", "description": "Link to source event" },
+                    "scope": { "type": "string", "description": "Scope path" },
+                    "importance": { "type": "number", "minimum": 0.0, "maximum": 1.0, "default": 0.5 },
+                    "metadata": { "description": "Arbitrary JSON metadata" },
+                    "t_valid": { "type": "string", "format": "date-time", "description": "Real-world validity start (future = scheduled memory)" },
+                    "t_invalid": { "type": "string", "format": "date-time", "description": "Real-world validity end" },
+                    "pinned": { "type": "boolean", "description": "Make this fact unforgettable" },
+                    "embedding": { "type": "array", "items": { "type": "number" }, "description": "Pre-computed embedding (bypasses server-side embedding)" }
+                },
+                "required": ["content"]
+            }),
+        ),
+        tool_def(
+            "memory_query",
+            "Search memory using hybrid FTS + vector retrieval.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "text": { "type": "string", "description": "Search query text" },
+                    "embedding": { "type": "array", "items": { "type": "number" }, "description": "Pre-computed query embedding" },
+                    "mode": { "type": "string", "enum": ["fts", "vector", "hybrid"], "default": "hybrid", "description": "Search mode" },
+                    "scope": { "type": "string" },
+                    "scope_mode": { "type": "string", "enum": ["exact", "subtree", "ancestors", "inherited"], "default": "subtree" },
+                    "period_start": { "type": "string", "format": "date-time" },
+                    "period_end": { "type": "string", "format": "date-time" },
+                    "fact_type": { "type": "string", "enum": ["Episodic", "Semantic", "Procedural"] },
+                    "min_importance": { "type": "number" },
+                    "pinned_only": { "type": "boolean", "default": false },
+                    "limit": { "type": "integer", "default": 10 },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                }
+            }),
+        ),
+        tool_def(
+            "memory_resume_context",
+            "Retrieve tiered cognitive boot context (5-tier: pinned → high-importance → due → recent → kb_stubs).",
+            json!({
+                "type": "object",
+                "properties": {
+                    "scope": { "type": "string" },
+                    "pinned_cap": { "type": "integer", "default": 50 },
+                    "high_importance_cap": { "type": "integer", "default": 20 },
+                    "high_importance_min": { "type": "number", "default": 0.7 },
+                    "due_cap": { "type": "integer", "default": 10 },
+                    "recent_cap": { "type": "integer", "default": 10 },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                }
+            }),
+        ),
+        tool_def(
+            "memory_list_due",
+            "List facts whose scheduled time (t_valid) has arrived.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "scope": { "type": "string" },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                }
+            }),
+        ),
+        tool_def(
+            "memory_next_due_time",
+            "Get the next scheduled fact time (for timer-based polling).",
+            json!({
+                "type": "object",
+                "properties": {
+                    "scope": { "type": "string" }
+                }
+            }),
+        ),
+        tool_def(
+            "memory_explain_fact",
+            "Explain a fact's state, provenance, and graph context.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "fact_id": { "type": "integer", "description": "Fact ID to explain" },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                },
+                "required": ["fact_id"]
+            }),
+        ),
+        tool_def(
+            "memory_get_fact",
+            "Retrieve a single fact by ID.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "fact_id": { "type": "integer", "description": "Fact ID" },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                },
+                "required": ["fact_id"]
+            }),
+        ),
+        tool_def(
+            "memory_statistics",
+            "Get aggregate engine statistics (facts, edges, scopes, storage).",
+            json!({
+                "type": "object",
+                "properties": {}
+            }),
+        ),
+        tool_def(
+            "memory_flush_insights",
+            "Batch-add insights before context window compaction.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "insights": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "content": { "type": "string" },
+                                "fact_type": { "type": "string", "enum": ["Episodic", "Semantic", "Procedural"], "default": "Semantic" },
+                                "scope": { "type": "string" },
+                                "importance": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+                                "metadata": { "description": "Arbitrary JSON metadata" }
+                            },
+                            "required": ["content"]
+                        },
+                        "description": "Array of insights to add as facts"
+                    }
+                },
+                "required": ["insights"]
+            }),
+        ),
+    ]
+}
+
+fn tool_def(name: &'static str, description: &'static str, schema: Value) -> Tool {
+    let schema_obj: Map<String, Value> = match schema {
+        Value::Object(m) => m,
+        _ => unreachable!("schema must be an object"),
+    };
+    Tool::new(name, description, Arc::new(schema_obj))
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/// Route a tool call to the appropriate handler.
+pub fn dispatch(
+    name: &str,
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+    embedder: Option<&HttpEmbeddingProvider>,
+    embed_dim: usize,
+) -> Result<CallToolResult, ErrorData> {
+    match name {
+        "memory_ingest" => handle_ingest(args, engine),
+        "memory_add_fact" => handle_add_fact(args, engine, embedder, embed_dim),
+        "memory_query" => handle_query(args, engine, embedder),
+        "memory_resume_context" => handle_resume_context(args, engine),
+        "memory_list_due" => handle_list_due(args, engine),
+        "memory_next_due_time" => handle_next_due_time(args, engine),
+        "memory_explain_fact" => handle_explain_fact(args, engine),
+        "memory_get_fact" => handle_get_fact(args, engine),
+        "memory_statistics" => handle_statistics(engine),
+        "memory_flush_insights" => handle_flush_insights(args, engine, embedder),
+        _ => Err(ErrorData::invalid_params(
+            format!("unknown tool: {name}"),
+            None,
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn get_str(args: &Map<String, Value>, key: &str) -> Option<String> {
+    args.get(key).and_then(Value::as_str).map(String::from)
+}
+
+fn get_i64(args: &Map<String, Value>, key: &str) -> Option<i64> {
+    args.get(key).and_then(Value::as_i64)
+}
+
+fn get_f64(args: &Map<String, Value>, key: &str) -> Option<f64> {
+    args.get(key).and_then(Value::as_f64)
+}
+
+fn get_bool(args: &Map<String, Value>, key: &str) -> Option<bool> {
+    args.get(key).and_then(Value::as_bool)
+}
+
+fn get_usize(args: &Map<String, Value>, key: &str) -> Option<usize> {
+    get_i64(args, key).and_then(|v| usize::try_from(v).ok())
+}
+
+fn get_datetime(args: &Map<String, Value>, key: &str) -> Result<Option<DateTime<Utc>>, ErrorData> {
+    match get_str(args, key) {
+        Some(s) => s
+            .parse::<DateTime<Utc>>()
+            .map(Some)
+            .map_err(|e| ErrorData::invalid_params(format!("invalid {key}: {e}"), None)),
+        None => Ok(None),
+    }
+}
+
+fn get_depth(args: &Map<String, Value>) -> Depth {
+    get_str(args, "depth")
+        .and_then(|s| match s.as_str() {
+            "sparse" => Some(Depth::Sparse),
+            "standard" => Some(Depth::Standard),
+            "full" => Some(Depth::Full),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+fn parse_event_type(s: &str) -> Result<EventType, ValidationError> {
+    match s {
+        "Interaction" => Ok(EventType::Interaction),
+        "ToolCall" => Ok(EventType::ToolCall),
+        "MemoryOp" => Ok(EventType::MemoryOp),
+        "SystemEvent" => Ok(EventType::SystemEvent),
+        other => Err(ValidationError::UnknownEventType(other.to_owned())),
+    }
+}
+
+fn parse_fact_type(s: &str) -> Result<FactType, ValidationError> {
+    match s {
+        "Episodic" => Ok(FactType::Episodic),
+        "Semantic" => Ok(FactType::Semantic),
+        "Procedural" => Ok(FactType::Procedural),
+        other => Err(ValidationError::UnknownFactType(other.to_owned())),
+    }
+}
+
+fn ok_json(value: Value) -> Result<CallToolResult, ErrorData> {
+    Ok(CallToolResult::success(vec![Content::json(value)?]))
+}
+
+// ---------------------------------------------------------------------------
+// Tool handlers
+// ---------------------------------------------------------------------------
+
+fn handle_ingest(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let event_type_str = get_str(&args, "event_type")
+        .ok_or_else(|| ErrorData::invalid_params("missing event_type", None))?;
+    let event_type = parse_event_type(&event_type_str)?;
+    let payload = args.get("payload").cloned().unwrap_or(json!({}));
+    let source = get_str(&args, "source")
+        .ok_or_else(|| ErrorData::invalid_params("missing source", None))?;
+    let session_id = get_str(&args, "session_id");
+    let timestamp = get_datetime(&args, "timestamp")?.unwrap_or_else(Utc::now);
+
+    let scope_id = match get_str(&args, "scope") {
+        Some(path) => engine.ensure_scope_path(&path).map_err(to_mcp_error)?,
+        None => 1, // root scope
+    };
+
+    let event = NewEvent {
+        timestamp,
+        event_type,
+        payload,
+        source,
+        session_id,
+        scope_id,
+        origin_node_id: "mcp".to_owned(),
+        sequence_id: 0,
+        created_at: None,
+    };
+
+    let event_id = engine.ingest(&event).map_err(to_mcp_error)?;
+    ok_json(json!({ "event_id": event_id }))
+}
+
+fn handle_add_fact(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+    embedder: Option<&HttpEmbeddingProvider>,
+    embed_dim: usize,
+) -> Result<CallToolResult, ErrorData> {
+    let content = get_str(&args, "content")
+        .ok_or_else(|| ErrorData::invalid_params("missing content", None))?;
+    let fact_type = match get_str(&args, "fact_type") {
+        Some(s) => parse_fact_type(&s)?,
+        None => FactType::Semantic,
+    };
+    let source_event_id = get_i64(&args, "source_event_id");
+    let scope = get_str(&args, "scope");
+
+    // Validate importance range
+    let importance = get_f64(&args, "importance");
+    if let Some(imp) = importance {
+        if !(0.0..=1.0).contains(&imp) {
+            return Err(ValidationError::ImportanceOutOfRange(imp).into());
+        }
+    }
+
+    // Validate temporal consistency
+    let t_valid = get_datetime(&args, "t_valid")?;
+    let t_invalid = get_datetime(&args, "t_invalid")?;
+    if let (Some(tv), Some(ti)) = (t_valid, t_invalid) {
+        if tv >= ti {
+            return Err(ValidationError::TemporalInconsistency.into());
+        }
+    }
+
+    let pinned = get_bool(&args, "pinned");
+    let metadata = args.get("metadata").cloned();
+
+    // Pre-computed embedding or server-side embedding
+    let pre_computed: Option<Vec<f32>> = args
+        .get("embedding")
+        .and_then(|v| serde_json::from_value::<Vec<f32>>(v.clone()).ok());
+
+    if let Some(ref emb) = pre_computed {
+        if emb.len() != embed_dim {
+            return Err(ValidationError::EmbeddingDimension {
+                expected: embed_dim,
+                actual: emb.len(),
+            }
+            .into());
+        }
+    }
+
+    let opts = AddFactOptions {
+        importance,
+        metadata,
+        t_valid,
+        t_invalid,
+        pinned,
+        ..Default::default()
+    };
+
+    let fact_id = if let Some(emb) = pre_computed {
+        let passthrough = PassthroughEmbedder::new(emb);
+        engine
+            .add_fact(
+                &content,
+                fact_type,
+                source_event_id,
+                &passthrough,
+                scope.as_deref(),
+                Some(&opts),
+                None,
+            )
+            .map_err(to_mcp_error)?
+    } else {
+        let emb = embedder.ok_or(ValidationError::NoEmbeddingProvider)?;
+        engine
+            .add_fact(
+                &content,
+                fact_type,
+                source_event_id,
+                emb,
+                scope.as_deref(),
+                Some(&opts),
+                None,
+            )
+            .map_err(to_mcp_error)?
+    };
+
+    ok_json(json!({ "fact_id": fact_id }))
+}
+
+fn handle_query(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+    embedder: Option<&HttpEmbeddingProvider>,
+) -> Result<CallToolResult, ErrorData> {
+    let depth_level = get_depth(&args);
+
+    let mut query = memory_engine::MemoryQuery::new();
+
+    if let Some(text) = get_str(&args, "text") {
+        query = query.text(text.clone());
+
+        // For hybrid/vector mode, compute embedding from text
+        let mode = get_str(&args, "mode").unwrap_or_else(|| "hybrid".to_owned());
+        if mode != "fts" {
+            // Try pre-computed embedding first
+            if let Some(emb) = args
+                .get("embedding")
+                .and_then(|v| serde_json::from_value::<Vec<f32>>(v.clone()).ok())
+            {
+                query = query.embedding(emb);
+            } else if let Some(emb_provider) = embedder {
+                let emb = emb_provider.embed(&text).map_err(to_mcp_error)?;
+                query = query.embedding(emb);
+            }
+            // If no embedder and no pre-computed, fall through — engine will do FTS-only
+        }
+    } else if let Some(emb) = args
+        .get("embedding")
+        .and_then(|v| serde_json::from_value::<Vec<f32>>(v.clone()).ok())
+    {
+        // Vector-only query with pre-computed embedding
+        query = query.embedding(emb);
+    }
+
+    // Scope
+    if let Some(scope) = get_str(&args, "scope") {
+        let scope_mode = get_str(&args, "scope_mode").unwrap_or_else(|| "subtree".to_owned());
+        query = match scope_mode.as_str() {
+            "exact" => query.scope_exact(scope),
+            "ancestors" => query.scope_ancestors(scope),
+            "inherited" => query.scope_inherited(scope),
+            _ => query.scope_subtree(scope),
+        };
+    }
+
+    // Temporal filters
+    if let (Some(start), Some(end)) = (
+        get_datetime(&args, "period_start")?,
+        get_datetime(&args, "period_end")?,
+    ) {
+        query = query.period(start, end);
+    }
+
+    if let Some(ft) = get_str(&args, "fact_type") {
+        query = query.fact_type(parse_fact_type(&ft)?);
+    }
+    if let Some(min) = get_f64(&args, "min_importance") {
+        query = query.min_importance_score(min);
+    }
+    if get_bool(&args, "pinned_only").unwrap_or(false) {
+        query = query.pinned_only();
+    }
+    if let Some(limit) = get_usize(&args, "limit") {
+        query = query.limit(limit);
+    }
+
+    let results = engine.execute_query(&query).map_err(to_mcp_error)?;
+
+    let shaped: Vec<Value> = results
+        .iter()
+        .map(|r| depth::shape_search_result(r, depth_level, None))
+        .collect();
+
+    ok_json(json!({ "results": shaped, "count": shaped.len() }))
+}
+
+fn handle_resume_context(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let depth_level = get_depth(&args);
+
+    let config = ResumeConfig {
+        scope_path: get_str(&args, "scope"),
+        now: Utc::now(),
+        pinned_cap: get_usize(&args, "pinned_cap").unwrap_or(50),
+        high_importance_cap: get_usize(&args, "high_importance_cap").unwrap_or(20),
+        high_importance_min: get_f64(&args, "high_importance_min").unwrap_or(0.7),
+        due_cap: get_usize(&args, "due_cap").unwrap_or(10),
+        recent_cap: get_usize(&args, "recent_cap").unwrap_or(10),
+    };
+
+    let ctx = engine.resume_context(&config).map_err(to_mcp_error)?;
+    let shaped = depth::shape_resume_context(&ctx, depth_level);
+
+    ok_json(shaped)
+}
+
+fn handle_list_due(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let depth_level = get_depth(&args);
+    let scope = get_str(&args, "scope");
+
+    let facts = engine
+        .list_due(Utc::now(), scope.as_deref())
+        .map_err(to_mcp_error)?;
+
+    let shaped: Vec<Value> = facts
+        .iter()
+        .map(|f| depth::shape_fact(f, depth_level, None))
+        .collect();
+
+    ok_json(json!({ "facts": shaped, "count": shaped.len() }))
+}
+
+fn handle_next_due_time(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let scope = get_str(&args, "scope");
+    let next = engine
+        .next_due_time(scope.as_deref())
+        .map_err(to_mcp_error)?;
+
+    ok_json(json!({ "next_due": next }))
+}
+
+fn handle_explain_fact(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let fact_id = get_i64(&args, "fact_id")
+        .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
+    let depth_level = get_depth(&args);
+
+    let explanation: FactExplanation = engine.explain_fact(fact_id).map_err(to_mcp_error)?;
+    let shaped = depth::shape_explanation(&explanation, depth_level);
+
+    ok_json(shaped)
+}
+
+fn handle_get_fact(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let fact_id = get_i64(&args, "fact_id")
+        .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
+    let depth_level = get_depth(&args);
+
+    let fact = engine.get_fact(fact_id).map_err(to_mcp_error)?;
+    let shaped = depth::shape_fact(&fact, depth_level, None);
+
+    ok_json(shaped)
+}
+
+fn handle_statistics(engine: &MemoryEngine) -> Result<CallToolResult, ErrorData> {
+    let stats = engine.statistics().map_err(to_mcp_error)?;
+    let value = serde_json::to_value(&stats)
+        .map_err(|e| ErrorData::internal_error(format!("serialize stats: {e}"), None))?;
+    ok_json(value)
+}
+
+fn handle_flush_insights(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+    embedder: Option<&HttpEmbeddingProvider>,
+) -> Result<CallToolResult, ErrorData> {
+    let insights = args
+        .get("insights")
+        .and_then(Value::as_array)
+        .ok_or_else(|| ErrorData::invalid_params("missing insights array", None))?;
+
+    let emb = embedder.ok_or(ErrorData::invalid_params(
+        "embedding provider not configured — required for flush_insights",
+        None,
+    ))?;
+
+    let mut fact_ids = Vec::new();
+    let mut failed = Vec::new();
+
+    for (i, insight) in insights.iter().enumerate() {
+        let obj = match insight.as_object() {
+            Some(o) => o,
+            None => {
+                failed.push(json!({ "index": i, "error": "not an object" }));
+                continue;
+            }
+        };
+
+        let content = match get_str(obj, "content") {
+            Some(c) => c,
+            None => {
+                failed.push(json!({ "index": i, "error": "missing content" }));
+                continue;
+            }
+        };
+
+        let fact_type = match get_str(obj, "fact_type") {
+            Some(s) => match parse_fact_type(&s) {
+                Ok(ft) => ft,
+                Err(e) => {
+                    failed.push(json!({ "index": i, "error": e.to_string() }));
+                    continue;
+                }
+            },
+            None => FactType::Semantic,
+        };
+
+        let scope = get_str(obj, "scope");
+        let importance = get_f64(obj, "importance");
+
+        let mut metadata = obj.get("metadata").cloned().unwrap_or(json!({}));
+        if let Value::Object(ref mut m) = metadata {
+            m.insert("source".to_owned(), json!("pre_compaction_flush"));
+        }
+
+        let opts = AddFactOptions {
+            importance,
+            metadata: Some(metadata),
+            ..Default::default()
+        };
+
+        match engine.add_fact(
+            &content,
+            fact_type,
+            None,
+            emb,
+            scope.as_deref(),
+            Some(&opts),
+            None,
+        ) {
+            Ok(id) => fact_ids.push(id),
+            Err(e) => {
+                failed.push(json!({ "index": i, "error": e.to_string() }));
+            }
+        }
+    }
+
+    ok_json(json!({
+        "fact_ids": fact_ids,
+        "added": fact_ids.len(),
+        "failed": failed,
+        "failed_count": failed.len(),
+    }))
+}

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -463,12 +463,11 @@ fn handle_query(
             } else if let Some(emb_provider) = embedder {
                 let emb = emb_provider.embed(&text).map_err(to_mcp_error)?;
                 query = query.embedding(emb);
-            } else if explicit_mode.is_some() {
+            } else if let Some(mode) = explicit_mode {
                 // User explicitly asked for vector/hybrid but no embedder available
                 return Err(ErrorData::invalid_params(
                     format!(
-                        "mode '{:?}' requires an embedding provider or pre-computed embedding",
-                        explicit_mode.unwrap()
+                        "mode '{mode:?}' requires an embedding provider or pre-computed embedding"
                     ),
                     None,
                 ));

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use memory_engine::engine::MemoryEngine;
 use memory_engine::inspect_types::FactExplanation;
 use memory_engine::resume::ResumeConfig;
+use memory_engine::search::hybrid::SearchMode;
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactOptions, EventType, FactType, NewEvent};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
@@ -30,7 +31,7 @@ pub fn all_tool_definitions() -> Vec<Tool> {
                     "payload": { "description": "Event payload (arbitrary JSON)" },
                     "source": { "type": "string", "description": "Event source identifier" },
                     "session_id": { "type": "string", "description": "Session identifier (optional)" },
-                    "scope": { "type": "string", "description": "Scope path (e.g. '/project/x'). Created if missing." },
+                    "scope": { "type": "string", "description": "Scope path (e.g. 'project/x'). Created if missing. No leading slash." },
                     "timestamp": { "type": "string", "format": "date-time", "description": "ISO 8601 timestamp. Defaults to now." }
                 },
                 "required": ["event_type", "payload", "source"]
@@ -257,6 +258,28 @@ fn get_depth(args: &Map<String, Value>) -> Depth {
         .unwrap_or_default()
 }
 
+/// Parse an embedding from a JSON value, returning an error if present but malformed.
+fn parse_embedding(args: &Map<String, Value>) -> Result<Option<Vec<f32>>, ErrorData> {
+    match args.get("embedding") {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => serde_json::from_value::<Vec<f32>>(v.clone())
+            .map(Some)
+            .map_err(|e| ErrorData::invalid_params(format!("invalid embedding: {e}"), None)),
+    }
+}
+
+fn parse_search_mode(s: &str) -> Result<SearchMode, ErrorData> {
+    match s {
+        "fts" => Ok(SearchMode::Fts),
+        "vector" => Ok(SearchMode::Vector),
+        "hybrid" => Ok(SearchMode::Hybrid),
+        other => Err(ErrorData::invalid_params(
+            format!("unknown search mode: {other}"),
+            None,
+        )),
+    }
+}
+
 fn parse_event_type(s: &str) -> Result<EventType, ValidationError> {
     match s {
         "Interaction" => Ok(EventType::Interaction),
@@ -354,9 +377,7 @@ fn handle_add_fact(
     let metadata = args.get("metadata").cloned();
 
     // Pre-computed embedding or server-side embedding
-    let pre_computed: Option<Vec<f32>> = args
-        .get("embedding")
-        .and_then(|v| serde_json::from_value::<Vec<f32>>(v.clone()).ok());
+    let pre_computed = parse_embedding(&args)?;
 
     if let Some(ref emb) = pre_computed {
         if emb.len() != embed_dim {
@@ -417,31 +438,40 @@ fn handle_query(
 
     let mut query = memory_engine::MemoryQuery::new();
 
+    // Parse and validate search mode
+    let mode = match get_str(&args, "mode") {
+        Some(s) => parse_search_mode(&s)?,
+        None => SearchMode::Hybrid,
+    };
+
+    // Parse embedding (with proper error on malformed input)
+    let pre_emb = parse_embedding(&args)?;
+
     if let Some(text) = get_str(&args, "text") {
         query = query.text(text.clone());
 
         // For hybrid/vector mode, compute embedding from text
-        let mode = get_str(&args, "mode").unwrap_or_else(|| "hybrid".to_owned());
-        if mode != "fts" {
-            // Try pre-computed embedding first
-            if let Some(emb) = args
-                .get("embedding")
-                .and_then(|v| serde_json::from_value::<Vec<f32>>(v.clone()).ok())
-            {
+        if mode != SearchMode::Fts {
+            if let Some(emb) = pre_emb {
                 query = query.embedding(emb);
             } else if let Some(emb_provider) = embedder {
                 let emb = emb_provider.embed(&text).map_err(to_mcp_error)?;
                 query = query.embedding(emb);
+            } else {
+                return Err(ErrorData::invalid_params(
+                    format!(
+                        "mode '{mode:?}' requires an embedding provider or pre-computed embedding"
+                    ),
+                    None,
+                ));
             }
-            // If no embedder and no pre-computed, fall through — engine will do FTS-only
         }
-    } else if let Some(emb) = args
-        .get("embedding")
-        .and_then(|v| serde_json::from_value::<Vec<f32>>(v.clone()).ok())
-    {
-        // Vector-only query with pre-computed embedding
+    } else if let Some(emb) = pre_emb {
         query = query.embedding(emb);
     }
+
+    // Explicitly set search mode — don't rely on engine inference
+    query = query.search_mode(mode);
 
     // Scope
     if let Some(scope) = get_str(&args, "scope") {
@@ -454,12 +484,20 @@ fn handle_query(
         };
     }
 
-    // Temporal filters
-    if let (Some(start), Some(end)) = (
-        get_datetime(&args, "period_start")?,
-        get_datetime(&args, "period_end")?,
-    ) {
-        query = query.period(start, end);
+    // Temporal filters — reject one-sided periods
+    let period_start = get_datetime(&args, "period_start")?;
+    let period_end = get_datetime(&args, "period_end")?;
+    match (period_start, period_end) {
+        (Some(start), Some(end)) => {
+            query = query.period(start, end);
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(ErrorData::invalid_params(
+                "both period_start and period_end must be provided, or neither",
+                None,
+            ));
+        }
+        (None, None) => {}
     }
 
     if let Some(ft) = get_str(&args, "fact_type") {
@@ -621,6 +659,13 @@ fn handle_flush_insights(
 
         let scope = get_str(obj, "scope");
         let importance = get_f64(obj, "importance");
+
+        if let Some(imp) = importance {
+            if !(0.0..=1.0).contains(&imp) {
+                failed.push(json!({ "index": i, "error": format!("importance must be in [0.0, 1.0], got {imp}") }));
+                continue;
+            }
+        }
 
         let mut metadata = obj.get("metadata").cloned().unwrap_or(json!({}));
         if let Value::Object(ref mut m) = metadata {

--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -453,11 +453,7 @@ mod tests {
     }
 
     fn opt(s: &str) -> Option<String> {
-        if s.is_empty() {
-            None
-        } else {
-            Some(s.into())
-        }
+        if s.is_empty() { None } else { Some(s.into()) }
     }
 
     fn user_entry(uuid: &str, parent: &str, text: &str, secs: i64) -> SessionEntry {
@@ -703,9 +699,11 @@ mod tests {
         let episodes = keyword_prefilter(&[turn], "s1");
         assert_eq!(episodes.len(), 1);
         assert_eq!(episodes[0].category, EpisodeCategory::Bug);
-        assert!(episodes[0]
-            .matched_keywords
-            .contains(&"root cause".to_owned()));
+        assert!(
+            episodes[0]
+                .matched_keywords
+                .contains(&"root cause".to_owned())
+        );
     }
 
     #[test]
@@ -732,9 +730,11 @@ mod tests {
         let episodes = keyword_prefilter(&[turn], "s1");
         assert_eq!(episodes.len(), 1);
         assert_eq!(episodes[0].category, EpisodeCategory::Convention);
-        assert!(episodes[0]
-            .matched_keywords
-            .contains(&"always use".to_owned()));
+        assert!(
+            episodes[0]
+                .matched_keywords
+                .contains(&"always use".to_owned())
+        );
     }
 
     #[test]
@@ -743,9 +743,11 @@ mod tests {
         let episodes = keyword_prefilter(&[turn], "s1");
         assert_eq!(episodes.len(), 1);
         assert_eq!(episodes[0].category, EpisodeCategory::Learning);
-        assert!(episodes[0]
-            .matched_keywords
-            .contains(&"turns out".to_owned()));
+        assert!(
+            episodes[0]
+                .matched_keywords
+                .contains(&"turns out".to_owned())
+        );
     }
 
     #[test]

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::graph::{EdgeData, MemoryGraph};

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::graph::MemoryGraph;
 use crate::pool::ConnectionPool;
 use crate::resume::context::{ResumeConfig, ResumeContext};
 use crate::scope::ScopeTree;
-use crate::search::hybrid::{hybrid_search, MatchType, SearchMode, SearchQuery, SearchResult};
+use crate::search::hybrid::{MatchType, SearchMode, SearchQuery, SearchResult, hybrid_search};
 use crate::search::query::MemoryQuery;
 use crate::search::strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
 use crate::store::events::EventStore;
@@ -2651,9 +2651,11 @@ mod tests {
 
         let results = engine.execute_query(&MemoryQuery::new()).unwrap();
         assert_eq!(results.len(), 2);
-        assert!(results
-            .iter()
-            .all(|r| r.match_type == MatchType::ImportanceRank));
+        assert!(
+            results
+                .iter()
+                .all(|r| r.match_type == MatchType::ImportanceRank)
+        );
     }
 
     #[test]
@@ -2760,9 +2762,11 @@ mod tests {
             .unwrap();
         // fact_type filtering in store path — list_by_importance_score doesn't filter by fact_type,
         // so it should be post-filtered
-        assert!(results
-            .iter()
-            .all(|r| r.fact.fact_type == FactType::Semantic));
+        assert!(
+            results
+                .iter()
+                .all(|r| r.fact.fact_type == FactType::Semantic)
+        );
     }
 
     #[test]
@@ -3619,12 +3623,16 @@ mod tests {
         assert_eq!(co_edges.len(), 2);
 
         // Both directions present
-        assert!(co_edges
-            .iter()
-            .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2));
-        assert!(co_edges
-            .iter()
-            .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1));
+        assert!(
+            co_edges
+                .iter()
+                .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2)
+        );
+        assert!(
+            co_edges
+                .iter()
+                .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1)
+        );
 
         // Weight matches constant
         for e in &co_edges {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::graph::MemoryGraph;
 use crate::pool::ConnectionPool;
 use crate::resume::context::{ResumeConfig, ResumeContext};
 use crate::scope::ScopeTree;
-use crate::search::hybrid::{hybrid_search, MatchType, SearchMode, SearchQuery, SearchResult};
+use crate::search::hybrid::{MatchType, SearchMode, SearchQuery, SearchResult, hybrid_search};
 use crate::search::query::MemoryQuery;
 use crate::search::strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
 use crate::store::events::EventStore;
@@ -1163,6 +1163,29 @@ impl MemoryEngine {
         self.pool.is_file_backed()
     }
 
+    // --- Public API: Scope management ---
+
+    /// Ensure the given scope path exists, creating missing segments as needed.
+    ///
+    /// Returns the scope id of the leaf node. This is side-effecting: missing
+    /// intermediate path segments are created in the database and the in-memory
+    /// scope tree is updated.
+    ///
+    /// Mirrors the scope resolution logic in [`add_fact()`] — both call sites
+    /// must stay in sync.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on insert failure.
+    pub fn ensure_scope_path(&self, path: &str) -> Result<i64> {
+        let conn = self.write_conn();
+        let scope_store = ScopeStore::new(&conn);
+        let id = scope_store.ensure_path(path)?;
+        let node = scope_store.get(id)?;
+        self.scope_tree.write().insert(node);
+        Ok(id)
+    }
+
     // --- Public API: Direct data access ---
 
     /// Get a fact by id.
@@ -1540,9 +1563,8 @@ impl MemoryEngine {
             });
         }
 
-        Self::open(config).map_err(|e| {
+        Self::open(config).inspect_err(|_| {
             let _ = std::fs::remove_file(&config.path);
-            e
         })
     }
 
@@ -2630,9 +2652,11 @@ mod tests {
 
         let results = engine.execute_query(&MemoryQuery::new()).unwrap();
         assert_eq!(results.len(), 2);
-        assert!(results
-            .iter()
-            .all(|r| r.match_type == MatchType::ImportanceRank));
+        assert!(
+            results
+                .iter()
+                .all(|r| r.match_type == MatchType::ImportanceRank)
+        );
     }
 
     #[test]
@@ -2739,9 +2763,11 @@ mod tests {
             .unwrap();
         // fact_type filtering in store path — list_by_importance_score doesn't filter by fact_type,
         // so it should be post-filtered
-        assert!(results
-            .iter()
-            .all(|r| r.fact.fact_type == FactType::Semantic));
+        assert!(
+            results
+                .iter()
+                .all(|r| r.fact.fact_type == FactType::Semantic)
+        );
     }
 
     #[test]
@@ -3598,12 +3624,16 @@ mod tests {
         assert_eq!(co_edges.len(), 2);
 
         // Both directions present
-        assert!(co_edges
-            .iter()
-            .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2));
-        assert!(co_edges
-            .iter()
-            .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1));
+        assert!(
+            co_edges
+                .iter()
+                .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2)
+        );
+        assert!(
+            co_edges
+                .iter()
+                .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1)
+        );
 
         // Weight matches constant
         for e in &co_edges {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::graph::MemoryGraph;
 use crate::pool::ConnectionPool;
 use crate::resume::context::{ResumeConfig, ResumeContext};
 use crate::scope::ScopeTree;
-use crate::search::hybrid::{MatchType, SearchMode, SearchQuery, SearchResult, hybrid_search};
+use crate::search::hybrid::{hybrid_search, MatchType, SearchMode, SearchQuery, SearchResult};
 use crate::search::query::MemoryQuery;
 use crate::search::strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
 use crate::store::events::EventStore;
@@ -348,6 +348,18 @@ impl MemoryEngine {
         self.pool.try_write()
     }
 
+    /// Ensure a scope path exists using an already-held connection.
+    ///
+    /// Shared helper for [`ensure_scope_path()`] and [`add_fact()`] to avoid
+    /// duplicating scope resolution logic.
+    fn ensure_scope_with_conn(&self, conn: &Connection, path: &str) -> Result<i64> {
+        let scope_store = ScopeStore::new(conn);
+        let id = scope_store.ensure_path(path)?;
+        let node = scope_store.get(id)?;
+        self.scope_tree.write().insert(node);
+        Ok(id)
+    }
+
     // --- Public API: Ingest ---
 
     /// Append an event to the event log. Returns the assigned event id.
@@ -427,13 +439,7 @@ impl MemoryEngine {
         let fact_id = {
             let conn = self.write_conn()?;
             let scope_id = match scope {
-                Some(path) => {
-                    let scope_store = ScopeStore::new(&conn);
-                    let id = scope_store.ensure_path(path)?;
-                    let node = scope_store.get(id)?;
-                    self.scope_tree.write().insert(node);
-                    id
-                }
+                Some(path) => self.ensure_scope_with_conn(&conn, path)?,
                 None => 1, // root scope
             };
 
@@ -1171,19 +1177,12 @@ impl MemoryEngine {
     /// intermediate path segments are created in the database and the in-memory
     /// scope tree is updated.
     ///
-    /// Mirrors the scope resolution logic in [`add_fact()`] — both call sites
-    /// must stay in sync.
-    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on insert failure.
     pub fn ensure_scope_path(&self, path: &str) -> Result<i64> {
         let conn = self.write_conn();
-        let scope_store = ScopeStore::new(&conn);
-        let id = scope_store.ensure_path(path)?;
-        let node = scope_store.get(id)?;
-        self.scope_tree.write().insert(node);
-        Ok(id)
+        self.ensure_scope_with_conn(&conn, path)
     }
 
     // --- Public API: Direct data access ---
@@ -2652,11 +2651,9 @@ mod tests {
 
         let results = engine.execute_query(&MemoryQuery::new()).unwrap();
         assert_eq!(results.len(), 2);
-        assert!(
-            results
-                .iter()
-                .all(|r| r.match_type == MatchType::ImportanceRank)
-        );
+        assert!(results
+            .iter()
+            .all(|r| r.match_type == MatchType::ImportanceRank));
     }
 
     #[test]
@@ -2763,11 +2760,9 @@ mod tests {
             .unwrap();
         // fact_type filtering in store path — list_by_importance_score doesn't filter by fact_type,
         // so it should be post-filtered
-        assert!(
-            results
-                .iter()
-                .all(|r| r.fact.fact_type == FactType::Semantic)
-        );
+        assert!(results
+            .iter()
+            .all(|r| r.fact.fact_type == FactType::Semantic));
     }
 
     #[test]
@@ -3624,16 +3619,12 @@ mod tests {
         assert_eq!(co_edges.len(), 2);
 
         // Both directions present
-        assert!(
-            co_edges
-                .iter()
-                .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2)
-        );
-        assert!(
-            co_edges
-                .iter()
-                .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1)
-        );
+        assert!(co_edges
+            .iter()
+            .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2));
+        assert!(co_edges
+            .iter()
+            .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1));
 
         // Weight matches constant
         for e in &co_edges {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1181,7 +1181,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::Database` on insert failure.
     pub fn ensure_scope_path(&self, path: &str) -> Result<i64> {
-        let conn = self.write_conn();
+        let conn = self.write_conn()?;
         self.ensure_scope_with_conn(&conn, path)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,9 @@ pub enum MemoryError {
     #[error("connection pool error: {0}")]
     Pool(String),
 
-    #[error("unsupported storage epoch: database is epoch {db_epoch}, this library supports epoch {supported_epoch}")]
+    #[error(
+        "unsupported storage epoch: database is epoch {db_epoch}, this library supports epoch {supported_epoch}"
+    )]
     UnsupportedEpoch { db_epoch: u16, supported_epoch: u16 },
 
     #[error("internal error: {0}")]

--- a/src/inspect/dump.rs
+++ b/src/inspect/dump.rs
@@ -7,13 +7,13 @@ use rusqlite::Connection;
 use serde::Serialize;
 
 use crate::error::{MemoryError, Result};
+use crate::store::UpcasterRegistry;
 use crate::store::edges::EdgeStore;
 use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
 use crate::store::schema::{get_config, list_config};
 use crate::store::scopes::ScopeStore;
 use crate::store::summaries::SummaryStore;
-use crate::store::UpcasterRegistry;
 
 /// Build a sibling temporary path for atomic write-then-rename.
 fn tmp_path(path: &Path) -> std::path::PathBuf {

--- a/src/inspect/replay.rs
+++ b/src/inspect/replay.rs
@@ -21,8 +21,8 @@ pub fn to_event_filter(filter: &ReplayFilter) -> EventFilter {
 mod tests {
     use super::*;
     use crate::engine::MemoryEngine;
-    use crate::store::events::EventStore;
     use crate::store::UpcasterRegistry;
+    use crate::store::events::EventStore;
     use crate::types::{EventType, NewEvent};
     use chrono::Utc;
 

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -11,7 +11,7 @@ use rusqlite::Connection;
 
 use crate::error::{MemoryError, Result};
 use crate::store::events::event_type_to_str;
-use crate::store::schema::{set_config, CURRENT_SCHEMA_VERSION, STORAGE_EPOCH};
+use crate::store::schema::{CURRENT_SCHEMA_VERSION, STORAGE_EPOCH, set_config};
 use crate::store::serialize_embedding;
 
 use super::types::EngineSnapshot;
@@ -429,7 +429,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.gz");
         // Write minimal gzip header
-        std::fs::write(&path, &[0x1f, 0x8b, 0x08, 0x00]).unwrap();
+        std::fs::write(&path, [0x1f, 0x8b, 0x08, 0x00]).unwrap();
         let mut f = File::open(&path).unwrap();
         assert_eq!(detect_compression(&mut f).unwrap(), Compression::Gzip);
     }
@@ -439,7 +439,7 @@ mod tests {
     fn detect_zstd_magic() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.zst");
-        std::fs::write(&path, &[0x28, 0xb5, 0x2f, 0xfd]).unwrap();
+        std::fs::write(&path, [0x28, 0xb5, 0x2f, 0xfd]).unwrap();
         let mut f = File::open(&path).unwrap();
         assert_eq!(detect_compression(&mut f).unwrap(), Compression::Zstd);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,11 @@ pub mod store;
 pub mod traits;
 pub mod types;
 
-pub use engine::{EngineConfig, MemoryEngine};
-pub use inspect::types as inspect_types;
-pub use error::*;
-pub use search::MemoryQuery;
-pub use store::{deserialize_embedding, serialize_embedding, UpcasterRegistry};
 pub use bootstrap::{BootstrapConfig, BootstrapReport, KeywordExtractor, SessionExtractor};
+pub use engine::{EngineConfig, MemoryEngine};
+pub use error::*;
+pub use inspect::types as inspect_types;
+pub use search::MemoryQuery;
+pub use store::{UpcasterRegistry, deserialize_embedding, serialize_embedding};
 pub use traits::{EmbeddingProvider, Reranker};
 pub use types::*;

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -8,7 +8,7 @@ use crate::store::facts::FactStore;
 use crate::types::Fact;
 
 /// Configuration for [`resume_context`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResumeConfig {
     /// Scope path to resume from. None = root only.
     pub scope_path: Option<String>,
@@ -41,7 +41,7 @@ impl Default for ResumeConfig {
 }
 
 /// Result of [`resume_context`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResumeContext {
     /// Pinned (unforgettable) facts — agent identity, core beliefs.
     pub pinned: Vec<Fact>,

--- a/src/search/ann.rs
+++ b/src/search/ann.rs
@@ -340,8 +340,8 @@ mod tests {
     #[test]
     fn hnsw_spike_basic_search() {
         use hnsw::{Hnsw, Searcher};
-        use rand::rngs::SmallRng;
         use rand::SeedableRng;
+        use rand::rngs::SmallRng;
         use space::Neighbor;
 
         // Build a small index: 5 vectors, dim=4, M=8, M0=16

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -10,8 +10,8 @@ pub mod vector;
 
 #[cfg(feature = "ann")]
 pub use ann::HnswStrategy;
-pub use fts::{fts_search, FtsResult};
-pub use hybrid::{hybrid_search, rrf_merge, MatchType, SearchMode, SearchQuery, SearchResult};
+pub use fts::{FtsResult, fts_search};
+pub use hybrid::{MatchType, SearchMode, SearchQuery, SearchResult, hybrid_search, rrf_merge};
 pub use query::MemoryQuery;
 pub use strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
-pub use vector::{cosine_similarity, vector_search, VectorResult};
+pub use vector::{VectorResult, cosine_similarity, vector_search};

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::Result;
 use crate::store::deserialize_embedding;
@@ -24,11 +24,7 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
         norm_b = y.mul_add(y, norm_b);
     }
     let denom = norm_a.sqrt() * norm_b.sqrt();
-    if denom == 0.0 {
-        0.0
-    } else {
-        dot / denom
-    }
+    if denom == 0.0 { 0.0 } else { dot / denom }
 }
 
 /// Brute-force vector similarity search over active facts.

--- a/src/store/events.rs
+++ b/src/store/events.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::store::upcaster::UpcasterRegistry;
@@ -404,9 +404,11 @@ mod tests {
         };
         let results = store.list(&filter).unwrap();
         assert_eq!(results.len(), 2);
-        assert!(results
-            .iter()
-            .all(|e| e.session_id == Some("sess-1".into())));
+        assert!(
+            results
+                .iter()
+                .all(|e| e.session_id == Some("sess-1".into()))
+        );
     }
 
     #[test]
@@ -528,8 +530,8 @@ mod tests {
         let conn = setup();
         let mut registry = UpcasterRegistry::new();
         // Interaction has upcasters 1→2 and 2→3, so latest = 3
-        registry.register("Interaction", 1, |v| Ok(v));
-        registry.register("Interaction", 2, |v| Ok(v));
+        registry.register("Interaction", 1, Ok);
+        registry.register("Interaction", 2, Ok);
         let store = EventStore::new(&conn, &registry);
 
         let id = store.insert(&make_event("test", None)).unwrap();

--- a/src/store/upcaster.rs
+++ b/src/store/upcaster.rs
@@ -176,7 +176,7 @@ mod tests {
     fn missing_in_chain_errors() {
         let mut registry = UpcasterRegistry::new();
         // Register 2→3 but NOT 1→2 — creates a gap
-        registry.register("ToolCall", 2, |v| Ok(v));
+        registry.register("ToolCall", 2, Ok);
 
         let payload = serde_json::json!({});
         let err = registry.upcast("ToolCall", 1, payload).unwrap_err();

--- a/tests/ann_recall_test.rs
+++ b/tests/ann_recall_test.rs
@@ -8,8 +8,8 @@
 use std::collections::HashSet;
 
 use memory_engine::engine::{EngineConfig, MemoryEngine};
-use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::search::SearchConfig;
+use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::FactType;
 
@@ -52,10 +52,26 @@ fn hnsw_recall_at_k_exceeds_threshold() {
     for i in 0..N {
         let content = format!("fact number {i} about topic {}", i % 50);
         engine_bf
-            .add_fact(&content, FactType::Semantic, None, &embedder, None, None)
+            .add_fact(
+                &content,
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         engine_ann
-            .add_fact(&content, FactType::Semantic, None, &embedder, None, None)
+            .add_fact(
+                &content,
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
             .unwrap();
     }
 

--- a/tests/restore_roundtrip_test.rs
+++ b/tests/restore_roundtrip_test.rs
@@ -1,9 +1,9 @@
 //! Integration tests for import/export round-trips.
 
+use memory_engine::EmbeddingProvider;
 use memory_engine::engine::{EngineConfig, MemoryEngine};
 use memory_engine::inspect_types::DumpFormat;
 use memory_engine::types::FactType;
-use memory_engine::EmbeddingProvider;
 
 const DIM: usize = 4;
 

--- a/tests/roundtrip_test.rs
+++ b/tests/roundtrip_test.rs
@@ -124,9 +124,11 @@ fn full_roundtrip() {
         })
         .unwrap();
     assert!(!vec_results.is_empty());
-    assert!(vec_results
-        .iter()
-        .all(|r| r.match_type == MatchType::Vector));
+    assert!(
+        vec_results
+            .iter()
+            .all(|r| r.match_type == MatchType::Vector)
+    );
 
     // 5. Query via hybrid — combine text and embedding
     let hybrid_emb = embedder.embed("Rust programming language").unwrap();
@@ -166,7 +168,9 @@ fn full_roundtrip() {
             scope: None,
         })
         .unwrap();
-    assert!(semantic_only
-        .iter()
-        .all(|r| r.fact.fact_type == FactType::Semantic));
+    assert!(
+        semantic_only
+            .iter()
+            .all(|r| r.fact.fact_type == FactType::Semantic)
+    );
 }


### PR DESCRIPTION
## Summary

Phase 4b MCP server for memory-engine. Implements `memory-engine-mcp`, a stdio-based MCP server binary exposing 10 P0 tools with tiered retrieval depth, pre-compaction flush, and protocol version pinning.

**Plan:** #146
**Issue:** #45
**Follow-ups:** P1 tools (#95), P2 tools (#96)

### Architecture

```
MCP Client (Claude, agent, etc.)
    │ JSON-RPC over stdio
    ▼
memory-engine-mcp (binary, rmcp 1.x)
├── config.rs         — TOML + env + CLI config
├── server.rs         — ServerHandler impl, tool router
├── embedding.rs      — HttpEmbeddingProvider (OpenAI-compatible)
├── depth.rs          — Tiered response shaping (sparse/standard/full)
├── error.rs          — MemoryError → MCP ErrorData mapping
└── tools/            — 10 P0 tool handlers
        │
        ▼ Arc<MemoryEngine> (sync, spawn_blocking)
memory-engine (lib, existing)
```

### P0 Tools

| Tool | Engine Method | Depth |
|------|--------------|-------|
| `memory_ingest` | `ingest()` + `ensure_scope_path()` | — |
| `memory_add_fact` | `add_fact()` | — |
| `memory_query` | `execute_query()` | ✓ |
| `memory_resume_context` | `resume_context()` | ✓ |
| `memory_list_due` | `list_due()` | ✓ |
| `memory_next_due_time` | `next_due_time()` | — |
| `memory_explain_fact` | `explain_fact()` | ✓ |
| `memory_get_fact` | `get_fact()` | ✓ |
| `memory_statistics` | `statistics()` | — |
| `memory_flush_insights` | `add_fact()` × N | — |

### Current state

- [x] Phase A: Scaffold (workspace, skeleton, library prep)
- [x] Phase B: Infrastructure (config, error, embedding, depth)
- [x] Phase C: Tool handlers + server wiring
- [x] Phase D: Integration tests

## Test plan

- [x] `cargo test --workspace --all-features` passes
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] Smoke test: run server, `memory_statistics` returns valid JSON
- [x] Depth test: sparse/standard/full produce correct field sets
- [x] Embedding test: ollama round-trip (add_fact → query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)