### PR TITLE
refactor: introduce AddFactRequest, reduce add_fact to 3 params

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Consumers bring their own embedding model, summarizer, and conflict resolver via
 ## Quick Example
 
 ```rust
-use memory_engine::{EngineConfig, MemoryEngine, FactType, EmbeddingProvider, MemoryError};
+use memory_engine::{EngineConfig, MemoryEngine, FactType, AddFactRequest, EmbeddingProvider, MemoryError};
 
 // Consumers implement EmbeddingProvider with their model of choice
 struct DummyEmbedder;
@@ -37,13 +37,15 @@ fn main() -> Result<(), MemoryError> {
 
     // Add a fact (embedding computed automatically)
     let id = engine.add_fact(
-        "Rust's ownership model prevents data races at compile time",
-        FactType::Semantic,
-        None,       // no source event
+        &AddFactRequest {
+            content: "Rust's ownership model prevents data races at compile time".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        },
         &embedder,
-        None,       // root scope
-        None,       // default options
-        None,       // no persistence classifier
+        None, // no persistence classifier
     )?;
 
     // Query with hybrid search

--- a/benches/search_bench.rs
+++ b/benches/search_bench.rs
@@ -25,7 +25,7 @@ use memory_engine::engine::{EngineConfig, MemoryEngine};
 use memory_engine::search::cosine_similarity;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::{FactType, ScopeQuery};
+use memory_engine::types::{AddFactRequest, FactType, ScopeQuery};
 
 const DIM: usize = 128;
 
@@ -73,12 +73,14 @@ fn setup_engine_with_dim(n: usize, dim: usize) -> MemoryEngine {
         let content = format!("{topic} — fact number {i}");
         engine
             .add_fact(
-                &content,
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: content.clone(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &embedder,
-                None,
-                None,
                 None,
             )
             .expect("add_fact");
@@ -113,12 +115,14 @@ fn setup_scoped_engine(n: usize) -> MemoryEngine {
         let content = format!("scoped fact number {i} in {scope}");
         engine
             .add_fact(
-                &content,
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content,
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: Some(scope.into()),
+                    opts: None,
+                },
                 &embedder,
-                Some(scope),
-                None,
                 None,
             )
             .expect("add_fact");
@@ -380,7 +384,17 @@ fn setup_hnsw_engine(n: usize) -> MemoryEngine {
         let topic = TOPICS[i % TOPICS.len()];
         let content = format!("{topic} — fact number {i}");
         engine
-            .add_fact(&content, FactType::Semantic, None, &embedder, None, None)
+            .add_fact(
+                &AddFactRequest {
+                    content,
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                &embedder,
+                None,
+            )
             .expect("add_fact");
     }
     std::mem::forget(dir);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -262,7 +262,7 @@ Discovered via automated super-qa audit ([PR #131](https://github.com/dutiona/me
 | Issue                                                       | Category    | Description                                                                      |
 | ----------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------- |
 | [#108](https://github.com/dutiona/memory-engine/issues/108) | refactoring | ~~`engine.rs` is a 3573-line god module — extract subsystems~~ ✅ PR #186        |
-| [#109](https://github.com/dutiona/memory-engine/issues/109) | refactoring | `add_fact` takes 8 parameters — introduce builder or struct                      |
+| [#109](https://github.com/dutiona/memory-engine/issues/109) | refactoring | ~~`add_fact` takes 8 parameters — introduce builder or struct~~ ✅ PR #194       |
 | [#110](https://github.com/dutiona/memory-engine/issues/110) | refactoring | ~~All modules are `pub` in `lib.rs` — no encapsulation~~ ✅ PR #188              |
 | [#111](https://github.com/dutiona/memory-engine/issues/111) | cleanup     | ~~`proptest` and `insta` dev-dependencies never used~~ ✅ PR #189               |
 | [#128](https://github.com/dutiona/memory-engine/issues/128) | testing     | `traits.rs` and `query.rs` have zero unit tests ✅ (#185)                        |

--- a/docs/advanced/bi-temporal-semantics.md
+++ b/docs/advanced/bi-temporal-semantics.md
@@ -56,12 +56,14 @@ let opts = AddFactOptions {
 };
 
 let id = engine.add_fact(
-    "deployment freeze until tomorrow",
-    FactType::Semantic,
-    None,
+    &AddFactRequest {
+        content: "deployment freeze until tomorrow".into(),
+        fact_type: FactType::Semantic,
+        opts: Some(opts),
+        ..Default::default()
+    },
     &embedder,
     None,
-    Some(&opts),
 )?;
 ```
 
