### PR TITLE
test(mcp): integration tests for tool handlers

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -242,7 +242,7 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 | [#95](https://github.com/dutiona/memory-engine/issues/95)   | P1       | MCP tools: consolidate, forget, dump_state, pin/unpin        |
 | [#150](https://github.com/dutiona/memory-engine/issues/150) | P1       | MCP: batch embedding + batch `add_fact` for `flush_insights` |
 | [#96](https://github.com/dutiona/memory-engine/issues/96)   | P2       | MCP tools: replay_events, fact_history, bootstrap            |
-| [#151](https://github.com/dutiona/memory-engine/issues/151) | P2       | MCP: integration tests for tool handlers                     |
+| [#151](https://github.com/dutiona/memory-engine/issues/151) | P2       | ✅ MCP: integration tests for tool handlers (PR #176)        |
 | [#152](https://github.com/dutiona/memory-engine/issues/152) | P1       | Abstention type exposure in Query results (4-type taxonomy)  |
 
 #### Phase 4c: Quality & Cold Storage
@@ -341,7 +341,7 @@ Phase 4a ✅ and 4b ✅ are complete. Phase 5 is **unblocked on the critical pat
 
 **Parallelizable right now (4 independent tracks):**
 
-1. **Phase 4 follow-ups** (5 open: #95, #96, #150, #151) — all non-blocking
+1. **Phase 4 follow-ups** (4 open: #95, #96, #150, #152; #151 ✅) — all non-blocking
 2. **Phase 4c** (#16, #46, #31) — #16 evaluation harness benefits from MCP being live; #31 depends on #46
 3. **Super-qa sweep** (25 open issues) — incremental, any order
 4. **Phase 5a design + implementation** — the critical path forward

--- a/memory-engine-mcp/Cargo.toml
+++ b/memory-engine-mcp/Cargo.toml
@@ -24,9 +24,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "2"
 
 [dev-dependencies]
+blake3 = "1"
 wiremock = "0.6"
 tempfile = "3"
 insta = { version = "1", features = ["yaml"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/memory-engine-mcp/src/lib.rs
+++ b/memory-engine-mcp/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod config;
+pub mod depth;
+pub mod embedding;
+pub mod error;
+pub mod server;
+pub mod tools;

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -1,14 +1,8 @@
-mod config;
-mod depth;
-mod embedding;
-mod error;
-mod server;
-mod tools;
-
 use std::sync::Arc;
 
 use clap::Parser;
 use memory_engine::engine::{EngineConfig, MemoryEngine};
+use memory_engine_mcp::{config, embedding, server};
 use rmcp::ServiceExt;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 

--- a/memory-engine-mcp/tests/config_merge.rs
+++ b/memory-engine-mcp/tests/config_merge.rs
@@ -1,0 +1,253 @@
+//! Tests for CLI-over-TOML configuration merging.
+//!
+//! Validates field-level merge semantics:
+//! - TOML provides defaults
+//! - CLI flags override individual TOML fields
+//! - Missing TOML sections handled gracefully
+//! - `embed_dim` probing from DB fallback
+//! - `deny_unknown_fields` rejects extra config
+
+use memory_engine::engine::{EngineConfig, MemoryEngine};
+use memory_engine_mcp::config::{EmbeddingSection, McpConfig};
+use std::io::Write;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// TOML deserialization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn full_config_deserializes() {
+    let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+embed_dim = 384
+
+[embedding]
+endpoint = "http://localhost:11434/v1/embeddings"
+model = "nomic-embed-text"
+dimensions = 384
+"#;
+    let config: McpConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.engine.embed_dim, Some(384));
+    assert!(config.embedding.is_some());
+    let emb = config.embedding.unwrap();
+    assert_eq!(emb.model, "nomic-embed-text");
+    assert_eq!(emb.timeout_secs, 30); // default
+}
+
+#[test]
+fn minimal_config_no_embedding_section() {
+    let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+"#;
+    let config: McpConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.engine.embed_dim, None);
+    assert!(config.embedding.is_none());
+}
+
+#[test]
+fn config_with_api_key() {
+    let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+embed_dim = 768
+
+[embedding]
+endpoint = "https://api.openai.com/v1/embeddings"
+model = "text-embedding-3-small"
+api_key = "sk-test-key"
+dimensions = 768
+timeout_secs = 60
+"#;
+    let config: McpConfig = toml::from_str(toml_str).unwrap();
+    let emb = config.embedding.unwrap();
+    assert_eq!(emb.api_key.as_deref(), Some("sk-test-key"));
+    assert_eq!(emb.timeout_secs, 60);
+    assert_eq!(emb.dimensions, 768);
+}
+
+#[test]
+fn unknown_field_rejected() {
+    let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+bogus_field = true
+"#;
+    let result = toml::from_str::<McpConfig>(toml_str);
+    assert!(result.is_err());
+}
+
+#[test]
+fn unknown_embedding_field_rejected() {
+    let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+
+[embedding]
+endpoint = "http://localhost:11434/v1/embeddings"
+model = "test"
+dimensions = 384
+unknown_option = "bad"
+"#;
+    let result = toml::from_str::<McpConfig>(toml_str);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// CLI-over-TOML field merge (simulated)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cli_db_path_overrides_toml() {
+    let toml_str = r#"
+[engine]
+db_path = "/tmp/original.db"
+embed_dim = 384
+"#;
+    let mut config: McpConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(
+        config.engine.db_path,
+        std::path::PathBuf::from("/tmp/original.db")
+    );
+
+    // Simulate CLI override
+    let cli_db_path = std::path::PathBuf::from("/tmp/override.db");
+    config.engine.db_path = cli_db_path.clone();
+    assert_eq!(config.engine.db_path, cli_db_path);
+}
+
+/// Simulate the CLI-over-TOML merge logic from `main.rs::build_embedder`.
+///
+/// Returns `(endpoint, model, api_key)` after merging CLI overrides.
+fn merge_embedding_config(
+    cli_endpoint: Option<&str>,
+    cli_model: Option<&str>,
+    cli_api_key: Option<&str>,
+    base: Option<&EmbeddingSection>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let endpoint = cli_endpoint
+        .map(String::from)
+        .or_else(|| base.map(|b| b.endpoint.clone()));
+    let model = cli_model
+        .map(String::from)
+        .or_else(|| base.map(|b| b.model.clone()));
+    let api_key = cli_api_key
+        .map(String::from)
+        .or_else(|| base.and_then(|b| b.api_key.clone()));
+    (endpoint, model, api_key)
+}
+
+#[test]
+fn embedding_field_merge_cli_over_toml() {
+    let base = EmbeddingSection {
+        endpoint: "http://toml-host:11434/v1/embeddings".into(),
+        model: "toml-model".into(),
+        api_key: None,
+        dimensions: 384,
+        timeout_secs: 30,
+    };
+
+    // CLI provides endpoint and api_key, model comes from TOML
+    let (endpoint, model, api_key) = merge_embedding_config(
+        Some("http://cli-host:8080/embed"),
+        None,
+        Some("sk-cli-key"),
+        Some(&base),
+    );
+
+    assert_eq!(endpoint.as_deref(), Some("http://cli-host:8080/embed"));
+    assert_eq!(model.as_deref(), Some("toml-model")); // From TOML
+    assert_eq!(api_key.as_deref(), Some("sk-cli-key")); // From CLI
+}
+
+#[test]
+fn no_embedding_section_no_cli_results_in_none() {
+    let (endpoint, model, _api_key) = merge_embedding_config(None, None, None, None);
+
+    // Both must be present to create an embedder
+    let has_embedder = endpoint.is_some() && model.is_some();
+    assert!(!has_embedder);
+}
+
+#[test]
+fn partial_cli_without_toml_insufficient() {
+    // CLI provides endpoint but not model, no TOML embedding section
+    let (endpoint, model, _api_key) =
+        merge_embedding_config(Some("http://localhost:8080/embed"), None, None, None);
+
+    let has_embedder = endpoint.is_some() && model.is_some();
+    assert!(!has_embedder); // Can't create embedder without model
+}
+
+// ---------------------------------------------------------------------------
+// embed_dim probing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn probe_embed_dim_from_existing_db() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Create a real database with known embed_dim
+    let config = EngineConfig::new(db_path.clone(), 384);
+    let engine = MemoryEngine::open(&config).unwrap();
+    drop(engine);
+
+    let probed = memory_engine_mcp::config::probe_embed_dim(&db_path).unwrap();
+    assert_eq!(probed, 384);
+}
+
+#[test]
+fn probe_embed_dim_nonexistent_db() {
+    let result =
+        memory_engine_mcp::config::probe_embed_dim(std::path::Path::new("/tmp/no_such_db.sqlite"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn probe_embed_dim_different_dimensions() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    let config = EngineConfig::new(db_path.clone(), 768);
+    let engine = MemoryEngine::open(&config).unwrap();
+    drop(engine);
+
+    let probed = memory_engine_mcp::config::probe_embed_dim(&db_path).unwrap();
+    assert_eq!(probed, 768);
+}
+
+// ---------------------------------------------------------------------------
+// Config from TOML file (round-trip)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_from_toml_file() {
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let mut f = std::fs::File::create(&config_path).unwrap();
+    writeln!(
+        f,
+        r#"
+[engine]
+db_path = "/tmp/test.db"
+embed_dim = 256
+
+[embedding]
+endpoint = "http://localhost:11434/v1/embeddings"
+model = "all-minilm"
+dimensions = 256
+timeout_secs = 10
+"#
+    )
+    .unwrap();
+
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    let config: McpConfig = toml::from_str(&content).unwrap();
+    assert_eq!(config.engine.embed_dim, Some(256));
+    let emb = config.embedding.unwrap();
+    assert_eq!(emb.model, "all-minilm");
+    assert_eq!(emb.timeout_secs, 10);
+}

--- a/memory-engine-mcp/tests/depth_shaping.rs
+++ b/memory-engine-mcp/tests/depth_shaping.rs
@@ -1,0 +1,577 @@
+//! Insta snapshot tests for depth-shaping at each tier (sparse/standard/full).
+//!
+//! Validates that the JSON shape returned by each `shape_*` function matches
+//! the documented contract: sparse ~4 fields, standard ~15, full includes
+//! `embedding_dim` and `content_hash`.
+
+use memory_engine::engine::MemoryEngine;
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine_mcp::tools;
+use serde_json::{Map, Value, json};
+
+const DIM: usize = 8;
+
+struct TestEmbedder {
+    dim: usize,
+}
+
+impl EmbeddingProvider for TestEmbedder {
+    fn embed(&self, text: &str) -> memory_engine::error::Result<Vec<f32>> {
+        let hash = blake3::hash(text.as_bytes());
+        let bytes = hash.as_bytes();
+        let mut embedding = vec![0.0_f32; self.dim];
+        for (i, val) in embedding.iter_mut().enumerate() {
+            let byte = bytes[i % 32];
+            *val = (f32::from(byte) - 128.0) / 128.0;
+        }
+        let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for val in &mut embedding {
+                *val /= norm;
+            }
+        }
+        Ok(embedding)
+    }
+}
+
+fn make_engine() -> MemoryEngine {
+    MemoryEngine::open_memory(DIM).expect("in-memory engine")
+}
+
+fn args(pairs: Value) -> Map<String, Value> {
+    match pairs {
+        Value::Object(m) => m,
+        _ => panic!("args() requires a JSON object"),
+    }
+}
+
+fn unwrap_ok(result: Result<rmcp::model::CallToolResult, rmcp::model::ErrorData>) -> Value {
+    let call_result = result.expect("dispatch should succeed");
+    let content = call_result.content.first().expect("no content in result");
+    let text = content
+        .as_text()
+        .expect("expected Text content")
+        .text
+        .as_str();
+    serde_json::from_str(text).expect("content is not valid JSON")
+}
+
+/// Redact volatile fields (timestamps, IDs) for stable snapshots.
+fn redact(v: &mut Value) {
+    if let Value::Object(map) = v {
+        for key in [
+            "t_created",
+            "t_expired",
+            "t_valid",
+            "t_invalid",
+            "last_accessed",
+            "surfaced_at",
+        ] {
+            if map.contains_key(key) {
+                map.insert(key.to_owned(), json!("[REDACTED]"));
+            }
+        }
+        for val in map.values_mut() {
+            redact(val);
+        }
+    } else if let Value::Array(arr) = v {
+        for val in arr.iter_mut() {
+            redact(val);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// memory_get_fact — fact shaping at all three depths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_fact_sparse() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Rust is a systems programming language with zero-cost abstractions",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": fact_id, "depth": "sparse" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("get_fact_sparse", body);
+}
+
+#[test]
+fn get_fact_standard() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Rust is a systems programming language with zero-cost abstractions",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": fact_id, "depth": "standard" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("get_fact_standard", body);
+}
+
+#[test]
+fn get_fact_full() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Rust is a systems programming language with zero-cost abstractions",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": fact_id, "depth": "full" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("get_fact_full", body);
+}
+
+// ---------------------------------------------------------------------------
+// memory_explain_fact — explanation shaping at all three depths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explain_fact_sparse() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Ebbinghaus forgetting curve",
+            memory_engine::types::FactType::Procedural,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_explain_fact",
+        args(json!({ "fact_id": fact_id, "depth": "sparse" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("explain_fact_sparse", body);
+}
+
+#[test]
+fn explain_fact_standard() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Ebbinghaus forgetting curve",
+            memory_engine::types::FactType::Procedural,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_explain_fact",
+        args(json!({ "fact_id": fact_id, "depth": "standard" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("explain_fact_standard", body);
+}
+
+#[test]
+fn explain_fact_full() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Ebbinghaus forgetting curve",
+            memory_engine::types::FactType::Procedural,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_explain_fact",
+        args(json!({ "fact_id": fact_id, "depth": "full" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("explain_fact_full", body);
+}
+
+// ---------------------------------------------------------------------------
+// memory_query — search result shaping at all three depths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn query_result_sparse() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    engine
+        .add_fact(
+            "Neural networks learn representations",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_query",
+        args(json!({ "text": "neural", "mode": "fts", "depth": "sparse" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("query_result_sparse", body);
+}
+
+#[test]
+fn query_result_standard() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    engine
+        .add_fact(
+            "Neural networks learn representations",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_query",
+        args(json!({ "text": "neural", "mode": "fts", "depth": "standard" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("query_result_standard", body);
+}
+
+#[test]
+fn query_result_full() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    engine
+        .add_fact(
+            "Neural networks learn representations",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_query",
+        args(json!({ "text": "neural", "mode": "fts", "depth": "full" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("query_result_full", body);
+}
+
+// ---------------------------------------------------------------------------
+// memory_resume_context — resume shaping at all three depths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resume_context_sparse() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let opts = memory_engine::types::AddFactOptions {
+        importance: Some(0.95),
+        pinned: Some(true),
+        ..Default::default()
+    };
+    engine
+        .add_fact(
+            "Critical pinned fact",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            Some(&opts),
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_resume_context",
+        args(json!({ "depth": "sparse" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("resume_context_sparse", body);
+}
+
+#[test]
+fn resume_context_standard() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let opts = memory_engine::types::AddFactOptions {
+        importance: Some(0.95),
+        pinned: Some(true),
+        ..Default::default()
+    };
+    engine
+        .add_fact(
+            "Critical pinned fact",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            Some(&opts),
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_resume_context",
+        args(json!({ "depth": "standard" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("resume_context_standard", body);
+}
+
+#[test]
+fn resume_context_full() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let opts = memory_engine::types::AddFactOptions {
+        importance: Some(0.95),
+        pinned: Some(true),
+        ..Default::default()
+    };
+    engine
+        .add_fact(
+            "Critical pinned fact",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            Some(&opts),
+            None,
+        )
+        .unwrap();
+
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_resume_context",
+        args(json!({ "depth": "full" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("resume_context_full", body);
+}
+
+// ---------------------------------------------------------------------------
+// memory_list_due — list shaping at all three depths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_due_sparse() {
+    let engine = make_engine();
+    let mut body = unwrap_ok(tools::dispatch(
+        "memory_list_due",
+        args(json!({ "depth": "sparse" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    redact(&mut body);
+    insta::assert_yaml_snapshot!("list_due_sparse", body);
+}
+
+// ---------------------------------------------------------------------------
+// Depth field-count assertions (structural, not snapshot)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sparse_has_exactly_4_fields() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Field count test",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let body = unwrap_ok(tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": fact_id, "depth": "sparse" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    assert_eq!(body.as_object().unwrap().len(), 4);
+}
+
+#[test]
+fn standard_excludes_embedding_and_hash() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Field exclusion test",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let body = unwrap_ok(tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": fact_id, "depth": "standard" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    let obj = body.as_object().unwrap();
+    assert!(!obj.contains_key("embedding"));
+    assert!(!obj.contains_key("content_hash"));
+    assert!(!obj.contains_key("embedding_dim"));
+}
+
+#[test]
+fn full_includes_embedding_dim_and_hash() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Full depth test",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let body = unwrap_ok(tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": fact_id, "depth": "full" })),
+        &engine,
+        None,
+        DIM,
+    ));
+    let obj = body.as_object().unwrap();
+    assert!(obj.contains_key("content_hash"));
+    assert!(obj.contains_key("embedding_dim"));
+    assert_eq!(obj["embedding_dim"], DIM);
+}
+
+// ---------------------------------------------------------------------------
+// Default depth is standard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_depth_is_standard() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+    let fact_id = engine
+        .add_fact(
+            "Default depth test",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    // No depth parameter → default (standard)
+    let body = unwrap_ok(tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": fact_id })),
+        &engine,
+        None,
+        DIM,
+    ));
+    let obj = body.as_object().unwrap();
+    // Standard has content + fact_type but no embedding_dim
+    assert!(obj.contains_key("fact_type"));
+    assert!(!obj.contains_key("embedding_dim"));
+}

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -1,0 +1,448 @@
+//! wiremock-based HTTP embedding round-trip tests.
+//!
+//! Validates `HttpEmbeddingProvider` against all three supported response
+//! formats (`OpenAI`, Ollama, direct) and exercises end-to-end embedding via
+//! `memory_add_fact` and `memory_flush_insights`.
+//!
+//! `HttpEmbeddingProvider` uses `reqwest::blocking::Client` which creates an
+//! internal tokio runtime. To avoid nested-runtime panics, the provider must
+//! be created AND dropped on the blocking thread pool. After async wiremock
+//! setup, all provider work runs inside a single `spawn_blocking` block.
+
+use memory_engine::engine::MemoryEngine;
+use memory_engine_mcp::embedding::HttpEmbeddingProvider;
+use memory_engine_mcp::tools;
+use serde_json::{Map, Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const DIM: usize = 4;
+
+fn args(pairs: Value) -> Map<String, Value> {
+    match pairs {
+        Value::Object(m) => m,
+        _ => panic!("args() requires a JSON object"),
+    }
+}
+
+fn unwrap_ok(result: Result<rmcp::model::CallToolResult, rmcp::model::ErrorData>) -> Value {
+    let call_result = result.expect("dispatch should succeed");
+    let content = call_result.content.first().expect("no content in result");
+    let text = content
+        .as_text()
+        .expect("expected Text content")
+        .text
+        .as_str();
+    serde_json::from_str(text).expect("content is not valid JSON")
+}
+
+fn make_embedding(dim: usize) -> Vec<f32> {
+    vec![0.25; dim]
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI response format
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn openai_format_embedding() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "embedding": emb }],
+            "model": "test-model",
+            "usage": { "prompt_tokens": 5, "total_tokens": 5 }
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let result = tools::dispatch(
+            "memory_add_fact",
+            args(json!({ "content": "OpenAI format test" })),
+            &engine,
+            Some(&provider),
+            DIM,
+        );
+        unwrap_ok(result)
+    })
+    .await
+    .unwrap();
+    assert!(body["fact_id"].as_i64().unwrap() > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Ollama response format
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ollama_format_embedding() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "embeddings": [emb]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "nomic-embed-text".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let result = tools::dispatch(
+            "memory_add_fact",
+            args(json!({ "content": "Ollama format test" })),
+            &engine,
+            Some(&provider),
+            DIM,
+        );
+        unwrap_ok(result)
+    })
+    .await
+    .unwrap();
+    assert!(body["fact_id"].as_i64().unwrap() > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Direct (single embedding) response format
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn direct_format_embedding() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "embedding": emb
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "custom-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let result = tools::dispatch(
+            "memory_add_fact",
+            args(json!({ "content": "Direct format test" })),
+            &engine,
+            Some(&provider),
+            DIM,
+        );
+        unwrap_ok(result)
+    })
+    .await
+    .unwrap();
+    assert!(body["fact_id"].as_i64().unwrap() > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Dimension mismatch from remote server
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn wrong_dimension_from_server() {
+    let server = MockServer::start().await;
+    let wrong_emb = vec![0.1; DIM + 3]; // wrong dimension
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "embedding": wrong_emb }]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let is_err = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        tools::dispatch(
+            "memory_add_fact",
+            args(json!({ "content": "Dim mismatch test" })),
+            &engine,
+            Some(&provider),
+            DIM,
+        )
+        .is_err()
+    })
+    .await
+    .unwrap();
+    assert!(is_err);
+}
+
+// ---------------------------------------------------------------------------
+// Server error propagation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn server_500_propagates_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let is_err = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        tools::dispatch(
+            "memory_add_fact",
+            args(json!({ "content": "Server error test" })),
+            &engine,
+            Some(&provider),
+            DIM,
+        )
+        .is_err()
+    })
+    .await
+    .unwrap();
+    assert!(is_err);
+}
+
+// ---------------------------------------------------------------------------
+// Bearer auth header
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bearer_auth_sent_when_configured() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .and(wiremock::matchers::header(
+            "Authorization",
+            "Bearer test-key-123",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "embedding": emb }]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            Some("test-key-123".into()),
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let result = tools::dispatch(
+            "memory_add_fact",
+            args(json!({ "content": "Auth test" })),
+            &engine,
+            Some(&provider),
+            DIM,
+        );
+        unwrap_ok(result)
+    })
+    .await
+    .unwrap();
+    assert!(body["fact_id"].as_i64().unwrap() > 0);
+}
+
+// ---------------------------------------------------------------------------
+// flush_insights with wiremock embedder
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn flush_insights_with_http_embedder() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "embedding": emb }]
+        })))
+        .expect(2) // Two insights = two embedding calls
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let result = tools::dispatch(
+            "memory_flush_insights",
+            args(json!({
+                "insights": [
+                    { "content": "Insight one", "importance": 0.8 },
+                    { "content": "Insight two", "fact_type": "Procedural" }
+                ]
+            })),
+            &engine,
+            Some(&provider),
+            DIM,
+        );
+        unwrap_ok(result)
+    })
+    .await
+    .unwrap();
+    assert_eq!(body["added"].as_u64().unwrap(), 2);
+    assert_eq!(body["failed_count"].as_u64().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn flush_insights_partial_failure() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "embedding": emb }]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let result = tools::dispatch(
+            "memory_flush_insights",
+            args(json!({
+                "insights": [
+                    { "content": "Good insight" },
+                    "not an object",
+                    { "no_content_field": true }
+                ]
+            })),
+            &engine,
+            Some(&provider),
+            DIM,
+        );
+        unwrap_ok(result)
+    })
+    .await
+    .unwrap();
+    assert_eq!(body["added"].as_u64().unwrap(), 1);
+    assert_eq!(body["failed_count"].as_u64().unwrap(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Query with server-side embedding
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn query_hybrid_with_http_embedder() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "embedding": emb }]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let emb_clone = emb;
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+
+        // Add a fact with pre-computed embedding (no provider needed)
+        tools::dispatch(
+            "memory_add_fact",
+            args(json!({
+                "content": "Tokio async runtime",
+                "embedding": emb_clone,
+            })),
+            &engine,
+            None,
+            DIM,
+        )
+        .unwrap();
+
+        // Query using server-side embedding
+        let result = tools::dispatch(
+            "memory_query",
+            args(json!({ "text": "async runtime", "mode": "hybrid" })),
+            &engine,
+            Some(&provider),
+            DIM,
+        );
+        unwrap_ok(result)
+    })
+    .await
+    .unwrap();
+    assert!(body["count"].as_u64().unwrap() >= 1);
+}

