### PR TITLE
feat: Phase 5a provenance infrastructure — PromotionProvenance + LineageTable

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -385,7 +385,7 @@ Phase 4a ✅, 4b ✅, and 4c ✅ are complete. Phase 5 is **unblocked on the cri
 
 **Phase 5 internal dependencies:**
 
-- #55 (provenance) + #63 (outcome tracking) are prerequisites for #49 (DreamCycle)
+- #55 (provenance) ✅ + #63 (outcome tracking) are prerequisites for #49 (DreamCycle)
 - #48 (InsightStream) is independent, can ship first
 - #132 (FactType::Prediction) and #133 (spreading activation) can be parallel with #49
 - #54 (sample_dormant) and #134 (vitality boosts) are independent of everything, any time
@@ -404,7 +404,7 @@ Phase 4a ✅, 4b ✅, and 4c ✅ are complete. Phase 5 is **unblocked on the cri
 | DreamCycle trait — cognitive pipeline ([#49](https://github.com/dutiona/memory-engine/issues/49), [#47](https://github.com/dutiona/memory-engine/issues/47) absorbed) | Full batch pipeline: consolidation → pattern detection → promotion → rescoring. Returns delta-based `CycleReport`. **Research update:** delta-based output (R7, ACE), retrieve-before-reflect (R8, DC), abstract pattern extraction (R9, AWM/APC/GEPA), hierarchical composition (R13, AWM). **Competitive urgency:** Signet, Hermes, Auto Dream implement similar pipelines. Single-agent design — multi-agent DreamCycle requires Byzantine fault tolerance (see Deferred) |
 | Outcome tracking ([#63](https://github.com/dutiona/memory-engine/issues/63))                                                                                          | `EventType::OutcomeSignal` for fact feedback loops. `record_outcome(fact_id, outcome)` API. Feeds DreamCycle rescoring. **Research basis:** ACE, Reflexion, AWM, GEPA                                                                                                                                                                                                                                                                                                        |
 | `sample_dormant()` API ([#54](https://github.com/dutiona/memory-engine/issues/54))                                                                                    | Passive resonance for autonomous agents. HNSW search filtered for dormant facts. Consumer-driven                                                                                                                                                                                                                                                                                                                                                                             |
-| Provenance infrastructure ([#55](https://github.com/dutiona/memory-engine/issues/55))                                                                                 | `PromotionProvenance` envelope + sidecar `LineageTable` in SQLite. Source fact expiry (`t_expired` set) with lineage preservation. **Structured evidence typing:** `EvidenceBasis { Observed, Inferred, Synthesized }`. **Adversarial self-review** step before promotion                                                                                                                                                                                                    |
+| ~~Provenance infrastructure~~ ([#55](https://github.com/dutiona/memory-engine/issues/55)) ✅                                                                           | `PromotionProvenance` envelope + sidecar `LineageTable` in SQLite. Source fact expiry (`t_expired` set) with lineage preservation. Done: [PR #223](https://github.com/dutiona/memory-engine/pull/223). **Remaining (separate issues):** structured evidence typing `EvidenceBasis { Observed, Inferred, Synthesized }` (#159), adversarial self-review step (#161)                                                                                                            |
 | `DreamCycleConfig` ([#56](https://github.com/dutiona/memory-engine/issues/56))                                                                                        | ±2 symmetric rescoring, quarantine path for contradictions. **Research update:** compression as opt-in archival (R10, ACE/DC), Pareto-diverse promotion (R11, GEPA)                                                                                                                                                                                                                                                                                                          |
 | Three-layer identity output ([#57](https://github.com/dutiona/memory-engine/issues/57))                                                                               | ANCHORS/CORE/PREDICTIONS structure in `CycleReport`. Each item: `{pattern, directive, false_positive}`                                                                                                                                                                                                                                                                                                                                                                       |
 | `FactType::Prediction` ([#132](https://github.com/dutiona/memory-engine/issues/132))                                                                                  | Predictive memory with `t_predicted` timestamp. JEPA-inspired gap — facts that encode expectations for future validation                                                                                                                                                                                                                                                                                                                                                     |
@@ -425,7 +425,7 @@ Phase 4a ✅, 4b ✅, and 4c ✅ are complete. Phase 5 is **unblocked on the cri
   - InsightStream trait (or `FactType::Insight` — decide during implementation)
   - DreamCycle trait with delta-based `CycleReport` (R7) and retrieve-before-reflect (R8)
   - Outcome tracking — `EventType::OutcomeSignal` (#63, R6)
-  - `PromotionProvenance` + `LineageTable`
+  - `PromotionProvenance` + `LineageTable` ✅ ([PR #223](https://github.com/dutiona/memory-engine/pull/223))
   - `DreamCycleConfig` with compression as opt-in archival (R10)
   - Three-layer identity output
   - `FactType::Prediction` with `t_predicted` (#132)
@@ -533,7 +533,7 @@ Consumer (AI agent, CLI tool, MCP server)
 │  ├─ EdgeStore (graph persistence)        │
 │  ├─ SummaryStore                         │
 │  ├─ ScopeStore (hierarchical scoping)   │  ← Phase 3 ✅
-│  └─ LineageTable (provenance sidecar)   │  ← Phase 5
+│  └─ LineageTable (provenance sidecar)   │  ← Phase 5a ✅
 ├──────────────────────────────────────────┤
 │  Graph (petgraph DiGraph)                │  ← Phase 2 ✅
 ├──────────────────────────────────────────┤

--- a/docs/superpowers/plans/2026-04-08-provenance-infrastructure.md
+++ b/docs/superpowers/plans/2026-04-08-provenance-infrastructure.md
@@ -1,0 +1,1006 @@
+# Phase 5a: Provenance Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add provenance tracking for wisdom promotions — a lightweight `PromotionProvenance` envelope on each promoted fact, backed by a sidecar `lineage` table in SQLite for full source chains.
+
+**Architecture:** New `lineage` table (sidecar, not embedded in `facts`) stores the full source-fact chain per promoted wisdom fact. A `PromotionProvenance` struct carries the lightweight envelope (source count, session count, confidence, representative IDs). A `LineageStore` module handles CRUD. The `MemoryEngine` facade exposes 4 public methods: `record_lineage`, `get_provenance`, `get_full_lineage`, and `delete_lineage`. Schema migration v7→v8 adds the table.
+
+**Tech Stack:** Rust, rusqlite, chrono, serde, serde_json
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/store/lineage.rs` | `LineageStore` — CRUD for `lineage` table |
+| Modify | `src/store/mod.rs` | Register `lineage` submodule |
+| Modify | `src/types.rs` | `PromotionProvenance`, `LineageRecord`, `NewLineageRecord` structs |
+| Modify | `src/error.rs` | `Lineage` error variant |
+| Modify | `src/store/schema.rs` | Migration v7→v8, bump version, add DDL |
+| Create | `src/engine/lineage.rs` | Engine facade methods for provenance |
+| Modify | `src/engine/mod.rs` | Register `lineage` submodule |
+| Modify | `src/lib.rs` | Re-export new public types |
+
+---
+
+### Task 1: Add types — `PromotionProvenance`, `LineageRecord`, `NewLineageRecord`
+
+**Files:**
+- Modify: `src/types.rs`
+
+- [ ] **Step 1: Write the test for `PromotionProvenance` serde round-trip**
+
+Add at the bottom of the `#[cfg(test)] mod tests` block in `src/types.rs`:
+
+```rust
+#[test]
+fn promotion_provenance_round_trip_json() {
+    let prov = PromotionProvenance {
+        source_count: 5,
+        session_count: 3,
+        date_range_start: Utc::now(),
+        date_range_end: Utc::now(),
+        confidence: 0.87,
+        method_version: "dreamcycle-v1".into(),
+        representative_ids: vec![10, 20, 30],
+        lineage_id: 42,
+    };
+    let json = serde_json::to_string(&prov).unwrap();
+    let back: PromotionProvenance = serde_json::from_str(&json).unwrap();
+    assert_eq!(prov, back);
+}
+
+#[test]
+fn lineage_record_round_trip_json() {
+    let rec = LineageRecord {
+        lineage_id: 1,
+        wisdom_fact_id: 42,
+        source_fact_ids: vec![10, 20, 30, 40, 50],
+    };
+    let json = serde_json::to_string(&rec).unwrap();
+    let back: LineageRecord = serde_json::from_str(&json).unwrap();
+    assert_eq!(rec, back);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p memory-engine promotion_provenance_round_trip -- --nocapture`
+Expected: FAIL — `PromotionProvenance` not defined.
+
+- [ ] **Step 3: Add the type definitions**
+
+Add these structs to `src/types.rs`, above the `// --- Options ---` section:
+
+```rust
+// --- Provenance (Phase 5a) ---
+
+/// Lightweight provenance envelope attached to promoted wisdom facts.
+///
+/// Carries summary statistics about the promotion (how many source facts,
+/// across how many sessions, confidence score). The full source chain lives
+/// in the sidecar `lineage` table, loaded on demand via `lineage_id`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PromotionProvenance {
+    pub source_count: u32,
+    pub session_count: u32,
+    pub date_range_start: DateTime<Utc>,
+    pub date_range_end: DateTime<Utc>,
+    pub confidence: f64,
+    pub method_version: String,
+    /// 3-5 most representative source fact IDs (for quick human review).
+    pub representative_ids: Vec<i64>,
+    /// Foreign key to the `lineage` table for the full source chain.
+    pub lineage_id: i64,
+}
+
+/// A row in the `lineage` sidecar table (full source chain).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineageRecord {
+    pub lineage_id: i64,
+    pub wisdom_fact_id: i64,
+    pub source_fact_ids: Vec<i64>,
+}
+
+/// Insert descriptor for a new lineage record (DB assigns `lineage_id`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NewLineageRecord {
+    pub wisdom_fact_id: i64,
+    pub source_fact_ids: Vec<i64>,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p memory-engine promotion_provenance_round_trip lineage_record_round_trip -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types.rs
+git commit -m "feat(types): add PromotionProvenance and LineageRecord types
+
+Phase 5a provenance infrastructure (#55). PromotionProvenance is the
+lightweight envelope for promoted wisdom facts. LineageRecord holds the
+full source chain in the sidecar lineage table."
+```
+
+---
+
+### Task 2: Add `Lineage` error variant
+
+**Files:**
+- Modify: `src/error.rs`
+
+- [ ] **Step 1: Write the test for the new error variant**
+
+Add at the bottom of the `#[cfg(test)] mod tests` block in `src/error.rs`:
+
+```rust
+#[test]
+fn lineage_error_display() {
+    let err = MemoryError::Lineage("wisdom fact 42 has no lineage record".into());
+    assert_eq!(
+        err.to_string(),
+        "lineage error: wisdom fact 42 has no lineage record"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p memory-engine lineage_error_display -- --nocapture`
+Expected: FAIL — no `Lineage` variant.
+
+- [ ] **Step 3: Add the error variant**
+
+Add to the `MemoryError` enum in `src/error.rs`, after the `ReadOnly` variant:
+
+```rust
+#[error("lineage error: {0}")]
+Lineage(String),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p memory-engine lineage_error_display -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run workspace build to check CLI/MCP crates still compile**
+
+Run: `cargo build --workspace`
+Expected: compiles cleanly. The new variant is non-exhaustive to downstream crates (they use `MemoryError` via the `error` module), and no match arms in CLI/MCP should break — they use `?` propagation, not exhaustive matching.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/error.rs
+git commit -m "feat(error): add Lineage error variant
+
+For provenance infrastructure (#55). Used when lineage records are
+missing, malformed, or reference nonexistent facts."
+```
+
+---
+
+### Task 3: Schema migration v7 → v8 — add `lineage` table
+
+**Files:**
+- Modify: `src/store/schema.rs`
+
+- [ ] **Step 1: Write the migration test**
+
+Add at the end of the test module in `src/store/schema.rs` (follow the pattern of `migrate_v6_to_v7_adds_archive_manifest`):
+
+```rust
+#[test]
+fn migrate_v7_to_v8_adds_lineage_table() {
+    let conn = open_memory().unwrap();
+    // Start at v7
+    init_schema(&conn).unwrap();
+    set_config(&conn, "schema_version", "7");
+
+    migrate(&conn, None).unwrap();
+
+    // Verify version bumped
+    let version = get_config(&conn, "schema_version").unwrap().unwrap();
+    assert_eq!(version, "8");
+
+    // Verify table exists with correct columns
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('lineage') WHERE name IN ('lineage_id', 'wisdom_fact_id', 'source_fact_ids', 'provenance')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 4, "lineage table should have 4 expected columns");
+
+    // Verify unique index on wisdom_fact_id
+    let idx_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_lineage_wisdom_fact_id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(idx_count, 1, "unique index on wisdom_fact_id should exist");
+}
+
+#[test]
+fn fresh_db_has_lineage_table() {
+    let conn = open_memory().unwrap();
+    init_schema(&conn).unwrap();
+
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('lineage')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(count > 0, "fresh DB should have lineage table");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p memory-engine migrate_v7_to_v8 fresh_db_has_lineage -- --nocapture`
+Expected: FAIL — no migration function, no DDL.
+
+- [ ] **Step 3: Write the migration function**
+
+Add after `migrate_v6_to_v7` in `src/store/schema.rs`:
+
+```rust
+fn migrate_v7_to_v8(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS lineage (
+            lineage_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id),
+            source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)),
+            provenance TEXT NOT NULL CHECK(json_valid(provenance))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_lineage_wisdom_fact_id
+            ON lineage(wisdom_fact_id);",
+    )?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Register the migration and bump the version**
+
+Update `CURRENT_SCHEMA_VERSION` from `7` to `8`.
+
+Add to the `MIGRATIONS` array:
+
+```rust
+(migrate_v7_to_v8, false),
+```
+
+- [ ] **Step 5: Add lineage table to `TABLES_DDL` for fresh databases**
+
+Add before the closing `";` of `TABLES_DDL`, after the `archive_manifest` unique index:
+
+```sql
+CREATE TABLE IF NOT EXISTS lineage (
+    lineage_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)),
+    provenance TEXT NOT NULL CHECK(json_valid(provenance))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_lineage_wisdom_fact_id
+    ON lineage(wisdom_fact_id);
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p memory-engine migrate_v7_to_v8 fresh_db_has_lineage -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 7: Run the full schema test suite**
+
+Run: `cargo test -p memory-engine schema -- -v`
+Expected: All schema tests pass (existing migrations unbroken).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/store/schema.rs
+git commit -m "feat(schema): add lineage table — migration v7→v8
+
+Sidecar table for provenance tracking (#55). Stores full source chain
+(source_fact_ids JSON array) and PromotionProvenance envelope (provenance
+JSON) per promoted wisdom fact. One-to-one with facts via unique index
+on wisdom_fact_id."
+```
+
+---
+
+### Task 4: Create `LineageStore` — CRUD for the lineage table
+
+**Files:**
+- Create: `src/store/lineage.rs`
+- Modify: `src/store/mod.rs`
+
+- [ ] **Step 1: Create `src/store/lineage.rs` with the store struct and test module skeleton**
+
+```rust
+use rusqlite::{params, Connection};
+
+use crate::error::{MemoryError, Result};
+use crate::types::{LineageRecord, NewLineageRecord, PromotionProvenance};
+
+/// Store for the `lineage` sidecar table — provenance tracking for promoted wisdom facts.
+pub struct LineageStore<'a> {
+    conn: &'a Connection,
+}
+
+#[allow(dead_code)] // complete CRUD API — engine facade wires methods incrementally
+impl<'a> LineageStore<'a> {
+    /// Create a new `LineageStore` borrowing the given connection.
+    #[must_use]
+    pub const fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::{init_schema, open_memory};
+
+    fn setup() -> rusqlite::Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        // Insert a dummy fact so FK constraints are satisfied
+        conn.execute(
+            "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, last_accessed, scope_id, importance_score)
+             VALUES (1, 'wisdom fact', 'abc123', X'00000000', 'semantic', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1, 0.9)",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, last_accessed, scope_id, importance_score)
+             VALUES (10, 'source 1', 'src1', X'00000000', 'episodic', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1, 0.5)",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, last_accessed, scope_id, importance_score)
+             VALUES (20, 'source 2', 'src2', X'00000000', 'episodic', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1, 0.5)",
+            [],
+        ).unwrap();
+        conn
+    }
+}
+```
+
+- [ ] **Step 2: Register the module in `src/store/mod.rs`**
+
+Add `pub mod lineage;` after the `pub mod facts;` line.
+
+- [ ] **Step 3: Write the failing test for `insert`**
+
+Add to the `tests` module in `src/store/lineage.rs`:
+
+```rust
+#[test]
+fn insert_and_get_by_wisdom_fact() {
+    let conn = setup();
+    let store = LineageStore::new(&conn);
+
+    let provenance = PromotionProvenance {
+        source_count: 2,
+        session_count: 1,
+        date_range_start: chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        date_range_end: chrono::DateTime::parse_from_rfc3339("2026-03-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        confidence: 0.85,
+        method_version: "dreamcycle-v1".into(),
+        representative_ids: vec![10, 20],
+        lineage_id: 0, // will be set by insert
+    };
+
+    let new_rec = NewLineageRecord {
+        wisdom_fact_id: 1,
+        source_fact_ids: vec![10, 20],
+    };
+
+    let lineage_id = store.insert(&new_rec, &provenance).unwrap();
+    assert!(lineage_id > 0);
+
+    let (record, prov) = store.get_by_wisdom_fact(1).unwrap();
+    assert_eq!(record.wisdom_fact_id, 1);
+    assert_eq!(record.source_fact_ids, vec![10, 20]);
+    assert_eq!(prov.source_count, 2);
+    assert_eq!(prov.confidence, 0.85);
+    assert_eq!(prov.method_version, "dreamcycle-v1");
+    assert_eq!(prov.lineage_id, lineage_id);
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cargo test -p memory-engine insert_and_get_by_wisdom_fact -- --nocapture`
+Expected: FAIL — `insert` method not defined.
+
+- [ ] **Step 5: Implement `insert` and `get_by_wisdom_fact`**
+
+Add to the `impl LineageStore` block:
+
+```rust
+/// Insert a new lineage record with its provenance envelope.
+/// Returns the auto-assigned `lineage_id`.
+///
+/// The `provenance.lineage_id` field is ignored on input — the DB assigns
+/// the ID, and the returned value is the authoritative one.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on insert failure (e.g., duplicate
+/// `wisdom_fact_id`, FK violation).
+pub fn insert(
+    &self,
+    record: &NewLineageRecord,
+    provenance: &PromotionProvenance,
+) -> Result<i64> {
+    let source_ids_json = serde_json::to_string(&record.source_fact_ids)?;
+    // Store provenance with the correct lineage_id placeholder — we'll
+    // update it after getting the rowid. Simpler: store without lineage_id
+    // in the JSON and set it in the returned struct at read time.
+    let prov_json = serde_json::to_string(provenance)?;
+
+    self.conn.execute(
+        "INSERT INTO lineage (wisdom_fact_id, source_fact_ids, provenance)
+         VALUES (?1, ?2, ?3)",
+        params![record.wisdom_fact_id, source_ids_json, prov_json],
+    )?;
+    Ok(self.conn.last_insert_rowid())
+}
+
+/// Look up the lineage record and provenance for a promoted wisdom fact.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Lineage` if no lineage exists for `wisdom_fact_id`.
+/// Returns `MemoryError::Serialization` if stored JSON is malformed.
+pub fn get_by_wisdom_fact(
+    &self,
+    wisdom_fact_id: i64,
+) -> Result<(LineageRecord, PromotionProvenance)> {
+    let mut stmt = self.conn.prepare(
+        "SELECT lineage_id, wisdom_fact_id, source_fact_ids, provenance
+         FROM lineage WHERE wisdom_fact_id = ?1",
+    )?;
+    let result = stmt.query_row(params![wisdom_fact_id], |row| {
+        let lineage_id: i64 = row.get(0)?;
+        let wfid: i64 = row.get(1)?;
+        let source_ids_json: String = row.get(2)?;
+        let prov_json: String = row.get(3)?;
+        Ok((lineage_id, wfid, source_ids_json, prov_json))
+    });
+    match result {
+        Ok((lineage_id, wfid, source_ids_json, prov_json)) => {
+            let source_fact_ids: Vec<i64> = serde_json::from_str(&source_ids_json)?;
+            let mut provenance: PromotionProvenance = serde_json::from_str(&prov_json)?;
+            provenance.lineage_id = lineage_id;
+            let record = LineageRecord {
+                lineage_id,
+                wisdom_fact_id: wfid,
+                source_fact_ids,
+            };
+            Ok((record, provenance))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Err(MemoryError::Lineage(
+            format!("no lineage record for wisdom fact {wisdom_fact_id}"),
+        )),
+        Err(e) => Err(MemoryError::Database(e)),
+    }
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cargo test -p memory-engine insert_and_get_by_wisdom_fact -v`
+Expected: PASS.
+
+- [ ] **Step 7: Write the failing test for `get_source_fact_ids` (lightweight accessor)**
+
+```rust
+#[test]
+fn get_source_fact_ids_returns_only_ids() {
+    let conn = setup();
+    let store = LineageStore::new(&conn);
+    let prov = test_provenance();
+    let new_rec = NewLineageRecord {
+        wisdom_fact_id: 1,
+        source_fact_ids: vec![10, 20],
+    };
+    store.insert(&new_rec, &prov).unwrap();
+
+    let ids = store.get_source_fact_ids(1).unwrap();
+    assert_eq!(ids, vec![10, 20]);
+}
+
+#[test]
+fn get_source_fact_ids_not_found() {
+    let conn = setup();
+    let store = LineageStore::new(&conn);
+    let err = store.get_source_fact_ids(999).unwrap_err();
+    assert!(matches!(err, MemoryError::Lineage(_)));
+}
+```
+
+Also add a `test_provenance()` helper to the test module:
+
+```rust
+fn test_provenance() -> PromotionProvenance {
+    PromotionProvenance {
+        source_count: 2,
+        session_count: 1,
+        date_range_start: chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        date_range_end: chrono::DateTime::parse_from_rfc3339("2026-03-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        confidence: 0.85,
+        method_version: "dreamcycle-v1".into(),
+        representative_ids: vec![10, 20],
+        lineage_id: 0,
+    }
+}
+```
+
+- [ ] **Step 8: Implement `get_source_fact_ids`**
+
+```rust
+/// Return just the source fact IDs for a wisdom fact's lineage.
+///
+/// Lighter than `get_by_wisdom_fact` — skips provenance deserialization.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Lineage` if no lineage exists.
+pub fn get_source_fact_ids(&self, wisdom_fact_id: i64) -> Result<Vec<i64>> {
+    let mut stmt = self.conn.prepare(
+        "SELECT source_fact_ids FROM lineage WHERE wisdom_fact_id = ?1",
+    )?;
+    let result = stmt.query_row(params![wisdom_fact_id], |row| {
+        let json: String = row.get(0)?;
+        Ok(json)
+    });
+    match result {
+        Ok(json) => Ok(serde_json::from_str(&json)?),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Err(MemoryError::Lineage(
+            format!("no lineage record for wisdom fact {wisdom_fact_id}"),
+        )),
+        Err(e) => Err(MemoryError::Database(e)),
+    }
+}
+```
+
+- [ ] **Step 9: Run tests**
+
+Run: `cargo test -p memory-engine get_source_fact_ids -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 10: Write failing test for `delete`**
+
+```rust
+#[test]
+fn delete_removes_lineage() {
+    let conn = setup();
+    let store = LineageStore::new(&conn);
+    let prov = test_provenance();
+    let new_rec = NewLineageRecord {
+        wisdom_fact_id: 1,
+        source_fact_ids: vec![10, 20],
+    };
+    store.insert(&new_rec, &prov).unwrap();
+
+    let deleted = store.delete(1).unwrap();
+    assert!(deleted);
+
+    let err = store.get_by_wisdom_fact(1).unwrap_err();
+    assert!(matches!(err, MemoryError::Lineage(_)));
+}
+
+#[test]
+fn delete_nonexistent_returns_false() {
+    let conn = setup();
+    let store = LineageStore::new(&conn);
+    let deleted = store.delete(999).unwrap();
+    assert!(!deleted);
+}
+```
+
+- [ ] **Step 11: Implement `delete`**
+
+```rust
+/// Delete the lineage record for a wisdom fact.
+///
+/// Returns `true` if a record was deleted, `false` if none existed.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure.
+pub fn delete(&self, wisdom_fact_id: i64) -> Result<bool> {
+    let rows = self.conn.execute(
+        "DELETE FROM lineage WHERE wisdom_fact_id = ?1",
+        params![wisdom_fact_id],
+    )?;
+    Ok(rows > 0)
+}
+```
+
+- [ ] **Step 12: Run tests**
+
+Run: `cargo test -p memory-engine delete_removes_lineage delete_nonexistent -v`
+Expected: PASS.
+
+- [ ] **Step 13: Write failing test for `has_lineage`**
+
+```rust
+#[test]
+fn has_lineage_check() {
+    let conn = setup();
+    let store = LineageStore::new(&conn);
+    assert!(!store.has_lineage(1).unwrap());
+
+    let prov = test_provenance();
+    let new_rec = NewLineageRecord {
+        wisdom_fact_id: 1,
+        source_fact_ids: vec![10, 20],
+    };
+    store.insert(&new_rec, &prov).unwrap();
+    assert!(store.has_lineage(1).unwrap());
+}
+```
+
+- [ ] **Step 14: Implement `has_lineage`**
+
+```rust
+/// Check whether a wisdom fact has a lineage record.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure.
+pub fn has_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
+    let count: i64 = self.conn.query_row(
+        "SELECT COUNT(*) FROM lineage WHERE wisdom_fact_id = ?1",
+        params![wisdom_fact_id],
+        |r| r.get(0),
+    )?;
+    Ok(count > 0)
+}
+```
+
+- [ ] **Step 15: Run all lineage store tests**
+
+Run: `cargo test -p memory-engine store::lineage -v`
+Expected: All pass.
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add src/store/lineage.rs src/store/mod.rs
+git commit -m "feat(store): add LineageStore for provenance sidecar table
+
+CRUD operations for the lineage table (#55): insert, get_by_wisdom_fact,
+get_source_fact_ids, delete, has_lineage. Follows FactStore/SummaryStore
+patterns — borrows connection, returns typed Results."
+```
+
+---
+
+### Task 5: Engine facade methods for provenance
+
+**Files:**
+- Create: `src/engine/lineage.rs`
+- Modify: `src/engine/mod.rs`
+
+- [ ] **Step 1: Create `src/engine/lineage.rs` with test skeleton**
+
+```rust
+use crate::error::Result;
+use crate::store::lineage::LineageStore;
+use crate::types::{LineageRecord, NewLineageRecord, PromotionProvenance};
+
+use super::MemoryEngine;
+
+impl MemoryEngine {
+    // Methods added in subsequent steps.
+}
+```
+
+- [ ] **Step 2: Register the module in `src/engine/mod.rs`**
+
+Add `mod lineage;` after the existing `mod inspect;` line.
+
+- [ ] **Step 3: Write the failing integration test for `record_lineage`**
+
+Add a test in `src/engine/lineage.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use crate::engine::MemoryEngine;
+    use crate::types::{NewLineageRecord, PromotionProvenance};
+    use chrono::Utc;
+
+    fn test_provenance() -> PromotionProvenance {
+        PromotionProvenance {
+            source_count: 2,
+            session_count: 1,
+            date_range_start: Utc::now(),
+            date_range_end: Utc::now(),
+            confidence: 0.85,
+            method_version: "dreamcycle-v1".into(),
+            representative_ids: vec![],
+            lineage_id: 0,
+        }
+    }
+
+    fn engine_with_facts() -> MemoryEngine {
+        use crate::types::{FactType, NewFact};
+        let engine = MemoryEngine::open_memory(4).unwrap();
+        // Insert wisdom fact
+        let conn = engine.pool.write();
+        let store = crate::store::facts::FactStore::new(&conn, 4);
+        let fact = NewFact {
+            content: "synthesized wisdom".into(),
+            content_hash: "w1".into(),
+            embedding: vec![0.1, 0.2, 0.3, 0.4],
+            fact_type: FactType::Semantic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.9,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+            scope_id: 1,
+            is_pinned: true,
+        };
+        store.insert(&fact).unwrap();
+        // Insert source facts
+        for (i, label) in ["source A", "source B"].iter().enumerate() {
+            let sf = NewFact {
+                content: label.to_string(),
+                content_hash: format!("s{i}"),
+                embedding: vec![0.0; 4],
+                fact_type: FactType::Episodic,
+                t_created: Utc::now(),
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                importance: 0.5,
+                access_count: 0,
+                last_accessed: Utc::now(),
+                metadata: serde_json::json!({}),
+                scope_id: 1,
+                is_pinned: false,
+            };
+            store.insert(&sf).unwrap();
+        }
+        drop(conn);
+        engine
+    }
+
+    #[test]
+    fn record_and_get_provenance() {
+        let engine = engine_with_facts();
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![2, 3],
+        };
+        let prov = test_provenance();
+        let lineage_id = engine.record_lineage(&new_rec, &prov).unwrap();
+        assert!(lineage_id > 0);
+
+        let (record, got_prov) = engine.get_provenance(1).unwrap();
+        assert_eq!(record.wisdom_fact_id, 1);
+        assert_eq!(record.source_fact_ids, vec![2, 3]);
+        assert_eq!(got_prov.source_count, 2);
+        assert_eq!(got_prov.lineage_id, lineage_id);
+    }
+
+    #[test]
+    fn get_full_lineage_returns_ids() {
+        let engine = engine_with_facts();
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![2, 3],
+        };
+        engine.record_lineage(&new_rec, &test_provenance()).unwrap();
+
+        let ids = engine.get_full_lineage(1).unwrap();
+        assert_eq!(ids, vec![2, 3]);
+    }
+
+    #[test]
+    fn delete_lineage_removes_record() {
+        let engine = engine_with_facts();
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![2, 3],
+        };
+        engine.record_lineage(&new_rec, &test_provenance()).unwrap();
+
+        let deleted = engine.delete_lineage(1).unwrap();
+        assert!(deleted);
+
+        let err = engine.get_provenance(1).unwrap_err();
+        assert!(matches!(err, crate::error::MemoryError::Lineage(_)));
+    }
+
+    #[test]
+    fn record_lineage_read_only_rejects() {
+        // Can't easily test read-only in memory, but verify the method
+        // goes through try_write by checking it works in normal mode.
+        let engine = engine_with_facts();
+        assert!(!engine.is_read_only());
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![2, 3],
+        };
+        let result = engine.record_lineage(&new_rec, &test_provenance());
+        assert!(result.is_ok());
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cargo test -p memory-engine record_and_get_provenance -- --nocapture`
+Expected: FAIL — `record_lineage` not defined.
+
+- [ ] **Step 5: Implement the four engine facade methods**
+
+In `src/engine/lineage.rs`, replace the empty `impl` block:
+
+```rust
+impl MemoryEngine {
+    /// Record provenance for a promoted wisdom fact.
+    ///
+    /// Writes to the `lineage` sidecar table via the writer connection.
+    /// Returns the auto-assigned `lineage_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::ReadOnly` if the engine is read-only.
+    /// Returns `MemoryError::Database` on insert failure.
+    pub fn record_lineage(
+        &self,
+        record: &NewLineageRecord,
+        provenance: &PromotionProvenance,
+    ) -> Result<i64> {
+        let conn = self.pool.try_write()?;
+        let store = LineageStore::new(&conn);
+        store.insert(record, provenance)
+    }
+
+    /// Retrieve the provenance envelope and lineage record for a wisdom fact.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Lineage` if no lineage exists.
+    pub fn get_provenance(
+        &self,
+        wisdom_fact_id: i64,
+    ) -> Result<(LineageRecord, PromotionProvenance)> {
+        let conn = self.pool.read();
+        let store = LineageStore::new(&conn);
+        store.get_by_wisdom_fact(wisdom_fact_id)
+    }
+
+    /// Retrieve just the full source-fact ID chain for a wisdom fact.
+    ///
+    /// Lighter than `get_provenance` — use when only the source chain is needed
+    /// (e.g., "Why?" button, debugging bad promotions).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Lineage` if no lineage exists.
+    pub fn get_full_lineage(&self, wisdom_fact_id: i64) -> Result<Vec<i64>> {
+        let conn = self.pool.read();
+        let store = LineageStore::new(&conn);
+        store.get_source_fact_ids(wisdom_fact_id)
+    }
+
+    /// Delete the lineage record for a wisdom fact (e.g., when reversing a promotion).
+    ///
+    /// Returns `true` if a record was deleted, `false` if none existed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::ReadOnly` if the engine is read-only.
+    pub fn delete_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
+        let conn = self.pool.try_write()?;
+        let store = LineageStore::new(&conn);
+        store.delete(wisdom_fact_id)
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p memory-engine engine::lineage -v`
+Expected: All 4 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/engine/lineage.rs src/engine/mod.rs
+git commit -m "feat(engine): expose provenance API on MemoryEngine facade
+
+Four public methods (#55): record_lineage, get_provenance,
+get_full_lineage, delete_lineage. Write methods go through try_write
+(read-only guard). Read methods use the reader pool."
+```
+
+---
+
+### Task 6: Re-export new types from `lib.rs`
+
+**Files:**
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Verify the types are already re-exported via `pub use types::*`**
+
+Check `src/lib.rs` — line `pub use types::*;` already glob-exports everything from `types.rs`. Since `PromotionProvenance`, `LineageRecord`, and `NewLineageRecord` were added to `types.rs`, they're already public. No changes needed.
+
+However, `LineageStore` should NOT be re-exported (it's an internal store detail — consumers use the engine facade).
+
+- [ ] **Step 2: Verify workspace compiles with all new public API**
+
+Run: `cargo build --workspace`
+Expected: All 3 crates compile.
+
+- [ ] **Step 3: Run full workspace tests**
+
+Run: `cargo test --workspace`
+Expected: All pass.
+
+- [ ] **Step 4: Run clippy on workspace**
+
+Run: `cargo clippy --workspace --all-targets`
+Expected: No warnings.
+
+- [ ] **Step 5: Commit (only if lib.rs needed changes)**
+
+If no changes needed, skip this commit.
+
+---
+
+### Task 7: Workspace verification gate
+
+- [ ] **Step 1: Full workspace build**
+
+Run: `cargo build --workspace`
+Expected: Clean.
+
+- [ ] **Step 2: Full workspace tests**
+
+Run: `cargo test --workspace`
+Expected: All pass.
+
+- [ ] **Step 3: Full workspace clippy**
+
+Run: `cargo clippy --workspace --all-targets`
+Expected: No warnings.
+
+- [ ] **Step 4: Format check**
+
+Run: `cargo fmt --check`
+Expected: Clean.

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -10,7 +10,7 @@ use memory_engine_embed::HttpEmbeddingProvider;
 use serde::{Deserialize, Serialize};
 
 use crate::db::open_engine;
-use crate::output::{print_json, OutputFormat};
+use crate::output::{OutputFormat, print_json};
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/memory-engine-cli/src/commands/dump.rs
+++ b/memory-engine-cli/src/commands/dump.rs
@@ -4,7 +4,7 @@ use memory_engine::inspect_types::ReplayFilter;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, truncate_str, OutputFormat};
+use crate::output::{self, OutputFormat, truncate_str};
 
 #[derive(clap::Args)]
 pub struct DumpArgs {

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use memory_engine::search::hybrid::MatchType;
 use memory_engine::MemoryQuery;
+use memory_engine::search::hybrid::MatchType;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, truncate_str, OutputFormat};
+use crate::output::{self, OutputFormat, truncate_str};
 
 #[derive(clap::Args)]
 pub struct QueryArgs {

--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -269,10 +269,12 @@ mod tests {
         let data = vec![serde_json::json!({"index": 0, "embedding": [0.1]})];
         let result = HttpEmbeddingProvider::parse_openai_batch(&data, 2);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("expected 2 results, got 1"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("expected 2 results, got 1")
+        );
     }
 
     #[test]
@@ -299,9 +301,11 @@ mod tests {
         let data = vec![serde_json::json!([0.1])];
         let result = HttpEmbeddingProvider::parse_ollama_batch(&data, 3);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("expected 3 results, got 1"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("expected 3 results, got 1")
+        );
     }
 }

--- a/memory-engine-mcp/src/error.rs
+++ b/memory-engine-mcp/src/error.rs
@@ -60,9 +60,7 @@ pub fn to_mcp_error(err: MemoryError) -> ErrorData {
             None,
         ),
 
-        MemoryError::Lineage(msg) => {
-            ErrorData::internal_error(format!("lineage error: {msg}"), None)
-        }
+        MemoryError::Lineage(msg) => ErrorData::resource_not_found(format!("lineage: {msg}"), None),
     }
 }
 

--- a/memory-engine-mcp/src/error.rs
+++ b/memory-engine-mcp/src/error.rs
@@ -59,6 +59,10 @@ pub fn to_mcp_error(err: MemoryError) -> ErrorData {
             "engine opened in read-only mode — write operations are not available",
             None,
         ),
+
+        MemoryError::Lineage(msg) => {
+            ErrorData::internal_error(format!("lineage error: {msg}"), None)
+        }
     }
 }
 

--- a/src/engine/lineage.rs
+++ b/src/engine/lineage.rs
@@ -71,9 +71,7 @@ impl MemoryEngine {
 #[cfg(test)]
 mod tests {
     use crate::engine::MemoryEngine;
-    use crate::types::{
-        AddFactRequest, FactType, NewLineageRecord, PromotionProvenance,
-    };
+    use crate::types::{AddFactRequest, FactType, NewLineageRecord, PromotionProvenance};
     use chrono::Utc;
 
     fn test_provenance() -> PromotionProvenance {
@@ -160,9 +158,7 @@ mod tests {
             wisdom_fact_id: 1,
             source_fact_ids: vec![2, 3],
         };
-        engine
-            .record_lineage(&new_rec, &test_provenance())
-            .unwrap();
+        engine.record_lineage(&new_rec, &test_provenance()).unwrap();
 
         let ids = engine.get_full_lineage(1).unwrap();
         assert_eq!(ids, vec![2, 3]);
@@ -175,9 +171,7 @@ mod tests {
             wisdom_fact_id: 1,
             source_fact_ids: vec![2, 3],
         };
-        engine
-            .record_lineage(&new_rec, &test_provenance())
-            .unwrap();
+        engine.record_lineage(&new_rec, &test_provenance()).unwrap();
 
         let deleted = engine.delete_lineage(1).unwrap();
         assert!(deleted);

--- a/src/engine/lineage.rs
+++ b/src/engine/lineage.rs
@@ -20,8 +20,7 @@ impl MemoryEngine {
         provenance: &PromotionProvenance,
     ) -> Result<i64> {
         let conn = self.write_conn()?;
-        let store = LineageStore::new(&conn);
-        store.insert(record, provenance)
+        LineageStore::new(&conn).insert(record, provenance)
     }
 
     /// Retrieve the provenance envelope and lineage record for a wisdom fact.
@@ -63,8 +62,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine is read-only.
     pub fn delete_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
         let conn = self.write_conn()?;
-        let store = LineageStore::new(&conn);
-        store.delete(wisdom_fact_id)
+        LineageStore::new(&conn).delete(wisdom_fact_id)
     }
 }
 

--- a/src/engine/lineage.rs
+++ b/src/engine/lineage.rs
@@ -1,0 +1,195 @@
+use crate::error::Result;
+use crate::store::lineage::LineageStore;
+use crate::types::{LineageRecord, NewLineageRecord, PromotionProvenance};
+
+use super::MemoryEngine;
+
+impl MemoryEngine {
+    /// Record provenance for a promoted wisdom fact.
+    ///
+    /// Writes to the `lineage` sidecar table via the writer connection.
+    /// Returns the auto-assigned `lineage_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::ReadOnly` if the engine is read-only.
+    /// Returns `MemoryError::Database` on insert failure.
+    pub fn record_lineage(
+        &self,
+        record: &NewLineageRecord,
+        provenance: &PromotionProvenance,
+    ) -> Result<i64> {
+        let conn = self.write_conn()?;
+        let store = LineageStore::new(&conn);
+        store.insert(record, provenance)
+    }
+
+    /// Retrieve the provenance envelope and lineage record for a wisdom fact.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Lineage` if no lineage exists.
+    pub fn get_provenance(
+        &self,
+        wisdom_fact_id: i64,
+    ) -> Result<(LineageRecord, PromotionProvenance)> {
+        self.with_read(|conn| {
+            let store = LineageStore::new(conn);
+            store.get_by_wisdom_fact(wisdom_fact_id)
+        })
+    }
+
+    /// Retrieve just the full source-fact ID chain for a wisdom fact.
+    ///
+    /// Lighter than `get_provenance` — use when only the source chain is needed
+    /// (e.g., "Why?" button, debugging bad promotions).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Lineage` if no lineage exists.
+    pub fn get_full_lineage(&self, wisdom_fact_id: i64) -> Result<Vec<i64>> {
+        self.with_read(|conn| {
+            let store = LineageStore::new(conn);
+            store.get_source_fact_ids(wisdom_fact_id)
+        })
+    }
+
+    /// Delete the lineage record for a wisdom fact (e.g., when reversing a promotion).
+    ///
+    /// Returns `true` if a record was deleted, `false` if none existed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::ReadOnly` if the engine is read-only.
+    pub fn delete_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
+        let conn = self.write_conn()?;
+        let store = LineageStore::new(&conn);
+        store.delete(wisdom_fact_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::engine::MemoryEngine;
+    use crate::types::{
+        AddFactRequest, FactType, NewLineageRecord, PromotionProvenance,
+    };
+    use chrono::Utc;
+
+    fn test_provenance() -> PromotionProvenance {
+        PromotionProvenance {
+            source_count: 2,
+            session_count: 1,
+            date_range_start: Utc::now(),
+            date_range_end: Utc::now(),
+            confidence: 0.85,
+            method_version: "dreamcycle-v1".into(),
+            representative_ids: vec![],
+            lineage_id: 0,
+        }
+    }
+
+    /// Minimal embedder for testing — returns a fixed-dimension vector.
+    struct FixedEmbedder;
+    impl crate::traits::EmbeddingProvider for FixedEmbedder {
+        fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
+            Ok(vec![0.1, 0.2, 0.3, 0.4])
+        }
+    }
+
+    fn engine_with_facts() -> MemoryEngine {
+        let engine = MemoryEngine::open_memory(4).unwrap();
+        let embedder = FixedEmbedder;
+
+        // Insert wisdom fact (id=1)
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: "synthesized wisdom".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                &embedder,
+                None,
+            )
+            .unwrap();
+
+        // Insert source facts (id=2, id=3)
+        for label in &["source A", "source B"] {
+            engine
+                .add_fact(
+                    &AddFactRequest {
+                        content: label.to_string(),
+                        fact_type: FactType::Episodic,
+                        source_event_id: None,
+                        scope: None,
+                        opts: None,
+                    },
+                    &embedder,
+                    None,
+                )
+                .unwrap();
+        }
+        engine
+    }
+
+    #[test]
+    fn record_and_get_provenance() {
+        let engine = engine_with_facts();
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![2, 3],
+        };
+        let prov = test_provenance();
+        let lineage_id = engine.record_lineage(&new_rec, &prov).unwrap();
+        assert!(lineage_id > 0);
+
+        let (record, got_prov) = engine.get_provenance(1).unwrap();
+        assert_eq!(record.wisdom_fact_id, 1);
+        assert_eq!(record.source_fact_ids, vec![2, 3]);
+        assert_eq!(got_prov.source_count, 2);
+        assert_eq!(got_prov.lineage_id, lineage_id);
+    }
+
+    #[test]
+    fn get_full_lineage_returns_ids() {
+        let engine = engine_with_facts();
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![2, 3],
+        };
+        engine
+            .record_lineage(&new_rec, &test_provenance())
+            .unwrap();
+
+        let ids = engine.get_full_lineage(1).unwrap();
+        assert_eq!(ids, vec![2, 3]);
+    }
+
+    #[test]
+    fn delete_lineage_removes_record() {
+        let engine = engine_with_facts();
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![2, 3],
+        };
+        engine
+            .record_lineage(&new_rec, &test_provenance())
+            .unwrap();
+
+        let deleted = engine.delete_lineage(1).unwrap();
+        assert!(deleted);
+
+        let err = engine.get_provenance(1).unwrap_err();
+        assert!(matches!(err, crate::error::MemoryError::Lineage(_)));
+    }
+
+    #[test]
+    fn get_provenance_not_found() {
+        let engine = engine_with_facts();
+        let err = engine.get_provenance(999).unwrap_err();
+        assert!(matches!(err, crate::error::MemoryError::Lineage(_)));
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -25,6 +25,7 @@ mod forgetting;
 mod graph;
 mod ingest;
 mod inspect;
+mod lineage;
 mod outcome;
 mod query;
 mod restore;

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum MemoryError {
     /// Attempted a write operation on a read-only engine.
     #[error("operation requires write access, but engine was opened read-only")]
     ReadOnly,
+
+    #[error("lineage error: {0}")]
+    Lineage(String),
 }
 
 /// Convenience alias for `Result<T, MemoryError>`.
@@ -89,6 +92,15 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "operation requires write access, but engine was opened read-only"
+        );
+    }
+
+    #[test]
+    fn lineage_error_display() {
+        let err = MemoryError::Lineage("wisdom fact 42 has no lineage record".into());
+        assert_eq!(
+            err.to_string(),
+            "lineage error: wisdom fact 42 has no lineage record"
         );
     }
 

--- a/src/inspect/dump.rs
+++ b/src/inspect/dump.rs
@@ -11,6 +11,7 @@ use crate::store::UpcasterRegistry;
 use crate::store::edges::EdgeStore;
 use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
+use crate::store::lineage::LineageStore;
 use crate::store::schema::{get_config, list_config};
 use crate::store::scopes::ScopeStore;
 use crate::store::summaries::SummaryStore;
@@ -60,6 +61,9 @@ fn stream_snapshot<W: Write>(conn: &Connection, embed_dim: usize, writer: &mut W
 
     write!(writer, r#","events":"#)?;
     stream_for_each(writer, |cb| EventStore::new(conn, &registry).for_each(cb))?;
+
+    write!(writer, r#","lineage":"#)?;
+    stream_for_each(writer, |cb| LineageStore::new(conn).for_each(cb))?;
 
     // Config is always small — serialize directly.
     let config = list_config(conn)?;

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -11,6 +11,7 @@ use rusqlite::Connection;
 
 use crate::error::{MemoryError, Result};
 use crate::store::events::event_type_to_str;
+use crate::store::lineage::LineageStore;
 use crate::store::schema::{CURRENT_SCHEMA_VERSION, STORAGE_EPOCH, set_config};
 use crate::store::serialize_embedding;
 
@@ -176,8 +177,9 @@ fn assert_empty_db(conn: &Connection) -> Result<()> {
     // scopes: root scope (id=1) is expected from init_schema
     let scope_count: i64 =
         conn.query_row("SELECT COUNT(*) FROM scopes WHERE id > 1", [], |r| r.get(0))?;
+    let lineage_count: i64 = conn.query_row("SELECT COUNT(*) FROM lineage", [], |r| r.get(0))?;
 
-    let total = event_count + fact_count + edge_count + summary_count + scope_count;
+    let total = event_count + fact_count + edge_count + summary_count + scope_count + lineage_count;
     if total > 0 {
         return Err(MemoryError::Conflict(
             "target database is not empty; restore only works on a fresh engine".into(),
@@ -337,14 +339,22 @@ pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Re
         }
     }
 
-    // 7. Import config keys (except managed ones).
+    // 7. Insert lineage records (Phase 5a provenance).
+    {
+        let lineage_store = LineageStore::new(&tx);
+        for entry in &snapshot.lineage {
+            lineage_store.insert_raw(entry)?;
+        }
+    }
+
+    // 8. Import config keys (except managed ones).
     for (key, value) in &snapshot.config {
         if !MANAGED_CONFIG_KEYS.contains(&key.as_str()) {
             set_config(&tx, key, value)?;
         }
     }
 
-    // 8. Reset autoincrement sequences so new inserts don't collide.
+    // 9. Reset autoincrement sequences so new inserts don't collide.
     reset_autoincrement(
         &tx,
         "scopes",
@@ -370,8 +380,17 @@ pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Re
         "summaries",
         &snapshot.summaries.iter().map(|s| s.id).collect::<Vec<_>>(),
     )?;
+    reset_autoincrement(
+        &tx,
+        "lineage",
+        &snapshot
+            .lineage
+            .iter()
+            .map(|l| l.lineage_id)
+            .collect::<Vec<_>>(),
+    )?;
 
-    // 9. Commit.
+    // 10. Commit.
     tx.commit()?;
     Ok(())
 }
@@ -457,6 +476,7 @@ mod tests {
             summaries: vec![],
             scopes: vec![],
             events: vec![],
+            lineage: vec![],
             config: HashMap::new(),
         };
         let err = validate_snapshot(&snapshot).unwrap_err();
@@ -474,6 +494,7 @@ mod tests {
             summaries: vec![],
             scopes: vec![],
             events: vec![],
+            lineage: vec![],
             config: HashMap::new(),
         };
         let err = validate_snapshot(&snapshot).unwrap_err();
@@ -491,6 +512,7 @@ mod tests {
             summaries: vec![],
             scopes: vec![],
             events: vec![],
+            lineage: vec![],
             config: HashMap::new(),
         };
         let err = validate_snapshot(&snapshot).unwrap_err();
@@ -514,6 +536,7 @@ mod tests {
                 depth: 1,
             }],
             events: vec![],
+            lineage: vec![],
             config: HashMap::new(),
         };
         let err = validate_snapshot(&snapshot).unwrap_err();
@@ -531,6 +554,7 @@ mod tests {
             summaries: vec![],
             scopes: vec![],
             events: vec![],
+            lineage: vec![],
             config: HashMap::new(),
         };
         validate_snapshot(&snapshot).unwrap();

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
@@ -14,6 +14,7 @@ scopes:
     label: root
     depth: 0
 events: []
+lineage: []
 config:
   schema_version: "8"
   storage_epoch: "1"

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
@@ -1,9 +1,8 @@
 ---
 source: src/inspect/dump.rs
-assertion_line: 479
 expression: snapshot
 ---
-schema_version: 7
+schema_version: 8
 storage_epoch: 1
 embed_dim: 4
 facts: []
@@ -16,5 +15,5 @@ scopes:
     depth: 0
 events: []
 config:
-  schema_version: "7"
+  schema_version: "8"
   storage_epoch: "1"

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
@@ -1,9 +1,8 @@
 ---
 source: src/inspect/dump.rs
-assertion_line: 510
 expression: snapshot
 ---
-schema_version: 7
+schema_version: 8
 storage_epoch: 1
 embed_dim: 4
 facts:

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
@@ -32,4 +32,5 @@ scopes:
     label: root
     depth: 0
 events: "[]"
+lineage: []
 config: "{}"

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -4,7 +4,9 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::types::{ConsolidationLevel, Edge, Event, EventType, Fact, ScopeNode, Summary};
+use crate::types::{
+    ConsolidationLevel, Edge, Event, EventType, Fact, LineageSnapshotEntry, ScopeNode, Summary,
+};
 
 // ---------------------------------------------------------------------------
 // Fact explanation
@@ -155,6 +157,10 @@ pub struct EngineSnapshot {
     pub summaries: Vec<Summary>,
     pub scopes: Vec<ScopeNode>,
     pub events: Vec<Event>,
+    /// Lineage records for promoted wisdom facts (Phase 5a).
+    /// Absent in pre-v8 snapshots — defaults to empty.
+    #[serde(default)]
+    pub lineage: Vec<LineageSnapshotEntry>,
     pub config: HashMap<String, String>,
 }
 

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -197,7 +197,7 @@ mod tests {
         assert_eq!(record.wisdom_fact_id, 1);
         assert_eq!(record.source_fact_ids, vec![10, 20]);
         assert_eq!(prov.source_count, 2);
-        assert_eq!(prov.confidence, 0.85);
+        assert!((prov.confidence - 0.85).abs() < f64::EPSILON);
         assert_eq!(prov.method_version, "dreamcycle-v1");
         assert_eq!(prov.lineage_id, lineage_id);
     }

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -1,7 +1,7 @@
 use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
-use crate::types::{LineageRecord, NewLineageRecord, PromotionProvenance};
+use crate::types::{LineageRecord, LineageSnapshotEntry, NewLineageRecord, PromotionProvenance};
 
 /// Store for the `lineage` sidecar table — provenance tracking for promoted wisdom facts.
 pub struct LineageStore<'a> {
@@ -19,11 +19,13 @@ impl<'a> LineageStore<'a> {
     /// Insert a new lineage record with its provenance envelope.
     /// Returns the auto-assigned `lineage_id`.
     ///
-    /// The `provenance.lineage_id` field is ignored on input — the DB assigns
-    /// the ID, and the returned value is the authoritative one.
+    /// Validates that all `source_fact_ids` reference existing facts before
+    /// inserting. The `provenance.lineage_id` field is not stored in the JSON
+    /// (`skip_serializing`) — the row PK is authoritative.
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::Lineage` if any source fact ID does not exist.
     /// Returns `MemoryError::Database` on insert failure (e.g., duplicate
     /// `wisdom_fact_id`, FK violation).
     pub fn insert(
@@ -31,6 +33,27 @@ impl<'a> LineageStore<'a> {
         record: &NewLineageRecord,
         provenance: &PromotionProvenance,
     ) -> Result<i64> {
+        // Validate that all source fact IDs exist.
+        if !record.source_fact_ids.is_empty() {
+            let placeholders: String = record
+                .source_fact_ids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            let query = format!("SELECT COUNT(*) FROM facts WHERE id IN ({placeholders})");
+            let count: i64 = self.conn.query_row(&query, [], |r| r.get(0))?;
+            let expected = i64::try_from(record.source_fact_ids.len())
+                .map_err(|e| MemoryError::Internal(e.to_string()))?;
+            if count != expected {
+                return Err(MemoryError::Lineage(format!(
+                    "source_fact_ids contains nonexistent fact IDs \
+                     (expected {} to exist, found {count})",
+                    record.source_fact_ids.len()
+                )));
+            }
+        }
+
         let source_ids_json = serde_json::to_string(&record.source_fact_ids)?;
         let prov_json = serde_json::to_string(provenance)?;
 
@@ -40,6 +63,31 @@ impl<'a> LineageStore<'a> {
             params![record.wisdom_fact_id, source_ids_json, prov_json],
         )?;
         Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Insert a raw lineage row with an explicit `lineage_id` (for snapshot restore).
+    ///
+    /// Skips source fact validation — the caller (restore) is responsible for
+    /// inserting facts before lineage.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on insert failure.
+    pub fn insert_raw(&self, entry: &LineageSnapshotEntry) -> Result<()> {
+        let source_ids_json = serde_json::to_string(&entry.source_fact_ids)?;
+        let prov_json = serde_json::to_string(&entry.provenance)?;
+
+        self.conn.execute(
+            "INSERT INTO lineage (lineage_id, wisdom_fact_id, source_fact_ids, provenance)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                entry.lineage_id,
+                entry.wisdom_fact_id,
+                source_ids_json,
+                prov_json,
+            ],
+        )?;
+        Ok(())
     }
 
     /// Look up the lineage record and provenance for a promoted wisdom fact.
@@ -133,6 +181,39 @@ impl<'a> LineageStore<'a> {
             |r| r.get(0),
         )?;
         Ok(count > 0)
+    }
+
+    /// Iterate over all lineage rows (for snapshot dump).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Serialization` on malformed stored JSON.
+    pub fn for_each<F>(&self, mut f: F) -> Result<()>
+    where
+        F: FnMut(LineageSnapshotEntry) -> Result<()>,
+    {
+        let mut stmt = self.conn.prepare(
+            "SELECT lineage_id, wisdom_fact_id, source_fact_ids, provenance
+             FROM lineage ORDER BY lineage_id ASC",
+        )?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let lineage_id: i64 = row.get(0)?;
+            let wisdom_fact_id: i64 = row.get(1)?;
+            let source_ids_json: String = row.get(2)?;
+            let prov_json: String = row.get(3)?;
+            let source_fact_ids: Vec<i64> = serde_json::from_str(&source_ids_json)?;
+            let mut provenance: PromotionProvenance = serde_json::from_str(&prov_json)?;
+            provenance.lineage_id = lineage_id;
+            f(LineageSnapshotEntry {
+                lineage_id,
+                wisdom_fact_id,
+                source_fact_ids,
+                provenance,
+            })?;
+        }
+        Ok(())
     }
 }
 
@@ -276,5 +357,52 @@ mod tests {
         // Second insert with same wisdom_fact_id should fail (unique index)
         let err = store.insert(&new_rec, &test_provenance()).unwrap_err();
         assert!(matches!(err, MemoryError::Database(_)));
+    }
+
+    #[test]
+    fn insert_rejects_nonexistent_source_facts() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![10, 999], // 999 does not exist
+        };
+        let err = store.insert(&new_rec, &test_provenance()).unwrap_err();
+        assert!(matches!(err, MemoryError::Lineage(_)));
+        assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn for_each_iterates_all_rows() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        // Insert two lineage records (need a second wisdom fact)
+        conn.execute(
+            "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, last_accessed, scope_id, importance_score)
+             VALUES (2, 'wisdom 2', 'w2', X'00000000', 'semantic', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1, 0.8)",
+            [],
+        ).unwrap();
+
+        let rec1 = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![10],
+        };
+        let rec2 = NewLineageRecord {
+            wisdom_fact_id: 2,
+            source_fact_ids: vec![20],
+        };
+        store.insert(&rec1, &test_provenance()).unwrap();
+        store.insert(&rec2, &test_provenance()).unwrap();
+
+        let mut entries = Vec::new();
+        store
+            .for_each(|entry| {
+                entries.push(entry);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].wisdom_fact_id, 1);
+        assert_eq!(entries[1].wisdom_fact_id, 2);
     }
 }

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -33,23 +33,24 @@ impl<'a> LineageStore<'a> {
         record: &NewLineageRecord,
         provenance: &PromotionProvenance,
     ) -> Result<i64> {
-        // Validate that all source fact IDs exist.
+        // Validate that all distinct source fact IDs exist.
         if !record.source_fact_ids.is_empty() {
-            let placeholders: String = record
-                .source_fact_ids
+            let unique_ids: std::collections::BTreeSet<i64> =
+                record.source_fact_ids.iter().copied().collect();
+            let placeholders: String = unique_ids
                 .iter()
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(",");
             let query = format!("SELECT COUNT(*) FROM facts WHERE id IN ({placeholders})");
             let count: i64 = self.conn.query_row(&query, [], |r| r.get(0))?;
-            let expected = i64::try_from(record.source_fact_ids.len())
+            let expected = i64::try_from(unique_ids.len())
                 .map_err(|e| MemoryError::Internal(e.to_string()))?;
             if count != expected {
                 return Err(MemoryError::Lineage(format!(
                     "source_fact_ids contains nonexistent fact IDs \
-                     (expected {} to exist, found {count})",
-                    record.source_fact_ids.len()
+                     (expected {} distinct IDs to exist, found {count})",
+                    unique_ids.len()
                 )));
             }
         }

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -1,0 +1,280 @@
+use rusqlite::{params, Connection};
+
+use crate::error::{MemoryError, Result};
+use crate::types::{LineageRecord, NewLineageRecord, PromotionProvenance};
+
+/// Store for the `lineage` sidecar table — provenance tracking for promoted wisdom facts.
+pub struct LineageStore<'a> {
+    conn: &'a Connection,
+}
+
+#[allow(dead_code)] // complete CRUD API — engine facade wires methods incrementally
+impl<'a> LineageStore<'a> {
+    /// Create a new `LineageStore` borrowing the given connection.
+    #[must_use]
+    pub const fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Insert a new lineage record with its provenance envelope.
+    /// Returns the auto-assigned `lineage_id`.
+    ///
+    /// The `provenance.lineage_id` field is ignored on input — the DB assigns
+    /// the ID, and the returned value is the authoritative one.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on insert failure (e.g., duplicate
+    /// `wisdom_fact_id`, FK violation).
+    pub fn insert(
+        &self,
+        record: &NewLineageRecord,
+        provenance: &PromotionProvenance,
+    ) -> Result<i64> {
+        let source_ids_json = serde_json::to_string(&record.source_fact_ids)?;
+        let prov_json = serde_json::to_string(provenance)?;
+
+        self.conn.execute(
+            "INSERT INTO lineage (wisdom_fact_id, source_fact_ids, provenance)
+             VALUES (?1, ?2, ?3)",
+            params![record.wisdom_fact_id, source_ids_json, prov_json],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Look up the lineage record and provenance for a promoted wisdom fact.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Lineage` if no lineage exists for `wisdom_fact_id`.
+    /// Returns `MemoryError::Serialization` if stored JSON is malformed.
+    pub fn get_by_wisdom_fact(
+        &self,
+        wisdom_fact_id: i64,
+    ) -> Result<(LineageRecord, PromotionProvenance)> {
+        let mut stmt = self.conn.prepare(
+            "SELECT lineage_id, wisdom_fact_id, source_fact_ids, provenance
+             FROM lineage WHERE wisdom_fact_id = ?1",
+        )?;
+        let result = stmt.query_row(params![wisdom_fact_id], |row| {
+            let lineage_id: i64 = row.get(0)?;
+            let wfid: i64 = row.get(1)?;
+            let source_ids_json: String = row.get(2)?;
+            let prov_json: String = row.get(3)?;
+            Ok((lineage_id, wfid, source_ids_json, prov_json))
+        });
+        match result {
+            Ok((lineage_id, wfid, source_ids_json, prov_json)) => {
+                let source_fact_ids: Vec<i64> = serde_json::from_str(&source_ids_json)?;
+                let mut provenance: PromotionProvenance = serde_json::from_str(&prov_json)?;
+                provenance.lineage_id = lineage_id;
+                let record = LineageRecord {
+                    lineage_id,
+                    wisdom_fact_id: wfid,
+                    source_fact_ids,
+                };
+                Ok((record, provenance))
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Err(MemoryError::Lineage(format!(
+                "no lineage record for wisdom fact {wisdom_fact_id}"
+            ))),
+            Err(e) => Err(MemoryError::Database(e)),
+        }
+    }
+
+    /// Return just the source fact IDs for a wisdom fact's lineage.
+    ///
+    /// Lighter than `get_by_wisdom_fact` — skips provenance deserialization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Lineage` if no lineage exists.
+    pub fn get_source_fact_ids(&self, wisdom_fact_id: i64) -> Result<Vec<i64>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT source_fact_ids FROM lineage WHERE wisdom_fact_id = ?1")?;
+        let result = stmt.query_row(params![wisdom_fact_id], |row| {
+            let json: String = row.get(0)?;
+            Ok(json)
+        });
+        match result {
+            Ok(json) => Ok(serde_json::from_str(&json)?),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Err(MemoryError::Lineage(format!(
+                "no lineage record for wisdom fact {wisdom_fact_id}"
+            ))),
+            Err(e) => Err(MemoryError::Database(e)),
+        }
+    }
+
+    /// Delete the lineage record for a wisdom fact.
+    ///
+    /// Returns `true` if a record was deleted, `false` if none existed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn delete(&self, wisdom_fact_id: i64) -> Result<bool> {
+        let rows = self.conn.execute(
+            "DELETE FROM lineage WHERE wisdom_fact_id = ?1",
+            params![wisdom_fact_id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Check whether a wisdom fact has a lineage record.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn has_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM lineage WHERE wisdom_fact_id = ?1",
+            params![wisdom_fact_id],
+            |r| r.get(0),
+        )?;
+        Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::{init_schema, open_memory};
+
+    fn setup() -> rusqlite::Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        // Insert dummy facts so FK constraints are satisfied
+        conn.execute(
+            "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, last_accessed, scope_id, importance_score)
+             VALUES (1, 'wisdom fact', 'abc123', X'00000000', 'semantic', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1, 0.9)",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, last_accessed, scope_id, importance_score)
+             VALUES (10, 'source 1', 'src1', X'00000000', 'episodic', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1, 0.5)",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, last_accessed, scope_id, importance_score)
+             VALUES (20, 'source 2', 'src2', X'00000000', 'episodic', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1, 0.5)",
+            [],
+        ).unwrap();
+        conn
+    }
+
+    fn test_provenance() -> PromotionProvenance {
+        PromotionProvenance {
+            source_count: 2,
+            session_count: 1,
+            date_range_start: chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            date_range_end: chrono::DateTime::parse_from_rfc3339("2026-03-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            confidence: 0.85,
+            method_version: "dreamcycle-v1".into(),
+            representative_ids: vec![10, 20],
+            lineage_id: 0,
+        }
+    }
+
+    #[test]
+    fn insert_and_get_by_wisdom_fact() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![10, 20],
+        };
+
+        let lineage_id = store.insert(&new_rec, &test_provenance()).unwrap();
+        assert!(lineage_id > 0);
+
+        let (record, prov) = store.get_by_wisdom_fact(1).unwrap();
+        assert_eq!(record.wisdom_fact_id, 1);
+        assert_eq!(record.source_fact_ids, vec![10, 20]);
+        assert_eq!(prov.source_count, 2);
+        assert_eq!(prov.confidence, 0.85);
+        assert_eq!(prov.method_version, "dreamcycle-v1");
+        assert_eq!(prov.lineage_id, lineage_id);
+    }
+
+    #[test]
+    fn get_source_fact_ids_returns_only_ids() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![10, 20],
+        };
+        store.insert(&new_rec, &test_provenance()).unwrap();
+
+        let ids = store.get_source_fact_ids(1).unwrap();
+        assert_eq!(ids, vec![10, 20]);
+    }
+
+    #[test]
+    fn get_source_fact_ids_not_found() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        let err = store.get_source_fact_ids(999).unwrap_err();
+        assert!(matches!(err, MemoryError::Lineage(_)));
+    }
+
+    #[test]
+    fn delete_removes_lineage() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![10, 20],
+        };
+        store.insert(&new_rec, &test_provenance()).unwrap();
+
+        let deleted = store.delete(1).unwrap();
+        assert!(deleted);
+
+        let err = store.get_by_wisdom_fact(1).unwrap_err();
+        assert!(matches!(err, MemoryError::Lineage(_)));
+    }
+
+    #[test]
+    fn delete_nonexistent_returns_false() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        let deleted = store.delete(999).unwrap();
+        assert!(!deleted);
+    }
+
+    #[test]
+    fn has_lineage_check() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        assert!(!store.has_lineage(1).unwrap());
+
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![10, 20],
+        };
+        store.insert(&new_rec, &test_provenance()).unwrap();
+        assert!(store.has_lineage(1).unwrap());
+    }
+
+    #[test]
+    fn duplicate_wisdom_fact_id_rejected() {
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![10, 20],
+        };
+        store.insert(&new_rec, &test_provenance()).unwrap();
+
+        // Second insert with same wisdom_fact_id should fail (unique index)
+        let err = store.insert(&new_rec, &test_provenance()).unwrap_err();
+        assert!(matches!(err, MemoryError::Database(_)));
+    }
+}

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::types::{LineageRecord, NewLineageRecord, PromotionProvenance};

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,6 +7,7 @@ pub mod archive_manifest;
 pub mod edges;
 pub mod events;
 pub mod facts;
+pub mod lineage;
 pub mod schema;
 pub mod scopes;
 pub mod summaries;

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use crate::error::{MemoryError, Result};
 
 /// Current schema version. Bump when adding migrations.
-pub(crate) const CURRENT_SCHEMA_VERSION: u32 = 7;
+pub(crate) const CURRENT_SCHEMA_VERSION: u32 = 8;
 
 /// Storage epoch — coarse-grained compatibility gate.
 ///
@@ -176,6 +176,7 @@ const MIGRATIONS: &[(MigrationFn, bool)] = &[
     (migrate_v4_to_v5, false),
     (migrate_v5_to_v6, false),
     (migrate_v6_to_v7, false),
+    (migrate_v7_to_v8, false),
 ];
 
 /// Run forward-only migrations from the current schema version to
@@ -646,6 +647,20 @@ fn migrate_v6_to_v7(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v7_to_v8(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS lineage (
+            lineage_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id),
+            source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)),
+            provenance TEXT NOT NULL CHECK(json_valid(provenance))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_lineage_wisdom_fact_id
+            ON lineage(wisdom_fact_id);",
+    )?;
+    Ok(())
+}
+
 // --- DDL constants ---
 
 const TABLES_DDL: &str = "
@@ -726,6 +741,16 @@ CREATE TABLE IF NOT EXISTS archive_manifest (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_archive_manifest_path
     ON archive_manifest(pak_path);
+
+CREATE TABLE IF NOT EXISTS lineage (
+    lineage_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)),
+    provenance TEXT NOT NULL CHECK(json_valid(provenance))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_lineage_wisdom_fact_id
+    ON lineage(wisdom_fact_id);
 ";
 
 const SCOPES_DDL: &str = "
@@ -1244,8 +1269,8 @@ CREATE TABLE IF NOT EXISTS config (
                 |r| r.get(0),
             )
             .unwrap();
-        // 9 original + 2 scopes indexes + 4 scope_id indexes + 4 v3 indexes + 1 archive_manifest
-        assert_eq!(count, 20);
+        // 9 original + 2 scopes indexes + 4 scope_id indexes + 4 v3 indexes + 1 archive_manifest + 1 lineage
+        assert_eq!(count, 21);
     }
 
     // --- Migration framework tests ---
