### PR TITLE
fix(mcp): update depth_shaping insta snapshots for QueryDiagnostics

### DIFF
--- a/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_full.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_full.snap
@@ -1,9 +1,14 @@
 ---
 source: memory-engine-mcp/tests/depth_shaping.rs
-assertion_line: 336
 expression: body
 ---
 count: 1
+diagnostics:
+  candidates_before_filter: 1
+  expired_matches: ~
+  fts_candidates: 1
+  results_returned: 1
+  vector_candidates: 0
 results:
   - access_count: 0
     content: Neural networks learn representations

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_sparse.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_sparse.snap
@@ -1,9 +1,11 @@
 ---
 source: memory-engine-mcp/tests/depth_shaping.rs
-assertion_line: 282
 expression: body
 ---
 count: 1
+diagnostics:
+  expired_matches: ~
+  results_returned: 1
 results:
   - content: Neural networks learn representations
     id: 1

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_standard.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__query_result_standard.snap
@@ -1,9 +1,14 @@
 ---
 source: memory-engine-mcp/tests/depth_shaping.rs
-assertion_line: 309
 expression: body
 ---
 count: 1
+diagnostics:
+  candidates_before_filter: 1
+  expired_matches: ~
+  fts_candidates: 1
+  results_returned: 1
+  vector_candidates: 0
 results:
   - access_count: 0
     content: Neural networks learn representations


### PR DESCRIPTION
## Summary

- Update 3 `insta` snapshot files to include the `diagnostics` field added by PR #180
- Removes stale `assertion_line` metadata from snapshot headers

## Test plan

- [x] `cargo test -p memory-engine-mcp --test depth_shaping` — 17 passed (was 3 failing)
- [x] Verified failures with committed (stale) snapshots via `git stash` round-trip

Fixes #187