### PR TITLE
refactor!: Reranker returns indices instead of SearchResult (#144)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -225,7 +225,7 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 | [#104](https://github.com/dutiona/memory-engine/issues/104)    | perf      | Add `LIMIT` to `list_active_facts` query                                                                                             |
 | ✅ [#105](https://github.com/dutiona/memory-engine/issues/105) | docs      | Mark issue #82 as complete in ROADMAP.md                                                                                             |
 | ✅ [#106](https://github.com/dutiona/memory-engine/issues/106) | docs      | Fix incorrect `MemoryEngine::open` API usage in GEMINI.md. [commit bb35f03](https://github.com/dutiona/memory-engine/commit/bb35f03) |
-| [#144](https://github.com/dutiona/memory-engine/issues/144)    | hardening | Reranker output validation — defend against content mutation (follow-up to #85)                                                      |
+| ✅ [#144](https://github.com/dutiona/memory-engine/issues/144) | hardening | Reranker output validation — index-based trait redesign. [PR #175](https://github.com/dutiona/memory-engine/pull/175)                |
 
 #### Phase 4b: Tooling (new workspace binaries) ✅
 
@@ -341,7 +341,7 @@ Phase 4a ✅ and 4b ✅ are complete. Phase 5 is **unblocked on the critical pat
 
 **Parallelizable right now (4 independent tracks):**
 
-1. **Phase 4 follow-ups** (8 open: #93, #95, #96, #104, #105, #144, #150, #151) — all non-blocking
+1. **Phase 4 follow-ups** (7 open: #93, #95, #96, #104, #105, #150, #151) — all non-blocking
 2. **Phase 4c** (#16, #46, #31) — #16 evaluation harness benefits from MCP being live; #31 depends on #46
 3. **Super-qa sweep** (25 open issues) — incremental, any order
 4. **Phase 5a design + implementation** — the critical path forward

--- a/docs/advanced/extensibility.md
+++ b/docs/advanced/extensibility.md
@@ -170,12 +170,14 @@ Called during `query()` to refine the top-K search results using a cross-encoder
 
 ```rust
 pub trait Reranker: Send + Sync {
-    fn rerank(&self, query: &str, candidates: Vec<SearchResult>) -> Result<Vec<SearchResult>>;
+    fn rerank(&self, query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>>;
     fn name(&self) -> &str;
 }
 ```
 
-The `rerank` method receives the query text and the candidate results from `hybrid_search()`. It returns a reordered (and optionally re-scored) vector of results. The method is failable -- errors propagate as `MemoryError::Reranker`.
+The `rerank` method receives the query text and a borrowed slice of candidate results from `hybrid_search()`. It returns `(index, score)` pairs referencing positions in the input slice. The engine reconstructs the final result set from these indices, preserving the original `Fact` and `MatchType` values unchanged — this structurally prevents the reranker from mutating fact content, embeddings, or match types.
+
+The method is failable -- errors propagate as `MemoryError::Reranker`. All returned scores must be finite (not NaN or Inf).
 
 `Send + Sync` bounds are required because `MemoryEngine` is shared across threads via `Arc`.
 
@@ -191,23 +193,21 @@ struct CrossEncoderReranker {
 }
 
 impl Reranker for CrossEncoderReranker {
-    fn rerank(&self, query: &str, mut candidates: Vec<SearchResult>) -> Result<Vec<SearchResult>> {
+    fn rerank(&self, query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
         // Score each (query, document) pair with the cross-encoder
-        let mut scored: Vec<(f64, SearchResult)> = candidates
-            .into_iter()
-            .map(|r| {
+        let mut scored: Vec<(usize, f64)> = candidates
+            .iter()
+            .enumerate()
+            .map(|(i, r)| {
                 let score = self.cross_encode(query, &r.fact.content)?;
-                Ok((score, r))
+                Ok((i, score))
             })
             .collect::<Result<Vec<_>>>()?;
 
         // Sort by cross-encoder score descending
-        scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
-        Ok(scored.into_iter().map(|(score, mut r)| {
-            r.score = score;  // replace RRF score with cross-encoder score
-            r
-        }).collect())
+        Ok(scored)
     }
 
     fn name(&self) -> &str {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -512,11 +512,13 @@ impl MemoryEngine {
         if let (Some(reranker), Some(text)) = (&self.reranker, &query.text) {
             let ranked = reranker.rerank(text, &results)?;
             Self::validate_reranker_output(results.len(), &ranked)?;
-            // Reconstruct results from indices — original Fact/MatchType preserved (#144).
+            // Reconstruct results from indices — move, don't clone (#144).
+            // Safe: validate_reranker_output guarantees unique indices.
+            let mut candidates: Vec<_> = results.into_iter().map(Some).collect();
             results = ranked
                 .into_iter()
                 .map(|(idx, score)| {
-                    let mut r = results[idx].clone();
+                    let mut r = candidates[idx].take().expect("index validated as unique");
                     r.score = score;
                     r
                 })

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -510,10 +510,17 @@ impl MemoryEngine {
         // Apply reranker if present and query has text (cross-encoder needs query text).
         // Runs OUTSIDE the read lock — reranking may involve slow inference/API calls.
         if let (Some(reranker), Some(text)) = (&self.reranker, &query.text) {
-            // Snapshot input IDs before reranking for subset validation (#85).
-            let input_snapshot: Vec<_> = results.iter().map(|r| r.fact.id).collect();
-            results = reranker.rerank(text, results)?;
-            Self::validate_reranker_output(&input_snapshot, &results)?;
+            let ranked = reranker.rerank(text, &results)?;
+            Self::validate_reranker_output(results.len(), &ranked)?;
+            // Reconstruct results from indices — original Fact/MatchType preserved (#144).
+            results = ranked
+                .into_iter()
+                .map(|(idx, score)| {
+                    let mut r = results[idx].clone();
+                    r.score = score;
+                    r
+                })
+                .collect();
         }
 
         // Always truncate to limit — rerank_depth may have over-fetched from hybrid_search.
@@ -1569,37 +1576,39 @@ impl MemoryEngine {
 
     // --- Private helpers ---
 
-    /// Validate that reranker output is a subset of input candidates.
+    /// Validate reranker output indices and scores.
     ///
-    /// Checks three invariants:
-    /// 1. Every output fact ID was present in the input candidates
-    /// 2. No duplicate fact IDs in the output
-    /// 3. Output length does not exceed input length (implied by 1+2, checked for clarity)
-    fn validate_reranker_output(input_ids: &[i64], output: &[SearchResult]) -> Result<()> {
+    /// Checks four invariants:
+    /// 1. Output length does not exceed input length
+    /// 2. Every index is within `0..num_candidates`
+    /// 3. No duplicate indices
+    /// 4. All scores are finite (not NaN or Inf)
+    fn validate_reranker_output(num_candidates: usize, output: &[(usize, f64)]) -> Result<()> {
         use std::collections::HashSet;
 
-        if output.len() > input_ids.len() {
+        if output.len() > num_candidates {
             return Err(MemoryError::Reranker(format!(
-                "reranker violated subset contract: output length ({}) exceeds input length ({})",
+                "reranker violated subset contract: output length ({}) exceeds input length ({num_candidates})",
                 output.len(),
-                input_ids.len(),
             )));
         }
 
-        let input_set: HashSet<i64> = input_ids.iter().copied().collect();
         let mut seen = HashSet::with_capacity(output.len());
 
-        for result in output {
-            let id = result.fact.id;
-            if !input_set.contains(&id) {
+        for &(idx, score) in output {
+            if idx >= num_candidates {
                 return Err(MemoryError::Reranker(format!(
-                    "reranker violated subset contract: output contains fact id {id} \
-                     not present in input candidates",
+                    "reranker returned out-of-bounds index {idx} (candidates length: {num_candidates})",
                 )));
             }
-            if !seen.insert(id) {
+            if !seen.insert(idx) {
                 return Err(MemoryError::Reranker(format!(
-                    "reranker violated subset contract: duplicate fact id {id} in output",
+                    "reranker violated subset contract: duplicate index {idx} in output",
+                )));
+            }
+            if !score.is_finite() {
+                return Err(MemoryError::Reranker(format!(
+                    "reranker returned non-finite score {score} for index {idx}",
                 )));
             }
         }
@@ -3092,13 +3101,9 @@ mod tests {
 
     struct ReverseReranker;
     impl Reranker for ReverseReranker {
-        fn rerank(
-            &self,
-            _query: &str,
-            mut candidates: Vec<SearchResult>,
-        ) -> Result<Vec<SearchResult>> {
-            candidates.reverse();
-            Ok(candidates)
+        fn rerank(&self, _query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
+            let n = candidates.len();
+            Ok((0..n).rev().map(|i| (i, candidates[i].score)).collect())
         }
         fn name(&self) -> &str {
             "reverse"
@@ -3107,11 +3112,7 @@ mod tests {
 
     struct FailingReranker;
     impl Reranker for FailingReranker {
-        fn rerank(
-            &self,
-            _query: &str,
-            _candidates: Vec<SearchResult>,
-        ) -> Result<Vec<SearchResult>> {
+        fn rerank(&self, _query: &str, _candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
             Err(MemoryError::Reranker("cross-encoder timeout".into()))
         }
         fn name(&self) -> &str {
@@ -3134,10 +3135,12 @@ mod tests {
         }
     }
     impl Reranker for SpyReranker {
-        fn rerank(&self, _query: &str, candidates: Vec<SearchResult>) -> Result<Vec<SearchResult>> {
+        fn rerank(&self, _query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
             self.seen_count
                 .store(candidates.len(), std::sync::atomic::Ordering::Relaxed);
-            Ok(candidates)
+            Ok((0..candidates.len())
+                .map(|i| (i, candidates[i].score))
+                .collect())
         }
         fn name(&self) -> &str {
             "spy"
@@ -3469,7 +3472,7 @@ mod tests {
     /// Wrapper to allow `Arc<SpyReranker>` to be `Box<dyn Reranker>`.
     struct SpyRerankerWrapper(std::sync::Arc<SpyReranker>);
     impl Reranker for SpyRerankerWrapper {
-        fn rerank(&self, query: &str, candidates: Vec<SearchResult>) -> Result<Vec<SearchResult>> {
+        fn rerank(&self, query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
             self.0.rerank(query, candidates)
         }
         fn name(&self) -> &str {
@@ -3822,57 +3825,28 @@ mod tests {
     // --- Reranker subset/permutation guard (issue #85) ---
 
     /// Returns all candidates plus a fabricated fact with a bogus ID.
-    struct FabricatingReranker;
-    impl Reranker for FabricatingReranker {
-        fn rerank(
-            &self,
-            _query: &str,
-            mut candidates: Vec<SearchResult>,
-        ) -> Result<Vec<SearchResult>> {
-            // Inject a fact that was NOT in the input candidates
-            candidates.push(SearchResult {
-                fact: Fact {
-                    id: 999_999,
-                    content: "fabricated".into(),
-                    content_hash: "fake_hash".into(),
-                    embedding: vec![0.0; DIM],
-                    fact_type: FactType::Episodic,
-                    t_created: Utc::now(),
-                    t_expired: None,
-                    t_valid: None,
-                    t_invalid: None,
-                    source_event_id: None,
-                    importance: 0.0,
-                    access_count: 0,
-                    last_accessed: Utc::now(),
-                    metadata: serde_json::Value::Null,
-                    scope_id: 0,
-                    is_pinned: false,
-                    importance_score: 0.0,
-                    surfaced_at: None,
-                },
-                score: 1.0,
-                match_type: MatchType::Fts,
-            });
-            Ok(candidates)
+    /// Returns a single out-of-bounds index.
+    struct OutOfBoundsReranker;
+    impl Reranker for OutOfBoundsReranker {
+        fn rerank(&self, _query: &str, _candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
+            Ok(vec![(999_999, 1.0)])
         }
         fn name(&self) -> &str {
-            "fabricating"
+            "out_of_bounds"
         }
     }
 
-    /// Replaces the last candidate with a clone of the first (same length, duplicate ID).
+    /// Returns first two candidates with the same index (duplicate).
     struct DuplicatingReranker;
     impl Reranker for DuplicatingReranker {
-        fn rerank(
-            &self,
-            _query: &str,
-            mut candidates: Vec<SearchResult>,
-        ) -> Result<Vec<SearchResult>> {
+        fn rerank(&self, _query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
             if candidates.len() >= 2 {
-                candidates[1] = candidates[0].clone();
+                Ok(vec![(0, candidates[0].score), (0, candidates[0].score)])
+            } else {
+                Ok((0..candidates.len())
+                    .map(|i| (i, candidates[i].score))
+                    .collect())
             }
-            Ok(candidates)
         }
         fn name(&self) -> &str {
             "duplicating"
@@ -3880,9 +3854,9 @@ mod tests {
     }
 
     #[test]
-    fn reranker_rejects_fabricated_facts() {
+    fn reranker_rejects_out_of_bounds_index() {
         let engine =
-            MemoryEngine::open_memory_with(DIM, None, Some(Box::new(FabricatingReranker))).unwrap();
+            MemoryEngine::open_memory_with(DIM, None, Some(Box::new(OutOfBoundsReranker))).unwrap();
         let embedder = MockEmbedder { dim: DIM };
         engine
             .add_fact(
@@ -3907,15 +3881,15 @@ mod tests {
             scope: None,
         });
 
-        assert!(result.is_err(), "should reject fabricated facts");
+        assert!(result.is_err(), "should reject out-of-bounds index");
         let err = result.unwrap_err();
         assert!(
             matches!(err, MemoryError::Reranker(_)),
             "should be a Reranker error, got: {err}"
         );
         assert!(
-            err.to_string().contains("subset"),
-            "error message should mention subset violation, got: {err}"
+            err.to_string().contains("out-of-bounds"),
+            "error message should mention out-of-bounds, got: {err}"
         );
     }
 
@@ -4026,10 +4000,13 @@ mod tests {
             fn rerank(
                 &self,
                 _query: &str,
-                mut candidates: Vec<SearchResult>,
-            ) -> Result<Vec<SearchResult>> {
-                candidates.truncate(1);
-                Ok(candidates)
+                candidates: &[SearchResult],
+            ) -> Result<Vec<(usize, f64)>> {
+                if candidates.is_empty() {
+                    Ok(vec![])
+                } else {
+                    Ok(vec![(0, candidates[0].score)])
+                }
             }
             fn name(&self) -> &str {
                 "filtering"
@@ -4079,5 +4056,63 @@ mod tests {
             result.err()
         );
         assert_eq!(result.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn reranker_rejects_non_finite_score() {
+        struct NanScoreReranker;
+        impl Reranker for NanScoreReranker {
+            fn rerank(
+                &self,
+                _query: &str,
+                candidates: &[SearchResult],
+            ) -> Result<Vec<(usize, f64)>> {
+                if candidates.is_empty() {
+                    Ok(vec![])
+                } else {
+                    Ok(vec![(0, f64::NAN)])
+                }
+            }
+            fn name(&self) -> &str {
+                "nan_score"
+            }
+        }
+
+        let engine =
+            MemoryEngine::open_memory_with(DIM, None, Some(Box::new(NanScoreReranker))).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        engine
+            .add_fact(
+                "score test fact",
+                FactType::Episodic,
+                None,
+                &embedder,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let result = engine.query(&SearchQuery {
+            text: Some("score".into()),
+            embedding: None,
+            mode: SearchMode::Fts,
+            limit: 10,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        });
+
+        assert!(result.is_err(), "should reject NaN score");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Reranker(_)),
+            "should be a Reranker error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("non-finite"),
+            "error message should mention non-finite score, got: {err}"
+        );
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -92,20 +92,28 @@ pub trait PersistenceClassifier {
 /// # Contract
 ///
 /// - Input: query text + candidates from hybrid search (FTS + vector + RRF)
-/// - Output: reordered/rescored candidates (may filter, must not add new facts)
+/// - Output: `Vec<(usize, f64)>` — each tuple is `(index_into_candidates, new_score)`
 /// - The returned vec length must be <= input length
-/// - Every returned fact ID must be present in the input candidates (no fabrication)
-/// - No duplicate fact IDs in the output
+/// - Every index must be in range `0..candidates.len()`
+/// - No duplicate indices in the output
+/// - All scores must be finite (not NaN or Inf)
+///
+/// Returning indices instead of full `SearchResult` values **structurally prevents**
+/// the reranker from mutating fact content, embeddings, or match types (issue #144).
 ///
 /// These invariants are enforced at runtime by `MemoryEngine::query()`.
 /// Violations produce `MemoryError::Reranker`.
 pub trait Reranker: Send + Sync {
     /// Rerank candidates for the given query text.
     ///
+    /// Returns `(index, score)` pairs referencing positions in the `candidates` slice.
+    /// The engine reconstructs the final result set from these indices, preserving
+    /// the original `Fact` and `MatchType` values unchanged.
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Reranker` if reranking fails (e.g., API call, inference error).
-    fn rerank(&self, query: &str, candidates: Vec<SearchResult>) -> Result<Vec<SearchResult>>;
+    fn rerank(&self, query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>>;
 
     /// Human-readable name for logging and debug output.
     fn name(&self) -> &str;


### PR DESCRIPTION
## Summary

- **Breaking API change**: `Reranker::rerank()` now returns `Vec<(usize, f64)>` (index + score) instead of `Vec<SearchResult>`, and borrows candidates (`&[SearchResult]`) instead of taking ownership
- **Structural safety**: Makes content mutation by reranker implementations impossible at the type level — the reranker can only select candidates and assign scores
- **New invariant**: Validates all returned scores are finite (not NaN/Inf), catching buggy cross-encoder inference
- **Updated validator**: `validate_reranker_output()` now checks index bounds, duplicate indices, and score finiteness (4 invariants, up from 3)

## What changed

| File | Change |
|------|--------|
| `src/traits.rs` | Trait signature: `Vec<SearchResult>` → `Vec<(usize, f64)>`, `Vec<SearchResult>` param → `&[SearchResult]` |
| `src/engine.rs` | Call site reconstructs results from indices; validator checks bounds + finiteness; all 7 test mocks updated; 1 new test (`reranker_rejects_non_finite_score`) |
| `docs/advanced/extensibility.md` | Updated trait docs and `CrossEncoderReranker` example |

## Test plan

- [x] All 381 tests pass (352 lib + 29 integration/doc)
- [x] New test: `reranker_rejects_non_finite_score` — verifies NaN scores are rejected
- [x] Existing test renamed: `reranker_rejects_out_of_bounds_index` — verifies OOB index rejected
- [x] Existing tests: `reranker_rejects_duplicates`, `reranker_allows_valid_subset`, `reranker_allows_filtering_subset` — all pass with new API
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt --check` — clean

Fixes #144