### PR TITLE
fix(resume): stamp surfaced_at for due facts in all tiers

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1657,12 +1657,19 @@ impl MemoryEngine {
             crate::resume::resume_context(conn, &scope_ids, self.embed_dim, config)
         })?;
 
-        // Step 3: Stamp surfaced_at on the final due facts (post-filter, post-cap).
+        // Step 3: Stamp surfaced_at on ALL due facts across ALL tiers (#93).
+        // A fact is "due" if t_valid <= now, regardless of which tier claimed it.
         // Must use write_conn — read connections have query_only = ON.
+        let is_due = |f: &Fact| -> bool {
+            f.t_valid.is_some_and(|tv| tv <= config.now) && f.surfaced_at.is_none()
+        };
         let unsurfaced_ids: Vec<i64> = ctx
-            .due
+            .pinned
             .iter()
-            .filter(|f| f.surfaced_at.is_none())
+            .chain(ctx.high_importance.iter())
+            .chain(ctx.due.iter())
+            .chain(ctx.recent.iter())
+            .filter(|f| is_due(f))
             .map(|f| f.id)
             .collect();
 
@@ -1672,7 +1679,13 @@ impl MemoryEngine {
                 .stamp_surfaced(&unsurfaced_ids, config.now)?;
             let stamped_map: std::collections::HashMap<i64, DateTime<Utc>> =
                 stamped.into_iter().collect();
-            for fact in &mut ctx.due {
+            for fact in ctx
+                .pinned
+                .iter_mut()
+                .chain(ctx.high_importance.iter_mut())
+                .chain(ctx.due.iter_mut())
+                .chain(ctx.recent.iter_mut())
+            {
                 if let Some(&ts) = stamped_map.get(&fact.id) {
                     fact.surfaced_at = Some(ts);
                 }
@@ -2352,6 +2365,96 @@ mod tests {
         };
         let err = engine.resume_context(&config).unwrap_err();
         assert!(matches!(err, MemoryError::NotFound(_)));
+    }
+
+    // --- Issue #93: surfaced_at for due facts in non-due tiers ---
+
+    #[test]
+    fn resume_stamps_surfaced_at_on_pinned_due_fact() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let now = Utc::now();
+        let past = now - chrono::Duration::hours(1);
+
+        // Pinned fact that is ALSO due (t_valid in the past).
+        // It will land in the pinned tier, not the due tier.
+        engine
+            .add_fact(
+                "CI pipeline uses 30min timeout",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                Some(&AddFactOptions {
+                    pinned: Some(true),
+                    t_valid: Some(past),
+                    importance: Some(0.9),
+                    ..Default::default()
+                }),
+                None,
+            )
+            .unwrap();
+
+        let config = ResumeConfig {
+            now,
+            ..ResumeConfig::default()
+        };
+        let ctx = engine.resume_context(&config).unwrap();
+
+        // Fact should appear in pinned tier (not due tier)
+        assert_eq!(ctx.pinned.len(), 1);
+        assert!(ctx.due.is_empty() || !ctx.due.iter().any(|f| f.content.contains("CI")));
+
+        // Bug: surfaced_at should be stamped because the fact IS due,
+        // even though it landed in the pinned tier.
+        assert!(
+            ctx.pinned[0].surfaced_at.is_some(),
+            "pinned-but-due fact must have surfaced_at stamped"
+        );
+    }
+
+    #[test]
+    fn resume_stamps_surfaced_at_on_high_importance_due_fact() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let now = Utc::now();
+        let past = now - chrono::Duration::hours(1);
+
+        // High-importance fact that is ALSO due. Not pinned.
+        // importance=0.9 → importance_score=0.9, which exceeds the 0.7 threshold.
+        // It will land in high_importance tier, not due tier.
+        engine
+            .add_fact(
+                "user prefers tabs over spaces",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                Some(&AddFactOptions {
+                    importance: Some(0.9),
+                    t_valid: Some(past),
+                    ..Default::default()
+                }),
+                None,
+            )
+            .unwrap();
+
+        let config = ResumeConfig {
+            now,
+            high_importance_min: 0.7,
+            ..ResumeConfig::default()
+        };
+        let ctx = engine.resume_context(&config).unwrap();
+
+        // Fact should appear in high_importance tier (not due tier)
+        assert_eq!(ctx.high_importance.len(), 1);
+        assert!(ctx.due.is_empty());
+
+        // Bug: surfaced_at should be stamped because the fact IS due.
+        assert!(
+            ctx.high_importance[0].surfaced_at.is_some(),
+            "high-importance-but-due fact must have surfaced_at stamped"
+        );
     }
 
     // --- Phase 3b / T6: SearchConfig in EngineConfig ---

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::graph::MemoryGraph;
 use crate::pool::ConnectionPool;
 use crate::resume::context::{ResumeConfig, ResumeContext};
 use crate::scope::ScopeTree;
