### PR TITLE
test: add proptest + insta tests for unused dev-deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ Thumbs.db
 # Worktrees
 .worktrees/
 
+# Proptest regressions
+proptest-regressions/
+
 # Build artifacts
 *.o
 *.so

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
 rand = { version = "0.8", features = ["small_rng"] }
 criterion = { version = "0.5", features = ["html_reports"] }
-insta = { version = "1", features = ["yaml"] }
+insta = { version = "1", features = ["yaml", "redactions"] }
 proptest = "1"
 
 [[bench]]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -264,7 +264,7 @@ Discovered via automated super-qa audit ([PR #131](https://github.com/dutiona/me
 | [#108](https://github.com/dutiona/memory-engine/issues/108) | refactoring | ~~`engine.rs` is a 3573-line god module — extract subsystems~~ ✅ PR #186        |
 | [#109](https://github.com/dutiona/memory-engine/issues/109) | refactoring | `add_fact` takes 8 parameters — introduce builder or struct                      |
 | [#110](https://github.com/dutiona/memory-engine/issues/110) | refactoring | ~~All modules are `pub` in `lib.rs` — no encapsulation~~ ✅ PR #188              |
-| [#111](https://github.com/dutiona/memory-engine/issues/111) | cleanup     | `proptest` and `insta` dev-dependencies never used                               |
+| [#111](https://github.com/dutiona/memory-engine/issues/111) | cleanup     | ~~`proptest` and `insta` dev-dependencies never used~~ ✅ PR #189               |
 | [#128](https://github.com/dutiona/memory-engine/issues/128) | testing     | `traits.rs` and `query.rs` have zero unit tests ✅ (#185)                        |
 | [#187](https://github.com/dutiona/memory-engine/issues/187) | bug         | ~~`depth_shaping` insta snapshots stale after #180 QueryDiagnostics~~ ✅ PR #193 |
 

--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -150,4 +150,42 @@ mod tests {
         // Weighted average: (0.6*3 + 0.8*5) / 8 = 5.8/8 = 0.725
         assert!((a.prewarm_metrics.avg_importance - 0.725).abs() < 0.001);
     }
+
+    #[test]
+    fn snapshot_default_report() {
+        let report = BootstrapReport::default();
+        insta::assert_yaml_snapshot!(report);
+    }
+
+    #[test]
+    fn snapshot_populated_report() {
+        let report = BootstrapReport {
+            sessions_processed: 3,
+            sessions_skipped: 1,
+            entries_parsed: 42,
+            entries_malformed: 2,
+            turns_reconstructed: 18,
+            candidates_found: 12,
+            facts_created: 8,
+            events_ingested: 15,
+            outcome_counts: OutcomeCounts {
+                success: 5,
+                failure: 2,
+                indeterminate: 1,
+            },
+            category_counts: CategoryCounts {
+                bug: 3,
+                decision: 2,
+                convention: 1,
+                learning: 2,
+            },
+            prewarm_metrics: PrewarmMetrics {
+                episodic_count: 3,
+                semantic_count: 3,
+                procedural_count: 2,
+                avg_importance: 0.72,
+            },
+        };
+        insta::assert_yaml_snapshot!(report);
+    }
 }

--- a/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_default_report.snap
+++ b/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_default_report.snap
@@ -1,0 +1,27 @@
+---
+source: src/bootstrap/metrics.rs
+assertion_line: 157
+expression: report
+---
+sessions_processed: 0
+sessions_skipped: 0
+entries_parsed: 0
+entries_malformed: 0
+turns_reconstructed: 0
+candidates_found: 0
+facts_created: 0
+events_ingested: 0
+outcome_counts:
+  success: 0
+  failure: 0
+  indeterminate: 0
+category_counts:
+  bug: 0
+  decision: 0
+  convention: 0
+  learning: 0
+prewarm_metrics:
+  episodic_count: 0
+  semantic_count: 0
+  procedural_count: 0
+  avg_importance: 0

--- a/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_populated_report.snap
+++ b/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_populated_report.snap
@@ -1,0 +1,27 @@
+---
+source: src/bootstrap/metrics.rs
+assertion_line: 189
+expression: report
+---
+sessions_processed: 3
+sessions_skipped: 1
+entries_parsed: 42
+entries_malformed: 2
+turns_reconstructed: 18
+candidates_found: 12
+facts_created: 8
+events_ingested: 15
+outcome_counts:
+  success: 5
+  failure: 2
+  indeterminate: 1
+category_counts:
+  bug: 3
+  decision: 2
+  convention: 1
+  learning: 2
+prewarm_metrics:
+  episodic_count: 3
+  semantic_count: 3
+  procedural_count: 2
+  avg_importance: 0.72

--- a/src/inspect/dump.rs
+++ b/src/inspect/dump.rs
@@ -455,4 +455,55 @@ mod tests {
         assert!(bytes.len() > 4, "file too small");
         assert_eq!(&bytes[..4], &[0x28, 0xb5, 0x2f, 0xfd], "zstd magic bytes");
     }
+
+    #[test]
+    fn snapshot_empty_engine_dump() {
+        use crate::store::schema::{init_schema, migrate, open_memory};
+
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        migrate(&conn, None).unwrap();
+
+        let mut buf = Vec::new();
+        stream_snapshot(&conn, DIM, &mut buf).unwrap();
+        let snapshot: EngineSnapshot = serde_json::from_slice(&buf).unwrap();
+
+        insta::assert_yaml_snapshot!(snapshot, {
+            ".config" => insta::sorted_redaction(),
+        });
+    }
+
+    #[test]
+    fn snapshot_populated_engine_dump() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        engine
+            .add_fact(
+                "snapshot fact",
+                FactType::Semantic,
+                None,
+                &FakeEmbed,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let json_path = dir.path().join("dump.json");
+        engine
+            .dump_state(&DumpFormat::Json(json_path.clone()))
+            .unwrap();
+
+        let content = std::fs::read_to_string(&json_path).unwrap();
+        let snapshot: EngineSnapshot = serde_json::from_str(&content).unwrap();
+
+        insta::assert_yaml_snapshot!(snapshot, {
+            ".facts[].t_created" => "[timestamp]",
+            ".facts[].last_accessed" => "[timestamp]",
+            ".facts[].embedding" => "[embedding]",
+            ".facts[].content_hash" => "[hash]",
+            ".events" => "[]",
+            ".config" => "{}",
+        });
+    }
 }

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -400,4 +400,22 @@ mod tests {
         assert_eq!(explanation.provenance.source_event_id, None);
         assert!(explanation.provenance.source_event.is_none());
     }
+
+    #[test]
+    fn snapshot_active_fact_explanation() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let id = engine
+            .add_fact(
+                "snapshot test fact",
+                FactType::Semantic,
+                None,
+                &FakeEmbed,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let explanation = engine.explain_fact(id).unwrap();
+        insta::assert_yaml_snapshot!(explanation);
+    }
 }

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
@@ -1,0 +1,20 @@
+---
+source: src/inspect/dump.rs
+assertion_line: 471
+expression: snapshot
+---
+schema_version: 6
+storage_epoch: 1
+embed_dim: 4
+facts: []
+edges: []
+summaries: []
+scopes:
+  - id: 1
+    parent_id: ~
+    label: root
+    depth: 0
+events: []
+config:
+  schema_version: "6"
+  storage_epoch: "1"

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
@@ -1,0 +1,36 @@
+---
+source: src/inspect/dump.rs
+assertion_line: 498
+expression: snapshot
+---
+schema_version: 6
+storage_epoch: 1
+embed_dim: 4
+facts:
+  - id: 1
+    content: snapshot fact
+    content_hash: "[hash]"
+    embedding: "[embedding]"
+    fact_type: Semantic
+    t_created: "[timestamp]"
+    t_expired: ~
+    t_valid: ~
+    t_invalid: ~
+    source_event_id: ~
+    importance: 0.5
+    access_count: 0
+    last_accessed: "[timestamp]"
+    metadata: {}
+    scope_id: 1
+    is_pinned: false
+    importance_score: 0.5
+    surfaced_at: ~
+edges: []
+summaries: []
+scopes:
+  - id: 1
+    parent_id: ~
+    label: root
+    depth: 0
+events: "[]"
+config: "{}"

--- a/src/inspect/snapshots/memory_engine__inspect__explain__tests__snapshot_active_fact_explanation.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__explain__tests__snapshot_active_fact_explanation.snap
@@ -1,0 +1,19 @@
+---
+source: src/inspect/explain.rs
+assertion_line: 419
+expression: explanation
+---
+fact_id: 1
+state: Active
+provenance:
+  source_event_id: ~
+  source_event: ~
+  importance: 0.5
+  importance_score: 0.5
+  is_pinned: false
+  access_count: 0
+graph_context:
+  degree: 0
+  neighbor_ids: []
+  component_size: 0
+scope_path: /

--- a/src/inspect/snapshots/memory_engine__inspect__statistics__tests__snapshot_empty_engine_statistics.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__statistics__tests__snapshot_empty_engine_statistics.snap
@@ -1,0 +1,28 @@
+---
+source: src/inspect/statistics.rs
+assertion_line: 216
+expression: stats
+---
+facts:
+  total: 0
+  active: 0
+  expired: 0
+  pinned: 0
+  due: 0
+edges:
+  total: 0
+  active: 0
+  expired: 0
+summaries:
+  total: 0
+  by_level: {}
+scopes:
+  total: 1
+  max_depth: 0
+events:
+  total: 0
+storage:
+  page_count: "[page_count]"
+  page_size: "[page_size]"
+  main_db_bytes: "[db_bytes]"
+  file_path: ~

--- a/src/inspect/snapshots/memory_engine__inspect__statistics__tests__snapshot_populated_statistics.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__statistics__tests__snapshot_populated_statistics.snap
@@ -1,0 +1,28 @@
+---
+source: src/inspect/statistics.rs
+assertion_line: 267
+expression: stats
+---
+facts:
+  total: 3
+  active: 3
+  expired: 0
+  pinned: 1
+  due: 0
+edges:
+  total: 0
+  active: 0
+  expired: 0
+summaries:
+  total: 0
+  by_level: {}
+scopes:
+  total: 1
+  max_depth: 0
+events:
+  total: 0
+storage:
+  page_count: "[page_count]"
+  page_size: "[page_size]"
+  main_db_bytes: "[db_bytes]"
+  file_path: ~

--- a/src/inspect/statistics.rs
+++ b/src/inspect/statistics.rs
@@ -208,4 +208,66 @@ mod tests {
         assert_eq!(stats.facts.expired, 0);
         assert_eq!(stats.facts.pinned, 1);
     }
+
+    #[test]
+    fn snapshot_empty_engine_statistics() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let stats = engine.statistics().unwrap();
+        insta::assert_yaml_snapshot!(stats, {
+            ".storage.page_count" => "[page_count]",
+            ".storage.page_size" => "[page_size]",
+            ".storage.main_db_bytes" => "[db_bytes]",
+        });
+    }
+
+    #[test]
+    fn snapshot_populated_statistics() {
+        use crate::types::AddFactOptions;
+
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        engine
+            .add_fact(
+                "fact one",
+                FactType::Semantic,
+                None,
+                &FakeEmbed,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        engine
+            .add_fact(
+                "fact two",
+                FactType::Episodic,
+                None,
+                &FakeEmbed,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let pin_opts = AddFactOptions {
+            pinned: Some(true),
+            ..Default::default()
+        };
+        engine
+            .add_fact(
+                "pinned fact",
+                FactType::Semantic,
+                None,
+                &FakeEmbed,
+                None,
+                Some(&pin_opts),
+                None,
+            )
+            .unwrap();
+
+        let stats = engine.statistics().unwrap();
+        insta::assert_yaml_snapshot!(stats, {
+            ".storage.page_count" => "[page_count]",
+            ".storage.page_size" => "[page_size]",
+            ".storage.main_db_bytes" => "[db_bytes]",
+        });
+    }
 }

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -283,4 +283,61 @@ mod tests {
         assert_eq!(tree.nodes.len(), node_count_before + 1);
         assert!(tree.children.get(&1).unwrap().contains(&999));
     }
+
+    mod proptest_scope {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn scope_segment() -> impl Strategy<Value = String> {
+            "[a-z]{1,8}:[a-z]{1,8}".prop_map(|s| s)
+        }
+
+        fn scope_path(max_depth: usize) -> impl Strategy<Value = String> {
+            proptest::collection::vec(scope_segment(), 1..max_depth).prop_map(|segs| segs.join("/"))
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(32))]
+
+            #[test]
+            fn resolve_roundtrip(path in scope_path(4)) {
+                let conn = open_memory().unwrap();
+                init_schema(&conn).unwrap();
+                migrate(&conn, None).unwrap();
+
+                let store = ScopeStore::new(&conn);
+                store.ensure_path(&path).unwrap();
+                let tree = ScopeTree::load(&conn).unwrap();
+
+                let resolved = tree.resolve_path(&path);
+                prop_assert!(resolved.is_some(),
+                    "path '{path}' was created but not resolvable");
+
+                let id = resolved.unwrap();
+                let reconstructed = tree.path_for_id(id);
+                prop_assert_eq!(reconstructed.as_deref(), Some(path.as_str()),
+                    "path_for_id roundtrip failed");
+            }
+
+            #[test]
+            fn ancestors_always_end_at_root(path in scope_path(4)) {
+                let conn = open_memory().unwrap();
+                init_schema(&conn).unwrap();
+                migrate(&conn, None).unwrap();
+
+                let store = ScopeStore::new(&conn);
+                store.ensure_path(&path).unwrap();
+                let tree = ScopeTree::load(&conn).unwrap();
+
+                let id = tree.resolve_path(&path).unwrap();
+                let ancestors = tree.ancestors(id);
+
+                prop_assert!(!ancestors.is_empty());
+                prop_assert_eq!(*ancestors.last().unwrap(), tree.root_id(),
+                    "ancestor chain should end at root");
+                prop_assert_eq!(ancestors[0], id,
+                    "ancestor chain should start at the node itself");
+            }
+        }
+    }
 }

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -478,4 +478,64 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].fact.fact_type, FactType::Semantic);
     }
