### PR TITLE
perf(store): add LIMIT to list_active_facts query

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -45,7 +45,7 @@ This page summarizes the public API surface of the `memory-engine` crate.
 | Method              | Signature                                                     | Description                                           |
 | ------------------- | ------------------------------------------------------------- | ----------------------------------------------------- |
 | `get_fact`          | `(&self, id: i64) -> Result<Fact>`                            | Retrieve a fact by ID. Returns `NotFound` if missing. |
-| `list_active_facts` | `(&self) -> Result<Vec<Fact>>`                                | List all non-expired facts.                           |
+| `list_active_facts` | `(&self, limit: Option<usize>) -> Result<Vec<Fact>>`          | List non-expired facts; `Some(n)` pushes SQL `LIMIT`. |
 | `list_summaries`    | `(&self, level: &ConsolidationLevel) -> Result<Vec<Summary>>` | List summaries filtered by consolidation level.       |
 
 ### Query
@@ -116,13 +116,13 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 ### Graph
 
-| Method               | Signature                                    | Description                                                                                                                              |
-| -------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `graph_degree`       | `(&self, fact_id: i64) -> usize`             | In + out edge count for a fact.                                                                                                          |
-| `graph_neighbors`    | `(&self, fact_id: i64) -> Vec<i64>`          | Outgoing neighbor fact IDs.                                                                                                              |
-| `graph_component`    | `(&self, fact_id: i64) -> Vec<i64>`          | All fact IDs in the connected component containing `fact_id`.                                                                            |
-| `graph_stats`        | `(&self) -> (usize, usize)`                  | `(node_count, edge_count)`.                                                                                                              |
-| `graph_has_node`     | `(&self, fact_id: i64) -> bool`              | Whether a node exists in the graph.                                                                                                      |
+| Method               | Signature                                                         | Description                                                                                                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `graph_degree`       | `(&self, fact_id: i64) -> usize`                                  | In + out edge count for a fact.                                                                                                                                                                                       |
+| `graph_neighbors`    | `(&self, fact_id: i64) -> Vec<i64>`                               | Outgoing neighbor fact IDs.                                                                                                                                                                                           |
+| `graph_component`    | `(&self, fact_id: i64) -> Vec<i64>`                               | All fact IDs in the connected component containing `fact_id`.                                                                                                                                                         |
+| `graph_stats`        | `(&self) -> (usize, usize)`                                       | `(node_count, edge_count)`.                                                                                                                                                                                           |
+| `graph_has_node`     | `(&self, fact_id: i64) -> bool`                                   | Whether a node exists in the graph.                                                                                                                                                                                   |
 | `link_session_facts` | `(&self, session_id: &str, scope: Option<&str>) -> Result<usize>` | Create bidirectional `co_session` edges between all active facts sharing a session. When `scope` is `Some`, only facts within that scope subtree are considered. Idempotent. Returns the number of new edges created. |
 
 ### Pinning
@@ -144,10 +144,10 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 ### Scheduling
 
-| Method          | Signature                                                               | Description                                                                                                                                                                                                 |
-| --------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Method          | Signature                                                               | Description                                                                                                                                                                                                                                                                                                                       |
+| --------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `list_due`      | `(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>>` | List active facts whose `t_valid <= now` (future memory that has surfaced). Stamps `surfaced_at` on first return so callers can distinguish newly-due from previously-surfaced facts — the old heuristic (`access_count > 0 && last_accessed > t_valid`) was unreliable for bootstrap/past-dated facts. `None` scope = root only. |
-| `next_due_time` | `(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>>`         | Scheduling hint: earliest `t_valid` among active future-dated facts. `None` scope = root only.                                                                                                              |
+| `next_due_time` | `(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>>`         | Scheduling hint: earliest `t_valid` among active future-dated facts. `None` scope = root only.                                                                                                                                                                                                                                    |
 
 ### Resume
 

--- a/docs/reference/cli-inspector.md
+++ b/docs/reference/cli-inspector.md
@@ -123,5 +123,5 @@ The `open_engine()` function sets `backup_dir` adjacent to the database as a saf
 ### Known Limitations
 
 - **No vector search in `query`**: The CLI doesn't implement `EmbeddingProvider`, so only FTS5 text matching works. Vector/hybrid search requires embeddings.