@@ -1256,13 +1281,13 @@ CREATE TABLE IF NOT EXISTS config (
         init_schema(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
         // migrate is a no-op on fresh DB
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
     }
 
@@ -1277,7 +1302,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
     }
 
@@ -1289,7 +1314,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
     }
 
@@ -1323,7 +1348,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
 
         // Data survived both migrations
@@ -1413,7 +1438,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
 
         // After migration: orphan scope_id fails (FK enforced)
@@ -1541,7 +1566,7 @@ CREATE TABLE IF NOT EXISTS config (
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
     }
 
@@ -1551,7 +1576,7 @@ CREATE TABLE IF NOT EXISTS config (
         init_schema(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
         conn.execute(
             "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed, is_pinned, importance_score)
@@ -1713,7 +1738,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
     }
 
@@ -1735,7 +1760,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
 
         // Existing events get default revision = 1
@@ -1819,7 +1844,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
 
         // Event survived all migrations, got default revision
@@ -1852,7 +1877,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
 
         // Existing facts have surfaced_at = NULL
@@ -2135,7 +2160,7 @@ CREATE TABLE IF NOT EXISTS config (
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
 
         // archive_manifest must exist after migration
@@ -2177,11 +2202,92 @@ CREATE TABLE IF NOT EXISTS config (
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(count, 1, "archive_manifest should exist in fresh v7 schema");
+        assert_eq!(count, 1, "archive_manifest should exist in fresh schema");
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("7".to_string())
+            Some("8".to_string())
         );
+    }
+
+    /// Create a v7 schema by initing v8 and removing lineage artifacts.
+    fn init_schema_v7(conn: &Connection) -> Result<()> {
+        init_schema(conn)?;
+        conn.execute_batch("DROP TABLE IF EXISTS lineage;")?;
+        conn.execute_batch("DROP INDEX IF EXISTS idx_lineage_wisdom_fact_id;")?;
+        set_config(conn, "schema_version", "7")?;
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_v7_to_v8_adds_lineage_table() {
+        let conn = open_memory().unwrap();
+        init_schema_v7(&conn).unwrap();
+
+        // lineage must NOT exist before migration
+        let count_before: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='lineage'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count_before, 0, "lineage should not exist before migration");
+
+        migrate(&conn, None).unwrap();
+
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap(),
+            Some("8".to_string())
+        );
+
+        // lineage table must exist after migration
+        let count_after: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='lineage'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count_after, 1, "lineage should exist after migration");
+
+        // Verify expected columns
+        let col_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('lineage')
+                 WHERE name IN ('lineage_id', 'wisdom_fact_id', 'source_fact_ids', 'provenance')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(col_count, 4, "lineage table should have 4 expected columns");
+
+        // Unique index on wisdom_fact_id must exist
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_lineage_wisdom_fact_id'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            idx_count, 1,
+            "unique index on wisdom_fact_id should exist"
+        );
+    }
+
+    #[test]
+    fn fresh_db_has_lineage_table() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('lineage')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(count > 0, "fresh DB should have lineage table");
     }
 }

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -651,7 +651,7 @@ fn migrate_v7_to_v8(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS lineage (
             lineage_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id),
+            wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
             source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)),
             provenance TEXT NOT NULL CHECK(json_valid(provenance))
         );
