### PR TITLE
feat(cli): add-fact command for creating facts with temporal metadata

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -256,9 +256,10 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 
 #### Phase 4b Follow-ups (CLI enhancements)
 
-| Issue                                                          | Priority | Description                                                                                                                           |
-| -------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ [#216](https://github.com/dutiona/memory-engine/issues/216) | P1       | CLI query: `--valid-at` temporal filtering + temporal columns in output. [PR #217](https://github.com/dutiona/memory-engine/pull/217) |
+| Issue                                                          | Priority | Description                                                                                                                                         |
+| -------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ [#214](https://github.com/dutiona/memory-engine/issues/214) | P1       | CLI `add-fact` command: create facts with pre-computed embeddings + temporal metadata. [PR #218](https://github.com/dutiona/memory-engine/pull/218) |
+| ✅ [#216](https://github.com/dutiona/memory-engine/issues/216) | P1       | CLI query: `--valid-at` temporal filtering + temporal columns in output. [PR #217](https://github.com/dutiona/memory-engine/pull/217)               |
 
 #### Phase 4c: Quality & Cold Storage
 

--- a/memory-engine-cli/src/commands/add_fact.rs
+++ b/memory-engine-cli/src/commands/add_fact.rs
@@ -1,0 +1,158 @@
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use clap::ValueEnum;
+use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
+
+use crate::db::open_engine_writable;
+use crate::embedding::PassthroughEmbedder;
+use crate::output::{self, OutputFormat};
+
+/// Fact type for CLI argument parsing.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum FactTypeArg {
+    Episodic,
+    Semantic,
+    Procedural,
+}
+
+impl From<FactTypeArg> for FactType {
+    fn from(arg: FactTypeArg) -> Self {
+        match arg {
+            FactTypeArg::Episodic => Self::Episodic,
+            FactTypeArg::Semantic => Self::Semantic,
+            FactTypeArg::Procedural => Self::Procedural,
+        }
+    }
+}
+
+#[derive(clap::Args)]
+pub struct AddFactArgs {
+    /// The fact text to store
+    #[arg(long)]
+    content: String,
+
+    /// Fact type
+    #[arg(long, value_enum)]
+    fact_type: FactTypeArg,
+
+    /// Pre-computed embedding as a JSON array of floats (e.g., "[0.1, 0.2, 0.3]")
+    #[arg(long)]
+    embedding: String,
+
+    /// Real-world validity start (RFC 3339, e.g., "2026-03-01T00:00:00Z")
+    #[arg(long, value_parser = parse_datetime)]
+    t_valid: Option<DateTime<Utc>>,
+
+    /// Real-world validity end (RFC 3339)
+    #[arg(long, value_parser = parse_datetime)]
+    t_invalid: Option<DateTime<Utc>>,
+
+    /// Importance score in [0, 1] (default: 0.5)
+    #[arg(long)]
+    importance: Option<f64>,
+
+    /// Scope path (e.g., "project/sub"). Auto-creates missing segments. Default: root
+    #[arg(long)]
+    scope: Option<String>,
+
+    /// Arbitrary JSON metadata (must be a JSON object, e.g., '{"source":"beam"}')
+    #[arg(long)]
+    metadata: Option<String>,
+
+    /// Pin this fact (unforgettable — exempt from decay)
+    #[arg(long)]
+    pinned: bool,
+
+    /// Link to an existing event ID in the database
+    #[arg(long)]
+    source_event_id: Option<i64>,
+}
+
+fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("invalid RFC 3339 datetime: {e}"))
+}
+
+pub fn run(db: &Path, args: &AddFactArgs, format: OutputFormat) -> anyhow::Result<()> {
+    // Parse embedding
+    let embedding: Vec<f32> = serde_json::from_str(&args.embedding)
+        .map_err(|e| anyhow::anyhow!("invalid embedding JSON: {e}"))?;
+    anyhow::ensure!(!embedding.is_empty(), "embedding must not be empty");
+
+    // Validate importance
+    if let Some(imp) = args.importance {
+        anyhow::ensure!(
+            (0.0..=1.0).contains(&imp),
+            "importance must be in [0, 1], got {imp}"
+        );
+    }
+
+    // Validate temporal consistency
+    if let (Some(tv), Some(ti)) = (args.t_valid, args.t_invalid) {
+        anyhow::ensure!(tv < ti, "t-valid ({tv}) must be before t-invalid ({ti})");
+    }
+
+    // Parse and validate metadata
+    let metadata = match &args.metadata {
+        Some(raw) => {
+            let val: serde_json::Value = serde_json::from_str(raw)
+                .map_err(|e| anyhow::anyhow!("invalid metadata JSON: {e}"))?;
+            anyhow::ensure!(
+                val.is_object(),
+                "metadata must be a JSON object, got {}",
+                match &val {
+                    serde_json::Value::Array(_) => "array",
+                    serde_json::Value::String(_) => "string",
+                    serde_json::Value::Number(_) => "number",
+                    serde_json::Value::Bool(_) => "boolean",
+                    serde_json::Value::Null => "null",
+                    serde_json::Value::Object(_) => unreachable!(),
+                }
+            );
+            Some(val)
+        }
+        None => None,
+    };
+
+    let engine = open_engine_writable(db)?;
+    let fact_type: FactType = args.fact_type.into();
+
+    let req = AddFactRequest {
+        content: args.content.clone(),
+        fact_type: fact_type.clone(),
+        source_event_id: args.source_event_id,
+        scope: args.scope.clone(),
+        opts: Some(AddFactOptions {
+            importance: args.importance,
+            metadata,
+            t_valid: args.t_valid,
+            t_invalid: args.t_invalid,
+            pinned: if args.pinned { Some(true) } else { None },
+            ..Default::default()
+        }),
+    };
+
+    let embedder = PassthroughEmbedder::new(embedding);
+    let fact_id = engine.add_fact(&req, &embedder, None)?;
+
+    match format {
+        OutputFormat::Json => {
+            let fact = engine.get_fact(fact_id)?;
+            output::print_json(&fact)?;
+        }
+        OutputFormat::Table => {
+            let importance = args.importance.unwrap_or(0.5);
+            eprintln!(
+                "Created fact {fact_id} ({fact_type}, importance={importance:.2}{})",
+                if args.pinned { ", pinned" } else { "" }
+            );
+        }
+        OutputFormat::Plain => {
+            println!("{fact_id}");
+        }
+    }
+
+    Ok(())
+}