+
+    mod proptest_rrf {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn fts_list(max_len: usize) -> impl Strategy<Value = Vec<(i64, f64)>> {
+            proptest::collection::vec((1..1000i64, any::<f64>()), 0..max_len)
+        }
+
+        fn vec_list(max_len: usize) -> impl Strategy<Value = Vec<(i64, f32)>> {
+            proptest::collection::vec((1..1000i64, any::<f32>()), 0..max_len)
+        }
+
+        proptest! {
+            #[test]
+            fn all_input_ids_appear_in_output(
+                fts in fts_list(32),
+                vec_results in vec_list(32),
+                k in 1..120u32,
+            ) {
+                let merged = rrf_merge(&fts, &vec_results, k);
+                let merged_ids: std::collections::HashSet<i64> =
+                    merged.iter().map(|&(id, _)| id).collect();
+                for &(id, _) in &fts {
+                    prop_assert!(merged_ids.contains(&id),
+                        "FTS id {id} missing from merged output");
+                }
+                for &(id, _) in &vec_results {
+                    prop_assert!(merged_ids.contains(&id),
+                        "Vec id {id} missing from merged output");
+                }
+            }
+
+            #[test]
+            fn descending_order(
+                fts in fts_list(16),
+                vec_results in vec_list(16),
+                k in 1..120u32,
+            ) {
+                let merged = rrf_merge(&fts, &vec_results, k);
+                for window in merged.windows(2) {
+                    prop_assert!(window[0].1 >= window[1].1,
+                        "not descending: {} < {}", window[0].1, window[1].1);
+                }
+            }
+
+            #[test]
+            fn scores_are_positive(
+                fts in fts_list(16),
+                vec_results in vec_list(16),
+                k in 1..120u32,
+            ) {
+                let merged = rrf_merge(&fts, &vec_results, k);
+                for &(id, score) in &merged {
+                    prop_assert!(score > 0.0,
+                        "id {id} has non-positive RRF score {score}");
+                }
+            }
+        }
+    }
 }

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -262,4 +262,54 @@ mod tests {
             vector_search(&conn, &query, DIM, 10, Some(&FactType::Semantic), None).unwrap();
         assert_eq!(results.len(), 1);
     }
