### PR TITLE
feat(cli): add --valid-at temporal filtering to query command

### DIFF
--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use memory_engine::MemoryQuery;
 use memory_engine::search::hybrid::MatchType;
+use memory_engine::MemoryQuery;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, OutputFormat, truncate_str};
+use crate::output::{self, truncate_str, OutputFormat};
 
 #[derive(clap::Args)]
 pub struct QueryArgs {
@@ -33,7 +33,7 @@ pub struct QueryArgs {
     #[arg(long)]
     pinned_only: bool,
 
-    /// Filter by bi-temporal validity (ISO 8601, e.g. 2026-03-25T00:00:00Z).
+    /// Filter by bi-temporal validity (RFC 3339, e.g. 2026-03-25T00:00:00Z).
     /// Returns facts valid at this point in time:
     /// t_valid <= dt AND (t_invalid IS NULL OR t_invalid > dt).
     #[arg(long, value_parser = parse_datetime)]
@@ -43,7 +43,7 @@ pub struct QueryArgs {
 fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
     DateTime::parse_from_rfc3339(s)
         .map(|dt| dt.with_timezone(&Utc))
-        .map_err(|e| format!("invalid ISO 8601 datetime: {e}"))
+        .map_err(|e| format!("invalid RFC 3339 datetime: {e}"))
 }
 
 #[derive(Tabled)]
@@ -69,7 +69,7 @@ struct ResultRow {
 fn fmt_optional_dt(dt: Option<&DateTime<Utc>>) -> String {
     match dt {
         Some(t) => t.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-        None => String::new(),
+        None => "-".into(),
     }
 }
 

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use chrono::{DateTime, Utc};
 use memory_engine::MemoryQuery;
 use memory_engine::search::hybrid::MatchType;
 use tabled::{Table, Tabled};
@@ -31,6 +32,18 @@ pub struct QueryArgs {
     /// Show only pinned facts
     #[arg(long)]
     pinned_only: bool,
+
+    /// Filter by bi-temporal validity (ISO 8601, e.g. 2026-03-25T00:00:00Z).
+    /// Returns facts valid at this point in time:
+    /// t_valid <= dt AND (t_invalid IS NULL OR t_invalid > dt).
+    #[arg(long, value_parser = parse_datetime)]
+    valid_at: Option<DateTime<Utc>>,
+}
+
+fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("invalid ISO 8601 datetime: {e}"))
 }
 
 #[derive(Tabled)]
@@ -45,8 +58,19 @@ struct ResultRow {
     fact_type: String,
     #[tabled(rename = "Pinned")]
     pinned: &'static str,
+    #[tabled(rename = "Valid")]
+    t_valid: String,
+    #[tabled(rename = "Invalid")]
+    t_invalid: String,
     #[tabled(rename = "Content")]
     content: String,
+}
+
+fn fmt_optional_dt(dt: Option<&DateTime<Utc>>) -> String {
+    match dt {
+        Some(t) => t.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        None => String::new(),
+    }
 }
 
 pub fn run(db: &Path, args: &QueryArgs, format: OutputFormat) -> anyhow::Result<()> {
@@ -78,6 +102,10 @@ pub fn run(db: &Path, args: &QueryArgs, format: OutputFormat) -> anyhow::Result<
         query = query.pinned_only();
     }
 
+    if let Some(dt) = args.valid_at {
+        query = query.valid_at(dt);
+    }
+
     let response = engine.execute_query(&query)?;
     let results = response.results;
 
@@ -102,6 +130,8 @@ pub fn run(db: &Path, args: &QueryArgs, format: OutputFormat) -> anyhow::Result<
                     },
                     fact_type: format!("{:?}", r.fact.fact_type),
                     pinned: if r.fact.is_pinned { "yes" } else { "" },
+                    t_valid: fmt_optional_dt(r.fact.t_valid.as_ref()),
+                    t_invalid: fmt_optional_dt(r.fact.t_invalid.as_ref()),
                     content: truncate_str(&r.fact.content, 80),
                 })
                 .collect();
@@ -109,7 +139,14 @@ pub fn run(db: &Path, args: &QueryArgs, format: OutputFormat) -> anyhow::Result<
         }
         OutputFormat::Plain => {
             for r in &results {
-                println!("{}\t{:.4}\t{}", r.fact.id, r.score, r.fact.content);
+                println!(
+                    "{}\t{:.4}\t{}\t{}\t{}",
+                    r.fact.id,
+                    r.score,
+                    fmt_optional_dt(r.fact.t_valid.as_ref()),
+                    fmt_optional_dt(r.fact.t_invalid.as_ref()),
+                    r.fact.content,
+                );
             }
         }
     }

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use memory_engine::search::hybrid::MatchType;
 use memory_engine::MemoryQuery;