-use crate::search::hybrid::{MatchType, SearchMode, SearchQuery, SearchResult, hybrid_search};
+use crate::search::hybrid::{hybrid_search, MatchType, SearchMode, SearchQuery, SearchResult};
 use crate::search::query::MemoryQuery;
 use crate::search::strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
 use crate::store::events::EventStore;
@@ -346,6 +346,18 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     fn write_conn(&self) -> Result<MutexGuard<'_, Connection>> {
         self.pool.try_write()
+    }
+
+    /// Stamp `surfaced_at` for the given fact IDs and return the DB-authoritative
+    /// `(id, timestamp)` pairs. Shared by `list_due()` and `resume_context()`.
+    fn stamp_surfaced_facts(
+        &self,
+        fact_ids: &[i64],
+        now: DateTime<Utc>,
+    ) -> Result<std::collections::HashMap<i64, DateTime<Utc>>> {
+        let conn = self.write_conn()?;
+        let stamped = FactStore::new(&conn, self.embed_dim).stamp_surfaced(fact_ids, now)?;
+        Ok(stamped.into_iter().collect())
     }
 
     /// Ensure a scope path exists using an already-held connection.
@@ -1234,17 +1246,8 @@ impl MemoryEngine {
             .collect();
 
         if !unsurfaced_ids.is_empty() {
-            let conn = self.write_conn()?;
-            let stamped =
-                FactStore::new(&conn, self.embed_dim).stamp_surfaced(&unsurfaced_ids, now)?;
-            // Update in-place with DB-authoritative timestamps
-            let stamped_map: std::collections::HashMap<i64, chrono::DateTime<chrono::Utc>> =
-                stamped.into_iter().collect();
-            for fact in &mut facts {
-                if let Some(&ts) = stamped_map.get(&fact.id) {
-                    fact.surfaced_at = Some(ts);
-                }
-            }
+            let stamped = self.stamp_surfaced_facts(&unsurfaced_ids, now)?;
+            apply_surfaced_stamps(facts.iter_mut(), &stamped);
         }
 
         Ok(facts)
@@ -1658,10 +1661,13 @@ impl MemoryEngine {
         })?;
 
         // Step 3: Stamp surfaced_at on ALL due facts across ALL tiers (#93).
-        // A fact is "due" if t_valid <= now, regardless of which tier claimed it.
+        // A fact is "due" if t_valid <= now AND not bi-temporally invalidated,
+        // regardless of which tier claimed it. Matches FactStore::list_due() predicate.
         // Must use write_conn — read connections have query_only = ON.
-        let is_due = |f: &Fact| -> bool {
-            f.t_valid.is_some_and(|tv| tv <= config.now) && f.surfaced_at.is_none()
+        let is_unsurfaced_due = |f: &Fact| -> bool {
+            f.surfaced_at.is_none()
+                && f.t_valid.is_some_and(|tv| tv <= config.now)
+                && f.t_invalid.is_none_or(|ti| ti > config.now)
         };
         let unsurfaced_ids: Vec<i64> = ctx
             .pinned
@@ -1669,30 +1675,35 @@ impl MemoryEngine {
             .chain(ctx.high_importance.iter())
             .chain(ctx.due.iter())
             .chain(ctx.recent.iter())
-            .filter(|f| is_due(f))
+            .filter(|f| is_unsurfaced_due(f))
             .map(|f| f.id)
             .collect();
 
         if !unsurfaced_ids.is_empty() {
-            let conn = self.write_conn()?;
-            let stamped = FactStore::new(&conn, self.embed_dim)
-                .stamp_surfaced(&unsurfaced_ids, config.now)?;
-            let stamped_map: std::collections::HashMap<i64, DateTime<Utc>> =
-                stamped.into_iter().collect();
-            for fact in ctx
-                .pinned
-                .iter_mut()
-                .chain(ctx.high_importance.iter_mut())
-                .chain(ctx.due.iter_mut())
-                .chain(ctx.recent.iter_mut())
-            {
-                if let Some(&ts) = stamped_map.get(&fact.id) {
-                    fact.surfaced_at = Some(ts);
-                }
-            }
+            let stamped = self.stamp_surfaced_facts(&unsurfaced_ids, config.now)?;
+            apply_surfaced_stamps(
+                ctx.pinned
+                    .iter_mut()
+                    .chain(ctx.high_importance.iter_mut())
+                    .chain(ctx.due.iter_mut())
+                    .chain(ctx.recent.iter_mut()),
+                &stamped,
+            );
         }
 
         Ok(ctx)
+    }
+}
+
+/// Apply DB-authoritative `surfaced_at` timestamps to in-memory facts.
+fn apply_surfaced_stamps<'a>(
+    facts: impl Iterator<Item = &'a mut Fact>,
+    stamped_map: &std::collections::HashMap<i64, DateTime<Utc>>,
+) {
+    for fact in facts {
+        if let Some(&ts) = stamped_map.get(&fact.id) {
+            fact.surfaced_at = Some(ts);
+        }
     }
 }
 