@@ -113,8 +115,13 @@ let opts = AddFactOptions {
     ..Default::default()
 };
 engine.add_fact(
-    "new API version goes live next week",
-    FactType::Semantic, None, &embedder, None, Some(&opts), None,
+    &AddFactRequest {
+        content: "new API version goes live next week".into(),
+        fact_type: FactType::Semantic,
+        opts: Some(opts),
+        ..Default::default()
+    },
+    &embedder, None,
 )?;
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -65,17 +65,19 @@ let event_id = engine.ingest(&NewEvent {
 Facts are derived knowledge the agent has internalized:
 
 ```rust
-use memory_engine::FactType;
+use memory_engine::{FactType, AddFactRequest};
 
 let embedder = DummyEmbedder;
 let fact_id = engine.add_fact(
-    "Rust is a systems programming language focused on safety and performance",
-    FactType::Semantic,
-    Some(event_id),  // link to source event
+    &AddFactRequest {
+        content: "Rust is a systems programming language focused on safety and performance".into(),
+        fact_type: FactType::Semantic,
+        source_event_id: Some(event_id),
+        scope: None,
+        opts: None,
+    },
     &embedder,
-    None,            // root scope
-    None,            // default options (importance=0.5)
-    None,            // no auto-pin classifier
+    None, // no auto-pin classifier
 )?;
 ```
 

--- a/docs/usage/adding-facts.md
+++ b/docs/usage/adding-facts.md
@@ -22,28 +22,41 @@ pub enum FactType {
 
 ## The `add_fact` method
 
+`add_fact` takes an `AddFactRequest` struct that bundles the fact's content, type, provenance, scope, and options:
+
 ```rust
 pub fn add_fact(
     &self,
-    content: &str,
-    fact_type: FactType,
-    source_event_id: Option<i64>,
+    req: &AddFactRequest,
     embedder: &dyn EmbeddingProvider,
-    scope: Option<&str>,
-    opts: Option<&AddFactOptions>,
     classifier: Option<&dyn PersistenceClassifier>,
 ) -> Result<i64>
 ```
 
-| Parameter         | Description                                                                                      |
+```rust
+pub struct AddFactRequest {
+    pub content: String,
+    pub fact_type: FactType,
+    pub source_event_id: Option<i64>,
+    pub scope: Option<String>,
+    pub opts: Option<AddFactOptions>,
+}
+```
+
+| Field             | Description                                                                                      |
 | ----------------- | ------------------------------------------------------------------------------------------------ |
 | `content`         | The textual content of the fact.                                                                 |
 | `fact_type`       | `Episodic`, `Semantic`, or `Procedural`.                                                         |
 | `source_event_id` | Optional link back to the originating event for provenance.                                      |
-| `embedder`        | Implementation of `EmbeddingProvider` to compute the embedding vector.                           |
 | `scope`           | Optional hierarchical scope path (e.g., `"user:michael/project:demo"`). `None` means root scope. |
-| `opts`            | Optional overrides for importance, metadata, temporal bounds, and pinning.                       |
-| `classifier`      | Optional `PersistenceClassifier` for auto-pinning. Pass `None` to skip.                          |
+| `opts`            | Optional `AddFactOptions` with overrides for importance, metadata, temporal bounds, and pinning. |
+
+The remaining parameters on `add_fact` itself:
+
+| Parameter    | Description                                                             |
+| ------------ | ----------------------------------------------------------------------- |
+| `embedder`   | Implementation of `EmbeddingProvider` to compute the embedding vector.  |
+| `classifier` | Optional `PersistenceClassifier` for auto-pinning. Pass `None` to skip. |
 
 The method computes the embedding **before** acquiring the write lock. This means slow embedding calls (e.g., network API round-trips) do not block concurrent readers.
 
@@ -64,7 +77,7 @@ The returned vector must match the `embed_dim` configured when opening the engin
 Here is a minimal example using a zero-vector embedder (useful for testing, not for production):
 
 ```rust
-use memory_engine::{MemoryEngine, FactType};
+use memory_engine::{MemoryEngine, FactType, AddFactRequest};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::error::Result;
 
@@ -83,13 +96,15 @@ let engine = MemoryEngine::open_memory(dim)?;
 let embedder = ZeroEmbedder { dim };
 
 let fact_id = engine.add_fact(
-    "Rust guarantees memory safety without a garbage collector",
-    FactType::Semantic,
-    None,       // no source event
+    &AddFactRequest {
+        content: "Rust guarantees memory safety without a garbage collector".into(),
+        fact_type: FactType::Semantic,
+        source_event_id: None,
+        scope: None,
+        opts: None,
+    },
     &embedder,
-    None,       // root scope
-    None,       // default options
-    None,       // no auto-pin classifier
+    None, // no auto-pin classifier
 )?;
 ```
 
@@ -132,13 +147,15 @@ let opts = AddFactOptions {
 };
 
 let id = engine.add_fact(
-    "Production API latency is 42ms p99",
-    FactType::Episodic,
-    Some(event_id),
+    &AddFactRequest {
+        content: "Production API latency is 42ms p99".into(),
+        fact_type: FactType::Episodic,
+        source_event_id: Some(event_id),
+        scope: Some("team:backend/service:api".into()),
+        opts: Some(opts),
+    },
     &embedder,
-    Some("team:backend/service:api"),
-    Some(&opts),
-    None,  // no auto-pin classifier
+    None, // no auto-pin classifier
 )?;
 ```
 
@@ -169,12 +186,32 @@ When `scope` is `None`, the fact is placed at the root scope (ID 1), which is vi
 
 ```rust
 // Facts at different scopes
-engine.add_fact("Global preference", FactType::Semantic, None, &embedder,
-    None, None, None)?;  // root scope
+engine.add_fact(
+    &AddFactRequest {
+        content: "Global preference".into(),
+        fact_type: FactType::Semantic,
+        ..Default::default()
+    },
+    &embedder, None,
+)?;
 
-engine.add_fact("Michael's preference", FactType::Semantic, None, &embedder,
-    Some("user:michael"), None, None)?;
+engine.add_fact(
+    &AddFactRequest {
+        content: "Michael's preference".into(),
+        fact_type: FactType::Semantic,
+        scope: Some("user:michael".into()),
+        ..Default::default()
+    },
+    &embedder, None,
+)?;
 
-engine.add_fact("Project-specific config", FactType::Procedural, None, &embedder,
-    Some("user:michael/project:demo"), None, None)?;
+engine.add_fact(
+    &AddFactRequest {
+        content: "Project-specific config".into(),
+        fact_type: FactType::Procedural,
+        scope: Some("user:michael/project:demo".into()),
+        ..Default::default()
+    },
+    &embedder, None,
+)?;
 ```

--- a/docs/usage/recording-events.md
+++ b/docs/usage/recording-events.md
@@ -78,11 +78,13 @@ let event_id = engine.ingest(&event)?;
 
 // Later, extract a fact from this event
 engine.add_fact(
-    "The capital of France is Paris",
-    FactType::Semantic,
-    Some(event_id),  // links fact back to source event
+    &AddFactRequest {
+        content: "The capital of France is Paris".into(),
+        fact_type: FactType::Semantic,
+        source_event_id: Some(event_id),
+        ..Default::default()
+    },
     &embedder,
-    None,
     None,
 )?;
 ```

--- a/examples/basic_roundtrip.rs
+++ b/examples/basic_roundtrip.rs
@@ -6,7 +6,7 @@ use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::{EventType, FactType, NewEvent};
+use memory_engine::types::{AddFactRequest, EventType, FactType, NewEvent};
 
 /// Zero-vector embedder for examples (no external model needed).
 struct DummyEmbedder;
@@ -37,23 +37,28 @@ fn main() -> Result<(), MemoryError> {
 
     // 2. Add facts derived from the interaction
     let fact1 = engine.add_fact(
-        "Rust is a systems programming language focused on safety and performance",
-        FactType::Semantic,
-        Some(event_id),
+        &AddFactRequest {
+            content: "Rust is a systems programming language focused on safety and performance"
+                .into(),
+            fact_type: FactType::Semantic,
+            source_event_id: Some(event_id),
+            scope: None,
+            opts: None,
+        },
         &embedder,
-        None, // root scope
-        None, // default options
         None, // no persistence classifier
     )?;
     println!("Added fact id={fact1}");
 
     let fact2 = engine.add_fact(
-        "Alice asked about Rust programming",
-        FactType::Episodic,
-        Some(event_id),
+        &AddFactRequest {
+            content: "Alice asked about Rust programming".into(),
+            fact_type: FactType::Episodic,
+            source_event_id: Some(event_id),
+            scope: None,
+            opts: None,
+        },
         &embedder,
-        None,
-        None,
         None,
     )?;
     println!("Added fact id={fact2}");

--- a/examples/bi_temporal_query.rs
+++ b/examples/bi_temporal_query.rs
@@ -9,7 +9,7 @@ use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::{AddFactOptions, FactType};
+use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 
 struct DummyEmbedder;
 
@@ -26,47 +26,53 @@ fn main() -> Result<(), MemoryError> {
 
     // Fact valid from yesterday, no expiry
     engine.add_fact(
-        "The project deadline is March 15",
-        FactType::Semantic,
-        None,
+        &AddFactRequest {
+            content: "The project deadline is March 15".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: Some(AddFactOptions {
+                importance: Some(0.9),
+                t_valid: Some(now - Duration::days(1)),
+                t_invalid: Some(now + Duration::days(5)),
+                ..Default::default()
+            }),
+        },
         &embedder,
-        None,
-        Some(&AddFactOptions {
-            importance: Some(0.9),
-            t_valid: Some(now - Duration::days(1)),
-            t_invalid: Some(now + Duration::days(5)),
-            ..Default::default()
-        }),
         None,
     )?;
 
     // Fact valid only in the future (scheduled memory)
     engine.add_fact(
-        "Remember to review PR after March 20",
-        FactType::Procedural,
-        None,
+        &AddFactRequest {
+            content: "Remember to review PR after March 20".into(),
+            fact_type: FactType::Procedural,
+            source_event_id: None,
+            scope: None,
+            opts: Some(AddFactOptions {
+                importance: Some(0.8),
+                t_valid: Some(now + Duration::days(10)),
+                ..Default::default()
+            }),
+        },
         &embedder,
-        None,
-        Some(&AddFactOptions {
-            importance: Some(0.8),
-            t_valid: Some(now + Duration::days(10)),
-            ..Default::default()
-        }),
         None,
     )?;
 
     // Fact that expired yesterday (historical knowledge)
     engine.add_fact(
-        "The meeting was scheduled for March 8",
-        FactType::Episodic,
-        None,
+        &AddFactRequest {
+            content: "The meeting was scheduled for March 8".into(),
+            fact_type: FactType::Episodic,
+            source_event_id: None,
+            scope: None,
+            opts: Some(AddFactOptions {
+                t_valid: Some(now - Duration::days(5)),
+                t_invalid: Some(now - Duration::days(1)),
+                ..Default::default()
+            }),
+        },
         &embedder,
-        None,
-        Some(&AddFactOptions {
-            t_valid: Some(now - Duration::days(5)),
-            t_invalid: Some(now - Duration::days(1)),
-            ..Default::default()
-        }),
         None,
     )?;
 

--- a/examples/custom_traits.rs
+++ b/examples/custom_traits.rs
@@ -8,7 +8,7 @@ use memory_engine::traits::{
     ConflictArbiter, ConsolidationConfig, CrudDecision, EmbeddingProvider, ForgetPolicy,
     SummaryGenerator,
 };
-use memory_engine::types::{Fact, FactType, NewFact};
+use memory_engine::types::{AddFactRequest, Fact, FactType, NewFact};
 
 // --- EmbeddingProvider: consumers bring their own embedding model ---
 
@@ -72,39 +72,47 @@ fn main() -> Result<(), MemoryError> {
 
     // Add some facts
     engine.add_fact(
-        "Rust uses ownership for memory safety",
-        FactType::Semantic,
-        None,
+        &AddFactRequest {
+            content: "Rust uses ownership for memory safety".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        },
         &embedder,
-        None,
-        None,
         None,
     )?;
     engine.add_fact(
-        "Rust was created by Graydon Hoare",
-        FactType::Semantic,
-        None,
+        &AddFactRequest {
+            content: "Rust was created by Graydon Hoare".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        },
         &embedder,
-        None,
-        None,
         None,
     )?;
     engine.add_fact(
-        "Rust 1.85 introduced edition 2024",
-        FactType::Semantic,
-        None,
+        &AddFactRequest {
+            content: "Rust 1.85 introduced edition 2024".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        },
         &embedder,
-        None,
-        None,
         None,
     )?;
     engine.add_fact(
-        "Rust uses ownership for memory safety",
-        FactType::Semantic,
-        None,
+        &AddFactRequest {
+            content: "Rust uses ownership for memory safety".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        },
         &embedder,
-        None,
-        None,
         None,
     )?; // duplicate
 
@@ -143,12 +151,14 @@ fn main() -> Result<(), MemoryError> {
 
     // --- Conflict resolution: uses ConflictArbiter ---
     let fact_id = engine.add_fact(
-        "Rust 1.85 is the latest stable",
-        FactType::Semantic,
-        None,
+        &AddFactRequest {
+            content: "Rust 1.85 is the latest stable".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        },
         &embedder,
-        None,
-        None,
         None,
     )?;
 

--- a/memory-engine-cli/examples/create_smoke_db.rs
+++ b/memory-engine-cli/examples/create_smoke_db.rs
@@ -1,4 +1,4 @@
-use memory_engine::{EmbeddingProvider, EngineConfig, FactType, MemoryEngine};
+use memory_engine::{AddFactRequest, EmbeddingProvider, EngineConfig, FactType, MemoryEngine};
 
 struct FakeEmbed;
 impl EmbeddingProvider for FakeEmbed {
@@ -18,56 +18,67 @@ fn main() {
 
     engine
         .add_fact(
-            "User prefers concise responses without filler words",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "User prefers concise responses without filler words".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &e,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Project uses Rust 2024 edition with clap for CLI parsing",
-            FactType::Procedural,
-            None,
+            &AddFactRequest {
+                content: "Project uses Rust 2024 edition with clap for CLI parsing".into(),
+                fact_type: FactType::Procedural,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &e,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Meeting discussed Q2 roadmap: Phase 4b CLI inspector then MCP server",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Meeting discussed Q2 roadmap: Phase 4b CLI inspector then MCP server"
+                    .into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &e,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "The database schema migrated from v5 to v6 on 2026-03-15",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "The database schema migrated from v5 to v6 on 2026-03-15".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &e,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Agent successfully resolved 3 merge conflicts in the auth module",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Agent successfully resolved 3 merge conflicts in the auth module".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &e,
-            None,
-            None,
             None,
         )
         .unwrap();

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -21,34 +21,40 @@ fn create_test_db() -> (TempDir, PathBuf) {
 
     engine
         .add_fact(
-            "The sky is blue",
-            memory_engine::FactType::Semantic,
-            None,
+            &memory_engine::AddFactRequest {
+                content: "The sky is blue".into(),
+                fact_type: memory_engine::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Rust is fast",
-            memory_engine::FactType::Procedural,
-            None,
+            &memory_engine::AddFactRequest {
+                content: "Rust is fast".into(),
+                fact_type: memory_engine::FactType::Procedural,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Memory engines consolidate facts",
-            memory_engine::FactType::Episodic,
-            None,
+            &memory_engine::AddFactRequest {
+                content: "Memory engines consolidate facts".into(),
+                fact_type: memory_engine::FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -12,7 +12,7 @@ use memory_engine::search::hybrid::SearchMode;
 use memory_engine::traits::{
     ConsolidationConfig, EmbeddingProvider, ForgetPolicy, SummaryGenerator,
 };
-use memory_engine::types::{AddFactOptions, BatchFactEntry, EventType, FactType, NewEvent};
+use memory_engine::types::{AddFactOptions, AddFactRequest, EventType, FactType, NewEvent};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
 use serde_json::{Map, Value, json};
 
@@ -525,41 +525,29 @@ fn handle_add_fact(
         }
     }
 
-    let opts = AddFactOptions {
-        importance,
-        metadata,
-        t_valid,
-        t_invalid,
-        pinned,
-        ..Default::default()
+    let req = AddFactRequest {
+        content,
+        fact_type,
+        source_event_id,
+        scope,
+        opts: Some(AddFactOptions {
+            importance,
+            metadata,
+            t_valid,
+            t_invalid,
+            pinned,
+            ..Default::default()
+        }),
     };
 
     let fact_id = if let Some(emb) = pre_computed {
         let passthrough = PassthroughEmbedder::new(emb);
         engine
-            .add_fact(
-                &content,
-                fact_type,
-                source_event_id,
-                &passthrough,
-                scope.as_deref(),
-                Some(&opts),
-                None,
-            )
+            .add_fact(&req, &passthrough, None)
             .map_err(to_mcp_error)?
     } else {
         let emb = embedder.ok_or(ValidationError::NoEmbeddingProvider)?;
-        engine
-            .add_fact(
-                &content,
-                fact_type,
-                source_event_id,
-                emb,
-                scope.as_deref(),
-                Some(&opts),
-                None,
-            )
-            .map_err(to_mcp_error)?
+        engine.add_fact(&req, emb, None).map_err(to_mcp_error)?
     };
 
     ok_json(json!({ "fact_id": fact_id }))
@@ -780,7 +768,7 @@ fn handle_flush_insights(
     ))?;
 
     // --- Phase 1: Parse + validate all insights upfront ---
-    let mut entries: Vec<BatchFactEntry> = Vec::new();
+    let mut entries: Vec<AddFactRequest> = Vec::new();
     let mut entry_indices: Vec<usize> = Vec::new(); // original index for each valid entry
     let mut failed: Vec<Value> = Vec::new();
 
@@ -833,7 +821,7 @@ fn handle_flush_insights(
             ..Default::default()
         };
 
-        entries.push(BatchFactEntry {
+        entries.push(AddFactRequest {
             content,
             fact_type,
             source_event_id: None,

--- a/memory-engine-mcp/tests/depth_shaping.rs
+++ b/memory-engine-mcp/tests/depth_shaping.rs
@@ -6,6 +6,7 @@
 
 use memory_engine::engine::MemoryEngine;
 use memory_engine::traits::EmbeddingProvider;
+use memory_engine::types::AddFactRequest;
 use memory_engine_mcp::tools;
 use serde_json::{Map, Value, json};
 
@@ -91,12 +92,15 @@ fn get_fact_sparse() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Rust is a systems programming language with zero-cost abstractions",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust is a systems programming language with zero-cost abstractions"
+                    .into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -119,12 +123,15 @@ fn get_fact_standard() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Rust is a systems programming language with zero-cost abstractions",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust is a systems programming language with zero-cost abstractions"
+                    .into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -147,12 +154,15 @@ fn get_fact_full() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Rust is a systems programming language with zero-cost abstractions",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust is a systems programming language with zero-cost abstractions"
+                    .into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -179,12 +189,14 @@ fn explain_fact_sparse() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Ebbinghaus forgetting curve",
-            memory_engine::types::FactType::Procedural,
-            None,
+            &AddFactRequest {
+                content: "Ebbinghaus forgetting curve".into(),
+                fact_type: memory_engine::types::FactType::Procedural,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -207,12 +219,14 @@ fn explain_fact_standard() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Ebbinghaus forgetting curve",
-            memory_engine::types::FactType::Procedural,
-            None,
+            &AddFactRequest {
+                content: "Ebbinghaus forgetting curve".into(),
+                fact_type: memory_engine::types::FactType::Procedural,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -235,12 +249,14 @@ fn explain_fact_full() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Ebbinghaus forgetting curve",
-            memory_engine::types::FactType::Procedural,
-            None,
+            &AddFactRequest {
+                content: "Ebbinghaus forgetting curve".into(),
+                fact_type: memory_engine::types::FactType::Procedural,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -267,12 +283,14 @@ fn query_result_sparse() {
     let embedder = TestEmbedder { dim: DIM };
     engine
         .add_fact(
-            "Neural networks learn representations",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Neural networks learn representations".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -295,12 +313,14 @@ fn query_result_standard() {
     let embedder = TestEmbedder { dim: DIM };
     engine
         .add_fact(
-            "Neural networks learn representations",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Neural networks learn representations".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -323,12 +343,14 @@ fn query_result_full() {
     let embedder = TestEmbedder { dim: DIM };
     engine
         .add_fact(
-            "Neural networks learn representations",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Neural networks learn representations".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -360,12 +382,14 @@ fn resume_context_sparse() {
     };
     engine
         .add_fact(
-            "Critical pinned fact",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Critical pinned fact".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts),
             None,
         )
         .unwrap();
@@ -393,12 +417,14 @@ fn resume_context_standard() {
     };
     engine
         .add_fact(
-            "Critical pinned fact",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Critical pinned fact".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts),
             None,
         )
         .unwrap();
@@ -426,12 +452,14 @@ fn resume_context_full() {
     };
     engine
         .add_fact(
-            "Critical pinned fact",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Critical pinned fact".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts),
             None,
         )
         .unwrap();
@@ -477,12 +505,14 @@ fn sparse_has_exactly_4_fields() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Field count test",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Field count test".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -504,12 +534,14 @@ fn standard_excludes_embedding_and_hash() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Field exclusion test",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Field exclusion test".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -534,12 +566,14 @@ fn full_includes_embedding_dim_and_hash() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Full depth test",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Full depth test".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -568,12 +602,14 @@ fn default_depth_is_standard() {
     let embedder = TestEmbedder { dim: DIM };
     let fact_id = engine
         .add_fact(
-            "Default depth test",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Default depth test".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -305,17 +305,20 @@ async fn bearer_auth_sent_when_configured() {
 // flush_insights with wiremock embedder
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn flush_insights_with_http_embedder() {
     let server = MockServer::start().await;
     let emb = make_embedding(DIM);
 
+    // Batch embed: one call with both texts, response needs index fields
     Mock::given(method("POST"))
         .and(path("/v1/embeddings"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": [{ "embedding": emb }]
+            "data": [
+                { "index": 0, "embedding": emb.clone() },
+                { "index": 1, "embedding": emb }
+            ]
         })))
-        .expect(2) // Two insights = two embedding calls
         .mount(&server)
         .await;
 
@@ -351,15 +354,16 @@ async fn flush_insights_with_http_embedder() {
     assert_eq!(body["failed_count"].as_u64().unwrap(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn flush_insights_partial_failure() {
     let server = MockServer::start().await;
     let emb = make_embedding(DIM);
 
+    // Only 1 valid insight passes pre-validation → batch embed with 1 text
     Mock::given(method("POST"))
         .and(path("/v1/embeddings"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": [{ "embedding": emb }]
+            "data": [{ "index": 0, "embedding": emb }]
         })))
         .mount(&server)
         .await;

--- a/memory-engine-mcp/tests/query_mode_inference.rs
+++ b/memory-engine-mcp/tests/query_mode_inference.rs
@@ -10,6 +10,7 @@
 
 use memory_engine::engine::MemoryEngine;
 use memory_engine::traits::EmbeddingProvider;
+use memory_engine::types::AddFactRequest;
 use memory_engine_mcp::tools;
 use serde_json::{Map, Value, json};
 
@@ -46,23 +47,27 @@ fn seed_facts(engine: &MemoryEngine) {
     let embedder = TestEmbedder { dim: DIM };
     engine
         .add_fact(
-            "Rust ownership model prevents data races",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust ownership model prevents data races".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Python GIL limits true parallelism",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Python GIL limits true parallelism".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -271,12 +276,14 @@ fn query_with_scope_parameters_accepted() {
 
     engine
         .add_fact(
-            "Rust borrow checker ensures safety",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust borrow checker ensures safety".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: Some("lang/rust".into()),
+                opts: None,
+            },
             &embedder,
-            Some("lang/rust"),
-            None,
             None,
         )
         .unwrap();
@@ -315,23 +322,27 @@ fn fts_with_fact_type_filter() {
 
     engine
         .add_fact(
-            "Rust compile-time guarantees",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust compile-time guarantees".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Today I learned about Rust lifetimes",
-            memory_engine::types::FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Today I learned about Rust lifetimes".into(),
+                fact_type: memory_engine::types::FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();

--- a/memory-engine-mcp/tests/tool_roundtrip.rs
+++ b/memory-engine-mcp/tests/tool_roundtrip.rs
@@ -6,6 +6,7 @@
 
 use memory_engine::engine::MemoryEngine;
 use memory_engine::traits::EmbeddingProvider;
+use memory_engine::types::AddFactRequest;
 use memory_engine_mcp::tools;
 use serde_json::{Map, Value, json};
 
@@ -286,23 +287,27 @@ fn query_fts_returns_results() {
     // Seed some facts
     engine
         .add_fact(
-            "Rust has zero-cost abstractions",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust has zero-cost abstractions".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Python is great for ML",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Python is great for ML".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -330,12 +335,14 @@ fn query_with_precomputed_embedding() {
 
     engine
         .add_fact(
-            "Memory consolidation during sleep",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Memory consolidation during sleep".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -427,12 +434,14 @@ fn resume_context_with_pinned_fact() {
     };
     engine
         .add_fact(
-            "Critical system invariant",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Critical system invariant".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts),
+            },
             &embedder,
-            None,
-            Some(&opts),
             None,
         )
         .unwrap();
@@ -491,12 +500,14 @@ fn explain_fact_existing() {
 
     let fact_id = engine
         .add_fact(
-            "Fact to explain",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Fact to explain".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -552,12 +563,14 @@ fn get_fact_existing() {
 
     let fact_id = engine
         .add_fact(
-            "Retrievable fact",
-            memory_engine::types::FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Retrievable fact".into(),
+                fact_type: memory_engine::types::FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -616,23 +629,27 @@ fn statistics_after_ingestion() {
 
     engine
         .add_fact(
-            "Fact 1",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Fact 1".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Fact 2",
-            memory_engine::types::FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Fact 2".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();

--- a/memory-engine-mcp/tests/tools.rs
+++ b/memory-engine-mcp/tests/tools.rs
@@ -1,6 +1,6 @@
 use memory_engine::engine::{EngineConfig, MemoryEngine};
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::FactType;
+use memory_engine::types::{AddFactRequest, FactType};
 use memory_engine_mcp::tools;
 use rmcp::model::{CallToolResult, RawContent};
 use serde_json::{Map, Value, json};
@@ -26,12 +26,14 @@ fn test_engine() -> (MemoryEngine, tempfile::TempDir) {
 fn add_test_fact(engine: &MemoryEngine, content: &str) -> i64 {
     engine
         .add_fact(
-            content,
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: content.into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap()

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -17,7 +17,7 @@ use crate::traits::{
     EmbeddingProvider, ForgetPolicy, PersistenceClassifier, PruneStats, SummaryGenerator,
 };
 use crate::types::{
-    AddFactOptions, BatchFactEntry, ConsolidationLevel, Fact, FactType, NewEvent, NewFact, Summary,
+    AddFactOptions, AddFactRequest, ConsolidationLevel, Fact, FactType, NewEvent, NewFact, Summary,
 };
 
 /// Async wrapper around [`MemoryEngine`].
@@ -28,8 +28,9 @@ use crate::types::{
 /// ```rust,ignore
 /// let engine = MemoryEngine::open_memory(768)?;
 /// let async_engine = AsyncMemoryEngine::new(engine);
-/// let id = async_engine.add_fact("hello".into(), FactType::Semantic, None,
-///     embedder, None, None).await?;
+/// let req = AddFactRequest { content: "hello".into(), fact_type: FactType::Semantic,
+///     source_event_id: None, scope: None, opts: None };
+/// let id = async_engine.add_fact(req, embedder, None).await?;
 /// ```
 #[derive(Clone)]
 pub struct AsyncMemoryEngine {
@@ -95,26 +96,17 @@ impl AsyncMemoryEngine {
     }
 
     /// Add a fact with embedding computation.
-    #[allow(clippy::too_many_arguments)]
     pub async fn add_fact(
         &self,
-        content: String,
-        fact_type: FactType,
-        source_event_id: Option<i64>,
+        req: AddFactRequest,
         embedder: Arc<dyn EmbeddingProvider + Send + Sync>,
-        scope: Option<String>,
-        opts: Option<AddFactOptions>,
         classifier: Option<Arc<dyn PersistenceClassifier + Send + Sync>>,
     ) -> Result<i64> {
         let engine = self.inner.clone();
         tokio::task::spawn_blocking(move || {
             engine.add_fact(
-                &content,
-                fact_type,
-                source_event_id,
+                &req,
                 embedder.as_ref(),
-                scope.as_deref(),
-                opts.as_ref(),
                 classifier
                     .as_ref()
                     .map(|c| c.as_ref() as &dyn PersistenceClassifier),
@@ -129,7 +121,7 @@ impl AsyncMemoryEngine {
     /// Async wrapper around [`MemoryEngine::add_facts_batch`].
     pub async fn add_facts_batch(
         &self,
-        entries: Vec<BatchFactEntry>,
+        entries: Vec<AddFactRequest>,
         embedder: Arc<dyn EmbeddingProvider + Send + Sync>,
         classifier: Option<Arc<dyn PersistenceClassifier + Send + Sync>>,
     ) -> Result<Vec<i64>> {
@@ -467,12 +459,14 @@ mod tests {
             Arc::new(MockEmbedder { dim: DIM });
         let id = engine
             .add_fact(
-                "async test fact".into(),
-                FactType::Semantic,
-                None,
+                AddFactRequest {
+                    content: "async test fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 embedder,
-                None,
-                None,
                 None,
             )
             .await
@@ -502,12 +496,14 @@ mod tests {
             Arc::new(MockEmbedder { dim: DIM });
         engine
             .add_fact(
-                "concurrent test".into(),
-                FactType::Semantic,
-                None,
+                AddFactRequest {
+                    content: "concurrent test".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 embedder,
-                None,
-                None,
                 None,
             )
             .await
@@ -564,12 +560,14 @@ mod tests {
         };
         engine
             .add_fact(
-                "reminder".into(),
-                FactType::Semantic,
-                None,
+                AddFactRequest {
+                    content: "reminder".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: Some(opts),
+                },
                 embedder,
-                None,
-                Some(opts),
                 None,
             )
             .await
@@ -587,12 +585,14 @@ mod tests {
             Arc::new(MockEmbedder { dim: DIM });
         let id = engine
             .add_fact(
-                "pinnable".into(),
-                FactType::Semantic,
-                None,
+                AddFactRequest {
+                    content: "pinnable".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 embedder,
-                None,
-                None,
                 None,
             )
             .await

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -5,7 +5,7 @@ use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
 use crate::store::scopes::ScopeStore;
 use crate::traits::{EmbeddingProvider, PersistenceClassifier};
-use crate::types::{AddFactOptions, BatchFactEntry, Fact, FactType, NewEvent, NewFact};
+use crate::types::{AddFactOptions, AddFactRequest, Fact, NewEvent, NewFact};
 
 #[cfg(feature = "ann")]
 use crate::search::strategy::VectorSearchStrategy;
@@ -34,21 +34,16 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns errors from embedding computation, dimension validation, or DB insert.
-    #[allow(clippy::too_many_arguments)]
     pub fn add_fact(
         &self,
-        content: &str,
-        fact_type: FactType,
-        source_event_id: Option<i64>,
+        req: &AddFactRequest,
         embedder: &dyn EmbeddingProvider,
-        scope: Option<&str>,
-        opts: Option<&AddFactOptions>,
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<i64> {
         // Embed OUTSIDE the write lock (potentially slow)
-        let embedding = embedder.embed(content)?;
+        let embedding = embedder.embed(&req.content)?;
         let now = Utc::now();
-        let opts = opts.cloned().unwrap_or_default();
+        let opts = req.opts.clone().unwrap_or_default();
         let base_importance = opts.importance.unwrap_or(0.5);
         let effective_created = opts.t_created.unwrap_or(now);
         let effective_last_accessed = opts.last_accessed.unwrap_or(now);
@@ -60,15 +55,15 @@ impl MemoryEngine {
             None => classifier.is_some_and(|c| {
                 let temp = Fact {
                     id: 0,
-                    content: content.into(),
+                    content: req.content.clone(),
                     content_hash: String::new(),
                     embedding: embedding.clone(),
-                    fact_type: fact_type.clone(),
+                    fact_type: req.fact_type.clone(),
                     t_created: effective_created,
                     t_expired: None,
                     t_valid: opts.t_valid,
                     t_invalid: opts.t_invalid,
-                    source_event_id,
+                    source_event_id: req.source_event_id,
                     importance: base_importance,
                     access_count: 0,
                     last_accessed: effective_last_accessed,
@@ -91,21 +86,21 @@ impl MemoryEngine {
 
         let fact_id = {
             let conn = self.write_conn()?;
-            let scope_id = match scope {
+            let scope_id = match &req.scope {
                 Some(path) => self.ensure_scope_with_conn(&conn, path)?,
                 None => 1, // root scope
             };
 
             let new_fact = NewFact {
-                content: content.into(),
+                content: req.content.clone(),
                 content_hash: String::new(), // FactStore::insert computes this via blake3
                 embedding,
-                fact_type,
+                fact_type: req.fact_type.clone(),
                 t_created: effective_created,
                 t_expired: None,
                 t_valid: opts.t_valid,
                 t_invalid: opts.t_invalid,
-                source_event_id,
+                source_event_id: req.source_event_id,
                 scope_id,
                 importance: opts.importance.unwrap_or(0.5),
                 access_count: 0,
@@ -143,7 +138,7 @@ impl MemoryEngine {
     /// Returns errors from batch embedding, dimension validation, or DB insert.
     pub fn add_facts_batch(
         &self,
-        entries: &[BatchFactEntry],
+        entries: &[AddFactRequest],
         embedder: &dyn EmbeddingProvider,
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<Vec<i64>> {

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -6,7 +6,7 @@ use crate::traits::{
     ConflictArbiter, ConsolidationConfig, CrudDecision, EmbeddingProvider, ForgetPolicy,
     PersistenceClassifier, SummaryGenerator,
 };
-use crate::types::{AddFactOptions, BatchFactEntry, EventType, Fact, FactType, NewEvent, NewFact};
+use crate::types::{AddFactOptions, AddFactRequest, EventType, Fact, FactType, NewEvent, NewFact};
 
 const DIM: usize = 4;
 
@@ -104,12 +104,14 @@ fn add_fact_returns_fact_id() {
     let embedder = MockEmbedder { dim: DIM };
     let id = engine
         .add_fact(
-            "Rust is fast",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust is fast".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -122,12 +124,14 @@ fn query_returns_results_after_adding_facts() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "Rust is a systems programming language",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust is a systems programming language".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -381,12 +385,14 @@ fn add_fact_with_custom_importance() {
     };
     let id = engine
         .add_fact(
-            "important fact",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "important fact".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts),
             None,
         )
         .unwrap();
@@ -406,12 +412,14 @@ fn add_fact_with_temporal_bounds() {
     };
     let id = engine
         .add_fact(
-            "temporal fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "temporal fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts),
             None,
         )
         .unwrap();
@@ -426,12 +434,14 @@ fn add_fact_with_scope_path() {
     let embedder = MockEmbedder { dim: DIM };
     let id = engine
         .add_fact(
-            "scoped fact",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "scoped fact".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: Some("user:test/project:demo".into()),
+                opts: None,
+            },
             &embedder,
-            Some("user:test/project:demo"),
-            None,
             None,
         )
         .unwrap();
@@ -445,12 +455,14 @@ fn add_fact_none_opts_uses_defaults() {
     let embedder = MockEmbedder { dim: DIM };
     let id = engine
         .add_fact(
-            "default fact",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "default fact".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -477,23 +489,27 @@ fn engine_concurrent_reads() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "Rust is fast",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust is fast".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Python is flexible",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Python is flexible".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -536,12 +552,14 @@ fn engine_write_then_read_across_threads() {
     let writer = std::thread::spawn(move || {
         let embedder = MockEmbedder { dim: DIM };
         e1.add_fact(
-            "Concurrent write test",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Concurrent write test".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -592,12 +610,14 @@ fn resume_with_facts() {
     };
     engine
         .add_fact(
-            "user prefers Rust",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "user prefers Rust".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_pinned.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_pinned),
             None,
         )
         .unwrap();
@@ -609,12 +629,14 @@ fn resume_with_facts() {
     };
     engine
         .add_fact(
-            "had coffee today",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "had coffee today".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_low.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_low),
             None,
         )
         .unwrap();
@@ -653,17 +675,19 @@ fn resume_stamps_surfaced_at_on_pinned_due_fact() {
     // It will land in the pinned tier, not the due tier.
     engine
         .add_fact(
-            "CI pipeline uses 30min timeout",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "CI pipeline uses 30min timeout".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(AddFactOptions {
+                    pinned: Some(true),
+                    t_valid: Some(past),
+                    importance: Some(0.9),
+                    ..Default::default()
+                }),
+            },
             &embedder,
-            None,
-            Some(&AddFactOptions {
-                pinned: Some(true),
-                t_valid: Some(past),
-                importance: Some(0.9),
-                ..Default::default()
-            }),
             None,
         )
         .unwrap();
@@ -698,16 +722,18 @@ fn resume_stamps_surfaced_at_on_high_importance_due_fact() {
     // It will land in high_importance tier, not due tier.
     engine
         .add_fact(
-            "user prefers tabs over spaces",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "user prefers tabs over spaces".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(AddFactOptions {
+                    importance: Some(0.9),
+                    t_valid: Some(past),
+                    ..Default::default()
+                }),
+            },
             &embedder,
-            None,
-            Some(&AddFactOptions {
-                importance: Some(0.9),
-                t_valid: Some(past),
-                ..Default::default()
-            }),
             None,
         )
         .unwrap();
@@ -742,18 +768,20 @@ fn resume_does_not_stamp_invalidated_pinned_due_fact() {
     // t_valid in the past, t_invalid ALSO in the past (before now).
     engine
         .add_fact(
-            "old CI timeout no longer valid",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "old CI timeout no longer valid".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(AddFactOptions {
+                    pinned: Some(true),
+                    t_valid: Some(past),
+                    t_invalid: Some(past_invalid),
+                    importance: Some(0.9),
+                    ..Default::default()
+                }),
+            },
             &embedder,
-            None,
-            Some(&AddFactOptions {
-                pinned: Some(true),
-                t_valid: Some(past),
-                t_invalid: Some(past_invalid),
-                importance: Some(0.9),
-                ..Default::default()
-            }),
             None,
         )
         .unwrap();
@@ -800,12 +828,14 @@ fn query_nonexistent_scope_returns_empty() {
     // Add a fact at root scope so there's something to find if search were unscoped
     engine
         .add_fact(
-            "visible without scope",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "visible without scope".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -841,15 +871,17 @@ fn list_due_returns_scheduled_facts() {
     // Past-due fact
     engine
         .add_fact(
-            "check release",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "check release".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(AddFactOptions {
+                    t_valid: Some(past),
+                    ..Default::default()
+                }),
+            },
             &embedder,
-            None,
-            Some(&AddFactOptions {
-                t_valid: Some(past),
-                ..Default::default()
-            }),
             None,
         )
         .unwrap();
@@ -857,15 +889,17 @@ fn list_due_returns_scheduled_facts() {
     // Future fact
     engine
         .add_fact(
-            "future check",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "future check".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(AddFactOptions {
+                    t_valid: Some(future),
+                    ..Default::default()
+                }),
+            },
             &embedder,
-            None,
-            Some(&AddFactOptions {
-                t_valid: Some(future),
-                ..Default::default()
-            }),
             None,
         )
         .unwrap();
@@ -873,12 +907,14 @@ fn list_due_returns_scheduled_facts() {
     // Regular fact (no t_valid)
     engine
         .add_fact(
-            "regular",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "regular".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -930,12 +966,14 @@ fn pin_unpin_fact() {
     let embedder = MockEmbedder { dim: DIM };
     let id = engine
         .add_fact(
-            "pinnable",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "pinnable".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -957,12 +995,14 @@ fn add_fact_with_explicit_pin() {
     };
     let id = engine
         .add_fact(
-            "identity",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "identity".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts),
             None,
         )
         .unwrap();
@@ -984,12 +1024,14 @@ fn add_fact_with_classifier() {
 
     let id = engine
         .add_fact(
-            "auto-pinned",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "auto-pinned".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             Some(&classifier),
         )
         .unwrap();
@@ -997,12 +1039,14 @@ fn add_fact_with_classifier() {
 
     let id2 = engine
         .add_fact(
-            "not pinned",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "not pinned".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             Some(&classifier),
         )
         .unwrap();
@@ -1029,12 +1073,14 @@ fn explicit_pin_overrides_classifier() {
     };
     let id = engine
         .add_fact(
-            "not pinned despite classifier",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "not pinned despite classifier".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts),
             Some(&classifier),
         )
         .unwrap();
@@ -1049,23 +1095,27 @@ fn execute_query_empty_returns_active_facts() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "fact one",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "fact one".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "fact two",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "fact two".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1085,23 +1135,27 @@ fn execute_query_text_search() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "Rust systems programming",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Rust systems programming".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Python machine learning",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Python machine learning".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1123,24 +1177,28 @@ fn execute_query_scope_only() {
     // Add fact to "project:demo" scope (auto-created by add_fact)
     engine
         .add_fact(
-            "scoped fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "scoped fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: Some("project:demo".into()),
+                opts: None,
+            },
             &embedder,
-            Some("project:demo"),
-            None,
             None,
         )
         .unwrap();
     // Add fact to root scope
     engine
         .add_fact(
-            "root fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "root fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1159,23 +1217,27 @@ fn execute_query_fact_type_filter() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "episodic",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "episodic".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "semantic",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "semantic".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1208,23 +1270,27 @@ fn execute_query_importance_threshold() {
     };
     engine
         .add_fact(
-            "low importance",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "low importance".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_low.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_low),
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "high importance",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "high importance".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_high.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_high),
             None,
         )
         .unwrap();
@@ -1244,12 +1310,14 @@ fn execute_query_pinned_only() {
 
     let id = engine
         .add_fact(
-            "pinned",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "pinned".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1257,12 +1325,14 @@ fn execute_query_pinned_only() {
 
     engine
         .add_fact(
-            "normal",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "normal".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1284,12 +1354,14 @@ fn execute_query_future_dated_excluded() {
     // Regular fact
     engine
         .add_fact(
-            "present fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "present fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1301,12 +1373,14 @@ fn execute_query_future_dated_excluded() {
     };
     engine
         .add_fact(
-            "future fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "future fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(future_opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&future_opts),
             None,
         )
         .unwrap();
@@ -1357,12 +1431,14 @@ fn execute_query_search_mode_inference() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "Rust programming",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Rust programming".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1390,12 +1466,14 @@ fn execute_query_period_filter() {
     };
     engine
         .add_fact(
-            "past fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "past fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(past_opts.clone()),
+            },
             &embedder,
-            None,
-            Some(&past_opts),
             None,
         )
         .unwrap();
@@ -1403,12 +1481,14 @@ fn execute_query_period_filter() {
     // Fact still valid
     engine
         .add_fact(
-            "current fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "current fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1443,34 +1523,40 @@ fn execute_query_composed_filters() {
 
     engine
         .add_fact(
-            "Rust high importance",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust high importance".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_high.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_high),
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Rust low importance",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "Rust low importance".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_low.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_low),
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "Python high importance",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Python high importance".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_high.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_high),
             None,
         )
         .unwrap();
@@ -1504,12 +1590,14 @@ fn execute_query_default_limit() {
     for i in 0..60 {
         engine
             .add_fact(
-                &format!("fact {i}"),
-                FactType::Episodic,
-                None,
+                &AddFactRequest {
+                    content: format!("fact {i}").to_string(),
+                    fact_type: FactType::Episodic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &embedder,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -1575,23 +1663,27 @@ fn reranker_none_results_unchanged() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "alpha fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "alpha fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "beta fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "beta fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1619,23 +1711,27 @@ fn reranker_reverses_order() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "alpha fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "alpha fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "beta fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "beta fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1644,23 +1740,27 @@ fn reranker_reverses_order() {
     let baseline_engine = MemoryEngine::open_memory(DIM).unwrap();
     baseline_engine
         .add_fact(
-            "alpha fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "alpha fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     baseline_engine
         .add_fact(
-            "beta fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "beta fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1705,23 +1805,27 @@ fn reranker_skipped_for_vector_only_no_text() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "alpha",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "alpha".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "beta",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "beta".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1751,23 +1855,27 @@ fn reranker_applies_to_fts_only_mode() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "alpha fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "alpha fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "beta fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "beta fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1797,23 +1905,27 @@ fn reranker_applies_to_vector_mode_with_text() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "alpha",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "alpha".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "beta",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "beta".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1849,12 +1961,14 @@ fn rerank_depth_overfetches_then_truncates() {
     for i in 0..10 {
         engine
             .add_fact(
-                &format!("rerank test fact {i}"),
-                FactType::Episodic,
-                None,
+                &AddFactRequest {
+                    content: format!("rerank test fact {i}").to_string(),
+                    fact_type: FactType::Episodic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &embedder,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -1906,12 +2020,14 @@ fn reranker_error_propagates() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "test fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "test fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -1960,12 +2076,14 @@ fn rerank_depth_none_falls_back_to_limit() {
     for i in 0..10 {
         engine
             .add_fact(
-                &format!("limit test fact {i}"),
-                FactType::Episodic,
-                None,
+                &AddFactRequest {
+                    content: format!("limit test fact {i}").to_string(),
+                    fact_type: FactType::Episodic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &embedder,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -2010,12 +2128,14 @@ fn add_session_fact(engine: &MemoryEngine, content: &str, session_id: &str) -> (
     let event_id = engine.ingest(&event).unwrap();
     let fact_id = engine
         .add_fact(
-            content,
-            FactType::Semantic,
-            Some(event_id),
+            &AddFactRequest {
+                content: content.into(),
+                fact_type: FactType::Semantic,
+                source_event_id: Some(event_id),
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -2169,12 +2289,14 @@ fn add_scoped_session_fact(
     let event_id = engine.ingest(&event).unwrap();
     let fact_id = engine
         .add_fact(
-            content,
-            FactType::Semantic,
-            Some(event_id),
+            &AddFactRequest {
+                content: content.into(),
+                fact_type: FactType::Semantic,
+                source_event_id: Some(event_id),
+                scope: Some(scope_path.into()),
+                opts: None,
+            },
             &embedder,
-            Some(scope_path),
-            None,
             None,
         )
         .unwrap();
@@ -2279,12 +2401,14 @@ fn reranker_rejects_out_of_bounds_index() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "real fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "real fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -2319,23 +2443,27 @@ fn reranker_rejects_duplicates() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "dup fact alpha",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "dup fact alpha".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "dup fact beta",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "dup fact beta".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -2371,23 +2499,27 @@ fn reranker_allows_valid_subset() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "guard alpha",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "guard alpha".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "guard beta",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "guard beta".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -2433,23 +2565,27 @@ fn reranker_allows_filtering_subset() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "filterable first",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "filterable first".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "filterable second",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "filterable second".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -2494,12 +2630,14 @@ fn reranker_rejects_non_finite_score() {
     let embedder = MockEmbedder { dim: DIM };
     engine
         .add_fact(
-            "score test fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "score test fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -2572,8 +2710,8 @@ fn add_facts_batch_inserts_all_facts() {
     let engine = MemoryEngine::open_memory(DIM).unwrap();
     let embedder = MockEmbedder { dim: DIM };
 
-    let entries: Vec<BatchFactEntry> = (0..5)
-        .map(|i| BatchFactEntry {
+    let entries: Vec<AddFactRequest> = (0..5)
+        .map(|i| AddFactRequest {
             content: format!("batch fact {i}"),
             fact_type: FactType::Semantic,
             source_event_id: None,
@@ -2612,21 +2750,21 @@ fn add_facts_batch_with_scopes() {
     let embedder = MockEmbedder { dim: DIM };
 
     let entries = vec![
-        BatchFactEntry {
+        AddFactRequest {
             content: "fact in project/a".into(),
             fact_type: FactType::Semantic,
             source_event_id: None,
             scope: Some("project/a".into()),
             opts: None,
         },
-        BatchFactEntry {
+        AddFactRequest {
             content: "fact in project/b".into(),
             fact_type: FactType::Semantic,
             source_event_id: None,
             scope: Some("project/b".into()),
             opts: None,
         },
-        BatchFactEntry {
+        AddFactRequest {
             content: "fact in root".into(),
             fact_type: FactType::Semantic,
             source_event_id: None,
@@ -2659,7 +2797,7 @@ fn add_facts_batch_with_classifier() {
     let embedder = MockEmbedder { dim: DIM };
     let classifier = AlwaysPin;
 
-    let entries = vec![BatchFactEntry {
+    let entries = vec![AddFactRequest {
         content: "important fact".into(),
         fact_type: FactType::Semantic,
         source_event_id: None,
@@ -2690,14 +2828,14 @@ fn add_facts_batch_rejects_embedding_count_mismatch() {
 
     let engine = MemoryEngine::open_memory(DIM).unwrap();
     let entries = vec![
-        BatchFactEntry {
+        AddFactRequest {
             content: "a".into(),
             fact_type: FactType::Semantic,
             source_event_id: None,
             scope: None,
             opts: None,
         },
-        BatchFactEntry {
+        AddFactRequest {
             content: "b".into(),
             fact_type: FactType::Semantic,
             source_event_id: None,
@@ -2738,21 +2876,21 @@ fn add_facts_batch_rollback_on_insert_failure() {
 
     // Use scoped entries to verify scopes also roll back
     let entries = vec![
-        BatchFactEntry {
+        AddFactRequest {
             content: "rollback test 0".into(),
             fact_type: FactType::Semantic,
             source_event_id: None,
             scope: Some("rollback/scope-a".into()),
             opts: None,
         },
-        BatchFactEntry {
+        AddFactRequest {
             content: "rollback test 1".into(),
             fact_type: FactType::Semantic,
             source_event_id: None,
             scope: Some("rollback/scope-b".into()),
             opts: None,
         },
-        BatchFactEntry {
+        AddFactRequest {
             content: "rollback test 2".into(),
             fact_type: FactType::Semantic,
             source_event_id: None,
@@ -2786,7 +2924,7 @@ fn add_facts_batch_rollback_on_insert_failure() {
     // Verify scope atomicity: scopes should NOT exist after rollback.
     // A successful add_facts_batch with the same scopes should create
     // them fresh (proving they were rolled back from the failed attempt).
-    let good_entries = vec![BatchFactEntry {
+    let good_entries = vec![AddFactRequest {
         content: "after rollback".into(),
         fact_type: FactType::Semantic,
         source_event_id: None,
@@ -2809,8 +2947,8 @@ fn add_facts_batch_temporal_consistency() {
     let engine = MemoryEngine::open_memory(DIM).unwrap();
     let embedder = MockEmbedder { dim: DIM };
 
-    let entries: Vec<BatchFactEntry> = (0..3)
-        .map(|i| BatchFactEntry {
+    let entries: Vec<AddFactRequest> = (0..3)
+        .map(|i| AddFactRequest {
             content: format!("temporal {i}"),
             fact_type: FactType::Semantic,
             source_event_id: None,

--- a/src/inspect/dump.rs
+++ b/src/inspect/dump.rs
@@ -225,7 +225,7 @@ mod tests {
     use crate::engine::MemoryEngine;
     use crate::inspect::types::{DumpFormat, EngineSnapshot};
     use crate::traits::EmbeddingProvider;
-    use crate::types::FactType;
+    use crate::types::{AddFactRequest, FactType};
 
     const DIM: usize = 4;
 
@@ -241,12 +241,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "test fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "test fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -373,12 +375,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "in-memory fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "in-memory fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -407,12 +411,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "gzip test",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "gzip test".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -435,12 +441,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "zstd test",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "zstd test".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -478,12 +486,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "snapshot fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "snapshot fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -196,7 +196,7 @@ mod tests {
     use super::*;
     use crate::engine::MemoryEngine;
     use crate::traits::EmbeddingProvider;
-    use crate::types::{AddFactOptions, EventType, FactType, NewEvent};
+    use crate::types::{AddFactOptions, AddFactRequest, EventType, FactType, NewEvent};
     use chrono::Duration;
 
     const DIM: usize = 4;
@@ -213,12 +213,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         let id = engine
             .add_fact(
-                "test fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "test fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -237,12 +239,14 @@ mod tests {
         };
         let id = engine
             .add_fact(
-                "pinned",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "pinned".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: Some(opts),
+                },
                 &FakeEmbed,
-                None,
-                Some(&opts),
                 None,
             )
             .unwrap();
@@ -260,12 +264,14 @@ mod tests {
         };
         let id = engine
             .add_fact(
-                "due fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "due fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: Some(opts),
+                },
                 &FakeEmbed,
-                None,
-                Some(&opts),
                 None,
             )
             .unwrap();
@@ -290,12 +296,14 @@ mod tests {
         };
         let id = engine
             .add_fact(
-                "temporal",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "temporal".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: Some(opts),
+                },
                 &FakeEmbed,
-                None,
-                Some(&opts),
                 None,
             )
             .unwrap();
@@ -322,12 +330,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         let id = engine
             .add_fact(
-                "simple",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "simple".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -360,12 +370,14 @@ mod tests {
         // Create a fact linked to that event
         let fact_id = engine
             .add_fact(
-                "fact from event",
-                FactType::Semantic,
-                Some(event_id),
+                &AddFactRequest {
+                    content: "fact from event".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: Some(event_id),
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -386,12 +398,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         let fact_id = engine
             .add_fact(
-                "standalone fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "standalone fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -406,12 +420,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         let id = engine
             .add_fact(
-                "snapshot test fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "snapshot test fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -400,7 +400,7 @@ mod tests {
     use crate::inspect::types::DumpFormat;
     use crate::store::schema::{get_config, init_schema, migrate, open_memory};
     use crate::traits::EmbeddingProvider;
-    use crate::types::FactType;
+    use crate::types::{AddFactRequest, FactType};
     use std::collections::HashMap;
 
     const DIM: usize = 4;
@@ -544,23 +544,27 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "alpha fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "alpha fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
         engine
             .add_fact(
-                "beta fact",
-                FactType::Episodic,
-                None,
+                &AddFactRequest {
+                    content: "beta fact".into(),
+                    fact_type: FactType::Episodic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -601,12 +605,14 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "existing",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "existing".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -640,23 +646,27 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "fact1",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "fact1".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
         engine
             .add_fact(
-                "fact2",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "fact2".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();

--- a/src/inspect/statistics.rs
+++ b/src/inspect/statistics.rs
@@ -127,7 +127,7 @@ pub fn compute_statistics(conn: &Connection, db_path: Option<&Path>) -> Result<E
 mod tests {
     use crate::engine::MemoryEngine;
     use crate::traits::EmbeddingProvider;
-    use crate::types::FactType;
+    use crate::types::{AddFactRequest, FactType};
 
     const DIM: usize = 4;
 
@@ -165,23 +165,27 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "fact one",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "fact one".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
         engine
             .add_fact(
-                "fact two",
-                FactType::Episodic,
-                None,
+                &AddFactRequest {
+                    content: "fact two".into(),
+                    fact_type: FactType::Episodic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -192,12 +196,14 @@ mod tests {
         };
         engine
             .add_fact(
-                "pinned fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "pinned fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: Some(pin_opts),
+                },
                 &FakeEmbed,
-                None,
-                Some(&pin_opts),
                 None,
             )
             .unwrap();
@@ -227,23 +233,27 @@ mod tests {
         let engine = MemoryEngine::open_memory(DIM).unwrap();
         engine
             .add_fact(
-                "fact one",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "fact one".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
         engine
             .add_fact(
-                "fact two",
-                FactType::Episodic,
-                None,
+                &AddFactRequest {
+                    content: "fact two".into(),
+                    fact_type: FactType::Episodic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();
@@ -253,12 +263,14 @@ mod tests {
         };
         engine
             .add_fact(
-                "pinned fact",
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: "pinned fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: Some(pin_opts.clone()),
+                },
                 &FakeEmbed,
-                None,
-                Some(&pin_opts),
                 None,
             )
             .unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -184,14 +184,15 @@ pub struct AddFactOptions {
     pub last_accessed: Option<DateTime<Utc>>,
 }
 
-// --- Batch input ---
+// --- Fact request ---
 
-/// Input descriptor for [`crate::engine::MemoryEngine::add_facts_batch`].
+/// Input descriptor for [`crate::engine::MemoryEngine::add_fact`] and
+/// [`crate::engine::MemoryEngine::add_facts_batch`].
 ///
-/// Each entry describes one fact to insert. The engine handles embedding,
-/// classification, scope resolution, and DB insertion atomically for the batch.
+/// Bundles all data-level parameters for fact insertion. Infrastructure
+/// concerns (embedder, classifier) remain separate method parameters.
 #[derive(Debug, Clone)]
-pub struct BatchFactEntry {
+pub struct AddFactRequest {
     /// The fact text to embed and store.
     pub content: String,
     /// Semantic, episodic, procedural, etc.

--- a/tests/ann_recall_test.rs
+++ b/tests/ann_recall_test.rs
@@ -11,7 +11,7 @@ use memory_engine::engine::{EngineConfig, MemoryEngine};
 use memory_engine::search::SearchConfig;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::FactType;
+use memory_engine::types::{AddFactRequest, FactType};
 
 const DIM: usize = 32;
 const N: usize = 5_000;
@@ -53,23 +53,27 @@ fn hnsw_recall_at_k_exceeds_threshold() {
         let content = format!("fact number {i} about topic {}", i % 50);
         engine_bf
             .add_fact(
-                &content,
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: content.clone(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &embedder,
-                None,
-                None,
                 None,
             )
             .unwrap();
         engine_ann
             .add_fact(
-                &content,
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content,
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &embedder,
-                None,
-                None,
                 None,
             )
             .unwrap();

--- a/tests/inspect_test.rs
+++ b/tests/inspect_test.rs
@@ -8,7 +8,7 @@ use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
 use memory_engine::inspect::types::*;
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::{AddFactOptions, FactType};
+use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 
 const DIM: usize = 4;
 
@@ -29,12 +29,14 @@ fn inspection_lifecycle() {
     // Active fact
     let active_id = engine
         .add_fact(
-            "active fact",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "active fact".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &TestEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -46,12 +48,14 @@ fn inspection_lifecycle() {
     };
     let pinned_id = engine
         .add_fact(
-            "pinned fact",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "pinned fact".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(pin_opts),
+            },
             &TestEmbed,
-            None,
-            Some(&pin_opts),
             None,
         )
         .unwrap();
@@ -63,12 +67,14 @@ fn inspection_lifecycle() {
     };
     let due_id = engine
         .add_fact(
-            "due fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "due fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(due_opts),
+            },
             &TestEmbed,
-            None,
-            Some(&due_opts),
             None,
         )
         .unwrap();
@@ -174,12 +180,14 @@ fn stamp_surfaced_on_list_due() {
     };
     engine
         .add_fact(
-            "due reminder",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "due reminder".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts),
+            },
             &TestEmbed,
-            None,
-            Some(&opts),
             None,
         )
         .unwrap();

--- a/tests/phase3b_lifecycle_test.rs
+++ b/tests/phase3b_lifecycle_test.rs
@@ -5,7 +5,7 @@ use memory_engine::ResumeConfig;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
 use memory_engine::traits::{EmbeddingProvider, ForgetPolicy, PersistenceClassifier};
-use memory_engine::types::{AddFactOptions, Fact, FactType};
+use memory_engine::types::{AddFactOptions, AddFactRequest, Fact, FactType};
 
 const DIM: usize = 8;
 
@@ -44,12 +44,14 @@ fn full_lifecycle_pinned_and_future_memory() {
     };
     let pin_id = engine
         .add_fact(
-            "I am an AI assistant",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "I am an AI assistant".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_pin.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_pin),
             None,
         )
         .unwrap();
@@ -62,12 +64,14 @@ fn full_lifecycle_pinned_and_future_memory() {
     };
     engine
         .add_fact(
-            "Check release notes tomorrow",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Check release notes tomorrow".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_future.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_future),
             None,
         )
         .unwrap();
@@ -75,12 +79,14 @@ fn full_lifecycle_pinned_and_future_memory() {
     // 3. Add normal fact (forgettable)
     engine
         .add_fact(
-            "Had coffee today",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "Had coffee today".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -158,12 +164,14 @@ fn classifier_auto_pins_semantic_facts() {
     // Semantic fact → auto-pinned by classifier
     let id1 = engine
         .add_fact(
-            "core identity",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "core identity".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             Some(&classifier),
         )
         .unwrap();
@@ -172,12 +180,14 @@ fn classifier_auto_pins_semantic_facts() {
     // Episodic fact → not pinned
     let id2 = engine
         .add_fact(
-            "ephemeral event",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "ephemeral event".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             Some(&classifier),
         )
         .unwrap();
@@ -190,12 +200,14 @@ fn classifier_auto_pins_semantic_facts() {
     };
     let id3 = engine
         .add_fact(
-            "not pinned despite classifier",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "not pinned despite classifier".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts),
+            },
             &embedder,
-            None,
-            Some(&opts),
             Some(&classifier),
         )
         .unwrap();
@@ -216,12 +228,14 @@ fn resume_context_5_tier_integration() {
     };
     engine
         .add_fact(
-            "pinned identity",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "pinned identity".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_pin.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_pin),
             None,
         )
         .unwrap();
@@ -234,12 +248,14 @@ fn resume_context_5_tier_integration() {
     };
     engine
         .add_fact(
-            "past reminder",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "past reminder".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(opts_due.clone()),
+            },
             &embedder,
-            None,
-            Some(&opts_due),
             None,
         )
         .unwrap();
@@ -247,12 +263,14 @@ fn resume_context_5_tier_integration() {
     // Tier 4: Regular recent fact
     engine
         .add_fact(
-            "recent observation",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "recent observation".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();

--- a/tests/restore_roundtrip_test.rs
+++ b/tests/restore_roundtrip_test.rs
@@ -3,7 +3,7 @@
 use memory_engine::EmbeddingProvider;
 use memory_engine::engine::{EngineConfig, MemoryEngine};
 use memory_engine::inspect_types::DumpFormat;
-use memory_engine::types::FactType;
+use memory_engine::types::{AddFactRequest, FactType};
 
 const DIM: usize = 4;
 
@@ -19,23 +19,27 @@ fn make_engine() -> MemoryEngine {
     let engine = MemoryEngine::open_memory(DIM).unwrap();
     engine
         .add_fact(
-            "alpha fact",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "alpha fact".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();
     engine
         .add_fact(
-            "beta fact",
-            FactType::Episodic,
-            None,
+            &AddFactRequest {
+                content: "beta fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -63,12 +67,14 @@ fn json_restore_to_file_engine() {
     // Verify engine is functional: can add new facts.
     let new_id = restored
         .add_fact(
-            "gamma fact",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "gamma fact".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -97,12 +103,14 @@ fn sqlite_restore_roundtrip() {
     let engine = MemoryEngine::open(&source_config).unwrap();
     engine
         .add_fact(
-            "sqlite test",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "sqlite test".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -125,12 +133,14 @@ fn sqlite_restore_roundtrip() {
     // Engine is functional.
     let new_id = restored
         .add_fact(
-            "new fact",
-            FactType::Semantic,
-            None,
+            &AddFactRequest {
+                content: "new fact".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
             &FakeEmbed,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -230,12 +240,14 @@ fn post_restore_ids_dont_collide() {
     for i in 0..5 {
         let id = restored
             .add_fact(
-                &format!("new fact {i}"),
-                FactType::Semantic,
-                None,
+                &AddFactRequest {
+                    content: format!("new fact {i}"),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
                 &FakeEmbed,
-                None,
-                None,
                 None,
             )
             .unwrap();

--- a/tests/roundtrip_test.rs
+++ b/tests/roundtrip_test.rs
@@ -3,7 +3,7 @@ use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
 use memory_engine::search::hybrid::{MatchType, SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::{EventType, FactType, NewEvent};
+use memory_engine::types::{AddFactRequest, EventType, FactType, NewEvent};
 
 /// Mock embedder that returns a vector pointing in the direction
 /// determined by a simple hash of the text, so different texts
@@ -57,34 +57,40 @@ fn full_roundtrip() {
     // 2. Add facts derived from the event
     let fact1_id = engine
         .add_fact(
-            "Rust is a systems programming language",
-            FactType::Semantic,
-            Some(event_id),
+            &AddFactRequest {
+                content: "Rust is a systems programming language".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: Some(event_id),
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     let fact2_id = engine
         .add_fact(
-            "Rust has zero-cost abstractions and memory safety",
-            FactType::Semantic,
-            Some(event_id),
+            &AddFactRequest {
+                content: "Rust has zero-cost abstractions and memory safety".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: Some(event_id),
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();
     let fact3_id = engine
         .add_fact(
-            "Python is popular for machine learning",
-            FactType::Episodic,
-            Some(event_id),
+            &AddFactRequest {
+                content: "Python is popular for machine learning".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: Some(event_id),
+                scope: None,
+                opts: None,
+            },
             &embedder,
-            None,
-            None,
             None,
         )
         .unwrap();


### PR DESCRIPTION
## Summary

- Rename `BatchFactEntry` → `AddFactRequest` — single input type for both `add_fact` and `add_facts_batch`
- Reduce `add_fact` from 8 parameters to 3: `add_fact(&AddFactRequest, &dyn EmbeddingProvider, Option<&dyn PersistenceClassifier>)`
- Same change propagated to `AsyncMemoryEngine::add_fact`
- Fix pre-existing `flush_insights` embedding integration test failures (missing `index` in mock responses, single-threaded tokio deadlock)

## Motivation

The `#[allow(clippy::too_many_arguments)]` suppression on `add_fact` was a known smell (issue #109). The new `AddFactRequest` struct bundles all data-level parameters (content, fact_type, source_event_id, scope, opts) while keeping infrastructure concerns (embedder, classifier) as separate method arguments.

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Core type | `src/types.rs` | Rename `BatchFactEntry` → `AddFactRequest`, update doc comments |
| Engine API | `src/engine.rs` | New `add_fact(&AddFactRequest, ...)` signature, remove `#[allow(clippy::too_many_arguments)]` |
| Async wrapper | `src/async_engine.rs` | Mirror new signature |
| MCP handler | `memory-engine-mcp/src/tools/mod.rs` | `handle_add_fact` + `handle_flush_insights` use `AddFactRequest` |
| Tests | 19 test/example/bench files | ~170 call sites updated |
| Test fix | `embedding_integration.rs` | Add `index` fields to mock responses, use `multi_thread` flavor |

## Test plan

- [x] `cargo test --all-features` — 420 passed
- [x] `cargo test -p memory-engine-mcp` — 116 passed
- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo fmt --check` — clean

Closes #109