+use memory_engine::search::hybrid::MatchType;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, truncate_str, OutputFormat};
+use crate::output::{self, OutputFormat, truncate_str};
 
 #[derive(clap::Args)]
 pub struct QueryArgs {

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -169,6 +169,156 @@ fn query_no_results() {
         .stdout(predicate::str::contains("No results"));
 }
 
+// --- query: --valid-at temporal filtering ---
+
+/// Create a test database with facts that have explicit t_valid / t_invalid
+/// temporal bounds, for testing --valid-at filtering.
+fn create_temporal_db() -> (TempDir, PathBuf) {
+    use chrono::{TimeZone, Utc};
+
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("temporal.db");
+
+    let config = memory_engine::EngineConfig::new(db_path.clone(), 4);
+    let engine = memory_engine::MemoryEngine::open(&config).unwrap();
+
+    struct FakeEmbed;
+    impl memory_engine::EmbeddingProvider for FakeEmbed {
+        fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
+            Ok(vec![0.1, 0.2, 0.3, 0.4])
+        }
+    }
+
+    // Fact 1: valid from March 1 to March 31
+    engine
+        .add_fact(
+            &memory_engine::AddFactRequest {
+                content: "March event: spring equinox observed".into(),
+                fact_type: memory_engine::FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(memory_engine::AddFactOptions {
+                    t_valid: Some(Utc.with_ymd_and_hms(2026, 3, 1, 0, 0, 0).unwrap()),
+                    t_invalid: Some(Utc.with_ymd_and_hms(2026, 3, 31, 0, 0, 0).unwrap()),
+                    ..Default::default()
+                }),
+            },
+            &FakeEmbed,
+            None,
+        )
+        .unwrap();
+
+    // Fact 2: valid from April 1, no end (still valid)
+    engine
+        .add_fact(
+            &memory_engine::AddFactRequest {
+                content: "April event: daylight saving adjustment".into(),
+                fact_type: memory_engine::FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(memory_engine::AddFactOptions {
+                    t_valid: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap()),
+                    ..Default::default()
+                }),
+            },
+            &FakeEmbed,
+            None,
+        )
+        .unwrap();
+
+    // Fact 3: no temporal bounds (always valid)
+    engine
+        .add_fact(
+            &memory_engine::AddFactRequest {
+                content: "Timeless event: gravity exists".into(),
+                fact_type: memory_engine::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+            &FakeEmbed,
+            None,
+        )
+        .unwrap();
+
+    drop(engine);
+    (dir, db_path)
+}
+
+#[test]
+fn query_valid_at_filters_to_march() {
+    let (_dir, db_path) = create_temporal_db();
+    // March 15 should match: March event (in range) + timeless (no bounds)
+    // but NOT April event (t_valid = April 1 > March 15)
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "query",
+            "event",
+            "--valid-at",
+            "2026-03-15T00:00:00Z",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("spring equinox"))
+        .stdout(predicate::str::contains("gravity"))
+        .stdout(predicate::str::contains("daylight").not());
+}
+
+#[test]
+fn query_valid_at_filters_to_april() {
+    let (_dir, db_path) = create_temporal_db();
+    // April 5 should match: April event (in range) + timeless (no bounds)
+    // but NOT March event (t_invalid = March 31 <= April 5)
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "query",
+            "event",
+            "--valid-at",
+            "2026-04-05T00:00:00Z",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("daylight"))
+        .stdout(predicate::str::contains("gravity"))
+        .stdout(predicate::str::contains("spring equinox").not());
+}
+
+#[test]
+fn query_valid_at_invalid_format_fails() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "query",
+            "sky",
+            "--valid-at",
+            "not-a-date",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid ISO 8601"));
+}
+
+#[test]
+fn query_table_output_shows_temporal_columns() {
+    let (_dir, db_path) = create_temporal_db();
+    cli()
+        .args(["--db", db_path.to_str().unwrap(), "query", "event"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Valid"))
+        .stdout(predicate::str::contains("Invalid"));
+}
+
 // --- export + import roundtrip ---
 
 // NOTE: Skipped due to pre-existing library bug — restore.rs has

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -305,7 +305,7 @@ fn query_valid_at_invalid_format_fails() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("invalid ISO 8601"));
+        .stderr(predicate::str::contains("invalid RFC 3339"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `--valid-at <ISO8601>` flag to CLI `query` command, wiring the existing `MemoryQuery::valid_at()` bi-temporal filter
- Adds `Valid` and `Invalid` columns to table and plain output formats so temporal bounds are always visible
- No core library changes — purely CLI wiring to existing engine capability

## Changes

| File | What |
|------|------|
| `memory-engine-cli/src/commands/query.rs` | `--valid-at` arg, `parse_datetime`, temporal columns in `ResultRow`, `fmt_optional_dt` helper |
| `memory-engine-cli/tests/cli_integration.rs` | 4 new tests: March filter, April filter, invalid format, table columns |

## Test plan

- [x] `query_valid_at_filters_to_march` — facts with `t_valid=March 1, t_invalid=March 31` match at March 15; April facts excluded
- [x] `query_valid_at_filters_to_april` — facts with `t_valid=April 1` match at April 5; expired March facts excluded
- [x] `query_valid_at_invalid_format_fails` — `--valid-at not-a-date` produces clear error
- [x] `query_table_output_shows_temporal_columns` — `Valid` and `Invalid` column headers present
- [x] All 690 workspace tests pass (including 17 CLI tests)

Fixes #216