### PR TITLE
feat: outcome tracking — EventType::OutcomeSignal (#63)

### DIFF
--- a/memory-engine-cli/src/commands/mod.rs
+++ b/memory-engine-cli/src/commands/mod.rs
@@ -5,5 +5,7 @@ pub mod explain;
 pub mod export;
 pub mod import;
 pub mod inspect;
+pub mod outcome_counts;
 pub mod query;
+pub mod record_outcome;
 pub mod stats;

--- a/memory-engine-cli/src/commands/outcome_counts.rs
+++ b/memory-engine-cli/src/commands/outcome_counts.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+
+use crate::db::open_engine;
+use crate::output::OutputFormat;
+
+#[derive(clap::Args)]
+pub struct OutcomeCountsArgs {
+    /// Fact ID to query outcome counts for
+    #[arg(long)]
+    fact_id: i64,
+}
+
+pub fn run(db: &Path, args: &OutcomeCountsArgs, format: OutputFormat) -> anyhow::Result<()> {
+    let engine = open_engine(db)?;
+    let counts = engine.get_outcome_counts(args.fact_id)?;
+
+    match format {
+        OutputFormat::Json => {
+            crate::output::print_json(&serde_json::json!({
+                "fact_id": args.fact_id,
+                "positive": counts.positive,
+                "negative": counts.negative,
+                "neutral": counts.neutral,
+            }))?;
+        }
+        OutputFormat::Table => {
+            println!("Outcome counts for fact {}:", args.fact_id);
+            println!("  positive: {}", counts.positive);
+            println!("  negative: {}", counts.negative);
+            println!("  neutral:  {}", counts.neutral);
+        }
+        OutputFormat::Plain => {
+            println!(
+                "+{} -{} ~{}",
+                counts.positive, counts.negative, counts.neutral
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/memory-engine-cli/src/commands/record_outcome.rs
+++ b/memory-engine-cli/src/commands/record_outcome.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+
+use clap::ValueEnum;
+use memory_engine::types::Outcome;
+
+use crate::db::open_engine_writable;
+use crate::output::OutputFormat;
+
+/// Outcome variant for CLI argument parsing.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum OutcomeArg {
+    Positive,
+    Negative,
+    Neutral,
+}
+
+impl From<OutcomeArg> for Outcome {
+    fn from(arg: OutcomeArg) -> Self {
+        match arg {
+            OutcomeArg::Positive => Self::Positive,
+            OutcomeArg::Negative => Self::Negative,
+            OutcomeArg::Neutral => Self::Neutral,
+        }
+    }
+}
+
+#[derive(clap::Args)]
+pub struct RecordOutcomeArgs {
+    /// Fact ID to record the outcome for
+    #[arg(long)]
+    fact_id: i64,
+
+    /// Outcome signal
+    #[arg(long, value_enum)]
+    outcome: OutcomeArg,
+}
+
+pub fn run(db: &Path, args: &RecordOutcomeArgs, format: OutputFormat) -> anyhow::Result<()> {
+    let engine = open_engine_writable(db)?;
+    let outcome: Outcome = args.outcome.into();
+
+    let event_id = engine.record_outcome(args.fact_id, outcome)?;
+
+    match format {
+        OutputFormat::Json => {
+            crate::output::print_json(&serde_json::json!({
+                "event_id": event_id,
+                "fact_id": args.fact_id,
+                "outcome": outcome,
+            }))?;
+        }
+        OutputFormat::Table => {
+            eprintln!(
+                "Recorded {outcome} outcome for fact {} (event {event_id})",
+                args.fact_id
+            );
+        }
+        OutputFormat::Plain => {
+            println!("{event_id}");
+        }
+    }
+
+    Ok(())
+}

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -60,6 +60,10 @@ enum Commands {
     AddFact(commands::add_fact::AddFactArgs),
     /// Ingest facts from a JSONL file via an embedding API
     BatchIngest(commands::batch_ingest::BatchIngestArgs),
+    /// Record an outcome signal (positive/negative/neutral) for a fact
+    RecordOutcome(commands::record_outcome::RecordOutcomeArgs),
+    /// Show aggregated outcome counts for a fact
+    OutcomeCounts(commands::outcome_counts::OutcomeCountsArgs),
 }
 
 fn main() -> ExitCode {
@@ -75,6 +79,12 @@ fn main() -> ExitCode {
         Commands::Dump(ref args) => commands::dump::run(&cli.db, args, cli.format),
         Commands::AddFact(ref args) => commands::add_fact::run(&cli.db, args, cli.format),
         Commands::BatchIngest(ref args) => commands::batch_ingest::run(&cli.db, args, cli.format),
+        Commands::RecordOutcome(ref args) => {
+            commands::record_outcome::run(&cli.db, args, cli.format)
+        }
+        Commands::OutcomeCounts(ref args) => {
+            commands::outcome_counts::run(&cli.db, args, cli.format)
+        }
     };
 
     match result {

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -12,7 +12,9 @@ use memory_engine::search::hybrid::SearchMode;
 use memory_engine::traits::{
     ConsolidationConfig, EmbeddingProvider, ForgetPolicy, SummaryGenerator,
 };
-use memory_engine::types::{AddFactOptions, AddFactRequest, EventType, FactType, NewEvent};
+use memory_engine::types::{
+    AddFactOptions, AddFactRequest, EventType, FactType, NewEvent, Outcome,
+};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
 use serde_json::{Map, Value, json};
 
@@ -286,6 +288,30 @@ pub fn all_tool_definitions() -> Vec<Tool> {
                 "required": ["jsonl_data"]
             }),
         ),
+        // Phase 5a: Outcome tracking
+        tool_def(
+            "memory_record_outcome",
+            "Record a positive, negative, or neutral outcome signal for a fact. Used by consumers to provide feedback on fact usefulness.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "fact_id": { "type": "integer", "description": "Fact ID to record outcome for" },
+                    "outcome": { "type": "string", "enum": ["Positive", "Negative", "Neutral"], "description": "Outcome signal" }
+                },
+                "required": ["fact_id", "outcome"]
+            }),
+        ),
+        tool_def(
+            "memory_outcome_counts",
+            "Get aggregated outcome counts (positive/negative/neutral) for a fact.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "fact_id": { "type": "integer", "description": "Fact ID to query outcome counts for" }
+                },
+                "required": ["fact_id"]
+            }),
+        ),
     ]
 }
 