@@ -744,7 +744,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_archive_manifest_path
 
 CREATE TABLE IF NOT EXISTS lineage (
     lineage_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id),
+    wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
     source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)),
     provenance TEXT NOT NULL CHECK(json_valid(provenance))
 );

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -2270,10 +2270,7 @@ CREATE TABLE IF NOT EXISTS config (
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(
-            idx_count, 1,
-            "unique index on wisdom_fact_id should exist"
-        );
+        assert_eq!(idx_count, 1, "unique index on wisdom_fact_id should exist");
     }
 
     #[test]

--- a/src/store/snapshots/memory_engine__store__schema__tests__schema_v7.snap
+++ b/src/store/snapshots/memory_engine__store__schema__tests__schema_v7.snap
@@ -1,6 +1,5 @@
 ---
 source: src/store/schema.rs
-assertion_line: 1983
 expression: schema
 ---
 -- index: idx_archive_manifest_path
@@ -97,7 +96,7 @@ CREATE TABLE 'facts_fts_docsize'(id INTEGER PRIMARY KEY, sz BLOB);
 CREATE TABLE 'facts_fts_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID;
 
 -- table: lineage
-CREATE TABLE lineage ( lineage_id INTEGER PRIMARY KEY AUTOINCREMENT, wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id), source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)), provenance TEXT NOT NULL CHECK(json_valid(provenance)) );
+CREATE TABLE lineage ( lineage_id INTEGER PRIMARY KEY AUTOINCREMENT, wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE, source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)), provenance TEXT NOT NULL CHECK(json_valid(provenance)) );
 
 -- table: scopes
 CREATE TABLE scopes ( id INTEGER PRIMARY KEY AUTOINCREMENT, parent_id INTEGER REFERENCES scopes(id), label TEXT NOT NULL, depth INTEGER NOT NULL DEFAULT 0 );

