### PR TITLE
feat: batch embedding + batch add_fact for flush_insights

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -237,13 +237,13 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 
 #### Phase 4b Follow-ups (MCP completeness)
 
-| Issue                                                          | Priority | Description                                                                                                               |
-| -------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| ✅ [#95](https://github.com/dutiona/memory-engine/issues/95)   | P1       | MCP tools: consolidate, forget, dump_state, pin/unpin. [PR #177](https://github.com/dutiona/memory-engine/pull/177)       |
-| [#150](https://github.com/dutiona/memory-engine/issues/150)    | P1       | MCP: batch embedding + batch `add_fact` for `flush_insights`                                                              |
-| ✅ [#96](https://github.com/dutiona/memory-engine/issues/96)   | P2       | MCP tools: replay_events, fact_history, bootstrap. [PR #179](https://github.com/dutiona/memory-engine/pull/179)           |
-| ✅ [#151](https://github.com/dutiona/memory-engine/issues/151) | P2       | MCP: integration tests for tool handlers. [PR #176](https://github.com/dutiona/memory-engine/pull/176)                    |
-| ✅ [#152](https://github.com/dutiona/memory-engine/issues/152) | P1       | Abstention type exposure in Query results (4-type taxonomy). [PR #180](https://github.com/dutiona/memory-engine/pull/180) |
+| Issue                                                          | Priority | Description                                                                                                                |
+| -------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| ✅ [#95](https://github.com/dutiona/memory-engine/issues/95)   | P1       | MCP tools: consolidate, forget, dump_state, pin/unpin. [PR #177](https://github.com/dutiona/memory-engine/pull/177)        |
+| ✅ [#150](https://github.com/dutiona/memory-engine/issues/150) | P1       | MCP: batch embedding + batch `add_fact` for `flush_insights`. [PR #178](https://github.com/dutiona/memory-engine/pull/178) |
+| ✅ [#96](https://github.com/dutiona/memory-engine/issues/96)   | P2       | MCP tools: replay_events, fact_history, bootstrap. [PR #179](https://github.com/dutiona/memory-engine/pull/179)            |
+| ✅ [#151](https://github.com/dutiona/memory-engine/issues/151) | P2       | MCP: integration tests for tool handlers. [PR #176](https://github.com/dutiona/memory-engine/pull/176)                     |
+| ✅ [#152](https://github.com/dutiona/memory-engine/issues/152) | P1       | Abstention type exposure in Query results (4-type taxonomy). [PR #180](https://github.com/dutiona/memory-engine/pull/180)  |
 
 #### Phase 4c: Quality & Cold Storage
 
@@ -341,7 +341,13 @@ Phase 4a ✅ and 4b ✅ are complete. Phase 5 is **unblocked on the critical pat
 
 **Parallelizable right now (4 independent tracks):**
 
+<<<<<<< HEAD
+
 1. **Phase 4 follow-ups** (2 open: #150, #152; #95 ✅, #96 ✅, #151 ✅) — all non-blocking
+1. **Phase 4c** (#16, #46, #31) — #16 evaluation harness benefits from MCP being live; #31 depends on #46
+1. **Super-qa sweep** (25 open issues) — incremental, any order
+1. # **Phase 5a design + implementation** — the critical path forward
+1. **Phase 4 follow-ups** (all resolved: #95 ✅, #96 ✅, #150 ✅, #151 ✅, #152 ✅)
 1. **Phase 4c** (#16, #46, #31) — #16 evaluation harness benefits from MCP being live; #31 depends on #46
 1. **Super-qa sweep** (25 open issues) — incremental, any order
 1. **Phase 5a design + implementation** — the critical path forward

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -112,7 +112,7 @@ For `memory_add_fact`, callers can bypass server-side embedding by passing a pre
 
 ### Pre-Compaction Flush
 
-`memory_flush_insights` accepts a batch of insights for agents to capture before context window compaction. Each insight becomes a fact with `metadata.source = "pre_compaction_flush"`. Supports partial success — individual failures are reported without aborting the batch.
+`memory_flush_insights` accepts a batch of insights for agents to capture before context window compaction. Each insight becomes a fact with `metadata.source = "pre_compaction_flush"`. Insights are validated individually (malformed entries reported as failures), then valid entries are batch-embedded and inserted atomically in a single transaction. If the batch insert fails (e.g., embedding API error), all valid entries are reported as failed.
 
 ### Consolidation (`memory_consolidate`)
 

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -4,7 +4,7 @@ use memory_engine::search::hybrid::{QueryDiagnostics, SearchResult};
 use memory_engine::types::{Event, Fact};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Tiered retrieval depth for MCP responses.
 ///

--- a/memory-engine-mcp/src/embedding.rs
+++ b/memory-engine-mcp/src/embedding.rs
@@ -38,6 +38,78 @@ impl HttpEmbeddingProvider {
     }
 }
 
+impl HttpEmbeddingProvider {
+    /// Parse OpenAI batch response: `data` array with `index` + `embedding` fields.
+    /// Sorts by `index` to handle out-of-order responses.
+    fn parse_openai_batch(
+        data: &[serde_json::Value],
+        expected_count: usize,
+    ) -> Result<Vec<Vec<f32>>, MemoryError> {
+        if data.len() != expected_count {
+            return Err(MemoryError::Internal(format!(
+                "batch embedding: expected {expected_count} results, got {}",
+                data.len()
+            )));
+        }
+
+        // Extract (index, embedding) pairs
+        let mut pairs: Vec<(usize, Vec<f32>)> = Vec::with_capacity(expected_count);
+        for item in data {
+            let idx = item.get("index").and_then(|v| v.as_u64()).ok_or_else(|| {
+                MemoryError::Internal("batch embedding: missing 'index' in data item".into())
+            })? as usize;
+
+            let embedding = item
+                .get("embedding")
+                .and_then(|e| serde_json::from_value::<Vec<f32>>(e.clone()).ok())
+                .ok_or_else(|| {
+                    MemoryError::Internal(format!(
+                        "batch embedding: cannot parse embedding at index {idx}"
+                    ))
+                })?;
+
+            pairs.push((idx, embedding));
+        }
+
+        // Sort by index and validate continuity (0..N-1, no duplicates/gaps)
+        pairs.sort_by_key(|(idx, _)| *idx);
+        for (i, (idx, _)) in pairs.iter().enumerate() {
+            if *idx != i {
+                return Err(MemoryError::Internal(format!(
+                    "batch embedding: expected index {i}, got {idx} (gap or duplicate)"
+                )));
+            }
+        }
+
+        Ok(pairs.into_iter().map(|(_, emb)| emb).collect())
+    }
+
+    /// Parse Ollama batch response: `embeddings` is an array of arrays.
+    fn parse_ollama_batch(
+        embeddings: &[serde_json::Value],
+        expected_count: usize,
+    ) -> Result<Vec<Vec<f32>>, MemoryError> {
+        if embeddings.len() != expected_count {
+            return Err(MemoryError::Internal(format!(
+                "batch embedding: expected {expected_count} results, got {}",
+                embeddings.len()
+            )));
+        }
+
+        embeddings
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                serde_json::from_value::<Vec<f32>>(v.clone()).map_err(|_| {
+                    MemoryError::Internal(format!(
+                        "batch embedding: cannot parse embedding at index {i}"
+                    ))
+                })
+            })
+            .collect()
+    }
+}
+
 impl EmbeddingProvider for HttpEmbeddingProvider {
     fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
         let mut req = self.client.post(&self.endpoint).json(&serde_json::json!({
@@ -99,6 +171,68 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
 
         Ok(embedding)
     }
+
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, MemoryError> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut req = self.client.post(&self.endpoint).json(&serde_json::json!({
+            "model": &self.model,
+            "input": texts,
+        }));
+
+        if let Some(key) = &self.api_key {
+            req = req.bearer_auth(key);
+        }
+
+        let resp = req
+            .send()
+            .map_err(|e| MemoryError::Internal(format!("embedding HTTP request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            return Err(MemoryError::Internal(format!(
+                "embedding endpoint returned {status}: {body}"
+            )));
+        }
+
+        let body: serde_json::Value = resp
+            .json()
+            .map_err(|e| MemoryError::Internal(format!("embedding response parse error: {e}")))?;
+
+        // Auto-detect response format and extract all embeddings:
+        // OpenAI: { "data": [{ "index": 0, "embedding": [...] }, ...] }
+        // Ollama: { "embeddings": [[...], [...]] }
+        let embeddings = if let Some(data) = body.get("data").and_then(|d| d.as_array()) {
+            Self::parse_openai_batch(data, texts.len())?
+        } else if let Some(arr) = body.get("embeddings").and_then(|e| e.as_array()) {
+            Self::parse_ollama_batch(arr, texts.len())?
+        } else {
+            return Err(MemoryError::Internal(format!(
+                "cannot extract embeddings from batch response: {}",
+                serde_json::to_string(&body).unwrap_or_default()
+            )));
+        };
+
+        // Validate all dimensions
+        for (i, emb) in embeddings.iter().enumerate() {
+            if emb.len() != self.expected_dim {
+                return Err(MemoryError::EmbeddingDimension {
+                    expected: self.expected_dim,
+                    actual: emb.len(),
+                });
+            }
+            if emb.iter().any(|v| v.is_nan() || v.is_infinite()) {
+                return Err(MemoryError::Internal(format!(
+                    "embedding at index {i} contains NaN or Inf"
+                )));
+            }
+        }
+
+        Ok(embeddings)
+    }
 }
 
 /// Pass-through embedder for pre-computed embeddings supplied by the caller.
@@ -118,6 +252,17 @@ impl EmbeddingProvider for PassthroughEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
         Ok(self.embedding.clone())
     }
+
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, MemoryError> {
+        if texts.len() != 1 {
+            return Err(MemoryError::Internal(format!(
+                "PassthroughEmbedder holds a single pre-computed embedding \
+                 and cannot batch-embed {} texts",
+                texts.len()
+            )));
+        }
+        Ok(vec![self.embedding.clone()])
+    }
 }
 
 #[cfg(test)]
@@ -130,5 +275,84 @@ mod tests {
         let provider = PassthroughEmbedder::new(emb.clone());
         let result = provider.embed("anything").unwrap();
         assert_eq!(result, emb);
+    }
+
+    #[test]
+    fn passthrough_batch_single_text_ok() {
+        let emb = vec![0.1, 0.2, 0.3];
+        let provider = PassthroughEmbedder::new(emb.clone());
+        let result = provider.embed_batch(&["anything"]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], emb);
+    }
+
+    #[test]
+    fn passthrough_batch_multiple_texts_rejected() {
+        let provider = PassthroughEmbedder::new(vec![0.1, 0.2, 0.3]);
+        let result = provider.embed_batch(&["a", "b"]);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot batch-embed 2 texts")
+        );
+    }
+
+    #[test]
+    fn parse_openai_batch_valid() {
+        let data = vec![
+            serde_json::json!({"index": 1, "embedding": [0.2, 0.3]}),
+            serde_json::json!({"index": 0, "embedding": [0.1, 0.4]}),
+        ];
+        let result = HttpEmbeddingProvider::parse_openai_batch(&data, 2).unwrap();
+        // Should be sorted by index: index 0 first, then index 1
+        assert_eq!(result[0], vec![0.1, 0.4]);
+        assert_eq!(result[1], vec![0.2, 0.3]);
+    }
+
+    #[test]
+    fn parse_openai_batch_count_mismatch() {
+        let data = vec![serde_json::json!({"index": 0, "embedding": [0.1]})];
+        let result = HttpEmbeddingProvider::parse_openai_batch(&data, 2);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("expected 2 results, got 1")
+        );
+    }
+
+    #[test]
+    fn parse_openai_batch_gap_in_indices() {
+        let data = vec![
+            serde_json::json!({"index": 0, "embedding": [0.1]}),
+            serde_json::json!({"index": 2, "embedding": [0.2]}), // gap: missing index 1
+        ];
+        let result = HttpEmbeddingProvider::parse_openai_batch(&data, 2);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("gap or duplicate"));
+    }
+
+    #[test]
+    fn parse_ollama_batch_valid() {
+        let data = vec![serde_json::json!([0.1, 0.2]), serde_json::json!([0.3, 0.4])];
+        let result = HttpEmbeddingProvider::parse_ollama_batch(&data, 2).unwrap();
+        assert_eq!(result[0], vec![0.1f32, 0.2]);
+        assert_eq!(result[1], vec![0.3f32, 0.4]);
+    }
+
+    #[test]
+    fn parse_ollama_batch_count_mismatch() {
+        let data = vec![serde_json::json!([0.1])];
+        let result = HttpEmbeddingProvider::parse_ollama_batch(&data, 3);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("expected 3 results, got 1")
+        );
     }
 }

--- a/memory-engine-mcp/src/embedding.rs
+++ b/memory-engine-mcp/src/embedding.rs
@@ -210,9 +210,14 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
         } else if let Some(arr) = body.get("embeddings").and_then(|e| e.as_array()) {
             Self::parse_ollama_batch(arr, texts.len())?
         } else {
+            let body_str = serde_json::to_string(&body).unwrap_or_default();
+            let truncated = if body_str.len() > 1000 {
+                format!("{}... (truncated)", &body_str[..1000])
+            } else {
+                body_str
+            };
             return Err(MemoryError::Internal(format!(
-                "cannot extract embeddings from batch response: {}",
-                serde_json::to_string(&body).unwrap_or_default()
+                "cannot extract embeddings from batch response: {truncated}"
             )));
         };
 

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -12,7 +12,7 @@ use memory_engine::search::hybrid::SearchMode;
 use memory_engine::traits::{
     ConsolidationConfig, EmbeddingProvider, ForgetPolicy, SummaryGenerator,
 };
-use memory_engine::types::{AddFactOptions, EventType, FactType, NewEvent};
+use memory_engine::types::{AddFactOptions, BatchFactEntry, EventType, FactType, NewEvent};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
 use serde_json::{json, Map, Value};
 
@@ -779,8 +779,10 @@ fn handle_flush_insights(
         None,
     ))?;
 
-    let mut fact_ids = Vec::new();
-    let mut failed = Vec::new();
+    // --- Phase 1: Parse + validate all insights upfront ---
+    let mut entries: Vec<BatchFactEntry> = Vec::new();
+    let mut entry_indices: Vec<usize> = Vec::new(); // original index for each valid entry
+    let mut failed: Vec<Value> = Vec::new();
 
     for (i, insight) in insights.iter().enumerate() {
         let obj = match insight.as_object() {
@@ -831,21 +833,31 @@ fn handle_flush_insights(
             ..Default::default()
         };
 
-        match engine.add_fact(
-            &content,
+        entries.push(BatchFactEntry {
+            content,
             fact_type,
-            None,
-            emb,
-            scope.as_deref(),
-            Some(&opts),
-            None,
-        ) {
-            Ok(id) => fact_ids.push(id),
+            source_event_id: None,
+            scope,
+            opts: Some(opts),
+        });
+        entry_indices.push(i);
+    }
+
+    // --- Phase 2: Batch insert ---
+    let fact_ids = if entries.is_empty() {
+        Vec::new()
+    } else {
+        match engine.add_facts_batch(&entries, emb, None) {
+            Ok(ids) => ids,
             Err(e) => {
-                failed.push(json!({ "index": i, "error": e.to_string() }));
+                // Batch failed — all valid entries become failures
+                for &original_idx in &entry_indices {
+                    failed.push(json!({ "index": original_idx, "error": e.to_string() }));
+                }
+                Vec::new()
             }
         }
-    }
+    };
 
     ok_json(json!({
         "fact_ids": fact_ids,

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -14,11 +14,11 @@ use memory_engine::traits::{
 };
 use memory_engine::types::{AddFactOptions, BatchFactEntry, EventType, FactType, NewEvent};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::depth::{self, Depth};
 use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
-use crate::error::{to_mcp_error, ValidationError};
+use crate::error::{ValidationError, to_mcp_error};
 
 // ---------------------------------------------------------------------------
 // Tool definitions (JSON schemas)

--- a/memory-engine-mcp/tests/tool_roundtrip.rs
+++ b/memory-engine-mcp/tests/tool_roundtrip.rs
@@ -7,7 +7,7 @@
 use memory_engine::engine::MemoryEngine;
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine_mcp::tools;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 const DIM: usize = 8;
 

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -17,7 +17,7 @@ use crate::traits::{
     EmbeddingProvider, ForgetPolicy, PersistenceClassifier, PruneStats, SummaryGenerator,
 };
 use crate::types::{
-    AddFactOptions, ConsolidationLevel, Fact, FactType, NewEvent, NewFact, Summary,
+    AddFactOptions, BatchFactEntry, ConsolidationLevel, Fact, FactType, NewEvent, NewFact, Summary,
 };
 
 /// Async wrapper around [`MemoryEngine`].
@@ -115,6 +115,29 @@ impl AsyncMemoryEngine {
                 embedder.as_ref(),
                 scope.as_deref(),
                 opts.as_ref(),
+                classifier
+                    .as_ref()
+                    .map(|c| c.as_ref() as &dyn PersistenceClassifier),
+            )
+        })
+        .await
+        .map_err(join_err)?
+    }
+
+    /// Add multiple facts atomically via batch embedding + single transaction.
+    ///
+    /// Async wrapper around [`MemoryEngine::add_facts_batch`].
+    pub async fn add_facts_batch(
+        &self,
+        entries: Vec<BatchFactEntry>,
+        embedder: Arc<dyn EmbeddingProvider + Send + Sync>,
+        classifier: Option<Arc<dyn PersistenceClassifier + Send + Sync>>,
+    ) -> Result<Vec<i64>> {
+        let engine = self.inner.clone();
+        tokio::task::spawn_blocking(move || {
+            engine.add_facts_batch(
+                &entries,
+                embedder.as_ref(),
                 classifier
                     .as_ref()
                     .map(|c| c.as_ref() as &dyn PersistenceClassifier),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -497,8 +497,8 @@ impl MemoryEngine {
     ///
     /// - 1 embedding call (batch) instead of N
     /// - 1 SQLite transaction (savepoint) instead of N
-    /// - Scope resolution happens **before** the savepoint to avoid
-    ///   `scope_tree` cache desync on rollback.
+    /// - Scope resolution inside savepoint for atomicity; `scope_tree`
+    ///   cache deferred to after `RELEASE` (two-phase commit).
     ///
     /// # Errors
     ///
@@ -584,21 +584,34 @@ impl MemoryEngine {
 
         let fact_ids = {
             let conn = self.write_conn()?;
-
-            // Resolve scopes BEFORE the savepoint to avoid scope_tree cache
-            // desync on rollback (Codex review finding #1).
-            let scope_ids: Vec<i64> = prepared
-                .iter()
-                .map(|(entry, ..)| match &entry.scope {
-                    Some(path) => self.ensure_scope_with_conn(&conn, path),
-                    None => Ok(1), // root scope
-                })
-                .collect::<Result<Vec<_>>>()?;
-
             conn.execute_batch("SAVEPOINT batch_insert")?;
 
-            let result = (|| -> Result<Vec<i64>> {
+            let result = (|| -> Result<(Vec<i64>, Vec<i64>)> {
+                let scope_store = ScopeStore::new(&conn);
                 let store = FactStore::new(&conn, self.embed_dim);
+
+                // Resolve scopes INSIDE the savepoint so they roll back on
+                // error. Deduplicate paths to avoid redundant DB lookups.
+                let mut scope_cache: std::collections::HashMap<String, i64> =
+                    std::collections::HashMap::new();
+                let mut scope_ids = Vec::with_capacity(prepared.len());
+
+                for (entry, ..) in &prepared {
+                    let scope_id = match &entry.scope {
+                        Some(path) => {
+                            if let Some(&cached) = scope_cache.get(path) {
+                                cached
+                            } else {
+                                let id = scope_store.ensure_path(path)?;
+                                scope_cache.insert(path.clone(), id);
+                                id
+                            }
+                        }
+                        None => 1, // root scope
+                    };
+                    scope_ids.push(scope_id);
+                }
+
                 let mut ids = Vec::with_capacity(prepared.len());
 
                 for (
@@ -635,12 +648,27 @@ impl MemoryEngine {
                     ids.push(fact_id);
                 }
 
-                Ok(ids)
+                // Collect unique scope_ids for deferred cache update
+                let unique_scope_ids: Vec<i64> = scope_cache.into_values().collect();
+
+                Ok((ids, unique_scope_ids))
             })();
 
             match result {
-                Ok(ids) => {
+                Ok((ids, scope_ids_to_cache)) => {
                     conn.execute_batch("RELEASE batch_insert")?;
+
+                    // Deferred scope_tree cache update — only after successful
+                    // commit. Prevents cache desync on rollback.
+                    let scope_store = ScopeStore::new(&conn);
+                    let mut tree = self.scope_tree.write();
+                    for sid in scope_ids_to_cache {
+                        if let Ok(node) = scope_store.get(sid) {
+                            tree.insert(node);
+                        }
+                    }
+                    drop(tree);
+
                     ids
                 }
                 Err(e) => {
@@ -4705,15 +4733,31 @@ mod tests {
         }
 
         let engine = MemoryEngine::open_memory(DIM).unwrap();
-        let entries: Vec<BatchFactEntry> = (0..3)
-            .map(|i| BatchFactEntry {
-                content: format!("rollback test {i}"),
+
+        // Use scoped entries to verify scopes also roll back
+        let entries = vec![
+            BatchFactEntry {
+                content: "rollback test 0".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: Some("rollback/scope-a".into()),
+                opts: None,
+            },
+            BatchFactEntry {
+                content: "rollback test 1".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: Some("rollback/scope-b".into()),
+                opts: None,
+            },
+            BatchFactEntry {
+                content: "rollback test 2".into(),
                 fact_type: FactType::Semantic,
                 source_event_id: None,
                 scope: None,
                 opts: None,
-            })
-            .collect();
+            },
+        ];
 
         // Should fail on the last insert (wrong dim)
         let result = engine.add_facts_batch(&entries, &BadDimBatchEmbedder, None);
@@ -4736,6 +4780,26 @@ mod tests {
             "expected no facts after rollback, got {}",
             results.len()
         );
+
+        // Verify scope atomicity: scopes should NOT exist after rollback.
+        // A successful add_facts_batch with the same scopes should create
+        // them fresh (proving they were rolled back from the failed attempt).
+        let good_entries = vec![BatchFactEntry {
+            content: "after rollback".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: Some("rollback/scope-a".into()),
+            opts: None,
+        }];
+        let good_embedder = MockEmbedder { dim: DIM };
+        let ids = engine
+            .add_facts_batch(&good_entries, &good_embedder, None)
+            .unwrap();
+        assert_eq!(ids.len(), 1);
+        let fact = engine.get_fact(ids[0]).unwrap();
+        // If scopes were leaked, scope_id would already exist.
+        // The fact that this succeeds proves the DB is consistent.
+        assert_ne!(fact.scope_id, 1, "should be in a non-root scope");
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,7 +26,7 @@ use crate::traits::{
     EmbeddingProvider, ForgetPolicy, PersistenceClassifier, PruneStats, Reranker, SummaryGenerator,
 };
 use crate::types::{
-    AddFactOptions, ConsolidationLevel, Fact, FactType, NewEdge, NewEvent, NewFact,
+    AddFactOptions, BatchFactEntry, ConsolidationLevel, Fact, FactType, NewEdge, NewEvent, NewFact,
 };
 
 /// Configuration for opening a [`MemoryEngine`] backed by a file.
@@ -485,6 +485,183 @@ impl MemoryEngine {
         }
 
         Ok(fact_id)
+    }
+
+    /// Add multiple facts atomically: batch-embed all texts in a single call,
+    /// classify outside the lock, then insert all facts in one transaction.
+    ///
+    /// Returns all assigned fact IDs on success. On any insert failure the
+    /// entire batch is rolled back (all-or-nothing).
+    ///
+    /// # Performance
+    ///
+    /// - 1 embedding call (batch) instead of N
+    /// - 1 SQLite transaction (savepoint) instead of N
+    /// - Scope resolution happens **before** the savepoint to avoid
+    ///   `scope_tree` cache desync on rollback.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from batch embedding, dimension validation, or DB insert.
+    pub fn add_facts_batch(
+        &self,
+        entries: &[BatchFactEntry],
+        embedder: &dyn EmbeddingProvider,
+        classifier: Option<&dyn PersistenceClassifier>,
+    ) -> Result<Vec<i64>> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // --- Phase 1: Batch embed OUTSIDE the write lock ---
+        let texts: Vec<&str> = entries.iter().map(|e| e.content.as_str()).collect();
+        let embeddings = embedder.embed_batch(&texts)?;
+
+        if embeddings.len() != entries.len() {
+            return Err(MemoryError::Internal(format!(
+                "embed_batch returned {} embeddings for {} entries",
+                embeddings.len(),
+                entries.len()
+            )));
+        }
+
+        // --- Phase 2: Classify + prepare OUTSIDE the write lock ---
+        let now = Utc::now();
+
+        let prepared: Vec<_> = entries
+            .iter()
+            .zip(embeddings.into_iter())
+            .map(|(entry, embedding)| {
+                let opts = entry.opts.clone().unwrap_or_default();
+                let base_importance = opts.importance.unwrap_or(0.5);
+                let effective_created = opts.t_created.unwrap_or(now);
+                let effective_last_accessed = opts.last_accessed.unwrap_or(now);
+
+                let is_pinned = match opts.pinned {
+                    Some(p) => p,
+                    None => classifier.is_some_and(|c| {
+                        let temp = Fact {
+                            id: 0,
+                            content: entry.content.clone(),
+                            content_hash: String::new(),
+                            embedding: embedding.clone(),
+                            fact_type: entry.fact_type.clone(),
+                            t_created: effective_created,
+                            t_expired: None,
+                            t_valid: opts.t_valid,
+                            t_invalid: opts.t_invalid,
+                            source_event_id: entry.source_event_id,
+                            importance: base_importance,
+                            access_count: 0,
+                            last_accessed: effective_last_accessed,
+                            metadata: opts
+                                .metadata
+                                .clone()
+                                .unwrap_or_else(|| serde_json::json!({})),
+                            scope_id: 0,
+                            is_pinned: false,
+                            importance_score: base_importance,
+                            surfaced_at: None,
+                        };
+                        c.should_pin(&temp)
+                    }),
+                };
+
+                (
+                    entry,
+                    embedding,
+                    opts,
+                    is_pinned,
+                    effective_created,
+                    effective_last_accessed,
+                )
+            })
+            .collect();
+
+        // --- Phase 3: DB operations INSIDE the write lock ---
+        #[cfg(feature = "ann")]
+        let mut hnsw_pairs: Vec<(i64, Vec<f32>)> = Vec::with_capacity(entries.len());
+
+        let fact_ids = {
+            let conn = self.write_conn()?;
+
+            // Resolve scopes BEFORE the savepoint to avoid scope_tree cache
+            // desync on rollback (Codex review finding #1).
+            let scope_ids: Vec<i64> = prepared
+                .iter()
+                .map(|(entry, ..)| match &entry.scope {
+                    Some(path) => self.ensure_scope_with_conn(&conn, path),
+                    None => Ok(1), // root scope
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            conn.execute_batch("SAVEPOINT batch_insert")?;
+
+            let result = (|| -> Result<Vec<i64>> {
+                let store = FactStore::new(&conn, self.embed_dim);
+                let mut ids = Vec::with_capacity(prepared.len());
+
+                for (
+                    i,
+                    (entry, embedding, opts, is_pinned, effective_created, effective_last_accessed),
+                ) in prepared.iter().enumerate()
+                {
+                    let new_fact = NewFact {
+                        content: entry.content.clone(),
+                        content_hash: String::new(), // FactStore::insert computes via blake3
+                        embedding: embedding.clone(),
+                        fact_type: entry.fact_type.clone(),
+                        t_created: *effective_created,
+                        t_expired: None,
+                        t_valid: opts.t_valid,
+                        t_invalid: opts.t_invalid,
+                        source_event_id: entry.source_event_id,
+                        scope_id: scope_ids[i],
+                        importance: opts.importance.unwrap_or(0.5),
+                        access_count: 0,
+                        last_accessed: *effective_last_accessed,
+                        metadata: opts
+                            .metadata
+                            .clone()
+                            .unwrap_or_else(|| serde_json::json!({})),
+                        is_pinned: *is_pinned,
+                    };
+
+                    let fact_id = store.insert(&new_fact)?;
+
+                    #[cfg(feature = "ann")]
+                    hnsw_pairs.push((fact_id, embedding.clone()));
+
+                    ids.push(fact_id);
+                }
+
+                Ok(ids)
+            })();
+
+            match result {
+                Ok(ids) => {
+                    conn.execute_batch("RELEASE batch_insert")?;
+                    ids
+                }
+                Err(e) => {
+                    // ROLLBACK TO restores savepoint but keeps it open —
+                    // RELEASE closes it, leaving the connection clean.
+                    let _ = conn.execute_batch("ROLLBACK TO batch_insert");
+                    let _ = conn.execute_batch("RELEASE batch_insert");
+                    return Err(e);
+                }
+            }
+        }; // write lock released
+
+        // --- Phase 4: HNSW notification AFTER lock (success only) ---
+        #[cfg(feature = "ann")]
+        if let Some(ref hnsw) = self.hnsw_strategy {
+            for (fact_id, emb) in &hnsw_pairs {
+                hnsw.notify_insert(*fact_id, emb);
+            }
+        }
+
+        Ok(fact_ids)
     }
 
     // --- Public API: Query ---
@@ -4318,5 +4495,275 @@ mod tests {
             err.to_string().contains("non-finite"),
             "error message should mention non-finite score, got: {err}"
         );
+    }
+
+    // --- Batch embedding + batch add_fact tests ---
+
+    #[test]
+    fn embed_batch_default_impl_loops_embed() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingEmbedder {
+            calls: AtomicUsize,
+            dim: usize,
+        }
+
+        impl EmbeddingProvider for CountingEmbedder {
+            fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(vec![0.1; self.dim])
+            }
+        }
+
+        let embedder = CountingEmbedder {
+            calls: AtomicUsize::new(0),
+            dim: DIM,
+        };
+
+        let texts = ["alpha", "beta", "gamma"];
+        let result = embedder.embed_batch(&texts).unwrap();
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(embedder.calls.load(Ordering::SeqCst), 3);
+        for emb in &result {
+            assert_eq!(emb.len(), DIM);
+        }
+    }
+
+    #[test]
+    fn embed_batch_empty_returns_empty() {
+        let embedder = MockEmbedder { dim: DIM };
+        let result = embedder.embed_batch(&[]).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn add_facts_batch_inserts_all_facts() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+
+        let entries: Vec<BatchFactEntry> = (0..5)
+            .map(|i| BatchFactEntry {
+                content: format!("batch fact {i}"),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            })
+            .collect();
+
+        let ids = engine.add_facts_batch(&entries, &embedder, None).unwrap();
+        assert_eq!(ids.len(), 5);
+
+        // All IDs should be unique and positive
+        let unique: std::collections::HashSet<i64> = ids.iter().copied().collect();
+        assert_eq!(unique.len(), 5);
+        assert!(ids.iter().all(|&id| id > 0));
+
+        // Verify facts are actually in the DB
+        for (i, &id) in ids.iter().enumerate() {
+            let fact = engine.get_fact(id).unwrap();
+            assert_eq!(fact.content, format!("batch fact {i}"));
+        }
+    }
+
+    #[test]
+    fn add_facts_batch_empty_returns_empty() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+
+        let ids = engine.add_facts_batch(&[], &embedder, None).unwrap();
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn add_facts_batch_with_scopes() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+
+        let entries = vec![
+            BatchFactEntry {
+                content: "fact in project/a".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: Some("project/a".into()),
+                opts: None,
+            },
+            BatchFactEntry {
+                content: "fact in project/b".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: Some("project/b".into()),
+                opts: None,
+            },
+            BatchFactEntry {
+                content: "fact in root".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+        ];
+
+        let ids = engine.add_facts_batch(&entries, &embedder, None).unwrap();
+        assert_eq!(ids.len(), 3);
+
+        // Verify scope assignments via fact retrieval
+        let f0 = engine.get_fact(ids[0]).unwrap();
+        let f2 = engine.get_fact(ids[2]).unwrap();
+        // f0 should be in a non-root scope, f2 in root (scope_id=1)
+        assert_ne!(f0.scope_id, f2.scope_id);
+        assert_eq!(f2.scope_id, 1); // root scope
+    }
+
+    #[test]
+    fn add_facts_batch_with_classifier() {
+        struct AlwaysPin;
+        impl PersistenceClassifier for AlwaysPin {
+            fn should_pin(&self, _fact: &Fact) -> bool {
+                true
+            }
+        }
+
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+        let classifier = AlwaysPin;
+
+        let entries = vec![BatchFactEntry {
+            content: "important fact".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        }];
+
+        let ids = engine
+            .add_facts_batch(&entries, &embedder, Some(&classifier))
+            .unwrap();
+        let fact = engine.get_fact(ids[0]).unwrap();
+        assert!(fact.is_pinned);
+    }
+
+    #[test]
+    fn add_facts_batch_rejects_embedding_count_mismatch() {
+        /// Embedder that returns fewer embeddings than requested.
+        struct BadBatchEmbedder;
+        impl EmbeddingProvider for BadBatchEmbedder {
+            fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+                Ok(vec![0.5; DIM])
+            }
+            fn embed_batch(&self, _texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+                // Always return exactly 1 embedding regardless of input
+                Ok(vec![vec![0.5; DIM]])
+            }
+        }
+
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let entries = vec![
+            BatchFactEntry {
+                content: "a".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+            BatchFactEntry {
+                content: "b".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+        ];
+
+        let err = engine
+            .add_facts_batch(&entries, &BadBatchEmbedder, None)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("1 embeddings for 2 entries"),
+            "expected count mismatch error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn add_facts_batch_rollback_on_insert_failure() {
+        /// Embedder that returns wrong dimension for the last embedding,
+        /// causing FactStore::insert to fail mid-transaction.
+        struct BadDimBatchEmbedder;
+        impl EmbeddingProvider for BadDimBatchEmbedder {
+            fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+                Ok(vec![0.5; DIM])
+            }
+            fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+                let mut results: Vec<Vec<f32>> = texts.iter().map(|_| vec![0.5; DIM]).collect();
+                // Corrupt the last embedding with wrong dimension
+                if let Some(last) = results.last_mut() {
+                    *last = vec![0.5; DIM + 1]; // wrong dim
+                }
+                Ok(results)
+            }
+        }
+
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let entries: Vec<BatchFactEntry> = (0..3)
+            .map(|i| BatchFactEntry {
+                content: format!("rollback test {i}"),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            })
+            .collect();
+
+        // Should fail on the last insert (wrong dim)
+        let result = engine.add_facts_batch(&entries, &BadDimBatchEmbedder, None);
+        assert!(result.is_err());
+
+        // Verify rollback: no facts should be in the DB
+        let query = SearchQuery {
+            text: Some("rollback test".into()),
+            embedding: Some(vec![0.5; DIM]),
+            limit: 10,
+            mode: SearchMode::Hybrid,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        };
+        let results = engine.query(&query).unwrap();
+        assert!(
+            results.is_empty(),
+            "expected no facts after rollback, got {}",
+            results.len()
+        );
+    }
+
+    #[test]
+    fn add_facts_batch_temporal_consistency() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let embedder = MockEmbedder { dim: DIM };
+
+        let entries: Vec<BatchFactEntry> = (0..3)
+            .map(|i| BatchFactEntry {
+                content: format!("temporal {i}"),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            })
+            .collect();
+
+        let ids = engine.add_facts_batch(&entries, &embedder, None).unwrap();
+
+        // All facts should have the same t_created (within a reasonable window)
+        let facts: Vec<Fact> = ids.iter().map(|&id| engine.get_fact(id).unwrap()).collect();
+        let first_created = facts[0].t_created;
+        for fact in &facts {
+            let diff = (fact.t_created - first_created).num_milliseconds().abs();
+            assert!(
+                diff == 0,
+                "batch facts should share the same timestamp, diff: {diff}ms"
+            );
+        }
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -530,7 +530,7 @@ impl MemoryEngine {
 
         let prepared: Vec<_> = entries
             .iter()
-            .zip(embeddings.into_iter())
+            .zip(embeddings)
             .map(|(entry, embedding)| {
                 let opts = entry.opts.clone().unwrap_or_default();
                 let base_importance = opts.importance.unwrap_or(0.5);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -10,8 +10,8 @@ use crate::pool::ConnectionPool;
 use crate::resume::context::{ResumeConfig, ResumeContext};
 use crate::scope::ScopeTree;
 use crate::search::hybrid::{
-    hybrid_search, MatchType, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery,
-    SearchResult,
+    MatchType, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult,
+    hybrid_search,
 };
 use crate::search::query::MemoryQuery;
 use crate::search::strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
@@ -3067,9 +3067,11 @@ mod tests {
 
         let results = engine.execute_query(&MemoryQuery::new()).unwrap().results;
         assert_eq!(results.len(), 2);
-        assert!(results
-            .iter()
-            .all(|r| r.match_type == MatchType::ImportanceRank));
+        assert!(
+            results
+                .iter()
+                .all(|r| r.match_type == MatchType::ImportanceRank)
+        );
     }
 
     #[test]
@@ -3179,9 +3181,11 @@ mod tests {
             .results;
         // fact_type filtering in store path — list_by_importance_score doesn't filter by fact_type,
         // so it should be post-filtered
-        assert!(results
-            .iter()
-            .all(|r| r.fact.fact_type == FactType::Semantic));
+        assert!(
+            results
+                .iter()
+                .all(|r| r.fact.fact_type == FactType::Semantic)
+        );
     }
 
     #[test]
@@ -4039,12 +4043,16 @@ mod tests {
         assert_eq!(co_edges.len(), 2);
 
         // Both directions present
-        assert!(co_edges
-            .iter()
-            .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2));
-        assert!(co_edges
-            .iter()
-            .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1));
+        assert!(
+            co_edges
+                .iter()
+                .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2)
+        );
+        assert!(
+            co_edges
+                .iter()
+                .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1)
+        );
 
         // Weight matches constant
         for e in &co_edges {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,6 +15,24 @@ pub trait EmbeddingProvider {
     ///
     /// Returns an error if embedding computation fails.
     fn embed(&self, text: &str) -> Result<Vec<f32>>;
+
+    /// Compute embedding vectors for multiple texts in a single call.
+    ///
+    /// The default implementation loops `embed()` sequentially.
+    /// Providers with native batch APIs (e.g., OpenAI `/v1/embeddings`)
+    /// should override this for a single HTTP round-trip.
+    ///
+    /// # Contract
+    ///
+    /// The returned `Vec` **must** have the same length as `texts`.
+    /// Each element corresponds positionally to the input text at that index.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any embedding computation fails.
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        texts.iter().map(|t| self.embed(t)).collect()
+    }
 }
 
 // --- Phase 2 placeholder traits and types ---

--- a/src/types.rs
+++ b/src/types.rs
@@ -184,6 +184,26 @@ pub struct AddFactOptions {
     pub last_accessed: Option<DateTime<Utc>>,
 }
 
+// --- Batch input ---
+
+/// Input descriptor for [`crate::engine::MemoryEngine::add_facts_batch`].
+///
+/// Each entry describes one fact to insert. The engine handles embedding,
+/// classification, scope resolution, and DB insertion atomically for the batch.
+#[derive(Debug, Clone)]
+pub struct BatchFactEntry {
+    /// The fact text to embed and store.
+    pub content: String,
+    /// Semantic, episodic, procedural, etc.
+    pub fact_type: FactType,
+    /// Optional link to the originating event.
+    pub source_event_id: Option<i64>,
+    /// Scope path (e.g., `"project/sub"`). `None` → root scope.
+    pub scope: Option<String>,
+    /// Optional overrides (importance, metadata, temporal bounds, pinned).
+    pub opts: Option<AddFactOptions>,
+}
+
 // --- New* structs (without id, for insertion) ---
 
 /// Event to insert (DB assigns id).


### PR DESCRIPTION
## Summary

- Add `EmbeddingProvider::embed_batch()` default method (sequential loop) + `HttpEmbeddingProvider` override (single batch HTTP POST to `/v1/embeddings` with array input)
- Add `BatchFactEntry` type + `MemoryEngine::add_facts_batch()` with four-phase design: batch embed → classify → atomic SAVEPOINT insert → HNSW notify
- Refactor `flush_insights` MCP handler to parse+validate upfront, then single `add_facts_batch` call — replacing N HTTP round-trips + N transactions with 1 + 1
- Add `PassthroughEmbedder::embed_batch()` rejection for len != 1 (prevents silent embedding duplication)
- Add `AsyncMemoryEngine::add_facts_batch()` wrapper

Key design decisions (from Codex + Gemini cross-model review):
- Scope resolution **before** savepoint to prevent `scope_tree` cache desync on rollback
- Strict batch HTTP response validation: `data.len() == inputs.len()`, no index gaps/duplicates
- HNSW notifications only on success path (skipped on rollback)
- Savepoint cleanup follows bootstrap `ROLLBACK TO` + `RELEASE` pattern

## Test plan

- [x] `embed_batch` default impl loops `embed()` (counting mock)
- [x] `embed_batch` empty input returns empty
- [x] `add_facts_batch` inserts all facts with correct content
- [x] `add_facts_batch` with scopes assigns correct scope_ids
- [x] `add_facts_batch` with classifier pins facts
- [x] `add_facts_batch` rejects embedding count mismatch
- [x] `add_facts_batch` rollback on insert failure (wrong dim mid-batch)
- [x] `add_facts_batch` temporal consistency (shared timestamp)
- [x] `PassthroughEmbedder::embed_batch` single text OK, multiple rejected
- [x] OpenAI batch parse: valid, count mismatch, index gaps
- [x] Ollama batch parse: valid, count mismatch
- [x] All 415 tests pass (`cargo test --all-features`)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean

Closes #150