--- a/memory-engine-cli/src/commands/add_fact.rs
+++ b/memory-engine-cli/src/commands/add_fact.rs
@@ -94,24 +94,27 @@ pub fn run(db: &Path, args: &AddFactArgs, format: OutputFormat) -> anyhow::Resul
         anyhow::ensure!(tv < ti, "t-valid ({tv}) must be before t-invalid ({ti})");
     }
 
-    // Parse and validate metadata
+    // Parse and validate metadata (explicit null treated as absent)
     let metadata = match &args.metadata {
         Some(raw) => {
             let val: serde_json::Value = serde_json::from_str(raw)
                 .map_err(|e| anyhow::anyhow!("invalid metadata JSON: {e}"))?;
-            anyhow::ensure!(
-                val.is_object(),
-                "metadata must be a JSON object, got {}",
-                match &val {
-                    serde_json::Value::Array(_) => "array",
-                    serde_json::Value::String(_) => "string",
-                    serde_json::Value::Number(_) => "number",
-                    serde_json::Value::Bool(_) => "boolean",
-                    serde_json::Value::Null => "null",
-                    serde_json::Value::Object(_) => unreachable!(),
-                }
-            );
-            Some(val)
+            if val.is_null() {
+                None
+            } else {
+                anyhow::ensure!(
+                    val.is_object(),
+                    "metadata must be a JSON object, got {}",
+                    match &val {
+                        serde_json::Value::Array(_) => "array",
+                        serde_json::Value::String(_) => "string",
+                        serde_json::Value::Number(_) => "number",
+                        serde_json::Value::Bool(_) => "boolean",
+                        serde_json::Value::Null | serde_json::Value::Object(_) => unreachable!(),
+                    }
+                );
+                Some(val)
+            }
         }
         None => None,
     };