@@ -2457,6 +2468,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn resume_does_not_stamp_invalidated_pinned_due_fact() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let now = Utc::now();
+        let past = now - chrono::Duration::hours(2);
+        let past_invalid = now - chrono::Duration::hours(1);
+
+        // Pinned fact that WAS due but is now bi-temporally invalidated:
+        // t_valid in the past, t_invalid ALSO in the past (before now).
+        engine
+            .add_fact(
+                "old CI timeout no longer valid",
+                FactType::Semantic,
+                None,
+                &embedder,
+                None,
+                Some(&AddFactOptions {
+                    pinned: Some(true),
+                    t_valid: Some(past),
+                    t_invalid: Some(past_invalid),
+                    importance: Some(0.9),
+                    ..Default::default()
+                }),
+                None,
+            )
+            .unwrap();
+
+        let config = ResumeConfig {
+            now,
+            ..ResumeConfig::default()
+        };
+        let ctx = engine.resume_context(&config).unwrap();
+
+        // Fact lands in pinned tier (it's pinned and not expired)
+        assert_eq!(ctx.pinned.len(), 1);
+
+        // But surfaced_at must NOT be stamped — the fact is bi-temporally
+        // invalidated (t_invalid <= now), so it's no longer "due".
+        assert!(
+            ctx.pinned[0].surfaced_at.is_none(),
+            "invalidated fact must not have surfaced_at stamped"
+        );
+    }
+
     // --- Phase 3b / T6: SearchConfig in EngineConfig ---
 
     #[test]
@@ -2754,11 +2810,9 @@ mod tests {
 
         let results = engine.execute_query(&MemoryQuery::new()).unwrap();
         assert_eq!(results.len(), 2);
-        assert!(
-            results
-                .iter()
-                .all(|r| r.match_type == MatchType::ImportanceRank)
-        );
+        assert!(results
+            .iter()
+            .all(|r| r.match_type == MatchType::ImportanceRank));
     }
 
     #[test]
@@ -2865,11 +2919,9 @@ mod tests {
             .unwrap();
         // fact_type filtering in store path — list_by_importance_score doesn't filter by fact_type,
         // so it should be post-filtered
-        assert!(
-            results
-                .iter()
-                .all(|r| r.fact.fact_type == FactType::Semantic)
-        );
+        assert!(results
+            .iter()
+            .all(|r| r.fact.fact_type == FactType::Semantic));
     }
 
     #[test]
@@ -3726,16 +3778,12 @@ mod tests {
         assert_eq!(co_edges.len(), 2);
 
         // Both directions present
-        assert!(
-            co_edges
-                .iter()
-                .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2)
-        );
-        assert!(
-            co_edges
-                .iter()
-                .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1)
-        );
+        assert!(co_edges
+            .iter()
+            .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2));
+        assert!(co_edges
+            .iter()
+            .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1));
 
         // Weight matches constant
         for e in &co_edges {


### PR DESCRIPTION
## Summary

- `resume_context()` only stamped `surfaced_at` on facts that landed in the **due** tier
- Facts with `t_valid <= now` claimed by higher-priority tiers (pinned, high_importance) had `surfaced_at` left as `NULL`
- Now collects unsurfaced due facts from **all four tiers** before stamping, and updates in-memory structs across all tiers

## What changed

**[src/engine.rs](src/engine.rs)** — `resume_context` stamping logic (lines 1660-1693):
- Added `is_due` closure: checks `t_valid <= now && surfaced_at.is_none()`
- Chains all four tier iterators (pinned, high_importance, due, recent) for both ID collection and post-stamp update

**Tests** — 2 new tests:
- `resume_stamps_surfaced_at_on_pinned_due_fact` — pinned fact with `t_valid` in past gets `surfaced_at` stamped
- `resume_stamps_surfaced_at_on_high_importance_due_fact` — high-importance fact with `t_valid` in past gets `surfaced_at` stamped

## Design decision

Option 1 from the issue: stamp all facts where `t_valid <= now`, regardless of tier. `surfaced_at` means "when did this due fact first get delivered to the consumer" — the tier bucket is an internal scheduling detail, not a semantic distinction.

Option 3 (`delivered_at` column) was rejected as overengineering — it would duplicate `last_accessed`/`access_count` for consumers that don't exist yet.

## Test plan

- [x] Both new tests fail before fix, pass after
- [x] Full `cargo test` passes (353 tests)
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt --check` — clean

Fixes #93