--- a/src/store/snapshots/memory_engine__store__schema__tests__schema_v7.snap
+++ b/src/store/snapshots/memory_engine__store__schema__tests__schema_v7.snap
@@ -1,6 +1,6 @@
 ---
 source: src/store/schema.rs
-assertion_line: 1822
+assertion_line: 1983
 expression: schema
 ---
 -- index: idx_archive_manifest_path
@@ -54,6 +54,9 @@ CREATE INDEX idx_facts_type ON facts(fact_type);
 -- index: idx_facts_valid
 CREATE INDEX idx_facts_valid ON facts(t_valid, t_invalid);
 
+-- index: idx_lineage_wisdom_fact_id
+CREATE UNIQUE INDEX idx_lineage_wisdom_fact_id ON lineage(wisdom_fact_id);
+
 -- index: idx_scopes_parent
 CREATE INDEX idx_scopes_parent ON scopes(parent_id);
 
@@ -92,6 +95,9 @@ CREATE TABLE 'facts_fts_docsize'(id INTEGER PRIMARY KEY, sz BLOB);
 
 -- table: facts_fts_idx
 CREATE TABLE 'facts_fts_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID;
+
+-- table: lineage
+CREATE TABLE lineage ( lineage_id INTEGER PRIMARY KEY AUTOINCREMENT, wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id), source_fact_ids TEXT NOT NULL CHECK(json_valid(source_fact_ids)), provenance TEXT NOT NULL CHECK(json_valid(provenance)) );
 
 -- table: scopes
 CREATE TABLE scopes ( id INTEGER PRIMARY KEY AUTOINCREMENT, parent_id INTEGER REFERENCES scopes(id), label TEXT NOT NULL, depth INTEGER NOT NULL DEFAULT 0 );