--- a/memory-engine-mcp/tests/query_mode_inference.rs
+++ b/memory-engine-mcp/tests/query_mode_inference.rs
@@ -1,0 +1,343 @@
+//! Tests for explicit search mode vs engine-inferred mode behavior.
+//!
+//! Validates the mode selection logic in `handle_query`:
+//! - Explicit `mode=fts` → FTS-only, no embedding needed
+//! - Explicit `mode=vector` → requires embedding (provider or pre-computed)
+//! - Explicit `mode=hybrid` → requires embedding
+//! - No mode + text only + no embedder → engine infers FTS
+//! - No mode + text + embedder → engine infers hybrid (embedding provided)
+//! - No mode + embedding only → engine infers vector
+
+use memory_engine::engine::MemoryEngine;
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine_mcp::tools;
+use serde_json::{Map, Value, json};
+
+const DIM: usize = 8;
+
+struct TestEmbedder {
+    dim: usize,
+}
+
+impl EmbeddingProvider for TestEmbedder {
+    fn embed(&self, text: &str) -> memory_engine::error::Result<Vec<f32>> {
+        let hash = blake3::hash(text.as_bytes());
+        let bytes = hash.as_bytes();
+        let mut embedding = vec![0.0_f32; self.dim];
+        for (i, val) in embedding.iter_mut().enumerate() {
+            let byte = bytes[i % 32];
+            *val = (f32::from(byte) - 128.0) / 128.0;
+        }
+        let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for val in &mut embedding {
+                *val /= norm;
+            }
+        }
+        Ok(embedding)
+    }
+}
+
+fn make_engine() -> MemoryEngine {
+    MemoryEngine::open_memory(DIM).expect("in-memory engine")
+}
+
+fn seed_facts(engine: &MemoryEngine) {
+    let embedder = TestEmbedder { dim: DIM };
+    engine
+        .add_fact(
+            "Rust ownership model prevents data races",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Python GIL limits true parallelism",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+}
+
+fn args(pairs: Value) -> Map<String, Value> {
+    match pairs {
+        Value::Object(m) => m,
+        _ => panic!("args() requires a JSON object"),
+    }
+}
+
+fn unwrap_ok(result: Result<rmcp::model::CallToolResult, rmcp::model::ErrorData>) -> Value {
+    let call_result = result.expect("dispatch should succeed");
+    let content = call_result.content.first().expect("no content in result");
+    let text = content
+        .as_text()
+        .expect("expected Text content")
+        .text
+        .as_str();
+    serde_json::from_str(text).expect("content is not valid JSON")
+}
+
+// ---------------------------------------------------------------------------
+// Explicit mode: fts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_fts_no_embedder_succeeds() {
+    let engine = make_engine();
+    seed_facts(&engine);
+
+    // mode=fts + text + no embedder → should work fine
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({ "text": "Rust", "mode": "fts" })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["count"].as_u64().unwrap() >= 1);
+}
+
+// ---------------------------------------------------------------------------
+// Explicit mode: vector (requires embedding)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_vector_no_embedder_no_embedding_fails() {
+    let engine = make_engine();
+    seed_facts(&engine);
+
+    // mode=vector + text + no embedder + no pre-computed embedding → error
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({ "text": "Rust", "mode": "vector" })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn explicit_vector_with_precomputed_embedding_succeeds() {
+    let engine = make_engine();
+    seed_facts(&engine);
+
+    let embedder = TestEmbedder { dim: DIM };
+    let emb = embedder.embed("Rust ownership").unwrap();
+
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({
+            "text": "Rust",
+            "mode": "vector",
+            "embedding": emb,
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["count"].as_u64().unwrap() >= 1);
+}
+
+// ---------------------------------------------------------------------------
+// Explicit mode: hybrid
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_hybrid_no_embedder_no_embedding_fails() {
+    let engine = make_engine();
+    seed_facts(&engine);
+
+    // mode=hybrid + text + no embedder + no embedding → error
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({ "text": "Rust", "mode": "hybrid" })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn explicit_hybrid_with_precomputed_embedding_succeeds() {
+    let engine = make_engine();
+    seed_facts(&engine);
+
+    let embedder = TestEmbedder { dim: DIM };
+    let emb = embedder.embed("Rust ownership").unwrap();
+
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({
+            "text": "Rust",
+            "mode": "hybrid",
+            "embedding": emb,
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["count"].as_u64().unwrap() >= 1);
+}
+
+// ---------------------------------------------------------------------------
+// No explicit mode — engine inference
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inferred_mode_text_only_no_embedder_falls_back_to_fts() {
+    let engine = make_engine();
+    seed_facts(&engine);
+
+    // No mode + text + no embedder → engine should infer FTS (no embedding provided)
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({ "text": "Rust" })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["count"].as_u64().unwrap() >= 1);
+}
+
+#[test]
+fn inferred_mode_embedding_only_works() {
+    let engine = make_engine();
+    seed_facts(&engine);
+
+    let embedder = TestEmbedder { dim: DIM };
+    let emb = embedder.embed("ownership memory safety").unwrap();
+
+    // No mode + no text + embedding → engine should infer vector search
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({ "embedding": emb })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    // Should return some results via vector search
+    assert!(body.as_object().unwrap().contains_key("results"));
+}
+
+// ---------------------------------------------------------------------------
+// Unknown mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_mode_returns_error() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({ "text": "test", "mode": "bogus" })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Scope + mode interaction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn query_with_scope_parameters_accepted() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+
+    engine
+        .add_fact(
+            "Rust borrow checker ensures safety",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            Some("lang/rust"),
+            None,
+            None,
+        )
+        .unwrap();
+
+    // Verify all scope_mode variants are accepted by the dispatch layer
+    for scope_mode in &["subtree", "exact", "ancestors", "inherited"] {
+        let result = tools::dispatch(
+            "memory_query",
+            args(json!({
+                "text": "Rust",
+                "mode": "fts",
+                "scope": "lang/rust",
+                "scope_mode": scope_mode,
+            })),
+            &engine,
+            None,
+            DIM,
+        );
+        // Should succeed (no validation error), regardless of result count
+        assert!(
+            result.is_ok(),
+            "scope_mode '{scope_mode}' should be accepted"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fact type filter with mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fts_with_fact_type_filter() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+
+    engine
+        .add_fact(
+            "Rust compile-time guarantees",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Today I learned about Rust lifetimes",
+            memory_engine::types::FactType::Episodic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({
+            "text": "Rust",
+            "mode": "fts",
+            "fact_type": "Episodic",
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert_eq!(body["count"].as_u64().unwrap(), 1);
+}

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__explain_fact_full.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__explain_fact_full.snap
@@ -1,0 +1,19 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 251
+expression: body
+---
+fact_id: 1
+graph_context:
+  component_size: 0
+  degree: 0
+  neighbor_ids: []
+provenance:
+  access_count: 0
+  importance: 0.5
+  importance_score: 0.5
+  is_pinned: false
+  source_event: ~
+  source_event_id: ~
+scope_path: /
+state: Active

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__explain_fact_sparse.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__explain_fact_sparse.snap
@@ -1,0 +1,8 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 197
+expression: body
+---
+fact_id: 1
+scope_path: /
+state: Active

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__explain_fact_standard.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__explain_fact_standard.snap
@@ -1,0 +1,17 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 224
+expression: body
+---
+fact_id: 1
+graph:
+  component_size: 0
+  degree: 0
+provenance:
+  access_count: 0
+  importance: 0.5
+  importance_score: 0.5
+  is_pinned: false
+  source_event_id: ~
+scope_path: /
+state: Active

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__get_fact_full.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__get_fact_full.snap
@@ -1,0 +1,24 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 166
+expression: body
+---
+access_count: 0
+content: Rust is a systems programming language with zero-cost abstractions
+content_hash: 8d720581b60ae95d28658d390bf68a2d
+embedding_dim: 8
+fact_type: Semantic
+id: 1
+importance: 0.5
+importance_score: 0.5
+is_pinned: false
+last_accessed: "[REDACTED]"
+metadata: {}
+scope: ""
+scope_id: 1
+source_event_id: ~
+surfaced_at: "[REDACTED]"
+t_created: "[REDACTED]"
+t_expired: "[REDACTED]"
+t_invalid: "[REDACTED]"
+t_valid: "[REDACTED]"

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__get_fact_sparse.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__get_fact_sparse.snap
@@ -1,0 +1,9 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 112
+expression: body
+---
+content: Rust is a systems programming language with zero-cost abstractions
+id: 1
+importance_score: 0.5
+scope: ""

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__get_fact_standard.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__get_fact_standard.snap
@@ -1,0 +1,22 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 139
+expression: body
+---
+access_count: 0
+content: Rust is a systems programming language with zero-cost abstractions
+fact_type: Semantic
+id: 1
+importance: 0.5
+importance_score: 0.5
+is_pinned: false
+last_accessed: "[REDACTED]"
+metadata: {}
+scope: ""
+scope_id: 1
+source_event_id: ~
+surfaced_at: "[REDACTED]"
+t_created: "[REDACTED]"
+t_expired: "[REDACTED]"
+t_invalid: "[REDACTED]"
+t_valid: "[REDACTED]"

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__list_due_sparse.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__list_due_sparse.snap
@@ -1,0 +1,7 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 454
+expression: body
+---
+count: 0
+facts: []

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_full.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_full.snap
@@ -1,0 +1,28 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 336
+expression: body
+---
+count: 1
+results:
+  - access_count: 0
+    content: Neural networks learn representations
+    content_hash: 7abe56521634402afac5a6f961d4f700
+    embedding_dim: 8
+    fact_type: Semantic
+    id: 1
+    importance: 0.5
+    importance_score: 0.5
+    is_pinned: false
+    last_accessed: "[REDACTED]"
+    match_type: Fts
+    metadata: {}
+    scope: ""
+    scope_id: 1
+    score: -0.000001
+    source_event_id: ~
+    surfaced_at: "[REDACTED]"
+    t_created: "[REDACTED]"
+    t_expired: "[REDACTED]"
+    t_invalid: "[REDACTED]"
+    t_valid: "[REDACTED]"

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_sparse.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_sparse.snap
@@ -1,0 +1,13 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 282
+expression: body
+---
+count: 1
+results:
+  - content: Neural networks learn representations
+    id: 1
+    importance_score: 0.5
+    match_type: Fts
+    scope: ""
+    score: -0.000001

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_standard.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_standard.snap
@@ -1,0 +1,26 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 309
+expression: body
+---
+count: 1
+results:
+  - access_count: 0
+    content: Neural networks learn representations
+    fact_type: Semantic
+    id: 1
+    importance: 0.5
+    importance_score: 0.5
+    is_pinned: false
+    last_accessed: "[REDACTED]"
+    match_type: Fts
+    metadata: {}
+    scope: ""
+    scope_id: 1
+    score: -0.000001
+    source_event_id: ~
+    surfaced_at: "[REDACTED]"
+    t_created: "[REDACTED]"
+    t_expired: "[REDACTED]"
+    t_invalid: "[REDACTED]"
+    t_valid: "[REDACTED]"

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_full.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_full.snap
@@ -1,0 +1,29 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 436
+expression: body
+---
+due: []
+high_importance: []
+kb_stubs: []
+pinned:
+  - access_count: 0
+    content: Critical pinned fact
+    content_hash: 2e54b5958121f71d211e17dfbbafd88d
+    embedding_dim: 8
+    fact_type: Semantic
+    id: 1
+    importance: 0.95
+    importance_score: 0.95
+    is_pinned: true
+    last_accessed: "[REDACTED]"
+    metadata: {}
+    scope: ""
+    scope_id: 1
+    source_event_id: ~
+    surfaced_at: "[REDACTED]"
+    t_created: "[REDACTED]"
+    t_expired: "[REDACTED]"
+    t_invalid: "[REDACTED]"
+    t_valid: "[REDACTED]"
+recent: []

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_sparse.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_sparse.snap
@@ -1,0 +1,14 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 372
+expression: body
+---
+due: []
+high_importance: []
+kb_stubs: []
+pinned:
+  - content: Critical pinned fact
+    id: 1
+    importance_score: 0.95
+    scope: ""
+recent: []

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_standard.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_standard.snap
@@ -1,0 +1,27 @@
+---
+source: memory-engine-mcp/tests/depth_shaping.rs
+assertion_line: 404
+expression: body
+---
+due: []
+high_importance: []
+kb_stubs: []
+pinned:
+  - access_count: 0
+    content: Critical pinned fact
+    fact_type: Semantic
+    id: 1
+    importance: 0.95
+    importance_score: 0.95
+    is_pinned: true
+    last_accessed: "[REDACTED]"
+    metadata: {}
+    scope: ""
+    scope_id: 1
+    source_event_id: ~
+    surfaced_at: "[REDACTED]"
+    t_created: "[REDACTED]"
+    t_expired: "[REDACTED]"
+    t_invalid: "[REDACTED]"
+    t_valid: "[REDACTED]"
+recent: []

--- a/memory-engine-mcp/tests/tool_roundtrip.rs
+++ b/memory-engine-mcp/tests/tool_roundtrip.rs
@@ -1,0 +1,650 @@
+//! Integration tests exercising all 10 MCP tools via `tools::dispatch()`.
+//!
+//! Each test creates an in-memory `MemoryEngine`, bypasses MCP transport,
+//! and calls the dispatch function directly — validating argument parsing,
+//! engine interaction, response shaping, and error mapping.
+
+use memory_engine::engine::MemoryEngine;
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine_mcp::tools;
+use serde_json::{Map, Value, json};
+
+const DIM: usize = 8;
+
+// ---------------------------------------------------------------------------
+// Test embedder (deterministic, blake3-based — mirrors roundtrip_test.rs)
+// ---------------------------------------------------------------------------
+
+struct TestEmbedder {
+    dim: usize,
+}
+
+impl EmbeddingProvider for TestEmbedder {
+    fn embed(&self, text: &str) -> memory_engine::error::Result<Vec<f32>> {
+        let hash = blake3::hash(text.as_bytes());
+        let bytes = hash.as_bytes();
+        let mut embedding = vec![0.0_f32; self.dim];
+        for (i, val) in embedding.iter_mut().enumerate() {
+            let byte = bytes[i % 32];
+            *val = (f32::from(byte) - 128.0) / 128.0;
+        }
+        let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for val in &mut embedding {
+                *val /= norm;
+            }
+        }
+        Ok(embedding)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_engine() -> MemoryEngine {
+    MemoryEngine::open_memory(DIM).expect("in-memory engine")
+}
+
+const fn make_embedder() -> TestEmbedder {
+    TestEmbedder { dim: DIM }
+}
+
+fn args(pairs: Value) -> Map<String, Value> {
+    match pairs {
+        Value::Object(m) => m,
+        _ => panic!("args() requires a JSON object"),
+    }
+}
+
+/// Extract the JSON body from a successful `CallToolResult`.
+fn unwrap_ok(result: Result<rmcp::model::CallToolResult, rmcp::model::ErrorData>) -> Value {
+    let call_result = result.expect("dispatch should succeed");
+    assert!(
+        !call_result.is_error.unwrap_or(false),
+        "tool returned is_error=true"
+    );
+    let content = call_result.content.first().expect("no content in result");
+    let text = content
+        .as_text()
+        .expect("expected Text content")
+        .text
+        .as_str();
+    serde_json::from_str(text).expect("content is not valid JSON")
+}
+
+// ---------------------------------------------------------------------------
+// 1. memory_ingest
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ingest_minimal() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_ingest",
+        args(json!({
+            "event_type": "Interaction",
+            "payload": {"msg": "hello"},
+            "source": "test"
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["event_id"].as_i64().unwrap() > 0);
+}
+
+#[test]
+fn ingest_with_all_optional_fields() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_ingest",
+        args(json!({
+            "event_type": "ToolCall",
+            "payload": {"tool": "grep"},
+            "source": "test",
+            "session_id": "sess-1",
+            "scope": "project/alpha",
+            "timestamp": "2025-06-01T12:00:00Z"
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["event_id"].as_i64().unwrap() > 0);
+}
+
+#[test]
+fn ingest_invalid_event_type() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_ingest",
+        args(json!({
+            "event_type": "BogusType",
+            "payload": {},
+            "source": "test"
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn ingest_missing_required_field() {
+    let engine = make_engine();
+    // Missing "source"
+    let result = tools::dispatch(
+        "memory_ingest",
+        args(json!({
+            "event_type": "Interaction",
+            "payload": {}
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// 2. memory_add_fact
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_fact_with_precomputed_embedding() {
+    let engine = make_engine();
+    let emb = vec![0.1; DIM];
+    let result = tools::dispatch(
+        "memory_add_fact",
+        args(json!({
+            "content": "Rust is a systems language",
+            "embedding": emb,
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["fact_id"].as_i64().unwrap() > 0);
+}
+
+#[test]
+fn add_fact_all_options() {
+    let engine = make_engine();
+    let emb = vec![0.2; DIM];
+    let result = tools::dispatch(
+        "memory_add_fact",
+        args(json!({
+            "content": "Ebbinghaus forgetting curve",
+            "fact_type": "Procedural",
+            "scope": "research/memory",
+            "importance": 0.9,
+            "pinned": true,
+            "metadata": {"source": "paper"},
+            "t_valid": "2025-01-01T00:00:00Z",
+            "t_invalid": "2026-01-01T00:00:00Z",
+            "embedding": emb,
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["fact_id"].as_i64().unwrap() > 0);
+}
+
+#[test]
+fn add_fact_importance_out_of_range() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_add_fact",
+        args(json!({
+            "content": "test",
+            "importance": 1.5,
+            "embedding": vec![0.1; DIM],
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn add_fact_temporal_inconsistency() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_add_fact",
+        args(json!({
+            "content": "test",
+            "t_valid": "2026-01-01T00:00:00Z",
+            "t_invalid": "2025-01-01T00:00:00Z",
+            "embedding": vec![0.1; DIM],
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn add_fact_wrong_embedding_dim() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_add_fact",
+        args(json!({
+            "content": "test",
+            "embedding": vec![0.1; DIM + 5],
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn add_fact_no_embedder_no_embedding() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_add_fact",
+        args(json!({
+            "content": "test without embedding",
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    // Should fail: no pre-computed embedding and no HttpEmbeddingProvider
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// 3. memory_query
+// ---------------------------------------------------------------------------
+
+#[test]
+fn query_fts_returns_results() {
+    let engine = make_engine();
+    let embedder = make_embedder();
+
+    // Seed some facts
+    engine
+        .add_fact(
+            "Rust has zero-cost abstractions",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Python is great for ML",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({
+            "text": "Rust",
+            "mode": "fts",
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["count"].as_u64().unwrap() >= 1);
+    assert!(!body["results"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn query_with_precomputed_embedding() {
+    let engine = make_engine();
+    let embedder = make_embedder();
+
+    engine
+        .add_fact(
+            "Memory consolidation during sleep",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let query_emb = embedder.embed("sleep memory").unwrap();
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({
+            "text": "memory",
+            "mode": "hybrid",
+            "embedding": query_emb,
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert!(body["count"].as_u64().unwrap() >= 1);
+}
+
+#[test]
+fn query_one_sided_period_rejected() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({
+            "text": "anything",
+            "period_start": "2025-01-01T00:00:00Z",
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn query_empty_engine() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({
+            "text": "nothing here",
+            "mode": "fts",
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert_eq!(body["count"].as_u64().unwrap(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// 4. memory_resume_context
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resume_context_empty_engine() {
+    let engine = make_engine();
+    let result = tools::dispatch("memory_resume_context", args(json!({})), &engine, None, DIM);
+    let body = unwrap_ok(result);
+    // All tiers should be empty arrays
+    assert!(body["pinned"].as_array().unwrap().is_empty());
+    assert!(body["high_importance"].as_array().unwrap().is_empty());
+    assert!(body["due"].as_array().unwrap().is_empty());
+    assert!(body["recent"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn resume_context_with_pinned_fact() {
+    let engine = make_engine();
+    let embedder = make_embedder();
+
+    let opts = memory_engine::types::AddFactOptions {
+        importance: Some(0.95),
+        pinned: Some(true),
+        ..Default::default()
+    };
+    engine
+        .add_fact(
+            "Critical system invariant",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            Some(&opts),
+            None,
+        )
+        .unwrap();
+
+    let result = tools::dispatch("memory_resume_context", args(json!({})), &engine, None, DIM);
+    let body = unwrap_ok(result);
+    assert!(!body["pinned"].as_array().unwrap().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 5. memory_list_due
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_due_empty() {
+    let engine = make_engine();
+    let result = tools::dispatch("memory_list_due", args(json!({})), &engine, None, DIM);
+    let body = unwrap_ok(result);
+    assert_eq!(body["count"].as_u64().unwrap(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// 6. memory_next_due_time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn next_due_time_empty() {
+    let engine = make_engine();
+    let result = tools::dispatch("memory_next_due_time", args(json!({})), &engine, None, DIM);
+    let body = unwrap_ok(result);
+    assert!(body["next_due"].is_null());
+}
+
+// ---------------------------------------------------------------------------
+// 7. memory_explain_fact
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explain_fact_existing() {
+    let engine = make_engine();
+    let embedder = make_embedder();
+
+    let fact_id = engine
+        .add_fact(
+            "Fact to explain",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let result = tools::dispatch(
+        "memory_explain_fact",
+        args(json!({ "fact_id": fact_id })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert_eq!(body["fact_id"].as_i64().unwrap(), fact_id);
+}
+
+#[test]
+fn explain_fact_nonexistent() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_explain_fact",
+        args(json!({ "fact_id": 9999 })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn explain_fact_missing_id() {
+    let engine = make_engine();
+    let result = tools::dispatch("memory_explain_fact", args(json!({})), &engine, None, DIM);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// 8. memory_get_fact
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_fact_existing() {
+    let engine = make_engine();
+    let embedder = make_embedder();
+
+    let fact_id = engine
+        .add_fact(
+            "Retrievable fact",
+            memory_engine::types::FactType::Episodic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let result = tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": fact_id })),
+        &engine,
+        None,
+        DIM,
+    );
+    let body = unwrap_ok(result);
+    assert_eq!(body["id"].as_i64().unwrap(), fact_id);
+    assert_eq!(body["content"].as_str().unwrap(), "Retrievable fact");
+}
+
+#[test]
+fn get_fact_nonexistent() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_get_fact",
+        args(json!({ "fact_id": 9999 })),
+        &engine,
+        None,
+        DIM,
+    );
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// 9. memory_statistics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn statistics_empty_engine() {
+    let engine = make_engine();
+    let result = tools::dispatch("memory_statistics", args(json!({})), &engine, None, DIM);
+    let body = unwrap_ok(result);
+    // Should return stats even on empty engine
+    assert!(body.is_object());
+}
+
+#[test]
+fn statistics_after_ingestion() {
+    let engine = make_engine();
+    let embedder = make_embedder();
+
+    engine
+        .add_fact(
+            "Fact 1",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    engine
+        .add_fact(
+            "Fact 2",
+            memory_engine::types::FactType::Semantic,
+            None,
+            &embedder,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let result = tools::dispatch("memory_statistics", args(json!({})), &engine, None, DIM);
+    let body = unwrap_ok(result);
+    assert!(body.is_object());
+}
+
+// ---------------------------------------------------------------------------
+// 10. memory_flush_insights
+// ---------------------------------------------------------------------------
+
+#[test]
+fn flush_insights_no_embedder() {
+    let engine = make_engine();
+    let result = tools::dispatch(
+        "memory_flush_insights",
+        args(json!({
+            "insights": [
+                {"content": "insight 1"},
+            ]
+        })),
+        &engine,
+        None,
+        DIM,
+    );
+    // Requires embedder — should fail
+    assert!(result.is_err());
+}
+
+#[test]
+fn flush_insights_missing_array() {
+    let engine = make_engine();
+    let result = tools::dispatch("memory_flush_insights", args(json!({})), &engine, None, DIM);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Unknown tool
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_tool_returns_error() {
+    let engine = make_engine();
+    let result = tools::dispatch("memory_nonexistent", args(json!({})), &engine, None, DIM);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_tool_definitions_returns_10() {
+    let defs = tools::all_tool_definitions();
+    assert_eq!(defs.len(), 10, "expected exactly 10 P0 tools");
+}
+
+#[test]
+fn all_tool_definitions_have_unique_names() {
+    let defs = tools::all_tool_definitions();
+    let names: Vec<&str> = defs.iter().map(|t| &*t.name).collect();
+    let mut deduped = names.clone();
+    deduped.sort_unstable();
+    deduped.dedup();
+    assert_eq!(names.len(), deduped.len(), "tool names must be unique");
+}


### PR DESCRIPTION
## Summary

- Add 5 integration test modules for the MCP server (79 new tests across the modules)
- Split MCP crate into `lib.rs` + `main.rs` for integration test access (zero behavior change)
- All 502 workspace tests pass, clippy clean, fmt clean

### Test modules

| Module | Tests | Coverage |
|--------|-------|----------|
| `tool_roundtrip.rs` | 30 | All 10 P0 tools via `dispatch()` — happy path, validation errors, missing fields |
| `depth_shaping.rs` | 17 | Insta snapshots for sparse/standard/full on facts, search results, explanations, resume context |
| `embedding_integration.rs` | 9 | wiremock HTTP embedding round-trip — OpenAI/Ollama/direct formats, auth, error propagation |
| `query_mode_inference.rs` | 10 | Explicit mode vs engine inference, scope/fact_type parameter pass-through |
| `config_merge.rs` | 13 | TOML deserialization, CLI-over-TOML field merge, `embed_dim` probing, `deny_unknown_fields` |

Fixes #151

## Test plan

- [x] `cargo test -p memory-engine-mcp` — all 92 tests pass (13 unit + 79 integration)
- [x] `cargo test --all` — full workspace (502 tests) passes
- [x] `cargo clippy -p memory-engine-mcp --all-targets` — no new warnings in test code
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)