### PR TITLE
feat: fast cold-start via sidecar snapshot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 rusqlite = { version = "0.34", features = ["bundled-full"] }
 blake3 = "1"
+rmp-serde = "1"
+tempfile = "3"
 tracing = "0.1"
 petgraph = "0.7"
 parking_lot = "0.12"

--- a/benches/search_bench.rs
+++ b/benches/search_bench.rs
@@ -374,10 +374,7 @@ fn setup_hnsw_engine(n: usize) -> MemoryEngine {
     let dir = tempfile::tempdir().expect("tempdir");
     let db_path = dir.path().join("bench_hnsw.db");
     let mut config = EngineConfig::new(db_path, DIM);
-    config.search_config = Some(SearchConfig {
-        ann_threshold: 0,
-        ..Default::default()
-    });
+    config.search_config = Some(SearchConfig { ann_threshold: 0 });
     let engine = MemoryEngine::open(&config).expect("open engine");
     let embedder = ConstEmbedder { dim: DIM };
     for i in 0..n {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -247,11 +247,11 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 
 #### Phase 4c: Quality & Cold Storage
 
-| Feature                                                                          | Description                                                                                                                                                                                                                  |
-| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Evaluation harness ([#16](https://github.com/dutiona/memory-engine/issues/16))   | Regression corpus for retrieval quality, consolidation correctness, forgetting behavior. After 4a/4b ship. **Research update:** context collapse detection (R4, DC/ACE), outcome-based retrieval quality (R5, ACE/Reflexion) |
-| ✅ Archival compression ([#46](https://github.com/dutiona/memory-engine/issues/46)) | Cold storage `.pak` files for old non-pinned facts (zstd, explicit trigger, slow fallback). [PR #196](https://github.com/dutiona/memory-engine/pull/196)                                                                      |
-| Fast cold-start ([#31](https://github.com/dutiona/memory-engine/issues/31))      | Snapshot + incremental replay for rapid engine boot                                                                                                                                                                          |
+| Feature                                                                             | Description                                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Evaluation harness ([#16](https://github.com/dutiona/memory-engine/issues/16))      | Regression corpus for retrieval quality, consolidation correctness, forgetting behavior. After 4a/4b ship. **Research update:** context collapse detection (R4, DC/ACE), outcome-based retrieval quality (R5, ACE/Reflexion) |
+| ✅ Archival compression ([#46](https://github.com/dutiona/memory-engine/issues/46)) | Cold storage `.pak` files for old non-pinned facts (zstd, explicit trigger, slow fallback). [PR #196](https://github.com/dutiona/memory-engine/pull/196)                                                                     |
+| ✅ Fast cold-start ([#31](https://github.com/dutiona/memory-engine/issues/31))      | Snapshot + incremental replay for rapid engine boot (PR #195)                                                                                                                                                                |
 
 #### Code Quality Sweep (super-qa — parallel track)
 
@@ -264,7 +264,7 @@ Discovered via automated super-qa audit ([PR #131](https://github.com/dutiona/me
 | [#108](https://github.com/dutiona/memory-engine/issues/108) | refactoring | ~~`engine.rs` is a 3573-line god module — extract subsystems~~ ✅ PR #186        |
 | [#109](https://github.com/dutiona/memory-engine/issues/109) | refactoring | ~~`add_fact` takes 8 parameters — introduce builder or struct~~ ✅ PR #194       |
 | [#110](https://github.com/dutiona/memory-engine/issues/110) | refactoring | ~~All modules are `pub` in `lib.rs` — no encapsulation~~ ✅ PR #188              |
-| [#111](https://github.com/dutiona/memory-engine/issues/111) | cleanup     | ~~`proptest` and `insta` dev-dependencies never used~~ ✅ PR #189               |
+| [#111](https://github.com/dutiona/memory-engine/issues/111) | cleanup     | ~~`proptest` and `insta` dev-dependencies never used~~ ✅ PR #189                |
 | [#128](https://github.com/dutiona/memory-engine/issues/128) | testing     | `traits.rs` and `query.rs` have zero unit tests ✅ (#185)                        |
 | [#187](https://github.com/dutiona/memory-engine/issues/187) | bug         | ~~`depth_shaping` insta snapshots stale after #180 QueryDiagnostics~~ ✅ PR #193 |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -328,9 +328,9 @@ Phase 4a ✅ and 4b ✅ are complete. Phase 5 is **unblocked on the critical pat
     │                │
     │           ┌────┴────┐
     │           │         │
-    │        eval #16   cold-start #31
-    │        (needs      (needs
-    │         data)       #46 first)
+    │        eval #16   cold-start #31 ✅
+    │        (needs      (PR #195)
+    │         data)
     │
     ▼
  Phase 5a ◀── CRITICAL PATH
@@ -353,7 +353,7 @@ Phase 4a ✅ and 4b ✅ are complete. Phase 5 is **unblocked on the critical pat
 **Parallelizable right now (4 independent tracks):**
 
 1. **Phase 4 follow-ups** (all resolved: #95 ✅, #96 ✅, #150 ✅, #151 ✅, #152 ✅)
-1. **Phase 4c** (#16, #46 ✅, #31) — #46 archival compression done ([PR #196](https://github.com/dutiona/memory-engine/pull/196)); #31 fast cold-start unblocked; #16 evaluation harness benefits from MCP being live
+1. **Phase 4c** (#16, #46 ✅, #31 ✅) — #46 archival compression done ([PR #196](https://github.com/dutiona/memory-engine/pull/196)); #31 fast cold-start done ([PR #195](https://github.com/dutiona/memory-engine/pull/195)); #16 evaluation harness remaining
 1. **Super-qa sweep** (24 open issues; #108 ✅, #128 ✅, #187 ✅; +#191, +#192 from #186 review) — incremental, any order
 1. **Phase 5a design + implementation** — the critical path forward
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -253,6 +253,14 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 | ✅ Archival compression ([#46](https://github.com/dutiona/memory-engine/issues/46)) | Cold storage `.pak` files for old non-pinned facts (zstd, explicit trigger, slow fallback). [PR #196](https://github.com/dutiona/memory-engine/pull/196)                                                                     |
 | ✅ Fast cold-start ([#31](https://github.com/dutiona/memory-engine/issues/31))      | Snapshot + incremental replay for rapid engine boot (PR #195)                                                                                                                                                                |
 
+#### Snapshot V2 improvements (follow-ups from #31 review)
+
+| Issue                                                                                              | Priority | Description                                                         |
+| -------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------- |
+| Shutdown perf ([#199](https://github.com/dutiona/memory-engine/issues/199))                        | HIGH     | Avoid DB re-scan in `to_snapshot` — cache vectors or use HNSW serde |
+| Direct HNSW serde ([#200](https://github.com/dutiona/memory-engine/issues/200))                    | MEDIUM   | Skip O(N log N) rebuild via `hnsw` crate `serde1` feature           |
+| Snapshot compression ([#201](https://github.com/dutiona/memory-engine/issues/201))                 | LOW      | zstd-wrap payload for large deployments (100k+ facts)               |
+
 #### Code Quality Sweep (super-qa — parallel track)
 
 Discovered via automated super-qa audit ([PR #131](https://github.com/dutiona/memory-engine/pull/131) auto-fixed 10 findings). Remaining issues are non-blocking and can be addressed incrementally alongside Phase 4b/5 work.

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -485,6 +485,16 @@ impl AsyncMemoryEngine {
         .map_err(join_err)??;
         Ok(Self::new(engine))
     }
+
+    /// Write a snapshot of in-memory state to the sidecar file.
+    ///
+    /// Delegates to [`MemoryEngine::write_snapshot`] on a blocking task.
+    pub async fn write_snapshot(&self) -> Result<bool> {
+        let engine = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || engine.write_snapshot())
+            .await
+            .map_err(join_err)?
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -29,6 +29,15 @@ mod query;
 mod restore;
 mod resume;
 mod scheduling;
+pub(crate) mod snapshot;
+
+/// Data loaded from a sidecar snapshot, ready to be assembled into a `MemoryEngine`.
+struct SnapshotData {
+    graph: MemoryGraph,
+    scope_tree: ScopeTree,
+    #[cfg(feature = "ann")]
+    hnsw_strategy: Option<crate::search::ann::HnswStrategy>,
+}
 
 #[cfg(feature = "archive")]
 mod archive;
@@ -213,6 +222,10 @@ impl MemoryEngine {
     }
 
     /// Shared constructor logic: validate embed_dim, load graph and scope tree.
+    ///
+    /// Tries the snapshot fast path first (file-backed engines only). If the
+    /// sidecar validates against the current DB fingerprint, loads from it.
+    /// Otherwise falls back to full SQLite scan.
     fn init_from_pool(
         pool: ConnectionPool,
         embed_dim: usize,
@@ -220,17 +233,35 @@ impl MemoryEngine {
         upcaster_registry: UpcasterRegistry,
         reranker: Option<Box<dyn Reranker>>,
     ) -> Result<Self> {
-        // Scope the guard so it drops before we move `pool` into the struct.
-        let (graph, scope_tree) = if pool.is_read_only() {
-            // Read-only: use read connection, validate only (no set)
+        // 1. Validate embed_dim (must happen first — ensures schema is ready).
+        if pool.is_read_only() {
             let conn = pool.read();
             Self::validate_embed_dim(&conn, embed_dim)?;
-            let graph = MemoryGraph::load_from_db(&conn)?;
-            let scope_tree = ScopeTree::load(&conn)?;
-            (graph, scope_tree)
         } else {
             let conn = pool.write();
             Self::validate_or_set_embed_dim(&conn, embed_dim)?;
+        }
+
+        // 2. Try snapshot fast path (file-backed engines only).
+        if let Some(loaded) = Self::try_load_snapshot(&pool, embed_dim, &search_config)? {
+            tracing::info!("loaded from snapshot (fingerprint match)");
+            return Ok(Self {
+                pool,
+                embed_dim,
+                graph: RwLock::new(loaded.graph),
+                scope_tree: RwLock::new(loaded.scope_tree),
+                vector_strategy: Box::new(BruteForce),
+                reranker,
+                #[cfg(feature = "ann")]
+                hnsw_strategy: loaded.hnsw_strategy,
+                search_config,
+                upcaster_registry,
+            });
+        }
+
+        // 3. Full rebuild from SQLite (current behavior).
+        let (graph, scope_tree) = {
+            let conn = pool.read();
             let graph = MemoryGraph::load_from_db(&conn)?;
             let scope_tree = ScopeTree::load(&conn)?;
             (graph, scope_tree)
@@ -263,6 +294,55 @@ impl MemoryEngine {
             search_config,
             upcaster_registry,
         })
+    }
+
+    /// Attempt to load in-memory structures from a sidecar snapshot.
+    ///
+    /// Returns `Ok(Some(data))` if the snapshot validated against the current
+    /// DB fingerprint. Returns `Ok(None)` if no snapshot exists or it's
+    /// stale/invalid. Returns `Err` only for unexpected DB query failures.
+    fn try_load_snapshot(
+        pool: &ConnectionPool,
+        embed_dim: usize,
+        #[cfg_attr(not(feature = "ann"), allow(unused_variables))] search_config: &Option<
+            SearchConfig,
+        >,
+    ) -> Result<Option<SnapshotData>> {
+        let Some(db_path) = pool.path() else {
+            return Ok(None); // in-memory engine
+        };
+
+        let snap_path = snapshot::snapshot_path(db_path);
+        let Some((header, payload)) = snapshot::load_from_file(&snap_path, embed_dim) else {
+            return Ok(None);
+        };
+
+        let conn = pool.read();
+        let current_fp = snapshot::read_fingerprint(&conn)?;
+        drop(conn);
+
+        if header.fingerprint != current_fp {
+            tracing::info!("snapshot stale (fingerprint mismatch), falling back to full rebuild");
+            return Ok(None);
+        }
+
+        let graph = MemoryGraph::from_snapshot(&payload.graph);
+        let scope_tree = ScopeTree::from_snapshot(&payload.scope_tree);
+
+        #[cfg(feature = "ann")]
+        let hnsw_strategy = match (search_config, payload.hnsw) {
+            (Some(cfg), Some(ref hnsw_snap)) if cfg.ann_threshold < usize::MAX => Some(
+                crate::search::ann::HnswStrategy::from_snapshot(hnsw_snap, embed_dim)?,
+            ),
+            _ => None,
+        };
+
+        Ok(Some(SnapshotData {
+            graph,
+            scope_tree,
+            #[cfg(feature = "ann")]
+            hnsw_strategy,
+        }))
     }
 
     /// Returns the name of the active reranker, if any.
@@ -336,6 +416,54 @@ impl MemoryEngine {
     #[must_use]
     pub fn is_read_only(&self) -> bool {
         self.pool.is_read_only()
+    }
+
+    /// Write a snapshot of in-memory state to the sidecar file.
+    ///
+    /// No-op for in-memory engines or read-only engines.
+    /// Returns `Ok(false)` if skipped, `Ok(true)` if written.
+    ///
+    /// # No-panic contract
+    ///
+    /// This method never panics. All internal operations use checked access
+    /// and propagate errors via `Result`. Safe to call from `Drop`.
+    pub fn write_snapshot(&self) -> Result<bool> {
+        let Some(db_path) = self.pool.path() else {
+            return Ok(false);
+        };
+        if self.pool.is_read_only() {
+            return Ok(false);
+        }
+
+        let conn = self.pool.read();
+        let fingerprint = snapshot::read_fingerprint(&conn)?;
+
+        let graph_snap = self.graph.read().to_snapshot();
+        let scope_snap = self.scope_tree.read().to_snapshot();
+
+        #[cfg(feature = "ann")]
+        let hnsw_snap = self
+            .hnsw_strategy
+            .as_ref()
+            .map(|h| h.to_snapshot(&conn, self.embed_dim))
+            .transpose()?;
+        #[cfg(not(feature = "ann"))]
+        let hnsw_snap: Option<snapshot::HnswSnapshot> = None;
+
+        let header = snapshot::SnapshotHeader {
+            format_version: snapshot::FORMAT_VERSION,
+            fingerprint,
+            embed_dim: self.embed_dim,
+            engine_version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        let payload = snapshot::SnapshotPayload {
+            graph: graph_snap,
+            scope_tree: scope_snap,
+            hnsw: hnsw_snap,
+        };
+
+        snapshot::write_to_file(&header, &payload, &snapshot::snapshot_path(db_path))?;
+        Ok(true)
     }
 
     // --- Private connection dispatch helpers ---
@@ -562,5 +690,13 @@ fn fact_to_search_result(fact: Fact) -> SearchResult {
         score: fact.importance_score,
         match_type: MatchType::ImportanceRank,
         fact,
+    }
+}
+
+impl Drop for MemoryEngine {
+    fn drop(&mut self) {
+        if let Err(e) = self.write_snapshot() {
+            tracing::warn!(error = %e, "failed to write snapshot on shutdown");
+        }
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -371,7 +371,7 @@ impl MemoryEngine {
 
     #[cfg(feature = "ann")]
     fn should_use_hnsw(&self) -> bool {
-        self.hnsw_strategy.as_ref().map_or(false, |hnsw| {
+        self.hnsw_strategy.as_ref().is_some_and(|hnsw| {
             hnsw.active_count()
                 >= self
                     .search_config

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -334,6 +334,14 @@ impl MemoryEngine {
             (Some(cfg), Some(ref hnsw_snap)) if cfg.ann_threshold < usize::MAX => Some(
                 crate::search::ann::HnswStrategy::from_snapshot(hnsw_snap, embed_dim)?,
             ),
+            (Some(cfg), None) if cfg.ann_threshold < usize::MAX => {
+                // Snapshot was created without HNSW data (e.g. non-ann build),
+                // but current config requires ANN. Fall back to DB rebuild.
+                let conn = pool.read();
+                Some(crate::search::ann::HnswStrategy::build_from_db(
+                    &conn, embed_dim,
+                )?)
+            }
             _ => None,
         };
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -431,6 +431,12 @@ impl MemoryEngine {
     /// No-op for in-memory engines or read-only engines.
     /// Returns `Ok(false)` if skipped, `Ok(true)` if written.
     ///
+    /// # Preconditions
+    ///
+    /// Assumes single-writer semantics: only one `MemoryEngine` instance per
+    /// database file. If multiple instances share the same file, the snapshot
+    /// may reflect stale in-memory state while the fingerprint matches the DB.
+    ///
     /// # No-panic contract
     ///
     /// This method never panics. All internal operations use checked access

--- a/src/engine/snapshot.rs
+++ b/src/engine/snapshot.rs
@@ -1,0 +1,521 @@
+//! Sidecar snapshot for fast cold-start.
+//!
+//! Serializes `MemoryGraph`, `ScopeTree`, and (optionally) HNSW state into a
+//! `.snapshot` file next to the database. On startup, if the snapshot validates
+//! against the current DB fingerprint, the engine loads from it instead of
+//! doing a full SQLite scan. Any failure falls back to full rebuild (current behavior).
+//!
+//! ## File format
+//!
+//! ```text
+//! [header_len: u32 LE][header (MessagePack, named)][payload (MessagePack, named)][blake3: 32 bytes]
+//! ```
+//!
+//! The blake3 checksum covers the payload bytes only. Header is checked first
+//! (cheap) so format_version/embed_dim mismatches reject without hashing.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{MemoryError, Result};
+use crate::types::ScopeNode;
+
+/// Current snapshot format version. Bump on breaking changes to the snapshot
+/// layout or type definitions.
+pub(crate) const FORMAT_VERSION: u32 = 1;
+
+/// Size of the blake3 checksum appended to the file.
+const BLAKE3_LEN: usize = 32;
+
+// ---------------------------------------------------------------------------
+// Snapshot types (decoupled from internal representations)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SnapshotHeader {
+    pub format_version: u32,
+    pub fingerprint: DbFingerprint,
+    pub embed_dim: usize,
+    pub engine_version: String,
+}
+
+/// Composite fingerprint from the three source-of-truth tables.
+///
+/// Catches inserts (`max_*_id` changes) and soft-deletes (`active_*_count`
+/// changes). **Not** based on the `events` table — many mutators
+/// (`add_fact`, `forget`, `consolidate`, `link_session_facts`) modify
+/// `facts`/`edges`/`scopes` without appending an event.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct DbFingerprint {
+    pub max_fact_id: i64,
+    pub active_fact_count: i64,
+    pub max_edge_id: i64,
+    pub active_edge_count: i64,
+    pub max_scope_id: i64,
+    pub scope_count: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SnapshotPayload {
+    pub graph: GraphSnapshot,
+    pub scope_tree: ScopeTreeSnapshot,
+    /// Present when built with `ann` feature AND HNSW was active.
+    /// `#[serde(default)]` allows non-ann snapshots to be loaded by ann builds
+    /// and vice versa (named MessagePack handles missing fields).
+    #[serde(default)]
+    pub hnsw: Option<HnswSnapshot>,
+}
+
+/// Edge list — decoupled from petgraph `DiGraph` internals.
+/// No isolated nodes: matches `MemoryGraph::load_from_db` semantics (edges only).
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct GraphSnapshot {
+    pub edges: Vec<GraphEdgeSnapshot>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct GraphEdgeSnapshot {
+    pub edge_id: i64,
+    pub source: i64,
+    pub target: i64,
+    pub relation_type: String,
+    pub weight: f64,
+}
+
+/// Flat list of scope nodes — `ScopeNode` is already serde.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ScopeTreeSnapshot {
+    pub nodes: Vec<ScopeNode>,
+}
+
+/// Compact HNSW rebuild data: active fact embeddings only, no tombstones.
+/// On load, rebuilds a fresh compact HNSW index (same as `build_from_db`).
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct HnswSnapshot {
+    pub entries: Vec<HnswEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct HnswEntry {
+    pub fact_id: i64,
+    pub embedding: Vec<f32>,
+}
+
+// ---------------------------------------------------------------------------
+// Path derivation
+// ---------------------------------------------------------------------------
+
+/// Derive the snapshot sidecar path from the database path.
+pub(crate) fn snapshot_path(db_path: &Path) -> PathBuf {
+    let mut p = db_path.as_os_str().to_owned();
+    p.push(".snapshot");
+    PathBuf::from(p)
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprint
+// ---------------------------------------------------------------------------
+
+/// Read a composite fingerprint from the three source-of-truth tables.
+///
+/// Uses a single query with subselects for atomicity within the SQLite
+/// read transaction.
+pub(crate) fn read_fingerprint(conn: &Connection) -> Result<DbFingerprint> {
+    conn.query_row(
+        "SELECT \
+            COALESCE((SELECT MAX(id) FROM facts), 0), \
+            (SELECT COUNT(*) FROM facts WHERE t_expired IS NULL), \
+            COALESCE((SELECT MAX(id) FROM edges), 0), \
+            (SELECT COUNT(*) FROM edges WHERE t_expired IS NULL), \
+            COALESCE((SELECT MAX(id) FROM scopes), 0), \
+            (SELECT COUNT(*) FROM scopes)",
+        [],
+        |row| {
+            Ok(DbFingerprint {
+                max_fact_id: row.get(0)?,
+                active_fact_count: row.get(1)?,
+                max_edge_id: row.get(2)?,
+                active_edge_count: row.get(3)?,
+                max_scope_id: row.get(4)?,
+                scope_count: row.get(5)?,
+            })
+        },
+    )
+    .map_err(MemoryError::from)
+}
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+/// Write a snapshot to disk atomically.
+///
+/// 1. Serialize header and payload with `rmp_serde::to_vec_named` (named
+///    MessagePack for forward/backward compatibility).
+/// 2. Compute blake3 hash over the payload bytes.
+/// 3. Write to a temp file in the same directory (`NamedTempFile` uses
+///    `O_CREAT | O_EXCL` — no symlink follow).
+/// 4. `fsync` the file.
+/// 5. Atomic rename via `persist()`.
+/// 6. `fsync` the parent directory for rename durability.
+pub(crate) fn write_to_file(
+    header: &SnapshotHeader,
+    payload: &SnapshotPayload,
+    path: &Path,
+) -> Result<()> {
+    let header_bytes = rmp_serde::to_vec_named(header)
+        .map_err(|e| MemoryError::Internal(format!("snapshot header serialize: {e}")))?;
+    let payload_bytes = rmp_serde::to_vec_named(payload)
+        .map_err(|e| MemoryError::Internal(format!("snapshot payload serialize: {e}")))?;
+
+    let checksum = blake3::hash(&payload_bytes);
+
+    let header_len = u32::try_from(header_bytes.len())
+        .map_err(|_| MemoryError::Internal("snapshot header too large".into()))?;
+
+    // Write to a temp file in the same directory for atomic rename.
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+
+    tmp.write_all(&header_len.to_le_bytes())?;
+    tmp.write_all(&header_bytes)?;
+    tmp.write_all(&payload_bytes)?;
+    tmp.write_all(checksum.as_bytes())?;
+    tmp.as_file().sync_all()?;
+
+    // Atomic rename. `persist` overwrites the target if it exists.
+    tmp.persist(path).map_err(|e| MemoryError::Io(e.error))?;
+
+    // fsync the parent directory so the rename is durable across power loss.
+    if let Ok(dir_fd) = fs::File::open(dir) {
+        let _ = dir_fd.sync_all();
+    }
+
+    Ok(())
+}
+
+/// Load and validate a snapshot from disk.
+///
+/// Returns `None` on any failure (missing file, corrupt data, version
+/// mismatch, checksum failure, embed_dim mismatch). Never errors — all
+/// failures are logged and treated as "snapshot unavailable".
+pub(crate) fn load_from_file(
+    path: &Path,
+    embed_dim: usize,
+) -> Option<(SnapshotHeader, SnapshotPayload)> {
+    let data = match fs::read(path) {
+        Ok(d) => d,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(path = %path.display(), error = %e, "snapshot read failed");
+            }
+            return None;
+        }
+    };
+
+    // Minimum size: 4 (header_len) + 1 (min header) + 1 (min payload) + 32 (blake3)
+    if data.len() < 4 + 1 + 1 + BLAKE3_LEN {
+        tracing::warn!(path = %path.display(), "snapshot too small");
+        return None;
+    }
+
+    // Parse header_len
+    let header_len = u32::from_le_bytes(data[..4].try_into().expect("4 bytes")) as usize;
+    let header_end = 4 + header_len;
+
+    if header_end >= data.len().saturating_sub(BLAKE3_LEN) {
+        tracing::warn!(path = %path.display(), "snapshot header_len out of bounds");
+        return None;
+    }
+
+    let header_bytes = &data[4..header_end];
+    let payload_end = data.len() - BLAKE3_LEN;
+    let payload_bytes = &data[header_end..payload_end];
+    let stored_checksum = &data[payload_end..];
+
+    // 1. Deserialize header first (cheap reject on version/dim mismatch)
+    let header: SnapshotHeader = match rmp_serde::from_slice(header_bytes) {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "snapshot header deserialize failed");
+            return None;
+        }
+    };
+
+    if header.format_version != FORMAT_VERSION {
+        tracing::info!(
+            path = %path.display(),
+            snapshot_version = header.format_version,
+            expected = FORMAT_VERSION,
+            "snapshot format version mismatch, discarding"
+        );
+        return None;
+    }
+
+    if header.embed_dim != embed_dim {
+        tracing::warn!(
+            path = %path.display(),
+            snapshot_dim = header.embed_dim,
+            expected = embed_dim,
+            "snapshot embed_dim mismatch"
+        );
+        return None;
+    }
+
+    // 2. Verify blake3 checksum
+    let computed = blake3::hash(payload_bytes);
+    if computed.as_bytes() != stored_checksum {
+        tracing::warn!(path = %path.display(), "snapshot checksum mismatch");
+        return None;
+    }
+
+    // 3. Deserialize payload
+    let payload: SnapshotPayload = match rmp_serde::from_slice(payload_bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "snapshot payload deserialize failed");
+            return None;
+        }
+    };
+
+    Some((header, payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_path_derivation() {
+        let p = snapshot_path(Path::new("/data/memory.db"));
+        assert_eq!(p, PathBuf::from("/data/memory.db.snapshot"));
+    }
+
+    #[test]
+    fn snapshot_path_no_extension() {
+        let p = snapshot_path(Path::new("/data/mydb"));
+        assert_eq!(p, PathBuf::from("/data/mydb.snapshot"));
+    }
+
+    #[test]
+    fn fingerprint_empty_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::store::schema::init_schema(&conn).unwrap();
+        let fp = read_fingerprint(&conn).unwrap();
+        assert_eq!(fp.max_fact_id, 0);
+        assert_eq!(fp.active_fact_count, 0);
+        assert_eq!(fp.max_edge_id, 0);
+        assert_eq!(fp.active_edge_count, 0);
+        // scopes table has the root scope after init
+        assert!(fp.max_scope_id >= 1);
+        assert!(fp.scope_count >= 1);
+    }
+
+    #[test]
+    fn corrupt_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db.snapshot");
+        fs::write(&path, b"garbage data here").unwrap();
+        assert!(load_from_file(&path, 128).is_none());
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        let path = Path::new("/nonexistent/path/test.db.snapshot");
+        assert!(load_from_file(path, 128).is_none());
+    }
+
+    #[test]
+    fn bad_checksum_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db.snapshot");
+
+        let header = SnapshotHeader {
+            format_version: FORMAT_VERSION,
+            fingerprint: DbFingerprint {
+                max_fact_id: 0,
+                active_fact_count: 0,
+                max_edge_id: 0,
+                active_edge_count: 0,
+                max_scope_id: 1,
+                scope_count: 1,
+            },
+            embed_dim: 128,
+            engine_version: "test".into(),
+        };
+        let payload = SnapshotPayload {
+            graph: GraphSnapshot { edges: vec![] },
+            scope_tree: ScopeTreeSnapshot { nodes: vec![] },
+            hnsw: None,
+        };
+
+        let header_bytes = rmp_serde::to_vec_named(&header).unwrap();
+        let payload_bytes = rmp_serde::to_vec_named(&payload).unwrap();
+        let header_len = (header_bytes.len() as u32).to_le_bytes();
+
+        // Write with wrong checksum
+        let mut data = Vec::new();
+        data.extend_from_slice(&header_len);
+        data.extend_from_slice(&header_bytes);
+        data.extend_from_slice(&payload_bytes);
+        data.extend_from_slice(&[0u8; 32]); // zeroed checksum
+        fs::write(&path, &data).unwrap();
+
+        assert!(load_from_file(&path, 128).is_none());
+    }
+
+    #[test]
+    fn wrong_format_version_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db.snapshot");
+
+        let header = SnapshotHeader {
+            format_version: 999,
+            fingerprint: DbFingerprint {
+                max_fact_id: 0,
+                active_fact_count: 0,
+                max_edge_id: 0,
+                active_edge_count: 0,
+                max_scope_id: 1,
+                scope_count: 1,
+            },
+            embed_dim: 128,
+            engine_version: "test".into(),
+        };
+        let payload = SnapshotPayload {
+            graph: GraphSnapshot { edges: vec![] },
+            scope_tree: ScopeTreeSnapshot { nodes: vec![] },
+            hnsw: None,
+        };
+
+        // Use correct checksum but wrong version
+        let header_bytes = rmp_serde::to_vec_named(&header).unwrap();
+        let payload_bytes = rmp_serde::to_vec_named(&payload).unwrap();
+        let checksum = blake3::hash(&payload_bytes);
+        let header_len = (header_bytes.len() as u32).to_le_bytes();
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&header_len);
+        data.extend_from_slice(&header_bytes);
+        data.extend_from_slice(&payload_bytes);
+        data.extend_from_slice(checksum.as_bytes());
+        fs::write(&path, &data).unwrap();
+
+        assert!(load_from_file(&path, 128).is_none());
+    }
+
+    #[test]
+    fn wrong_embed_dim_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db.snapshot");
+
+        let header = SnapshotHeader {
+            format_version: FORMAT_VERSION,
+            fingerprint: DbFingerprint {
+                max_fact_id: 0,
+                active_fact_count: 0,
+                max_edge_id: 0,
+                active_edge_count: 0,
+                max_scope_id: 1,
+                scope_count: 1,
+            },
+            embed_dim: 256, // mismatch — we'll request 128
+            engine_version: "test".into(),
+        };
+        let payload = SnapshotPayload {
+            graph: GraphSnapshot { edges: vec![] },
+            scope_tree: ScopeTreeSnapshot { nodes: vec![] },
+            hnsw: None,
+        };
+
+        let header_bytes = rmp_serde::to_vec_named(&header).unwrap();
+        let payload_bytes = rmp_serde::to_vec_named(&payload).unwrap();
+        let checksum = blake3::hash(&payload_bytes);
+        let header_len = (header_bytes.len() as u32).to_le_bytes();
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&header_len);
+        data.extend_from_slice(&header_bytes);
+        data.extend_from_slice(&payload_bytes);
+        data.extend_from_slice(checksum.as_bytes());
+        fs::write(&path, &data).unwrap();
+
+        assert!(load_from_file(&path, 128).is_none());
+    }
+
+    #[test]
+    fn round_trip_write_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db.snapshot");
+
+        let header = SnapshotHeader {
+            format_version: FORMAT_VERSION,
+            fingerprint: DbFingerprint {
+                max_fact_id: 42,
+                active_fact_count: 10,
+                max_edge_id: 7,
+                active_edge_count: 5,
+                max_scope_id: 3,
+                scope_count: 3,
+            },
+            embed_dim: 128,
+            engine_version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        let payload = SnapshotPayload {
+            graph: GraphSnapshot {
+                edges: vec![GraphEdgeSnapshot {
+                    edge_id: 1,
+                    source: 10,
+                    target: 20,
+                    relation_type: "supplements".into(),
+                    weight: 0.8,
+                }],
+            },
+            scope_tree: ScopeTreeSnapshot {
+                nodes: vec![ScopeNode {
+                    id: 1,
+                    parent_id: None,
+                    label: "root".into(),
+                    depth: 0,
+                }],
+            },
+            hnsw: None,
+        };
+
+        write_to_file(&header, &payload, &path).unwrap();
+        assert!(path.exists());
+
+        let (h, p) = load_from_file(&path, 128).expect("round-trip should succeed");
+        assert_eq!(h.fingerprint, header.fingerprint);
+        assert_eq!(h.embed_dim, 128);
+        assert_eq!(p.graph.edges.len(), 1);
+        assert_eq!(p.graph.edges[0].edge_id, 1);
+        assert_eq!(p.scope_tree.nodes.len(), 1);
+        assert!(p.hnsw.is_none());
+    }
+
+    #[test]
+    fn named_msgpack_handles_missing_hnsw_field() {
+        // Simulate a payload serialized WITHOUT the hnsw field (non-ann build).
+        // The named MessagePack + #[serde(default)] should handle this.
+        #[derive(Serialize)]
+        struct PayloadWithoutHnsw {
+            graph: GraphSnapshot,
+            scope_tree: ScopeTreeSnapshot,
+            // no hnsw field
+        }
+
+        let minimal = PayloadWithoutHnsw {
+            graph: GraphSnapshot { edges: vec![] },
+            scope_tree: ScopeTreeSnapshot { nodes: vec![] },
+        };
+
+        let bytes = rmp_serde::to_vec_named(&minimal).unwrap();
+        let full: SnapshotPayload = rmp_serde::from_slice(&bytes).unwrap();
+        assert!(full.hnsw.is_none());
+    }
+}

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -2970,3 +2970,180 @@ fn add_facts_batch_temporal_consistency() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Snapshot integration tests
+// ---------------------------------------------------------------------------
+
+mod snapshot_integration {
+    use super::*;
+
+    fn open_file_engine(dir: &std::path::Path) -> MemoryEngine {
+        let config = EngineConfig::new(dir.join("test.db"), DIM);
+        MemoryEngine::open(&config).unwrap()
+    }
+
+    fn add_test_fact(engine: &MemoryEngine, content: &str) -> i64 {
+        let embedder = MockEmbedder { dim: DIM };
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: content.into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                &embedder,
+                None,
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn snapshot_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Create engine, add data, write snapshot
+        {
+            let engine = open_file_engine(dir.path());
+            add_test_fact(&engine, "fact one");
+            add_test_fact(&engine, "fact two");
+            engine.write_snapshot().unwrap();
+        }
+
+        // Verify snapshot file exists
+        let snap_path = super::snapshot::snapshot_path(&db_path);
+        assert!(snap_path.exists(), "snapshot file should exist");
+
+        // Re-open — should load from snapshot
+        let engine = open_file_engine(dir.path());
+        let facts = engine.list_active_facts(None).unwrap();
+        assert_eq!(facts.len(), 2);
+    }
+
+    #[test]
+    fn snapshot_fallback_on_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Create engine, add data, do NOT write snapshot
+        {
+            let config = EngineConfig::new(dir.path().join("test.db"), DIM);
+            let engine = MemoryEngine::open(&config).unwrap();
+            add_test_fact(&engine, "fact one");
+            // Remove snapshot if Drop wrote one
+            let snap_path = super::snapshot::snapshot_path(&dir.path().join("test.db"));
+            let _ = std::fs::remove_file(&snap_path);
+        }
+
+        // Re-open — should fall back to full rebuild
+        let engine = open_file_engine(dir.path());
+        let facts = engine.list_active_facts(None).unwrap();
+        assert_eq!(facts.len(), 1);
+    }
+
+    #[test]
+    fn snapshot_fallback_on_stale_fingerprint() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let snap_path = super::snapshot::snapshot_path(&db_path);
+
+        // Phase 1: create engine with one fact, write snapshot explicitly.
+        {
+            let engine = open_file_engine(dir.path());
+            add_test_fact(&engine, "original fact");
+            engine.write_snapshot().unwrap();
+        }
+
+        // Save the snapshot bytes so we can restore them later.
+        let snapshot_bytes = std::fs::read(&snap_path).unwrap();
+
+        // Phase 2: add more data. Drop writes a fresh (updated) snapshot.
+        {
+            let engine = open_file_engine(dir.path());
+            add_test_fact(&engine, "second fact");
+            // Drop writes snapshot with fingerprint reflecting 2 facts.
+        }
+
+        // Phase 3: overwrite the snapshot with the stale one from phase 1.
+        std::fs::write(&snap_path, &snapshot_bytes).unwrap();
+
+        // Phase 4: re-open — stale snapshot fingerprint should mismatch,
+        // engine falls back to full rebuild and sees both facts.
+        let engine = open_file_engine(dir.path());
+        let facts = engine.list_active_facts(None).unwrap();
+        assert_eq!(facts.len(), 2, "should see both facts via full rebuild");
+    }
+
+    #[test]
+    fn snapshot_skipped_for_memory_engine() {
+        let engine = MemoryEngine::open_memory(DIM).unwrap();
+        let result = engine.write_snapshot().unwrap();
+        assert!(!result, "in-memory engine should skip snapshot");
+    }
+
+    #[test]
+    fn snapshot_skipped_for_read_only() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // First open in read-write to create the DB
+        {
+            let _engine = open_file_engine(dir.path());
+        }
+
+        // Open read-only
+        let mut config = EngineConfig::new(dir.path().join("test.db"), DIM);
+        config.read_only = true;
+        let engine = MemoryEngine::open(&config).unwrap();
+        let result = engine.write_snapshot().unwrap();
+        assert!(!result, "read-only engine should skip snapshot");
+    }
+
+    #[test]
+    fn drop_writes_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let snap_path = super::snapshot::snapshot_path(&db_path);
+
+        {
+            let engine = open_file_engine(dir.path());
+            add_test_fact(&engine, "will be snapshotted");
+            // Do NOT call write_snapshot — let Drop do it
+        }
+
+        assert!(snap_path.exists(), "Drop should write snapshot file");
+    }
+
+    #[test]
+    fn snapshot_and_full_rebuild_agree() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Create engine with data
+        {
+            let engine = open_file_engine(dir.path());
+            add_test_fact(&engine, "alpha");
+            add_test_fact(&engine, "beta");
+            add_test_fact(&engine, "gamma");
+            engine.write_snapshot().unwrap();
+        }
+
+        // Load from snapshot
+        let engine_snap = open_file_engine(dir.path());
+        let snap_facts = engine_snap.list_active_facts(None).unwrap();
+        let snap_graph_nodes = engine_snap.graph.read().node_count();
+        let snap_graph_edges = engine_snap.graph.read().edge_count();
+
+        // Delete snapshot, force full rebuild
+        let snap_path = super::snapshot::snapshot_path(&dir.path().join("test.db"));
+        std::fs::remove_file(&snap_path).unwrap();
+        let engine_rebuild = open_file_engine(dir.path());
+        let rebuild_facts = engine_rebuild.list_active_facts(None).unwrap();
+        let rebuild_graph_nodes = engine_rebuild.graph.read().node_count();
+        let rebuild_graph_edges = engine_rebuild.graph.read().edge_count();
+
+        assert_eq!(snap_facts.len(), rebuild_facts.len());
+        assert_eq!(snap_graph_nodes, rebuild_graph_nodes);
+        assert_eq!(snap_graph_edges, rebuild_graph_edges);
+    }
+}

--- a/src/graph/memory_graph.rs
+++ b/src/graph/memory_graph.rs
@@ -206,6 +206,47 @@ impl MemoryGraph {
 
         Ok(graph)
     }
+
+    /// Extract all edges for snapshotting.
+    ///
+    /// No isolated nodes — matches `load_from_db` semantics (edges only).
+    pub(crate) fn to_snapshot(&self) -> crate::engine::snapshot::GraphSnapshot {
+        use crate::engine::snapshot::{GraphEdgeSnapshot, GraphSnapshot};
+        let edges = self
+            .graph
+            .edge_references()
+            .map(|e| {
+                let source = self.graph[e.source()];
+                let target = self.graph[e.target()];
+                let data = e.weight();
+                GraphEdgeSnapshot {
+                    edge_id: data.edge_id,
+                    source,
+                    target,
+                    relation_type: data.relation_type.clone(),
+                    weight: data.weight,
+                }
+            })
+            .collect();
+        GraphSnapshot { edges }
+    }
+
+    /// Rebuild graph from a snapshot (same logic as `load_from_db`).
+    pub(crate) fn from_snapshot(snap: &crate::engine::snapshot::GraphSnapshot) -> Self {
+        let mut graph = Self::new();
+        for edge in &snap.edges {
+            graph.add_edge(
+                edge.source,
+                edge.target,
+                EdgeData {
+                    edge_id: edge.edge_id,
+                    relation_type: edge.relation_type.clone(),
+                    weight: edge.weight,
+                },
+            );
+        }
+        graph
+    }
 }
 
 impl Default for MemoryGraph {

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -166,6 +166,28 @@ impl ScopeTree {
         segments.reverse();
         Some(segments.join("/"))
     }
+
+    /// Snapshot all nodes for serialization.
+    pub(crate) fn to_snapshot(&self) -> crate::engine::snapshot::ScopeTreeSnapshot {
+        crate::engine::snapshot::ScopeTreeSnapshot {
+            nodes: self.nodes.values().cloned().collect(),
+        }
+    }
+
+    /// Rebuild tree from a snapshot (same logic as `load` but from snapshot data).
+    pub(crate) fn from_snapshot(snap: &crate::engine::snapshot::ScopeTreeSnapshot) -> Self {
+        let mut nodes = HashMap::with_capacity(snap.nodes.len());
+        let mut children: HashMap<i64, Vec<i64>> = HashMap::new();
+
+        for node in &snap.nodes {
+            if let Some(pid) = node.parent_id {
+                children.entry(pid).or_default().push(node.id);
+            }
+            nodes.insert(node.id, node.clone());
+        }
+
+        Self { nodes, children }
+    }
 }
 
 #[cfg(test)]

--- a/src/search/ann.rs
+++ b/src/search/ann.rs
@@ -136,6 +136,85 @@ impl HnswStrategy {
             embed_dim,
         })
     }
+
+    /// Snapshot active embeddings for fast cold-start.
+    ///
+    /// Reads embeddings from DB (vectors are not kept in memory). Returns
+    /// compact data: only active facts, ordered by fact_id. On load,
+    /// `from_snapshot` rebuilds a fresh compact HNSW index from this data.
+    pub(crate) fn to_snapshot(
+        &self,
+        conn: &Connection,
+        embed_dim: usize,
+    ) -> Result<crate::engine::snapshot::HnswSnapshot> {
+        use crate::engine::snapshot::{HnswEntry, HnswSnapshot};
+
+        let mut stmt =
+            conn.prepare("SELECT id, embedding FROM facts WHERE t_expired IS NULL ORDER BY id")?;
+        let rows = stmt.query_map([], |row| {
+            let id: i64 = row.get(0)?;
+            let blob: Vec<u8> = row.get(1)?;
+            Ok((id, blob))
+        })?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            let (fact_id, blob) = row?;
+            let embedding = deserialize_embedding(&blob, embed_dim)?;
+            entries.push(HnswEntry { fact_id, embedding });
+        }
+
+        Ok(HnswSnapshot { entries })
+    }
+
+    /// Rebuild a compact HNSW index from snapshot data (no DB I/O needed).
+    ///
+    /// Uses the same seed and parameters as `build_from_db` for deterministic
+    /// topology.
+    pub(crate) fn from_snapshot(
+        snap: &crate::engine::snapshot::HnswSnapshot,
+        embed_dim: usize,
+    ) -> Result<Self> {
+        use rand::SeedableRng;
+
+        const HNSW_SEED: u64 = 42;
+        let mut index: Hnsw<CosineMetric, Vec<f32>, SmallRng, 16, 32> = Hnsw::new_params_and_prng(
+            CosineMetric,
+            hnsw::Params::new().ef_construction(200),
+            SmallRng::seed_from_u64(HNSW_SEED),
+        );
+        let mut searcher: Searcher<u32> = Searcher::default();
+        let mut index_to_fact = Vec::new();
+        let mut fact_to_hnsw = HashMap::new();
+
+        for entry in &snap.entries {
+            if entry.embedding.len() != embed_dim {
+                return Err(crate::error::MemoryError::EmbeddingDimension {
+                    expected: embed_dim,
+                    actual: entry.embedding.len(),
+                });
+            }
+            let hnsw_id = index.insert(entry.embedding.clone(), &mut searcher);
+            if hnsw_id != index_to_fact.len() {
+                return Err(crate::error::MemoryError::Internal(format!(
+                    "HNSW index must assign sequential IDs (got {hnsw_id}, expected {})",
+                    index_to_fact.len()
+                )));
+            }
+            index_to_fact.push(entry.fact_id);
+            fact_to_hnsw.insert(entry.fact_id, hnsw_id);
+        }
+
+        Ok(Self {
+            inner: RwLock::new(HnswInner {
+                index,
+                index_to_fact,
+                fact_to_hnsw,
+                tombstones: HashSet::new(),
+            }),
+            embed_dim,
+        })
+    }
 }
 
 impl VectorSearchStrategy for HnswStrategy {

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -307,7 +307,7 @@ mod tests {
             ) {
                 let len = a.len().min(b.len());
                 let sim = cosine_similarity(&a[..len], &b[..len]);
-                prop_assert!(sim >= -1.0 - 1e-5 && sim <= 1.0 + 1e-5,
+                prop_assert!((-1.0 - 1e-5..=1.0 + 1e-5).contains(&sim),
                     "cosine similarity {sim} out of [-1, 1] bounds");
             }
         }

--- a/tests/ann_recall_test.rs
+++ b/tests/ann_recall_test.rs
@@ -42,10 +42,7 @@ fn hnsw_recall_at_k_exceeds_threshold() {
     // Build HNSW engine (threshold=0 -> always use HNSW)
     let dir_ann = tempfile::tempdir().unwrap();
     let mut config_ann = EngineConfig::new(dir_ann.path().join("ann.db"), DIM);
-    config_ann.search_config = Some(SearchConfig {
-        ann_threshold: 0,
-        ..Default::default()
-    });
+    config_ann.search_config = Some(SearchConfig { ann_threshold: 0 });
     let engine_ann = MemoryEngine::open(&config_ann).unwrap();
 
     let embedder = Blake3Embedder;


### PR DESCRIPTION
## Summary

- On graceful shutdown, serialize `MemoryGraph` + `ScopeTree` + HNSW state into a `.snapshot` sidecar file (named MessagePack + blake3 checksum)
- On startup, validate against a composite `DbFingerprint` (max_id + active_count from facts/edges/scopes) — load from snapshot or silently fall back to full rebuild
- Atomic write via `tempfile` + `fsync` + rename for crash safety; no-panic contract in `Drop` path

## Design

Dedicated snapshot types decoupled from petgraph/hnsw internals (the "pickle lesson"). Composite fingerprint instead of `MAX(events.id)` — Codex review caught that many mutators (`add_fact`, `forget`, `consolidate`) modify source tables without appending events.

**New file:** `src/engine/snapshot.rs` — types, I/O, validation
**Modified:** `init_from_pool` (snapshot fast path), `MemoryGraph`/`ScopeTree`/`HnswStrategy` (to/from_snapshot), `Drop` impl, `AsyncMemoryEngine`

## Test plan

- [x] 10 unit tests in `snapshot.rs` (path derivation, fingerprint, round-trip, corrupt/stale/wrong-version/checksum rejection, cross-feature serde)
- [x] 7 integration tests in `tests.rs` (full round-trip, stale fingerprint fallback, missing file fallback, in-memory skip, read-only skip, Drop writes, snapshot vs rebuild agree)
- [x] `cargo test --all-features` — 506 passed
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo fmt --check` — clean

Fixes #31