--- a/memory-engine-cli/src/commands/dump.rs
+++ b/memory-engine-cli/src/commands/dump.rs
@@ -4,7 +4,7 @@ use memory_engine::inspect_types::ReplayFilter;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, OutputFormat, truncate_str};
+use crate::output::{self, truncate_str, OutputFormat};
 
 #[derive(clap::Args)]
 pub struct DumpArgs {

--- a/memory-engine-cli/src/commands/export.rs
+++ b/memory-engine-cli/src/commands/export.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use memory_engine::inspect_types::DumpFormat;
 
-use crate::db::open_engine_writable;
+use crate::db::{open_engine, open_engine_writable};
 
 #[derive(clap::Args)]
 pub struct ExportArgs {
@@ -16,7 +16,12 @@ pub struct ExportArgs {
 }
 
 pub fn run(db: &Path, args: &ExportArgs) -> anyhow::Result<()> {
-    let engine = open_engine_writable(db)?;
+    // Only SQLite export needs write access (VACUUM INTO); others are read-only.
+    let engine = if args.export_format == "sqlite" {
+        open_engine_writable(db)?
+    } else {
+        open_engine(db)?
+    };
 
     let format = match args.export_format.as_str() {
         "json" => DumpFormat::Json(args.output.clone()),

--- a/memory-engine-cli/src/commands/export.rs
+++ b/memory-engine-cli/src/commands/export.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use memory_engine::inspect_types::DumpFormat;
 
-use crate::db::open_engine;
+use crate::db::open_engine_writable;
 
 #[derive(clap::Args)]
 pub struct ExportArgs {
@@ -16,7 +16,7 @@ pub struct ExportArgs {
 }
 
 pub fn run(db: &Path, args: &ExportArgs) -> anyhow::Result<()> {
-    let engine = open_engine(db)?;
+    let engine = open_engine_writable(db)?;
 
     let format = match args.export_format.as_str() {
         "json" => DumpFormat::Json(args.output.clone()),

--- a/memory-engine-cli/src/commands/mod.rs
+++ b/memory-engine-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod add_fact;
 pub mod dump;
 pub mod explain;
 pub mod export;

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use memory_engine::MemoryQuery;
 use memory_engine::search::hybrid::MatchType;
+use memory_engine::MemoryQuery;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, OutputFormat, truncate_str};
+use crate::output::{self, truncate_str, OutputFormat};
 
 #[derive(clap::Args)]
 pub struct QueryArgs {

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -2,25 +2,15 @@ use std::path::Path;
 
 use memory_engine::{EngineConfig, MemoryEngine};
 
-/// Open a `MemoryEngine` from an existing database file.
-///
-/// Reads `embed_dim` from the database config table so the user
-/// doesn't have to specify it manually.
-///
-/// # Caveat
-///
-/// `MemoryEngine::open()` may run schema migrations on the writable pool.
-/// We mitigate this by setting `backup_dir` next to the database so any
-/// migration creates a WAL-safe backup first. A true read-only open path
-/// requires library support (tracked as a follow-up issue).
-pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
+/// Peek `embed_dim` from an existing database's config table.
+fn peek_embed_dim(path: &Path) -> anyhow::Result<usize> {
     anyhow::ensure!(path.exists(), "database not found: {}", path.display());
 
     let conn = rusqlite::Connection::open_with_flags(
         path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
-    let embed_dim: usize = conn
+    let raw: String = conn
         .query_row(
             "SELECT value FROM config WHERE key = 'embed_dim'",
             [],
@@ -30,11 +20,30 @@ pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
             anyhow::anyhow!(
                 "database has no embed_dim in config table — is this a memory-engine database? ({e})"
             )
-        })?
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid embed_dim value in config table"))?;
-    drop(conn);
+        })?;
+    raw.parse()
+        .map_err(|_| anyhow::anyhow!("invalid embed_dim value in config table"))
+}
 
+/// Open a `MemoryEngine` in **read-only** mode.
+///
+/// Uses the library's `read_only` config flag so the connection pool
+/// never acquires a write lock and never runs migrations.
+pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
+    let embed_dim = peek_embed_dim(path)?;
+    let mut config = EngineConfig::new(path.to_path_buf(), embed_dim);
+    config.read_only = true;
+    let engine = MemoryEngine::open(&config)?;
+    Ok(engine)
+}
+
+/// Open a `MemoryEngine` with **write** capability.
+///
+/// Needed for commands that mutate the database (e.g., `add-fact`, `export`
+/// with SQLite format). Sets `backup_dir` next to the database so any
+/// schema migration creates a WAL-safe backup first.
+pub fn open_engine_writable(path: &Path) -> anyhow::Result<MemoryEngine> {
+    let embed_dim = peek_embed_dim(path)?;
     let backup_dir = path.parent().map(Path::to_path_buf);
     let mut config = EngineConfig::new(path.to_path_buf(), embed_dim);
     config.backup_dir = backup_dir;

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -4,7 +4,11 @@ use memory_engine::{EngineConfig, MemoryEngine};
 
 /// Peek `embed_dim` from an existing database's config table.
 fn peek_embed_dim(path: &Path) -> anyhow::Result<usize> {
-    anyhow::ensure!(path.exists(), "database not found: {}", path.display());
+    anyhow::ensure!(
+        path.is_file(),
+        "database not found (or is a directory): {}",
+        path.display()
+    );
 
     let conn = rusqlite::Connection::open_with_flags(
         path,

--- a/memory-engine-cli/src/embedding.rs
+++ b/memory-engine-cli/src/embedding.rs
@@ -1,0 +1,29 @@
+use memory_engine::error::MemoryError;
+use memory_engine::traits::EmbeddingProvider;
+
+/// Pass-through embedder for pre-computed embeddings supplied via `--embedding`.
+pub struct PassthroughEmbedder {
+    embedding: Vec<f32>,
+}
+
+impl PassthroughEmbedder {
+    pub fn new(embedding: Vec<f32>) -> Self {
+        Self { embedding }
+    }
+}
+
+impl EmbeddingProvider for PassthroughEmbedder {
+    fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
+        Ok(self.embedding.clone())
+    }
+
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, MemoryError> {
+        if texts.len() != 1 {
+            return Err(MemoryError::Internal(format!(
+                "PassthroughEmbedder holds a single embedding and cannot batch-embed {} texts",
+                texts.len()
+            )));
+        }
+        Ok(vec![self.embedding.clone()])
+    }
+}

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod db;
+mod embedding;
 mod output;
 
 use std::path::PathBuf;
@@ -55,6 +56,8 @@ enum Commands {
     Import(commands::import::ImportArgs),
     /// Dump facts or events to stdout (debug/inspection)
     Dump(commands::dump::DumpArgs),
+    /// Add a fact to the database with pre-computed embedding
+    AddFact(commands::add_fact::AddFactArgs),
 }
 
 fn main() -> ExitCode {
@@ -68,6 +71,7 @@ fn main() -> ExitCode {
         Commands::Export(ref args) => commands::export::run(&cli.db, args),
         Commands::Import(ref args) => commands::import::run(&cli.db, args),
         Commands::Dump(ref args) => commands::dump::run(&cli.db, args, cli.format),
+        Commands::AddFact(ref args) => commands::add_fact::run(&cli.db, args, cli.format),
     };
 
     match result {

--- a/memory-engine-cli/tests/add_fact.rs
+++ b/memory-engine-cli/tests/add_fact.rs
@@ -1,0 +1,422 @@
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+const EMBED_DIM: usize = 4;
+const EMBEDDING_JSON: &str = "[0.1, 0.2, 0.3, 0.4]";
+
+/// Create a test database (empty, with schema initialized) and return (tempdir, db_path).
+fn create_empty_db() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let config = memory_engine::EngineConfig::new(db_path.clone(), EMBED_DIM);
+    let _engine = memory_engine::MemoryEngine::open(&config).unwrap();
+    (dir, db_path)
+}
+
+/// Create a test database with a seeded event for source_event_id tests.
+fn create_db_with_event() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let config = memory_engine::EngineConfig::new(db_path.clone(), EMBED_DIM);
+    let engine = memory_engine::MemoryEngine::open(&config).unwrap();
+
+    engine
+        .ingest(&memory_engine::NewEvent {
+            timestamp: chrono::Utc::now(),
+            event_type: memory_engine::EventType::Interaction,
+            payload: serde_json::json!({"test": true}),
+            source: "test".into(),
+            session_id: None,
+            scope_id: 1,
+            origin_node_id: "test-node".into(),
+            sequence_id: 1,
+            created_at: None,
+        })
+        .unwrap();
+
+    drop(engine);
+    (dir, db_path)
+}
+
+fn cli() -> Command {
+    Command::cargo_bin("memory-engine-cli").unwrap()
+}
+
+// --- Happy paths ---
+
+#[test]
+fn add_fact_happy_path_plain() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "plain",
+            "add-fact",
+            "--content",
+            "The sky is blue",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^\d+\n$").unwrap());
+}
+
+#[test]
+fn add_fact_happy_path_table() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "The sky is blue",
+            "--fact-type",
+            "episodic",
+            "--embedding",
+            EMBEDDING_JSON,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Created fact"))
+        .stderr(predicate::str::contains("episodic"));
+}
+
+#[test]
+fn add_fact_json_output() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "add-fact",
+            "--content",
+            "Rust is fast",
+            "--fact-type",
+            "procedural",
+            "--embedding",
+            EMBEDDING_JSON,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"content\""))
+        .stdout(predicate::str::contains("Rust is fast"))
+        .stdout(predicate::str::contains("\"fact_type\""))
+        .stdout(predicate::str::contains("\"id\""));
+}
+
+#[test]
+fn add_fact_with_optional_flags() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "add-fact",
+            "--content",
+            "User moved to Istanbul",
+            "--fact-type",
+            "episodic",
+            "--embedding",
+            EMBEDDING_JSON,
+            "--importance",
+            "0.9",
+            "--t-valid",
+            "2026-03-01T00:00:00Z",
+            "--t-invalid",
+            "2026-06-01T00:00:00Z",
+            "--scope",
+            "beam/experiment",
+            "--metadata",
+            r#"{"source":"beam","trial":1}"#,
+            "--pinned",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"is_pinned\": true"))
+        .stdout(predicate::str::contains("\"importance\": 0.9"));
+}
+
+#[test]
+fn add_fact_with_source_event_id() {
+    let (_dir, db_path) = create_db_with_event();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "add-fact",
+            "--content",
+            "Event-linked fact",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+            "--source-event-id",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"source_event_id\": 1"));
+}
+
+// --- Validation errors ---
+
+#[test]
+fn add_fact_invalid_fact_type() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "invalid",
+            "--embedding",
+            EMBEDDING_JSON,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn add_fact_importance_out_of_range() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+            "--importance",
+            "1.5",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("importance must be in [0, 1]"));
+}
+
+#[test]
+fn add_fact_temporal_inconsistency() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+            "--t-valid",
+            "2026-06-01T00:00:00Z",
+            "--t-invalid",
+            "2026-03-01T00:00:00Z",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("t-valid"));
+}
+
+#[test]
+fn add_fact_embedding_dimension_mismatch() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            "[0.1, 0.2]", // 2-dim, DB expects 4
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn add_fact_missing_embedding() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--embedding"));
+}
+
+#[test]
+fn add_fact_malformed_embedding() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            "[not, valid, json]",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid embedding JSON"));
+}
+
+#[test]
+fn add_fact_nonexistent_db() {
+    cli()
+        .args([
+            "--db",
+            "/tmp/nonexistent_add_fact_test.db",
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn add_fact_metadata_non_object() {
+    let (_dir, db_path) = create_empty_db();
+    // String scalar
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+            "--metadata",
+            "\"just a string\"",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("metadata must be a JSON object"));
+
+    // Array
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+            "--metadata",
+            "[1, 2, 3]",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("metadata must be a JSON object"));
+}
+
+#[test]
+fn add_fact_scope_creates_segments() {
+    let (_dir, db_path) = create_empty_db();
+
+    // Add fact with a nested scope path
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "plain",
+            "add-fact",
+            "--content",
+            "Scoped fact",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+            "--scope",
+            "project/experiment",
+        ])
+        .assert()
+        .success();
+
+    // Verify the fact exists and inspect it
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "inspect",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Scoped fact"));
+}
+
+#[test]
+fn add_fact_invalid_datetime() {
+    let (_dir, db_path) = create_empty_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "test",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON,
+            "--t-valid",
+            "not-a-date",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid"));
+}