@@ -331,6 +357,9 @@ pub fn dispatch(
         "memory_replay_events" => handle_replay_events(args, engine),
         "memory_fact_history" => handle_fact_history(args, engine),
         "memory_bootstrap_session" => handle_bootstrap_session(args, engine, embedder),
+        // Phase 5a: Outcome tracking
+        "memory_record_outcome" => handle_record_outcome(args, engine),
+        "memory_outcome_counts" => handle_outcome_counts(args, engine),
         _ => Err(ErrorData::invalid_params(
             format!("unknown tool: {name}"),
             None,
@@ -1058,8 +1087,8 @@ fn handle_replay_events(
     let until = get_datetime(&args, "until")?;
 
     // Both-or-neither validation (like period_start/period_end in handle_query)
-    if since.is_some() && until.is_some() {
-        if since.unwrap() > until.unwrap() {
+    if let (Some(s), Some(u)) = (since, until) {
+        if s > u {
             return Err(ErrorData::invalid_params("since must be <= until", None));
         }
     }
@@ -1166,4 +1195,58 @@ fn handle_bootstrap_session(
     let value = serde_json::to_value(&report)
         .map_err(|e| ErrorData::internal_error(format!("serialize report: {e}"), None))?;
     ok_json(value)
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5a: Outcome tracking handlers
+// ---------------------------------------------------------------------------
+
+fn parse_outcome(s: &str) -> Result<Outcome, ErrorData> {
+    match s {
+        "Positive" => Ok(Outcome::Positive),
+        "Negative" => Ok(Outcome::Negative),
+        "Neutral" => Ok(Outcome::Neutral),
+        other => Err(ErrorData::invalid_params(
+            format!("invalid outcome: {other} (expected Positive, Negative, or Neutral)"),
+            None,
+        )),
+    }
+}
+
+fn handle_record_outcome(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let fact_id = get_i64(&args, "fact_id")
+        .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
+    let outcome_str = get_str(&args, "outcome")
+        .ok_or_else(|| ErrorData::invalid_params("missing outcome", None))?;
+    let outcome = parse_outcome(&outcome_str)?;
+
+    let event_id = engine
+        .record_outcome(fact_id, outcome)
+        .map_err(to_mcp_error)?;
+
+    ok_json(json!({
+        "event_id": event_id,
+        "fact_id": fact_id,
+        "outcome": outcome,
+    }))
+}
+
+fn handle_outcome_counts(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let fact_id = get_i64(&args, "fact_id")
+        .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
+
+    let counts = engine.get_outcome_counts(fact_id).map_err(to_mcp_error)?;
+
+    ok_json(json!({
+        "fact_id": fact_id,
+        "positive": counts.positive,
+        "negative": counts.negative,
+        "neutral": counts.neutral,
+    }))
 }

--- a/memory-engine-mcp/tests/tool_roundtrip.rs
+++ b/memory-engine-mcp/tests/tool_roundtrip.rs
@@ -726,9 +726,13 @@ fn unknown_tool_returns_error() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn all_tool_definitions_returns_18() {
+fn all_tool_definitions_returns_20() {
     let defs = tools::all_tool_definitions();
-    assert_eq!(defs.len(), 18, "expected 10 P0 + 5 P1 + 3 P2 tools");
+    assert_eq!(
+        defs.len(),
+        20,
+        "expected 10 P0 + 5 P1 + 3 P2 + 2 Phase 5a tools"
+    );
 }
 
 #[test]

--- a/memory-engine-mcp/tests/tools.rs
+++ b/memory-engine-mcp/tests/tools.rs
@@ -274,3 +274,98 @@ fn test_dump_state_default_path() {
 
     std::fs::remove_file(path).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Outcome tracking (Phase 5a, #63)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_record_outcome_and_counts() {
+    let (engine, _dir) = test_engine();
+    let fact_id = add_test_fact(&engine, "outcome test fact");
+
+    // Record outcomes via MCP dispatch
+    let r1 = tools::dispatch(
+        "memory_record_outcome",
+        args(&[("fact_id", json!(fact_id)), ("outcome", json!("Positive"))]),
+        &engine,
+        None,
+        None,
+        3,
+    )
+    .unwrap();
+    let v1 = extract_json(&r1);
+    assert_eq!(v1["fact_id"], fact_id);
+    assert_eq!(v1["outcome"], "Positive");
+    assert!(v1["event_id"].as_i64().unwrap() > 0);
+
+    let _ = tools::dispatch(
+        "memory_record_outcome",
+        args(&[("fact_id", json!(fact_id)), ("outcome", json!("Negative"))]),
+        &engine,
+        None,
+        None,
+        3,
+    )
+    .unwrap();
+
+    let _ = tools::dispatch(
+        "memory_record_outcome",
+        args(&[("fact_id", json!(fact_id)), ("outcome", json!("Positive"))]),
+        &engine,
+        None,
+        None,
+        3,
+    )
+    .unwrap();
+
+    // Query counts
+    let r2 = tools::dispatch(
+        "memory_outcome_counts",
+        args(&[("fact_id", json!(fact_id))]),
+        &engine,
+        None,
+        None,
+        3,
+    )
+    .unwrap();
+    let v2 = extract_json(&r2);
+    assert_eq!(v2["fact_id"], fact_id);
+    assert_eq!(v2["positive"], 2);
+    assert_eq!(v2["negative"], 1);
+    assert_eq!(v2["neutral"], 0);
+}
+
+#[test]
+fn test_record_outcome_nonexistent_fact() {
+    let (engine, _dir) = test_engine();
+
+    let result = tools::dispatch(
+        "memory_record_outcome",
+        args(&[("fact_id", json!(999)), ("outcome", json!("Positive"))]),
+        &engine,
+        None,
+        None,
+        3,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_record_outcome_invalid_variant() {
+    let (engine, _dir) = test_engine();
+    let fact_id = add_test_fact(&engine, "variant test");
+
+    let result = tools::dispatch(
+        "memory_record_outcome",
+        args(&[
+            ("fact_id", json!(fact_id)),
+            ("outcome", json!("InvalidVariant")),
+        ]),
+        &engine,
+        None,
+        None,
+        3,
+    );
+    assert!(result.is_err());
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -25,6 +25,7 @@ mod forgetting;
 mod graph;
 mod ingest;
 mod inspect;
+mod outcome;
 mod query;
 mod restore;
 mod resume;

--- a/src/engine/outcome.rs
+++ b/src/engine/outcome.rs
@@ -1,11 +1,15 @@
 use chrono::Utc;
-
-use crate::error::{MemoryError, Result};
-use crate::store::events::{EventFilter, EventStore};
+use rusqlite::params;
+use crate::error::Result;
+use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
 use crate::types::{EventType, NewEvent, Outcome, OutcomeCounts};
 
 use super::MemoryEngine;
+
+/// Root scope ID as inserted by `init_schema`. Outcome signals are cross-scope
+/// and always written to the root.
+const ROOT_SCOPE_ID: i64 = 1;
 
 impl MemoryEngine {
     // --- Public API: Outcome tracking ---
@@ -23,11 +27,12 @@ impl MemoryEngine {
     /// - [`MemoryError::ReadOnly`] if the engine is read-only.
     /// - [`MemoryError::Database`] on insert failure.
     pub fn record_outcome(&self, fact_id: i64, outcome: Outcome) -> Result<i64> {
-        // Validate fact exists via read pool — no write lock needed for check.
+        // Validate fact exists via read pool — propagate DB errors as-is,
+        // only remap NotFound for a clearer message.
         self.with_read(|conn| {
             FactStore::new(conn, self.embed_dim)
                 .get(fact_id)
-                .map_err(|_| MemoryError::NotFound(format!("fact {fact_id}")))
+                .map(|_| ())
         })?;
 
         let event = NewEvent {
@@ -39,7 +44,7 @@ impl MemoryEngine {
             }),
             source: "outcome_tracking".into(),
             session_id: None,
-            scope_id: 1, // root scope — outcome signals are cross-scope
+            scope_id: ROOT_SCOPE_ID,
             origin_node_id: "local".into(),
             sequence_id: 0,
             created_at: None,
@@ -51,44 +56,42 @@ impl MemoryEngine {
 
     /// Return aggregated outcome counts for a fact.
     ///
-    /// Scans all [`EventType::OutcomeSignal`] events whose payload references
-    /// `fact_id` and tallies positive, negative, and neutral outcomes.
-    ///
-    /// Returns [`OutcomeCounts::default()`] (all zeros) if no outcomes have
-    /// been recorded — this is not an error.
+    /// Pushes `fact_id` filtering into SQL via `json_extract` so only matching
+    /// events are scanned. Returns [`OutcomeCounts::default()`] (all zeros) if
+    /// the fact exists but has no outcomes recorded.
     ///
     /// # Errors
     ///
+    /// - [`MemoryError::NotFound`] if `fact_id` does not exist.
     /// - [`MemoryError::Database`] on query failure.
     pub fn get_outcome_counts(&self, fact_id: i64) -> Result<OutcomeCounts> {
         self.with_read(|conn| {
-            let store = EventStore::new(conn, &self.upcaster_registry);
+            // Validate fact exists (consistent with record_outcome).
+            FactStore::new(conn, self.embed_dim)
+                .get(fact_id)
+                .map(|_| ())?;
 
-            let filter = EventFilter {
-                event_type: Some(EventType::OutcomeSignal),
-                ..EventFilter::default()
-            };
-
-            let events = store.list(&filter)?;
+            // Aggregate in SQL — avoids loading all OutcomeSignal events into memory.
+            let mut stmt = conn.prepare(
+                "SELECT json_extract(payload, '$.outcome') AS outcome, COUNT(*) AS cnt
+                 FROM events
+                 WHERE event_type = 'OutcomeSignal'
+                   AND json_extract(payload, '$.fact_id') = ?1
+                 GROUP BY outcome",
+            )?;
 
             let mut counts = OutcomeCounts::default();
-            for event in &events {
-                let payload_fact_id = event.payload.get("fact_id").and_then(|v| v.as_i64());
-                if payload_fact_id != Some(fact_id) {
-                    continue;
-                }
+            let rows = stmt.query_map(params![fact_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+            })?;
 
-                let outcome_str = event
-                    .payload
-                    .get("outcome")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-
-                match outcome_str {
-                    "Positive" => counts.positive += 1,
-                    "Negative" => counts.negative += 1,
-                    "Neutral" => counts.neutral += 1,
-                    _ => {} // skip malformed payloads
+            for row in rows {
+                let (outcome_str, cnt) = row?;
+                match outcome_str.as_str() {
+                    "Positive" => counts.positive = cnt,
+                    "Negative" => counts.negative = cnt,
+                    "Neutral" => counts.neutral = cnt,
+                    _ => {} // skip unknown variants (forward-compat)
                 }
             }
 

--- a/src/engine/outcome.rs
+++ b/src/engine/outcome.rs
@@ -1,9 +1,9 @@
-use chrono::Utc;
-use rusqlite::params;
 use crate::error::Result;
 use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
 use crate::types::{EventType, NewEvent, Outcome, OutcomeCounts};
+use chrono::Utc;
+use rusqlite::params;
 
 use super::MemoryEngine;
 

--- a/src/engine/outcome.rs
+++ b/src/engine/outcome.rs
@@ -1,0 +1,98 @@
+use chrono::Utc;
+
+use crate::error::{MemoryError, Result};
+use crate::store::events::{EventFilter, EventStore};
+use crate::store::facts::FactStore;
+use crate::types::{EventType, NewEvent, Outcome, OutcomeCounts};
+
+use super::MemoryEngine;
+
+impl MemoryEngine {
+    // --- Public API: Outcome tracking ---
+
+    /// Record an outcome signal for a fact.
+    ///
+    /// Appends an [`EventType::OutcomeSignal`] event to the event log with
+    /// payload `{"fact_id": <id>, "outcome": "<variant>"}`. The fact must
+    /// exist (active or expired); recording on a nonexistent fact returns
+    /// [`MemoryError::NotFound`].
+    ///
+    /// # Errors
+    ///
+    /// - [`MemoryError::NotFound`] if `fact_id` does not exist.
+    /// - [`MemoryError::ReadOnly`] if the engine is read-only.
+    /// - [`MemoryError::Database`] on insert failure.
+    pub fn record_outcome(&self, fact_id: i64, outcome: Outcome) -> Result<i64> {
+        // Validate fact exists via read pool — no write lock needed for check.
+        self.with_read(|conn| {
+            FactStore::new(conn, self.embed_dim)
+                .get(fact_id)
+                .map_err(|_| MemoryError::NotFound(format!("fact {fact_id}")))
+        })?;
+
+        let event = NewEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::OutcomeSignal,
+            payload: serde_json::json!({
+                "fact_id": fact_id,
+                "outcome": outcome,
+            }),
+            source: "outcome_tracking".into(),
+            session_id: None,
+            scope_id: 1, // root scope — outcome signals are cross-scope
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
+        };
+
+        let conn = self.write_conn()?;
+        EventStore::new(&conn, &self.upcaster_registry).insert(&event)
+    }
+
+    /// Return aggregated outcome counts for a fact.
+    ///
+    /// Scans all [`EventType::OutcomeSignal`] events whose payload references
+    /// `fact_id` and tallies positive, negative, and neutral outcomes.
+    ///
+    /// Returns [`OutcomeCounts::default()`] (all zeros) if no outcomes have
+    /// been recorded — this is not an error.
+    ///
+    /// # Errors
+    ///
+    /// - [`MemoryError::Database`] on query failure.
+    pub fn get_outcome_counts(&self, fact_id: i64) -> Result<OutcomeCounts> {
+        self.with_read(|conn| {
+            let store = EventStore::new(conn, &self.upcaster_registry);
+
+            let filter = EventFilter {
+                event_type: Some(EventType::OutcomeSignal),
+                ..EventFilter::default()
+            };
+
+            let events = store.list(&filter)?;
+
+            let mut counts = OutcomeCounts::default();
+            for event in &events {
+                let payload_fact_id = event.payload.get("fact_id").and_then(|v| v.as_i64());
+                if payload_fact_id != Some(fact_id) {
+                    continue;
+                }
+
+                let outcome_str = event
+                    .payload
+                    .get("outcome")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+
+                match outcome_str {
+                    "Positive" => counts.positive += 1,
+                    "Negative" => counts.negative += 1,
+                    "Neutral" => counts.neutral += 1,
+                    _ => {} // skip malformed payloads
+                }
+            }
+
+            Ok(counts)
+        })
+    }
+}

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -2995,10 +2995,7 @@ fn record_outcome_nonexistent_fact_returns_not_found() {
 
     let result = engine.record_outcome(999, crate::types::Outcome::Negative);
     assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err(),
-        MemoryError::NotFound(msg) if msg.contains("999")
-    ));
+    assert!(matches!(result.unwrap_err(), MemoryError::NotFound(_)));
 }
 
 #[test]
@@ -3022,6 +3019,15 @@ fn record_outcome_read_only_returns_error() {
     let result = engine.record_outcome(fact_id, crate::types::Outcome::Positive);
     assert!(result.is_err());
     assert!(matches!(result.unwrap_err(), MemoryError::ReadOnly));
+}
+
+#[test]
+fn get_outcome_counts_nonexistent_fact_returns_not_found() {
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+
+    let result = engine.get_outcome_counts(999);
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), MemoryError::NotFound(_)));
 }
 
 #[test]

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -2975,6 +2975,129 @@ fn add_facts_batch_temporal_consistency() {
 // Snapshot integration tests
 // ---------------------------------------------------------------------------
 
+// --- Outcome tracking tests (#63) ---
+
+#[test]
+fn record_outcome_returns_event_id() {
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    let fact = make_new_fact("outcome target", vec![0.5; DIM]);
+    let fact_id = insert_raw_fact(&engine, &fact);
+
+    let event_id = engine
+        .record_outcome(fact_id, crate::types::Outcome::Positive)
+        .unwrap();
+    assert!(event_id > 0);
+}
+
+#[test]
+fn record_outcome_nonexistent_fact_returns_not_found() {
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+
+    let result = engine.record_outcome(999, crate::types::Outcome::Negative);
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        MemoryError::NotFound(msg) if msg.contains("999")
+    ));
+}
+
+#[test]
+fn record_outcome_read_only_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Create DB with a fact
+    let fact_id = {
+        let config = EngineConfig::new(db_path.clone(), DIM);
+        let engine = MemoryEngine::open(&config).unwrap();
+        let fact = make_new_fact("pinned for ro", vec![0.5; DIM]);
+        insert_raw_fact(&engine, &fact)
+    };
+
+    // Re-open read-only
+    let mut config = EngineConfig::new(db_path, DIM);
+    config.read_only = true;
+    let engine = MemoryEngine::open(&config).unwrap();
+
+    let result = engine.record_outcome(fact_id, crate::types::Outcome::Positive);
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), MemoryError::ReadOnly));
+}
+
+#[test]
+fn get_outcome_counts_no_outcomes_returns_zeros() {
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    let fact = make_new_fact("no outcomes", vec![0.5; DIM]);
+    let fact_id = insert_raw_fact(&engine, &fact);
+
+    let counts = engine.get_outcome_counts(fact_id).unwrap();
+    assert_eq!(counts.positive, 0);
+    assert_eq!(counts.negative, 0);
+    assert_eq!(counts.neutral, 0);
+}
+
+#[test]
+fn get_outcome_counts_tallies_correctly() {
+    use crate::types::Outcome;
+
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    let fact = make_new_fact("tallied fact", vec![0.5; DIM]);
+    let fact_id = insert_raw_fact(&engine, &fact);
+
+    // Record mixed outcomes
+    engine.record_outcome(fact_id, Outcome::Positive).unwrap();
+    engine.record_outcome(fact_id, Outcome::Positive).unwrap();
+    engine.record_outcome(fact_id, Outcome::Negative).unwrap();
+    engine.record_outcome(fact_id, Outcome::Neutral).unwrap();
+    engine.record_outcome(fact_id, Outcome::Positive).unwrap();
+
+    let counts = engine.get_outcome_counts(fact_id).unwrap();
+    assert_eq!(counts.positive, 3);
+    assert_eq!(counts.negative, 1);
+    assert_eq!(counts.neutral, 1);
+}
+
+#[test]
+fn get_outcome_counts_isolates_per_fact() {
+    use crate::types::Outcome;
+
+    let engine = MemoryEngine::open_memory(DIM).unwrap();
+    let f1 = insert_raw_fact(&engine, &make_new_fact("fact one", vec![0.5; DIM]));
+    let f2 = insert_raw_fact(&engine, &make_new_fact("fact two", vec![0.3; DIM]));
+
+    engine.record_outcome(f1, Outcome::Positive).unwrap();
+    engine.record_outcome(f1, Outcome::Positive).unwrap();
+    engine.record_outcome(f2, Outcome::Negative).unwrap();
+
+    let c1 = engine.get_outcome_counts(f1).unwrap();
+    assert_eq!(c1.positive, 2);
+    assert_eq!(c1.negative, 0);
+
+    let c2 = engine.get_outcome_counts(f2).unwrap();
+    assert_eq!(c2.positive, 0);
+    assert_eq!(c2.negative, 1);
+}
+
+#[test]
+fn outcome_serde_round_trip() {
+    use crate::types::Outcome;
+
+    for variant in [Outcome::Positive, Outcome::Negative, Outcome::Neutral] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: Outcome = serde_json::from_str(&json).unwrap();
+        assert_eq!(variant, back);
+    }
+}
+
+#[test]
+fn outcome_display() {
+    use crate::types::Outcome;
+
+    assert_eq!(Outcome::Positive.to_string(), "positive");
+    assert_eq!(Outcome::Negative.to_string(), "negative");
+    assert_eq!(Outcome::Neutral.to_string(), "neutral");
+}
+
 mod snapshot_integration {
     use super::*;
 

--- a/src/store/events.rs
+++ b/src/store/events.rs
@@ -31,6 +31,7 @@ pub(crate) const fn event_type_to_str(et: &EventType) -> &'static str {
         EventType::ToolCall => "ToolCall",
         EventType::MemoryOp => "MemoryOp",
         EventType::SystemEvent => "SystemEvent",
+        EventType::OutcomeSignal => "OutcomeSignal",
     }
 }
 
@@ -40,6 +41,7 @@ fn str_to_event_type(s: &str) -> Result<EventType> {
         "ToolCall" => Ok(EventType::ToolCall),
         "MemoryOp" => Ok(EventType::MemoryOp),
         "SystemEvent" => Ok(EventType::SystemEvent),
+        "OutcomeSignal" => Ok(EventType::OutcomeSignal),
         other => Err(MemoryError::NotFound(format!(
             "unknown event type: {other}"
         ))),

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,39 @@ pub enum EventType {
     ToolCall,
     MemoryOp,
     SystemEvent,
+    /// Outcome feedback signal for a fact (positive, negative, or neutral).
+    /// Payload carries `{"fact_id": i64, "outcome": "Positive"|"Negative"|"Neutral"}`.
+    OutcomeSignal,
+}
+
+/// Outcome of using a fact — consumer-supplied feedback signal.
+///
+/// Stored as an [`EventType::OutcomeSignal`] event in the append-only log.
+/// DreamCycle queries outcome history to adjust importance scores:
+/// consistently negative outcomes decrease importance, positive ones increase it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Outcome {
+    Positive,
+    Negative,
+    Neutral,
+}
+
+impl fmt::Display for Outcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Positive => write!(f, "positive"),
+            Self::Negative => write!(f, "negative"),
+            Self::Neutral => write!(f, "neutral"),
+        }
+    }
+}
+
+/// Aggregated outcome counts for a single fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct OutcomeCounts {
+    pub positive: u32,
+    pub negative: u32,
+    pub neutral: u32,
 }
 
 /// Type of fact (`CoALA` mapping: Episodic, Semantic, Procedural).


### PR DESCRIPTION
## Summary

- Adds `Outcome` enum (`Positive`, `Negative`, `Neutral`) and `EventType::OutcomeSignal` variant for consumer-supplied fact feedback signals
- `MemoryEngine::record_outcome(fact_id, outcome)` validates the fact exists then appends an outcome event to the append-only log
- `MemoryEngine::get_outcome_counts(fact_id)` returns aggregated `OutcomeCounts` (positive/negative/neutral tallies)
- CLI: `record-outcome` and `outcome-counts` commands
- MCP: `memory_record_outcome` and `memory_outcome_counts` tools
- No schema migration — outcome signals are events, not columns (preserves append-only semantics)
- 8 new tests covering serde round-trip, error paths (NotFound, ReadOnly), per-fact isolation, and correct tallying

## Design decisions

- `OutcomeSignal` is a flat `EventType` variant (no data in the variant itself); `fact_id` and `outcome` live in the event `payload` JSON — consistent with how all events work
- `get_outcome_counts` scans `OutcomeSignal` events and filters in Rust — acceptable for Phase 5a volumes; can be optimized with a SQL view or dedicated table if needed
- Outcome signals use `scope_id: 1` (root) because they're cross-scope feedback, not scoped knowledge

## Dependencies

- Consumed by: #49 (DreamCycle rescoring), #43 (session log bootstrap outcome classification)

## Test plan

- [x] `cargo test --workspace` — 742 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets` — 0 errors
- [x] `cargo fmt --check` — clean
- [x] Manual CLI smoke test with a real database
- [x] MCP tool invocation via MCP dispatch integration tests

Fixes #63