--- a/src/types.rs
+++ b/src/types.rs
@@ -191,6 +191,42 @@ pub enum ScopeQuery {
     Inherited(String),
 }
 
+// --- Provenance (Phase 5a) ---
+
+/// Lightweight provenance envelope attached to promoted wisdom facts.
+///
+/// Carries summary statistics about the promotion (how many source facts,
+/// across how many sessions, confidence score). The full source chain lives
+/// in the sidecar `lineage` table, loaded on demand via `lineage_id`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PromotionProvenance {
+    pub source_count: u32,
+    pub session_count: u32,
+    pub date_range_start: DateTime<Utc>,
+    pub date_range_end: DateTime<Utc>,
+    pub confidence: f64,
+    pub method_version: String,
+    /// 3-5 most representative source fact IDs (for quick human review).
+    pub representative_ids: Vec<i64>,
+    /// Foreign key to the `lineage` table for the full source chain.
+    pub lineage_id: i64,
+}
+
+/// A row in the `lineage` sidecar table (full source chain).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineageRecord {
+    pub lineage_id: i64,
+    pub wisdom_fact_id: i64,
+    pub source_fact_ids: Vec<i64>,
+}
+
+/// Insert descriptor for a new lineage record (DB assigns `lineage_id`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NewLineageRecord {
+    pub wisdom_fact_id: i64,
+    pub source_fact_ids: Vec<i64>,
+}
+
 // --- Options ---
 
 /// Optional parameters for [`crate::engine::MemoryEngine::add_fact`].