+
+    mod proptest_cosine {
+        use super::*;
+        use proptest::prelude::*;
+
+        // Bounded to avoid f32 overflow in squared-sum (x*x).
+        // Real embeddings are typically in [-1, 1] or small magnitudes.
+        fn bounded_f32() -> impl Strategy<Value = f32> {
+            -1e18_f32..1e18_f32
+        }
+
+        fn nonzero_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+            proptest::collection::vec(bounded_f32(), 1..max_len)
+                .prop_filter("at least one nonzero", |v| v.iter().any(|&x| x != 0.0))
+        }
+
+        proptest! {
+            #[test]
+            fn symmetry(
+                a in proptest::collection::vec(bounded_f32(), 1..64usize),
+                b in proptest::collection::vec(bounded_f32(), 1..64usize),
+            ) {
+                let len = a.len().min(b.len());
+                let a = &a[..len];
+                let b = &b[..len];
+                let ab = cosine_similarity(a, b);
+                let ba = cosine_similarity(b, a);
+                prop_assert!((ab - ba).abs() < 1e-6,
+                    "symmetry violated: cos(a,b)={ab} != cos(b,a)={ba}");
+            }
+
+            #[test]
+            fn identical_vectors_equal_one(v in nonzero_vec(64)) {
+                let sim = cosine_similarity(&v, &v);
+                prop_assert!((sim - 1.0).abs() < 1e-5,
+                    "identical vectors should give 1.0, got {sim}");
+            }
+
+            #[test]
+            fn bounded(
+                a in proptest::collection::vec(bounded_f32(), 1..64usize),
+                b in proptest::collection::vec(bounded_f32(), 1..64usize),
+            ) {
+                let len = a.len().min(b.len());
+                let sim = cosine_similarity(&a[..len], &b[..len]);
+                prop_assert!(sim >= -1.0 - 1e-5 && sim <= 1.0 + 1e-5,
+                    "cosine similarity {sim} out of [-1, 1] bounds");
+            }
+        }
+    }
 }

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1328,4 +1328,26 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].content, "semantic");
     }