-- **`dump --limit` is post-hoc**: `list_active_facts()` loads all facts before truncating. Fine for operator use but won't scale to very large databases. Tracked in #104.
+- **`dump --limit` pushes SQL LIMIT**: `list_active_facts(Some(n))` adds a `LIMIT` clause to avoid materializing the full corpus.
 - **Import schema version**: Export/import roundtrip fails due to schema v6 vs restore v5 mismatch. Tracked in #80.

--- a/examples/basic_roundtrip.rs
+++ b/examples/basic_roundtrip.rs
@@ -86,7 +86,7 @@ fn main() -> Result<(), MemoryError> {
 
     // 4. Check engine stats
     let (nodes, edges) = engine.graph_stats();
-    let facts = engine.list_active_facts()?;
+    let facts = engine.list_active_facts(None)?;
     println!(
         "\nEngine stats: {} facts, {} graph nodes, {} edges",
         facts.len(),

--- a/examples/custom_traits.rs
+++ b/examples/custom_traits.rs
@@ -109,7 +109,7 @@ fn main() -> Result<(), MemoryError> {
     )?; // duplicate
 
     println!("Added 4 facts (1 duplicate)");
-    println!("Active facts: {}", engine.list_active_facts()?.len());
+    println!("Active facts: {}", engine.list_active_facts(None)?.len());
 
     // --- Consolidation: uses SummaryGenerator ---
     let summarizer = ConcatSummarizer;
@@ -126,7 +126,7 @@ fn main() -> Result<(), MemoryError> {
     );
     println!(
         "Active facts after consolidation: {}",
-        engine.list_active_facts()?.len()
+        engine.list_active_facts(None)?.len()
     );
 
     // --- Forgetting: uses ForgetPolicy (configurable struct, not a trait) ---
@@ -178,7 +178,7 @@ fn main() -> Result<(), MemoryError> {
     );
 
     // Final state
-    let facts = engine.list_active_facts()?;
+    let facts = engine.list_active_facts(None)?;
     println!("\nFinal active facts: {}", facts.len());
     for f in &facts {
         println!("  [id={}] {}", f.id, f.content);

--- a/memory-engine-cli/src/commands/dump.rs
+++ b/memory-engine-cli/src/commands/dump.rs
@@ -64,8 +64,7 @@ fn dump_all(
     format: OutputFormat,
 ) -> anyhow::Result<()> {
     if format == OutputFormat::Json {
-        let mut facts = engine.list_active_facts()?;
-        facts.truncate(limit);
+        let facts = engine.list_active_facts(Some(limit))?;
         let filter = ReplayFilter {
             limit: Some(limit),
             ..ReplayFilter::default()
@@ -89,8 +88,7 @@ fn dump_facts(
     limit: usize,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let mut facts = engine.list_active_facts()?;
-    facts.truncate(limit);
+    let facts = engine.list_active_facts(Some(limit))?;
 
     match format {
         OutputFormat::Json => output::print_json(&facts)?,

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -186,10 +186,10 @@ impl AsyncMemoryEngine {
             .map_err(join_err)?
     }
 
-    /// List all active facts.
-    pub async fn list_active_facts(&self) -> Result<Vec<Fact>> {
+    /// List active facts, optionally limited.
+    pub async fn list_active_facts(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
         let engine = self.inner.clone();
-        tokio::task::spawn_blocking(move || engine.list_active_facts())
+        tokio::task::spawn_blocking(move || engine.list_active_facts(limit))
             .await
             .map_err(join_err)?
     }

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -481,7 +481,7 @@ mod tests {
         assert!(old.t_invalid.is_none());
 
         // No new facts should exist
-        let active = FactStore::new(&conn, dim).list_active().unwrap();
+        let active = FactStore::new(&conn, dim).list_active(None).unwrap();
         assert_eq!(active.len(), 1);
     }
 }

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -36,7 +36,7 @@ pub fn cluster_fusion(
     const MAX_CLUSTER_FACTS: usize = 50_000;
 
     let fact_store = FactStore::new(conn, embed_dim);
-    let active_facts = fact_store.list_active()?;
+    let active_facts = fact_store.list_active(None)?;
 
     if active_facts.len() > MAX_CLUSTER_FACTS {
         tracing::warn!(

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -31,7 +31,7 @@ pub fn local_dedup(
 
     let fact_store = FactStore::new(conn, embed_dim);
     let edge_store = EdgeStore::new(conn);
-    let active_facts = fact_store.list_active()?;
+    let active_facts = fact_store.list_active(None)?;
 
     if active_facts.len() > MAX_DEDUP_FACTS {
         tracing::warn!(
@@ -169,7 +169,7 @@ mod tests {
 
         // Lower importance (B) should be expired
         let store = FactStore::new(&conn, dim);
-        let active = store.list_active().unwrap();
+        let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].content, "fact A");
     }
@@ -185,7 +185,7 @@ mod tests {
         assert_eq!(removed, 0);
 
         let store = FactStore::new(&conn, dim);
-        assert_eq!(store.list_active().unwrap().len(), 2);
+        assert_eq!(store.list_active(None).unwrap().len(), 2);
     }
 
     #[test]
@@ -241,7 +241,7 @@ mod tests {
         let (removed, _) = local_dedup(&conn, dim, 0.90, Some(since), Utc::now()).unwrap();
         assert_eq!(removed, 1); // new duplicate should be expired against old
 
-        let active = store.list_active().unwrap();
+        let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].content, "old fact"); // old survives (higher importance wins)
     }
@@ -261,7 +261,7 @@ mod tests {
         local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
 
         let store = FactStore::new(&conn, dim);
-        let active = store.list_active().unwrap();
+        let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].content, "high importance");
     }
@@ -276,7 +276,7 @@ mod tests {
         local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
 
         let store = FactStore::new(&conn, dim);
-        let active = store.list_active().unwrap();
+        let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].content, "older fact");
     }
@@ -337,7 +337,7 @@ mod tests {
         assert_eq!(removed, 0);
 
         let store = FactStore::new(&conn, dim);
-        let active = store.list_active().unwrap();
+        let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 2);
     }
 
@@ -358,7 +358,7 @@ mod tests {
         assert_eq!(removed, 0);
 
         let store = FactStore::new(&conn, dim);
-        assert_eq!(store.list_active().unwrap().len(), 2);
+        assert_eq!(store.list_active(None).unwrap().len(), 2);
     }
 
     #[test]
@@ -375,7 +375,7 @@ mod tests {
 
         local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
 
-        let active = store.list_active().unwrap();
+        let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].content, "high imp");
         // Survivor inherits max base importance (0.9 > 0.3)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1196,13 +1196,16 @@ impl MemoryEngine {
         self.with_read(|conn| FactStore::new(conn, self.embed_dim).get(id))
     }
 
-    /// List all active (non-expired) facts.
+    /// List active (non-expired) facts, optionally limited.
+    ///
+    /// When `limit` is `Some(n)`, a SQL `LIMIT` clause avoids materializing
+    /// the entire corpus. `None` returns all active facts.
     ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on query failure.
-    pub fn list_active_facts(&self) -> Result<Vec<Fact>> {
-        self.with_read(|conn| FactStore::new(conn, self.embed_dim).list_active())
+    pub fn list_active_facts(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
+        self.with_read(|conn| FactStore::new(conn, self.embed_dim).list_active(limit))
     }
 
     /// List summaries by consolidation level.
@@ -1919,7 +1922,7 @@ mod tests {
         let stats = engine.consolidate(&MockGen, &config).unwrap();
         assert_eq!(stats.duplicates_removed, 1);
 
-        let active = engine.list_active_facts().unwrap();
+        let active = engine.list_active_facts(None).unwrap();
         assert_eq!(active.len(), 1);
     }
 
@@ -1946,7 +1949,7 @@ mod tests {
         // Second run should find 0 new duplicates
         assert_eq!(stats2.duplicates_removed, 0);
         // Both facts still active
-        assert_eq!(engine.list_active_facts().unwrap().len(), 2);
+        assert_eq!(engine.list_active_facts(None).unwrap().len(), 2);
     }
 
     #[test]

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -89,7 +89,7 @@ pub fn prune(
     policy.validate()?;
 
     let fact_store = FactStore::new(conn, embed_dim);
-    let active_facts = fact_store.list_active()?;
+    let active_facts = fact_store.list_active(None)?;
     let facts_evaluated = active_facts.len();
 
     // Score all facts before mutating, so degree values are consistent.
@@ -432,7 +432,7 @@ mod tests {
         assert_eq!(stats.facts_evaluated, 2);
 
         // Pinned fact still active
-        let active = fact_store.list_active().unwrap();
+        let active = fact_store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
         assert!(active[0].is_pinned);
     }

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -119,19 +119,32 @@ impl<'a> FactStore<'a> {
         }
     }
 
-    /// List all active facts (`t_expired IS NULL`).
+    /// List active facts (`t_expired IS NULL`), optionally limited.
+    ///
+    /// When `limit` is `Some(n)`, a SQL `LIMIT n` clause is pushed into the
+    /// query so that at most `n` rows are materialized. `None` returns all.
     ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on query failure.
-    pub fn list_active(&self) -> Result<Vec<Fact>> {
-        let mut stmt = self.conn.prepare(
+    pub fn list_active(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
+        let sql = if let Some(n) = limit {
+            format!(
+                "SELECT id, content, content_hash, embedding, fact_type,
+                        t_created, t_expired, t_valid, t_invalid,
+                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
+                        is_pinned, importance_score, surfaced_at
+                 FROM facts WHERE t_expired IS NULL LIMIT {n}"
+            )
+        } else {
             "SELECT id, content, content_hash, embedding, fact_type,
                     t_created, t_expired, t_valid, t_invalid,
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
                     is_pinned, importance_score, surfaced_at
-             FROM facts WHERE t_expired IS NULL",
-        )?;
+             FROM facts WHERE t_expired IS NULL"
+                .to_owned()
+        };
+        let mut stmt = self.conn.prepare(&sql)?;
         let dim = self.embed_dim;
         let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
         let mut facts = Vec::new();
@@ -841,14 +854,36 @@ mod tests {
         let id2 = store.insert(&make_fact("fact 2", vec![0.2; DIM])).unwrap();
 
         // Both active
-        let active = store.list_active().unwrap();
+        let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 2);
 
         // Expire fact 1
         store.expire(id1, Utc::now()).unwrap();
-        let active = store.list_active().unwrap();
+        let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].id, id2);
+    }
+
+    #[test]
+    fn list_active_with_limit() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store.insert(&make_fact("fact 1", vec![0.1; DIM])).unwrap();
+        store.insert(&make_fact("fact 2", vec![0.2; DIM])).unwrap();
+        store.insert(&make_fact("fact 3", vec![0.3; DIM])).unwrap();
+
+        // No limit returns all
+        assert_eq!(store.list_active(None).unwrap().len(), 3);
+
+        // Limit returns at most N
+        assert_eq!(store.list_active(Some(2)).unwrap().len(), 2);
+        assert_eq!(store.list_active(Some(1)).unwrap().len(), 1);
+
+        // Limit larger than corpus returns all
+        assert_eq!(store.list_active(Some(100)).unwrap().len(), 3);
+
+        // Limit zero returns empty
+        assert_eq!(store.list_active(Some(0)).unwrap().len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `limit: Option<usize>` parameter to `FactStore::list_active()` and `MemoryEngine::list_active_facts()`, pushing SQL `LIMIT N` into the query when `Some(n)` is provided
- CLI `dump facts --limit N` now materializes only N rows instead of the full corpus + post-hoc truncation
- All internal callers (consolidation, forgetting, conflict resolution) pass `None` for unchanged semantics
- Includes store-level test covering limit boundary conditions (exact, over, zero)

Fixes #104

## Test plan

- [x] New test `list_active_with_limit` verifies: `None` returns all, `Some(2)` returns 2, `Some(100)` returns all (oversized), `Some(0)` returns empty
- [x] All 381 existing tests pass (352 lib + 29 subcrates)
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt --check` — clean

## Files changed (12)

| File | Change |
|------|--------|
| `src/store/facts.rs` | Core: add `limit` param, format SQL with `LIMIT N`, add test |
| `src/engine.rs` | Public API: propagate `limit` param |
| `src/async_engine.rs` | Async wrapper: propagate `limit` param |
| `memory-engine-cli/src/commands/dump.rs` | CLI: pass `Some(limit)`, remove `.truncate()` |
| `src/consolidation/dedup.rs` | Internal caller: pass `None` |
| `src/consolidation/cluster.rs` | Internal caller: pass `None` |
| `src/forgetting/policy.rs` | Internal caller: pass `None` |
| `src/conflict/temporal.rs` | Internal caller: pass `None` |
| `examples/basic_roundtrip.rs` | Example: pass `None` |
| `examples/custom_traits.rs` | Example: pass `None` |
| `docs/reference/api.md` | Update API signature |
| `docs/reference/cli-inspector.md` | Remove known-limitation note |