### PR TITLE
feat(mcp): add P2 tools — replay_events, fact_history, bootstrap_session

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -237,13 +237,13 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 
 #### Phase 4b Follow-ups (MCP completeness)
 
-| Issue                                                       | Priority | Description                                                  |
-| ----------------------------------------------------------- | -------- | ------------------------------------------------------------ |
-| [#95](https://github.com/dutiona/memory-engine/issues/95)   | P1       | MCP tools: consolidate, forget, dump_state, pin/unpin        |
-| [#150](https://github.com/dutiona/memory-engine/issues/150) | P1       | MCP: batch embedding + batch `add_fact` for `flush_insights` |
-| [#96](https://github.com/dutiona/memory-engine/issues/96)   | P2       | MCP tools: replay_events, fact_history, bootstrap            |
-| [#151](https://github.com/dutiona/memory-engine/issues/151) | P2       | ✅ MCP: integration tests for tool handlers (PR #176)        |
-| [#152](https://github.com/dutiona/memory-engine/issues/152) | P1       | Abstention type exposure in Query results (4-type taxonomy)  |
+| Issue                                                          | Priority | Description                                                                                                     |
+| -------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| [#95](https://github.com/dutiona/memory-engine/issues/95)      | P1       | MCP tools: consolidate, forget, dump_state, pin/unpin                                                           |
+| [#150](https://github.com/dutiona/memory-engine/issues/150)    | P1       | MCP: batch embedding + batch `add_fact` for `flush_insights`                                                    |
+| ✅ [#96](https://github.com/dutiona/memory-engine/issues/96)   | P2       | MCP tools: replay_events, fact_history, bootstrap. [PR #179](https://github.com/dutiona/memory-engine/pull/179) |
+| ✅ [#151](https://github.com/dutiona/memory-engine/issues/151) | P2       | MCP: integration tests for tool handlers. [PR #176](https://github.com/dutiona/memory-engine/pull/176)          |
+| [#152](https://github.com/dutiona/memory-engine/issues/152)    | P1       | Abstention type exposure in Query results (4-type taxonomy)                                                     |
 
 #### Phase 4c: Quality & Cold Storage
 
@@ -341,7 +341,7 @@ Phase 4a ✅ and 4b ✅ are complete. Phase 5 is **unblocked on the critical pat
 
 **Parallelizable right now (4 independent tracks):**
 
-1. **Phase 4 follow-ups** (4 open: #95, #96, #150, #152; #151 ✅) — all non-blocking
+1. **Phase 4 follow-ups** (3 open: #95, #150, #152; #96 ✅, #151 ✅) — all non-blocking
 2. **Phase 4c** (#16, #46, #31) — #16 evaluation harness benefits from MCP being live; #31 depends on #46
 3. **Super-qa sweep** (25 open issues) — incremental, any order
 4. **Phase 5a design + implementation** — the critical path forward

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -1,7 +1,7 @@
-use memory_engine::inspect_types::FactExplanation;
+use memory_engine::inspect_types::{FactExplanation, FactHistory};
 use memory_engine::resume::ResumeContext;
 use memory_engine::search::hybrid::SearchResult;
-use memory_engine::types::Fact;
+use memory_engine::types::{Event, Fact};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -155,6 +155,69 @@ pub fn shape_resume_context(ctx: &ResumeContext, depth: Depth) -> Value {
     })
 }
 
+/// Shape an [`Event`] according to the requested depth.
+///
+/// `scope_path` is resolved externally (via `engine.get_scope_path()`) to provide
+/// human-readable context, consistent with other shapers.
+pub fn shape_event(event: &Event, depth: Depth, scope_path: Option<&str>) -> Value {
+    match depth {
+        Depth::Sparse => json!({
+            "id": event.id,
+            "event_type": event.event_type,
+            "timestamp": event.timestamp,
+            "scope": scope_path.unwrap_or(""),
+        }),
+        Depth::Standard => json!({
+            "id": event.id,
+            "event_type": event.event_type,
+            "timestamp": event.timestamp,
+            "source": event.source,
+            "session_id": event.session_id,
+            "scope": scope_path.unwrap_or(""),
+        }),
+        Depth::Full => json!({
+            "id": event.id,
+            "event_type": event.event_type,
+            "timestamp": event.timestamp,
+            "source": event.source,
+            "session_id": event.session_id,
+            "scope_id": event.scope_id,
+            "scope": scope_path.unwrap_or(""),
+            "payload": event.payload,
+            "origin_node_id": event.origin_node_id,
+            "sequence_id": event.sequence_id,
+            "created_at": event.created_at,
+            "event_revision": event.event_revision,
+        }),
+    }
+}
+
+/// Shape a [`FactHistory`] according to the requested depth.
+pub fn shape_fact_history(history: &FactHistory, depth: Depth) -> Value {
+    match depth {
+        Depth::Sparse => json!({
+            "fact_id": history.fact_id,
+            "event_count": history.timeline.len(),
+        }),
+        Depth::Standard | Depth::Full => {
+            let timeline: Vec<Value> = history
+                .timeline
+                .iter()
+                .map(|entry| {
+                    json!({
+                        "timestamp": entry.timestamp,
+                        "kind": format!("{:?}", entry.kind),
+                    })
+                })
+                .collect();
+            json!({
+                "fact_id": history.fact_id,
+                "timeline": timeline,
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,5 +305,104 @@ mod tests {
         // Should not split the emoji
         assert!(truncated.len() <= 8);
         assert!(truncated.is_char_boundary(truncated.len()));
+    }
+
+    // --- Event shaping tests ---
+
+    fn make_test_event() -> Event {
+        use memory_engine::types::EventType;
+        Event {
+            id: 7,
+            timestamp: Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::json!({"role": "user", "text": "hello"}),
+            source: "test-agent".into(),
+            session_id: Some("sess-001".into()),
+            scope_id: 2,
+            origin_node_id: "node-1".into(),
+            sequence_id: 42,
+            created_at: Some(Utc::now()),
+            event_revision: 1,
+        }
+    }
+
+    #[test]
+    fn shape_event_sparse_has_4_fields() {
+        let event = make_test_event();
+        let shaped = shape_event(&event, Depth::Sparse, Some("project/test"));
+        let obj = shaped.as_object().unwrap();
+        assert_eq!(obj.len(), 4);
+        assert!(obj.contains_key("id"));
+        assert!(obj.contains_key("event_type"));
+        assert!(obj.contains_key("timestamp"));
+        assert!(obj.contains_key("scope"));
+        // payload must NOT be present at sparse depth
+        assert!(!obj.contains_key("payload"));
+    }
+
+    #[test]
+    fn shape_event_standard_includes_source_excludes_payload() {
+        let event = make_test_event();
+        let shaped = shape_event(&event, Depth::Standard, None);
+        let obj = shaped.as_object().unwrap();
+        assert!(obj.contains_key("source"));
+        assert!(obj.contains_key("session_id"));
+        assert!(!obj.contains_key("payload"));
+        assert!(!obj.contains_key("origin_node_id"));
+    }
+
+    #[test]
+    fn shape_event_full_includes_payload() {
+        let event = make_test_event();
+        let shaped = shape_event(&event, Depth::Full, Some("root"));
+        let obj = shaped.as_object().unwrap();
+        assert!(obj.contains_key("payload"));
+        assert!(obj.contains_key("origin_node_id"));
+        assert!(obj.contains_key("sequence_id"));
+        assert!(obj.contains_key("created_at"));
+        assert!(obj.contains_key("event_revision"));
+        assert_eq!(obj["scope"], "root");
+    }
+
+    // --- FactHistory shaping tests ---
+
+    fn make_test_history() -> FactHistory {
+        use memory_engine::inspect_types::{FactHistoryEntry, HistoryEventKind};
+        FactHistory {
+            fact_id: 42,
+            timeline: vec![
+                FactHistoryEntry {
+                    timestamp: Utc::now(),
+                    kind: HistoryEventKind::Created,
+                },
+                FactHistoryEntry {
+                    timestamp: Utc::now(),
+                    kind: HistoryEventKind::BecameValid,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn shape_fact_history_sparse_only_count() {
+        let history = make_test_history();
+        let shaped = shape_fact_history(&history, Depth::Sparse);
+        let obj = shaped.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj["fact_id"], 42);
+        assert_eq!(obj["event_count"], 2);
+        assert!(!obj.contains_key("timeline"));
+    }
+
+    #[test]
+    fn shape_fact_history_standard_includes_timeline() {
+        let history = make_test_history();
+        let shaped = shape_fact_history(&history, Depth::Standard);
+        let obj = shaped.as_object().unwrap();
+        assert_eq!(obj["fact_id"], 42);
+        let timeline = obj["timeline"].as_array().unwrap();
+        assert_eq!(timeline.len(), 2);
+        assert_eq!(timeline[0]["kind"], "Created");
+        assert_eq!(timeline[1]["kind"], "BecameValid");
     }
 }

--- a/memory-engine-mcp/src/server.rs
+++ b/memory-engine-mcp/src/server.rs
@@ -58,7 +58,8 @@ impl ServerHandler for MemoryMcpServer {
             .with_instructions(
                 "Memory engine MCP server. Tools: memory_ingest, memory_add_fact, memory_query, \
              memory_resume_context, memory_list_due, memory_next_due_time, memory_explain_fact, \
-             memory_get_fact, memory_statistics, memory_flush_insights. \
+             memory_get_fact, memory_statistics, memory_flush_insights, \
+             memory_replay_events, memory_fact_history, memory_bootstrap_session. \
              Use depth=sparse|standard|full on query tools to control response verbosity.",
             )
     }

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -10,11 +10,11 @@ use memory_engine::search::hybrid::SearchMode;
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactOptions, EventType, FactType, NewEvent};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::depth::{self, Depth};
 use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
-use crate::error::{to_mcp_error, ValidationError};
+use crate::error::{ValidationError, to_mcp_error};
 
 // ---------------------------------------------------------------------------
 // Tool definitions (JSON schemas)

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -10,11 +10,11 @@ use memory_engine::search::hybrid::SearchMode;
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactOptions, EventType, FactType, NewEvent};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 
 use crate::depth::{self, Depth};
 use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
-use crate::error::{ValidationError, to_mcp_error};
+use crate::error::{to_mcp_error, ValidationError};
 
 // ---------------------------------------------------------------------------
 // Tool definitions (JSON schemas)
@@ -821,7 +821,12 @@ fn handle_replay_events(
         Some(s) => Some(parse_event_type(&s)?),
         None => None,
     };
-    let limit = get_usize(&args, "limit").or(Some(100));
+    // 0 = no limit (unbounded), absent = default cap of 100
+    let limit = match get_usize(&args, "limit") {
+        Some(0) => None,
+        Some(n) => Some(n),
+        None => Some(100),
+    };
     let upcast = get_bool(&args, "upcast").unwrap_or(false);
     let order = match get_str(&args, "order") {
         Some(s) => parse_replay_order(&s)?,

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1,8 +1,10 @@
+use std::io::Cursor;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use memory_engine::bootstrap::{BootstrapConfig, KeywordExtractor};
 use memory_engine::engine::MemoryEngine;
-use memory_engine::inspect_types::FactExplanation;
+use memory_engine::inspect_types::{FactExplanation, ReplayFilter, ReplayOrder};
 use memory_engine::resume::ResumeConfig;
 use memory_engine::search::hybrid::SearchMode;
 use memory_engine::traits::EmbeddingProvider;
@@ -172,6 +174,52 @@ pub fn all_tool_definitions() -> Vec<Tool> {
                 "required": ["insights"]
             }),
         ),
+        // ----- P2 tools (debugging / operator) -----
+        tool_def(
+            "memory_replay_events",
+            "Replay events from the append-only event log with filtering. Debugging tool for inspecting consolidation/forgetting/conflict decisions.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "since": { "type": "string", "format": "date-time", "description": "Temporal lower bound (inclusive)" },
+                    "until": { "type": "string", "format": "date-time", "description": "Temporal upper bound (inclusive)" },
+                    "id_range_start": { "type": "integer", "minimum": 0, "description": "Event ID lower bound (inclusive). Must provide both start and end." },
+                    "id_range_end": { "type": "integer", "minimum": 0, "description": "Event ID upper bound (inclusive). Must provide both start and end." },
+                    "session_id": { "type": "string", "description": "Filter by session identifier" },
+                    "event_type": { "type": "string", "enum": ["Interaction", "ToolCall", "MemoryOp", "SystemEvent"] },
+                    "limit": { "type": "integer", "minimum": 0, "default": 100, "description": "Maximum events to return (0 = no limit)" },
+                    "upcast": { "type": "boolean", "default": false, "description": "Apply event payload upcasting" },
+                    "order": { "type": "string", "enum": ["insertion", "timestamp"], "default": "insertion" },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                }
+            }),
+        ),
+        tool_def(
+            "memory_fact_history",
+            "Get the temporal timeline for a single fact — created, became valid, became invalid, expired.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "fact_id": { "type": "integer", "description": "Fact ID to inspect" },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                },
+                "required": ["fact_id"]
+            }),
+        ),
+        tool_def(
+            "memory_bootstrap_session",
+            "Bulk import facts from a Claude Code JSONL session log. Requires embedding provider.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "jsonl_data": { "type": "string", "description": "Raw JSONL session log content" },
+                    "scope": { "type": "string", "description": "Scope path for imported facts" },
+                    "max_turns": { "type": "integer", "minimum": 0, "default": 0, "description": "Max turns to process (0 = unlimited)" },
+                    "skip_existing": { "type": "boolean", "default": true, "description": "Skip sessions already bootstrapped" }
+                },
+                "required": ["jsonl_data"]
+            }),
+        ),
     ]
 }
 
@@ -206,6 +254,9 @@ pub fn dispatch(
         "memory_get_fact" => handle_get_fact(args, engine),
         "memory_statistics" => handle_statistics(engine),
         "memory_flush_insights" => handle_flush_insights(args, engine, embedder),
+        "memory_replay_events" => handle_replay_events(args, engine),
+        "memory_fact_history" => handle_fact_history(args, engine),
+        "memory_bootstrap_session" => handle_bootstrap_session(args, engine, embedder),
         _ => Err(ErrorData::invalid_params(
             format!("unknown tool: {name}"),
             None,
@@ -711,4 +762,134 @@ fn handle_flush_insights(
         "failed": failed,
         "failed_count": failed.len(),
     }))
+}
+
+// ---------------------------------------------------------------------------
+// P2 tool handlers (debugging / operator)
+// ---------------------------------------------------------------------------
+
+fn parse_replay_order(s: &str) -> Result<ReplayOrder, ErrorData> {
+    match s {
+        "insertion" => Ok(ReplayOrder::InsertionOrder),
+        "timestamp" => Ok(ReplayOrder::TimestampOrder),
+        other => Err(ErrorData::invalid_params(
+            format!("unknown replay order: {other}"),
+            None,
+        )),
+    }
+}
+
+fn handle_replay_events(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let depth_level = get_depth(&args);
+
+    let since = get_datetime(&args, "since")?;
+    let until = get_datetime(&args, "until")?;
+
+    // Both-or-neither validation (like period_start/period_end in handle_query)
+    if since.is_some() && until.is_some() {
+        if since.unwrap() > until.unwrap() {
+            return Err(ErrorData::invalid_params("since must be <= until", None));
+        }
+    }
+
+    let id_start = get_i64(&args, "id_range_start");
+    let id_end = get_i64(&args, "id_range_end");
+    let id_range = match (id_start, id_end) {
+        (Some(s), Some(e)) => {
+            if s > e {
+                return Err(ErrorData::invalid_params(
+                    "id_range_start must be <= id_range_end",
+                    None,
+                ));
+            }
+            Some((s, e))
+        }
+        (None, None) => None,
+        _ => {
+            return Err(ErrorData::invalid_params(
+                "both id_range_start and id_range_end must be provided, or neither",
+                None,
+            ));
+        }
+    };
+
+    let session_id = get_str(&args, "session_id");
+    let event_type = match get_str(&args, "event_type") {
+        Some(s) => Some(parse_event_type(&s)?),
+        None => None,
+    };
+    let limit = get_usize(&args, "limit").or(Some(100));
+    let upcast = get_bool(&args, "upcast").unwrap_or(false);
+    let order = match get_str(&args, "order") {
+        Some(s) => parse_replay_order(&s)?,
+        None => ReplayOrder::InsertionOrder,
+    };
+
+    let filter = ReplayFilter {
+        since,
+        until,
+        id_range,
+        session_id,
+        event_type,
+        limit,
+        upcast,
+        order,
+    };
+
+    let events = engine.replay_events(&filter).map_err(to_mcp_error)?;
+
+    let shaped: Vec<Value> = events
+        .iter()
+        .map(|e| depth::shape_event(e, depth_level, None))
+        .collect();
+
+    ok_json(json!({ "events": shaped, "count": shaped.len() }))
+}
+
+fn handle_fact_history(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let fact_id = get_i64(&args, "fact_id")
+        .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
+    let depth_level = get_depth(&args);
+
+    let history = engine.fact_history(fact_id).map_err(to_mcp_error)?;
+    let shaped = depth::shape_fact_history(&history, depth_level);
+
+    ok_json(shaped)
+}
+
+fn handle_bootstrap_session(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+    embedder: Option<&HttpEmbeddingProvider>,
+) -> Result<CallToolResult, ErrorData> {
+    let jsonl_data = get_str(&args, "jsonl_data")
+        .ok_or_else(|| ErrorData::invalid_params("missing jsonl_data", None))?;
+
+    let emb = embedder.ok_or(ErrorData::invalid_params(
+        "embedding provider not configured — required for bootstrap_session",
+        None,
+    ))?;
+
+    let config = BootstrapConfig {
+        scope: get_str(&args, "scope"),
+        max_turns: get_usize(&args, "max_turns").unwrap_or(0),
+        skip_existing: get_bool(&args, "skip_existing").unwrap_or(true),
+    };
+
+    let reader = Cursor::new(jsonl_data.into_bytes());
+    let extractor = KeywordExtractor;
+
+    let report = engine
+        .bootstrap_session(reader, emb, &extractor, &config, None)
+        .map_err(to_mcp_error)?;
+
+    let value = serde_json::to_value(&report)
+        .map_err(|e| ErrorData::internal_error(format!("serialize report: {e}"), None))?;
+    ok_json(value)
 }

--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -1,5 +1,7 @@
 //! Bootstrap configuration, reporting, and pre-warming metrics.
 
+use serde::Serialize;
+
 /// Configuration for the bootstrap pipeline.
 #[derive(Debug, Clone)]
 pub struct BootstrapConfig {
@@ -22,7 +24,7 @@ impl Default for BootstrapConfig {
 }
 
 /// Report returned by the bootstrap pipeline.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct BootstrapReport {
     pub sessions_processed: usize,
     pub sessions_skipped: usize,
@@ -72,7 +74,7 @@ impl BootstrapReport {
 }
 
 /// Outcome classification counts.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct OutcomeCounts {
     pub success: usize,
     pub failure: usize,
@@ -80,7 +82,7 @@ pub struct OutcomeCounts {
 }
 
 /// Episode category counts.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct CategoryCounts {
     pub bug: usize,
     pub decision: usize,
@@ -89,7 +91,7 @@ pub struct CategoryCounts {
 }
 
 /// Pre-warming quality metrics (R3, APC).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct PrewarmMetrics {
     pub episodic_count: usize,
     pub semantic_count: usize,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::graph::MemoryGraph;
 use crate::pool::ConnectionPool;
 use crate::resume::context::{ResumeConfig, ResumeContext};
 use crate::scope::ScopeTree;
-use crate::search::hybrid::{hybrid_search, MatchType, SearchMode, SearchQuery, SearchResult};
+use crate::search::hybrid::{MatchType, SearchMode, SearchQuery, SearchResult, hybrid_search};
 use crate::search::query::MemoryQuery;
 use crate::search::strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
 use crate::store::events::EventStore;
@@ -2824,9 +2824,11 @@ mod tests {
 
         let results = engine.execute_query(&MemoryQuery::new()).unwrap();
         assert_eq!(results.len(), 2);
-        assert!(results
-            .iter()
-            .all(|r| r.match_type == MatchType::ImportanceRank));
+        assert!(
+            results
+                .iter()
+                .all(|r| r.match_type == MatchType::ImportanceRank)
+        );
     }
 
     #[test]
@@ -2933,9 +2935,11 @@ mod tests {
             .unwrap();
         // fact_type filtering in store path — list_by_importance_score doesn't filter by fact_type,
         // so it should be post-filtered
-        assert!(results
-            .iter()
-            .all(|r| r.fact.fact_type == FactType::Semantic));
+        assert!(
+            results
+                .iter()
+                .all(|r| r.fact.fact_type == FactType::Semantic)
+        );
     }
 
     #[test]
@@ -3786,12 +3790,16 @@ mod tests {
         assert_eq!(co_edges.len(), 2);
 
         // Both directions present
-        assert!(co_edges
-            .iter()
-            .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2));
-        assert!(co_edges
-            .iter()
-            .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1));
+        assert!(
+            co_edges
+                .iter()
+                .any(|e| e.source_fact_id == f1 && e.target_fact_id == f2)
+        );
+        assert!(
+            co_edges
+                .iter()
+                .any(|e| e.source_fact_id == f2 && e.target_fact_id == f1)
+        );
 
         // Weight matches constant
         for e in &co_edges {


### PR DESCRIPTION
## Summary

- Adds 3 P2 operator/debugging MCP tools: `memory_replay_events`, `memory_fact_history`, `memory_bootstrap_session`
- Adds `Serialize` derive to `BootstrapReport` + sub-structs for clean JSON serialization
- Adds `shape_event()` and `shape_fact_history()` depth shapers with 5 new unit tests

## Details

All three tools wrap existing engine methods with no core logic changes:

| Tool | Engine Method | Key Feature |
|------|-------------|-------------|
| `memory_replay_events` | `replay_events()` | Tiered depth (sparse hides payload), both-or-neither `id_range` validation |
| `memory_fact_history` | `fact_history()` | Temporal timeline with depth control (sparse = count only) |
| `memory_bootstrap_session` | `bootstrap_session()` | Bulk JSONL import via `KeywordExtractor`, returns `BootstrapReport` |

Plan reviewed by Codex + Gemini (1 round). Key fixes from review:
- `id_range` both-or-neither validation (Codex BLOCKER)
- `Serialize` derive instead of manual JSON (Gemini HIGH)
- Inclusive time validation matching store semantics
- Consistent `{ events: [...], count: N }` response shape

## Test plan

- [x] 5 new depth shaping tests (shape_event sparse/standard/full, shape_fact_history sparse/standard)
- [x] `cargo test --all-features` — 406 tests pass
- [x] `cargo clippy --all-targets` — zero warnings in MCP crate
- [x] `cargo fmt --check` — clean

Fixes #96