@@ -401,5 +437,34 @@ mod tests {
             .surfaced_at
             .expect("surfaced_at should deserialize when present");
         assert_eq!(ts.to_rfc3339(), "2026-03-15T12:00:00+00:00");
+    }
+
+    #[test]
+    fn promotion_provenance_round_trip_json() {
+        let prov = PromotionProvenance {
+            source_count: 5,
+            session_count: 3,
+            date_range_start: Utc::now(),
+            date_range_end: Utc::now(),
+            confidence: 0.87,
+            method_version: "dreamcycle-v1".into(),
+            representative_ids: vec![10, 20, 30],
+            lineage_id: 42,
+        };
+        let json = serde_json::to_string(&prov).unwrap();
+        let back: PromotionProvenance = serde_json::from_str(&json).unwrap();
+        assert_eq!(prov, back);
+    }
+
+    #[test]
+    fn lineage_record_round_trip_json() {
+        let rec = LineageRecord {
+            lineage_id: 1,
+            wisdom_fact_id: 42,
+            source_fact_ids: vec![10, 20, 30, 40, 50],
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: LineageRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -198,6 +198,9 @@ pub enum ScopeQuery {
 /// Carries summary statistics about the promotion (how many source facts,
 /// across how many sessions, confidence score). The full source chain lives
 /// in the sidecar `lineage` table, loaded on demand via `lineage_id`.
+///
+/// `lineage_id` is reconstructed from the DB row PK on read and is
+/// **not** persisted in the JSON column (skipped during serialization).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PromotionProvenance {
     pub source_count: u32,
@@ -209,6 +212,8 @@ pub struct PromotionProvenance {
     /// 3-5 most representative source fact IDs (for quick human review).
     pub representative_ids: Vec<i64>,
     /// Foreign key to the `lineage` table for the full source chain.
+    /// Reconstructed from the row PK on read — not stored in the provenance JSON.
+    #[serde(skip_serializing, default)]
     pub lineage_id: i64,
 }
 
@@ -225,6 +230,18 @@ pub struct LineageRecord {
 pub struct NewLineageRecord {
     pub wisdom_fact_id: i64,
     pub source_fact_ids: Vec<i64>,
+}
+
+/// Complete lineage row for snapshot dump/restore.
+///
+/// Combines the `LineageRecord` fields with the full `PromotionProvenance`
+/// envelope into a single serializable entry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LineageSnapshotEntry {
+    pub lineage_id: i64,
+    pub wisdom_fact_id: i64,
+    pub source_fact_ids: Vec<i64>,
+    pub provenance: PromotionProvenance,
 }
 
 // --- Options ---
@@ -452,8 +469,13 @@ mod tests {
             lineage_id: 42,
         };
         let json = serde_json::to_string(&prov).unwrap();
+        // lineage_id is skip_serializing — should not appear in JSON
+        assert!(!json.contains("lineage_id"));
         let back: PromotionProvenance = serde_json::from_str(&json).unwrap();
-        assert_eq!(prov, back);
+        // lineage_id defaults to 0 on deserialization (not round-tripped)
+        assert_eq!(back.lineage_id, 0);
+        assert_eq!(back.source_count, prov.source_count);
+        assert_eq!(back.method_version, prov.method_version);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `PromotionProvenance` struct (lightweight envelope) and `LineageRecord`/`NewLineageRecord` types for provenance tracking on promoted wisdom facts
- Add `lineage` sidecar table in SQLite via migration v7→v8 — stores full source-fact chain (`source_fact_ids` JSON array) and provenance envelope (`provenance` JSON) per promoted wisdom fact
- Add `LineageStore` with full CRUD: `insert`, `get_by_wisdom_fact`, `get_source_fact_ids`, `delete`, `has_lineage`
- Expose 4 public methods on `MemoryEngine` facade: `record_lineage`, `get_provenance`, `get_full_lineage`, `delete_lineage`
- Add `Lineage` error variant to `MemoryError` + MCP error mapping

Fixes #55

## Design decisions

- **Sidecar table, not columns on `facts`**: The `lineage` table has a 1:1 relationship with promoted wisdom facts via `UNIQUE INDEX` on `wisdom_fact_id`. This keeps the `facts` table clean for the 99% of facts that are not promoted.
- **Provenance stored as JSON**: The full `PromotionProvenance` envelope is stored as a JSON column with `CHECK(json_valid(...))`. The `lineage_id` field in the struct is reconstructed from the row's PK on read (not stored in JSON), avoiding post-insert UPDATE round-trips.
- **Source facts are soft-deleted**: Per the design doc, source facts get `t_expired` set but are never hard-deleted, ensuring lineage chains remain resolvable indefinitely.

## Test plan

- [x] `PromotionProvenance` and `LineageRecord` serde round-trip tests
- [x] `Lineage` error variant display test
- [x] Migration v7→v8 test (lineage table creation, columns, unique index)
- [x] Fresh DB has lineage table test
- [x] All existing schema migration tests updated and passing
- [x] `LineageStore` CRUD tests (7 tests: insert, get, get_source_ids, delete, has_lineage, not_found, duplicate rejection)
- [x] Engine facade integration tests (4 tests: record+get, full_lineage, delete, not_found)
- [x] Insta snapshots updated for inspect dump
- [x] Full workspace gate: `cargo build --workspace` + `cargo test --workspace` (573 tests, 0 failures) + `cargo clippy --workspace` (clean on new code) + `cargo fmt --check` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)