### PR DESCRIPTION
## Summary

- Add `add-fact` subcommand to `memory-engine-cli` for scripting fact creation without the MCP server (#214)
- Split `db.rs` into read-only (`open_engine`) + writable (`open_engine_writable`) paths for defense-in-depth
- Support pre-computed embeddings (`--embedding`), temporal bounds, scope paths, metadata, pinning, and 3 output formats (table/plain/json)
- 15 integration tests covering happy paths and validation errors

## Design Decisions

1. **Pre-computed embeddings only (v1)** — HTTP embedding (`--embed-url`/`--embed-model`) deferred to avoid pulling `reqwest` into CLI
2. **Read-only/writable split** — existing read-only commands (`stats`, `inspect`, etc.) now use `config.read_only = true`; `export` and `add-fact` use writable path
3. **FactType as clap ValueEnum** — gives tab-completion, auto help text, and error messages for free
4. **DB must exist** — `add-fact` requires a pre-existing database, consistent with operator-tool philosophy

## Test plan

- [x] `cargo build --workspace` — all 3 crates compile
- [x] `cargo test --workspace` — 701 passed, 6 ignored (15 new add-fact tests)
- [x] `cargo clippy --workspace --all-targets` — no warnings in new code
- [x] Manual smoke test with `create_smoke_db` example + `add-fact` + `inspect`

Closes #214