+
+    mod proptest_content_hash {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn deterministic(s in ".*") {
+                let h1 = content_hash(&s);
+                let h2 = content_hash(&s);
+                prop_assert_eq!(&h1, &h2, "content_hash is not deterministic");
+            }
+
+            #[test]
+            fn always_32_hex_chars(s in ".*") {
+                let h = content_hash(&s);
+                prop_assert_eq!(h.len(), 32, "expected 32 chars, got {}", h.len());
+                prop_assert!(h.chars().all(|c| c.is_ascii_hexdigit()),
+                    "non-hex character in hash: {h}");
+            }
+        }
+    }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -116,7 +116,10 @@ mod tests {
 
         proptest! {
             #[test]
-            fn roundtrip(embedding in proptest::collection::vec(any::<f32>(), 0..512)) {
+            fn roundtrip(embedding in proptest::collection::vec(
+                any::<f32>().prop_filter("NaN != NaN in PartialEq", |f| !f.is_nan()),
+                0..512,
+            )) {
                 let blob = serialize_embedding(&embedding);
                 let recovered = deserialize_embedding(&blob, embedding.len()).unwrap();
                 prop_assert_eq!(recovered, embedding);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -109,4 +109,29 @@ mod tests {
         let recovered = deserialize_embedding(&blob, 0).unwrap();
         assert!(recovered.is_empty());
     }
+
+    mod proptest_embedding {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn roundtrip(embedding in proptest::collection::vec(any::<f32>(), 0..512)) {
+                let blob = serialize_embedding(&embedding);
+                let recovered = deserialize_embedding(&blob, embedding.len()).unwrap();
+                prop_assert_eq!(recovered, embedding);
+            }
+
+            #[test]
+            fn wrong_dim_rejects(
+                embedding in proptest::collection::vec(any::<f32>(), 1..128usize),
+                delta in 1..64usize,
+            ) {
+                let blob = serialize_embedding(&embedding);
+                let wrong_dim = embedding.len() + delta;
+                let result = deserialize_embedding(&blob, wrong_dim);
+                prop_assert!(result.is_err());
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds **proptest** property-based tests for 5 candidates identified in #111:
  - `serialize_embedding`/`deserialize_embedding` roundtrip (arbitrary `Vec<f32>`, arbitrary dim)
  - `cosine_similarity` properties: symmetry, identical vectors → 1.0, bounded [-1,1]
  - `rrf_merge` properties: all input IDs appear in output, descending order, positive scores
  - `ScopeTree` path resolution roundtrip + ancestors always end at root
  - `content_hash` determinism + always 32 hex chars

- Adds **insta** snapshot tests for 4 candidates:
  - `EngineStatistics` (empty + populated engine)
  - `FactExplanation` (active fact)
  - `EngineSnapshot` (empty + populated, with timestamp/embedding redactions)
  - `BootstrapReport` (default + populated)

- Enables insta `redactions` feature for stable snapshot comparisons
- Adds `proptest-regressions/` to `.gitignore`

**Test count:** 420 → 439 (+19 new tests)

## Test plan

- [x] `cargo test --all-features` — 439 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features` — no new warnings
- [x] `cargo fmt --check` — clean
- [x] Snapshot tests stable across multiple runs (HashMap ordering handled via `sorted_redaction`)
- [x] Proptest passes with bounded f32 range (avoids overflow-induced NaN)

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)