### PR TITLE
feat: activity stream + session lifecycle MCP endpoints (#224)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -266,7 +266,7 @@ Spawned during Phase 4a implementation reviews. All non-blocking for Phase 4b/4c
 
 | Issue                                                       | Priority | Description                                                                                                                                       |
 | ----------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [#224](https://github.com/dutiona/memory-engine/issues/224) | P0       | MCP: activity stream + session lifecycle (`record_activity`, `checkpoint_session`, `load_context`) + server-side filtering. Part of #221 umbrella |
+| ✅ [#224](https://github.com/dutiona/memory-engine/issues/224) | P0       | MCP: activity stream + session lifecycle (`record_activity`, `checkpoint_session`, `load_context`) + server-side filtering. Part of #221 umbrella. [PR #230](https://github.com/dutiona/memory-engine/pull/230) |
 
 See also: [#225](https://github.com/dutiona/memory-engine/issues/225) (cognitive endpoints, Phase 5a), [#226](https://github.com/dutiona/memory-engine/issues/226) (cross-layer linking, Phase 6).
 
@@ -351,9 +351,9 @@ Phase 4a ✅, 4b ✅, and 4c ✅ are complete. Phase 5a **in progress** — trai
          ┌────────────────┼─────────────────┐
          │                │                 │
          ▼                ▼                 ▼
-      #224 ◀─ READY     super-qa          Phase 5a ◀── CRITICAL PATH
+      #224 ✅ DONE      super-qa          Phase 5a ◀── CRITICAL PATH
       activity stream    (25 issues)       (#48✅,#49✅,#55✅,#56✅,#63✅
-      + session lifecycle parallel track    remaining: #57,#132,#133,#158,#159,#160,#161)
+      PR #230             parallel track    remaining: #57,#132,#133,#158,#159,#160,#161)
       (part of #221)                            │
          │                                      ├──▶ #225 (cognitive MCP endpoints)
          │                                      │    (part of #221, #48✅ #49✅ done)
@@ -379,7 +379,7 @@ Phase 4a ✅, 4b ✅, and 4c ✅ are complete. Phase 5a **in progress** — trai
 
 **Parallelizable right now (3 independent tracks):**
 
-1. **#224 — Activity stream + session lifecycle** (unblocked, part of #221 umbrella)
+1. ~~**#224 — Activity stream + session lifecycle**~~ ✅ Done ([PR #230](https://github.com/dutiona/memory-engine/pull/230))
 1. **Super-qa sweep** (25 open issues; #108 ✅, #128 ✅, #187 ✅; +#191, +#192 from #186 review; +#203 from #195 review) — incremental, any order
 1. **Phase 5a remaining** (#57, #132, #133, #158–#161, #206–#211, #225) — critical path continues
 

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## What
 
-A stdio-based MCP server binary that exposes memory-engine as 15 tools (10 P0 + 5 P1) for autonomous AI agents. Part of the four-layer cognitive architecture (Knowledge → Memory → Wisdom → Intelligence) — this crate bridges Memory to Intelligence via the Model Context Protocol.
+A stdio-based MCP server binary that exposes memory-engine as 18 tools (10 P0 + 5 P1 + 3 activity stream) for autonomous AI agents. Part of the four-layer cognitive architecture (Knowledge → Memory → Wisdom → Intelligence) — this crate bridges Memory to Intelligence via the Model Context Protocol.
 
 ## Why
 
@@ -70,23 +70,26 @@ Add to `.claude/settings.json`:
 
 ### Tools
 
-| Tool                    | Priority | Purpose                              | Depth                |
-| ----------------------- | -------- | ------------------------------------ | -------------------- |
-| `memory_ingest`         | P0       | Append event to log                  | —                    |
-| `memory_add_fact`       | P0       | Add fact with embedding              | —                    |
-| `memory_query`          | P0       | Hybrid FTS + vector search           | sparse/standard/full |
-| `memory_resume_context` | P0       | 5-tier cognitive boot                | sparse/standard/full |
-| `memory_list_due`       | P0       | Scheduled fact surfacing             | sparse/standard/full |
-| `memory_next_due_time`  | P0       | Next scheduled time                  | —                    |
-| `memory_explain_fact`   | P0       | Fact provenance                      | sparse/standard/full |
-| `memory_get_fact`       | P0       | Single fact by ID                    | sparse/standard/full |
-| `memory_statistics`     | P0       | Aggregate stats                      | —                    |
-| `memory_flush_insights` | P0       | Batch pre-compaction capture         | —                    |
-| `memory_consolidate`    | P1       | Dedup + cluster facts into summaries | —                    |
-| `memory_forget`         | P1       | Ebbinghaus decay pruning             | —                    |
-| `memory_dump_state`     | P1       | Export snapshot (JSON/SQLite)         | —                    |
-| `memory_pin_fact`       | P1       | Make fact unforgettable              | —                    |
-| `memory_unpin_fact`     | P1       | Allow forgetting a pinned fact       | —                    |
+| Tool                        | Priority | Purpose                                | Depth                |
+| --------------------------- | -------- | -------------------------------------- | -------------------- |
+| `memory_ingest`             | P0       | Append event to log                    | —                    |
+| `memory_add_fact`           | P0       | Add fact with embedding                | —                    |
+| `memory_query`              | P0       | Hybrid FTS + vector search             | sparse/standard/full |
+| `memory_resume_context`     | P0       | 5-tier cognitive boot                  | sparse/standard/full |
+| `memory_list_due`           | P0       | Scheduled fact surfacing               | sparse/standard/full |
+| `memory_next_due_time`      | P0       | Next scheduled time                    | —                    |
+| `memory_explain_fact`       | P0       | Fact provenance                        | sparse/standard/full |
+| `memory_get_fact`           | P0       | Single fact by ID                      | sparse/standard/full |
+| `memory_statistics`         | P0       | Aggregate stats                        | —                    |
+| `memory_flush_insights`     | P0       | Batch pre-compaction capture           | —                    |
+| `memory_consolidate`        | P1       | Dedup + cluster facts into summaries   | —                    |
+| `memory_forget`             | P1       | Ebbinghaus decay pruning               | —                    |
+| `memory_dump_state`         | P1       | Export snapshot (JSON/SQLite)          | —                    |
+| `memory_pin_fact`           | P1       | Make fact unforgettable                | —                    |
+| `memory_unpin_fact`         | P1       | Allow forgetting a pinned fact         | —                    |
+| `memory_record_activity`    | Activity | Record tool invocation with dedup      | —                    |
+| `memory_checkpoint_session` | Activity | Checkpoint session state (LWW)         | —                    |
+| `memory_load_context`       | Activity | Load project context for session start | sparse/standard/full |
 
 ### Tiered Depth
 
@@ -126,14 +129,14 @@ Parameters: `dedup_threshold` (default 0.92), `min_cluster_size` (default 3).
 
 All parameters are optional — defaults from `ForgetPolicy::default()`:
 
-| Parameter                | Default | Description                            |
-| ------------------------ | ------- | -------------------------------------- |
-| `half_life_days`         | 69.0    | Base Ebbinghaus half-life              |
-| `min_importance`         | 0.1     | Threshold below which facts are pruned |
-| `recency_weight`         | 0.3     | Weight for recency signal              |
-| `frequency_weight`       | 0.2     | Weight for access frequency            |
-| `graph_degree_weight`    | 0.3     | Weight for graph connectivity          |
-| `base_importance_weight` | 0.2     | Weight for base importance             |
+| Parameter                | Default | Description                                       |
+| ------------------------ | ------- | ------------------------------------------------- |
+| `half_life_days`         | 69.0    | Base Ebbinghaus half-life                         |
+| `min_importance`         | 0.1     | Threshold below which facts are pruned            |
+| `recency_weight`         | 0.3     | Weight for recency signal                         |
+| `frequency_weight`       | 0.2     | Weight for access frequency                       |
+| `graph_degree_weight`    | 0.3     | Weight for graph connectivity                     |
+| `base_importance_weight` | 0.2     | Weight for base importance                        |
 | `half_life_overrides`    | `{}`    | Per-FactType overrides, e.g. `{"Episodic": 30.0}` |
 
 ### Dump State (`memory_dump_state`)
@@ -144,14 +147,76 @@ Exports the full engine snapshot. Formats: `json`, `sqlite`. Client-supplied pat
 
 `memory_pin_fact` and `memory_unpin_fact` toggle a fact's persistence. Pinned facts are immune to `memory_forget`.
 
+### Activity Stream (`memory_record_activity`)
+
+Records tool invocations with server-side filtering. The pipeline runs: **ignore** (drop noise) → **dedup** (collapse repeats within a configurable window) → **promote** (auto-create facts from significant actions).
+
+Parameters:
+
+| Param           | Type   | Required | Description                                                         |
+| --------------- | ------ | -------- | ------------------------------------------------------------------- |
+| `tool`          | string | yes      | Tool name that was invoked                                          |
+| `session_id`    | string | yes      | Current session ID                                                  |
+| `args`          | object | no       | Tool arguments (arbitrary JSON)                                     |
+| `result`        | string | no       | Tool result summary (truncated at 512 chars server-side)            |
+| `timestamp`     | string | no       | ISO 8601 timestamp. Defaults to now                                 |
+| `scope`         | string | no       | Scope path for the activity                                         |
+| `outcome_class` | string | no       | `"success"`, `"error"`, `"test_failure"`, etc. Default: `"success"` |
+
+Returns `{ activity_id, was_deduplicated, promoted_fact_id, status }`.
+
+Dedup key: `(session_id, tool_name, args_hash, outcome_class, scope_id)` within the configured window (default 300s). Outcome-class-aware: a passing `cargo test` and a failing one within the same window are NOT collapsed.
+
+Filtering policy is adapter-specific — the MCP adapter supplies Claude Code heuristics (ignore/promote patterns) via `activity_policy.rs`. The core engine is generic.
+
+### Session Checkpoint (`memory_checkpoint_session`)
+
+Saves session state (last-write-wins per `session_id`). Designed to be called from a Stop hook.
+
+Parameters:
+
+| Param        | Type   | Required | Description               |
+| ------------ | ------ | -------- | ------------------------- |
+| `session_id` | string | yes      | Session ID to checkpoint  |
+| `scope`      | string | no       | Scope path                |
+| `summary`    | string | no       | Free-form session summary |
+| `metadata`   | object | no       | Arbitrary JSON metadata   |
+
+Returns `{ session_id, checkpointed: true }`.
+
+### Load Context (`memory_load_context`)
+
+Loads project-scoped context for session bootstrap. Returns recent activities, the last checkpoint, and relevant scope-filtered facts in a single read snapshot (consistent cross-query results).
+
+Parameters:
+
+| Param            | Type    | Required | Description                                                 |
+| ---------------- | ------- | -------- | ----------------------------------------------------------- |
+| `scope`          | string  | yes      | Scope path                                                  |
+| `activity_limit` | integer | no       | Max recent activities (default 20)                          |
+| `fact_limit`     | integer | no       | Max relevant facts (default 10)                             |
+| `depth`          | string  | no       | `"sparse"` / `"standard"` / `"full"` (default `"standard"`) |
+
+Returns `{ scope_path, recent_activities, last_checkpoint, relevant_facts }` shaped by the requested depth level.
+
+### Schema v9
+
+The activity stream adds two tables in schema version 9:
+
+- **`activities`** — append-only log of tool invocations with dedup counters, outcome classification, and optional promotion linkage (`promoted_fact_id` FK to `facts`).
+- **`session_checkpoints`** — last-write-wins session state (scope, summary, metadata, timestamp).
+
+Migration from v8 is automatic on first open.
+
 ### Architecture
 
 ```
 Agent (Claude, etc.) → stdio JSON-RPC → memory-engine-mcp → MemoryEngine (SQLite)
                                          ├── config.rs (TOML + env + CLI)
                                          ├── server.rs (ServerHandler, spawn_blocking)
-                                         ├── tools/   (15 handlers + dispatch)
+                                         ├── tools/   (18 handlers + dispatch)
                                          ├── depth.rs (response shaping)
+                                         ├── activity_policy.rs (Claude Code filter heuristics)
                                          ├── embedding.rs (HTTP embedding provider)
                                          ├── summary.rs (HTTP summary generator)
                                          └── error.rs (MemoryError → MCP)

--- a/memory-engine-mcp/src/activity_policy.rs
+++ b/memory-engine-mcp/src/activity_policy.rs
@@ -1,0 +1,43 @@
+//! Claude Code adapter-specific activity filter policy.
+//!
+//! Provides default ignore/promote patterns for Claude Code tool streams.
+//! This keeps adapter-specific tool-name knowledge out of the core engine crate.
+
+use memory_engine::ActivityFilterConfig;
+
+/// Default activity filter configuration for Claude Code tool streams.
+///
+/// - **Ignore:** formatting-only tools and lint auto-fixes
+/// - **Promote:** git commits, test failures, new file creation
+/// - **Dedup window:** 300 seconds (5 minutes)
+#[must_use]
+pub fn default_filter_config() -> ActivityFilterConfig {
+    ActivityFilterConfig {
+        dedup_window_secs: 300,
+        ignore_patterns: vec![
+            // Formatting tools that produce no semantic value
+            "prettier".into(),
+            "eslint_fix".into(),
+            "ruff_format".into(),
+            "clang_format".into(),
+        ],
+        promote_patterns: vec![
+            // Significant actions worth promoting to facts
+            "git_commit".into(),
+            "git_push".into(),
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_sensible_defaults() {
+        let config = default_filter_config();
+        assert_eq!(config.dedup_window_secs, 300);
+        assert!(!config.ignore_patterns.is_empty());
+        assert!(!config.promote_patterns.is_empty());
+    }
+}

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -1,7 +1,7 @@
 use memory_engine::ResumeContext;
 use memory_engine::inspect_types::{FactExplanation, FactHistory};
 use memory_engine::search::hybrid::{QueryDiagnostics, SearchResult};
-use memory_engine::types::{Event, Fact};
+use memory_engine::types::{Activity, Event, Fact, ProjectContext, SessionCheckpoint};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -236,6 +236,89 @@ pub fn shape_fact_history(history: &FactHistory, depth: Depth) -> Value {
             })
         }
     }
+}
+
+/// Shape an [`Activity`] according to the requested depth.
+pub fn shape_activity(activity: &Activity, depth: Depth) -> Value {
+    match depth {
+        Depth::Sparse => json!({
+            "id": activity.id,
+            "tool_name": activity.tool_name,
+            "status": activity.status.to_string(),
+            "last_seen": activity.last_seen,
+        }),
+        Depth::Standard => json!({
+            "id": activity.id,
+            "session_id": activity.session_id,
+            "tool_name": activity.tool_name,
+            "result_summary": activity.result_summary,
+            "outcome_class": activity.outcome_class,
+            "status": activity.status.to_string(),
+            "occurrence_count": activity.occurrence_count,
+            "first_seen": activity.first_seen,
+            "last_seen": activity.last_seen,
+            "scope_id": activity.scope_id,
+        }),
+        Depth::Full => json!({
+            "id": activity.id,
+            "session_id": activity.session_id,
+            "tool_name": activity.tool_name,
+            "args_hash": activity.args_hash,
+            "args": activity.args,
+            "result_summary": activity.result_summary,
+            "outcome_class": activity.outcome_class,
+            "status": activity.status.to_string(),
+            "occurrence_count": activity.occurrence_count,
+            "first_seen": activity.first_seen,
+            "last_seen": activity.last_seen,
+            "scope_id": activity.scope_id,
+            "promoted_fact_id": activity.promoted_fact_id,
+        }),
+    }
+}
+
+/// Shape a [`SessionCheckpoint`] according to the requested depth.
+pub fn shape_checkpoint(checkpoint: &SessionCheckpoint, depth: Depth) -> Value {
+    match depth {
+        Depth::Sparse => json!({
+            "session_id": checkpoint.session_id,
+            "scope_path": checkpoint.scope_path,
+            "checkpoint_at": checkpoint.checkpoint_at,
+        }),
+        Depth::Standard | Depth::Full => json!({
+            "session_id": checkpoint.session_id,
+            "scope_path": checkpoint.scope_path,
+            "summary": checkpoint.summary,
+            "last_activity_id": checkpoint.last_activity_id,
+            "checkpoint_at": checkpoint.checkpoint_at,
+            "metadata": checkpoint.metadata,
+        }),
+    }
+}
+
+/// Shape a [`ProjectContext`] according to the requested depth.
+pub fn shape_project_context(ctx: &ProjectContext, depth: Depth) -> Value {
+    let activities: Vec<Value> = ctx
+        .recent_activities
+        .iter()
+        .map(|a| shape_activity(a, depth))
+        .collect();
+    let facts: Vec<Value> = ctx
+        .relevant_facts
+        .iter()
+        .map(|f| shape_fact(f, depth, None))
+        .collect();
+    let checkpoint = ctx
+        .last_checkpoint
+        .as_ref()
+        .map(|cp| shape_checkpoint(cp, depth));
+
+    json!({
+        "scope_path": ctx.scope_path,
+        "recent_activities": activities,
+        "last_checkpoint": checkpoint,
+        "relevant_facts": facts,
+    })
 }
 
 #[cfg(test)]

--- a/memory-engine-mcp/src/lib.rs
+++ b/memory-engine-mcp/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod activity_policy;
 pub mod config;
 pub mod depth;
 pub mod embedding;

--- a/memory-engine-mcp/src/server.rs
+++ b/memory-engine-mcp/src/server.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use memory_engine::ActivityFilterConfig;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::traits::SummaryGenerator;
 use rmcp::RoleServer;
@@ -23,6 +24,7 @@ pub struct MemoryMcpServer {
     pub embedder: Option<Arc<HttpEmbeddingProvider>>,
     pub summary_gen: Option<Arc<dyn SummaryGenerator + Send + Sync>>,
     pub embed_dim: usize,
+    pub filter_config: Arc<ActivityFilterConfig>,
 }
 
 impl MemoryMcpServer {
@@ -37,6 +39,7 @@ impl MemoryMcpServer {
             embedder,
             summary_gen,
             embed_dim,
+            filter_config: Arc::new(crate::activity_policy::default_filter_config()),
         }
     }
 
@@ -90,6 +93,7 @@ impl ServerHandler for MemoryMcpServer {
         let embedder = self.embedder.clone();
         let summary_gen = self.summary_gen.clone();
         let embed_dim = self.embed_dim;
+        let filter_config = Arc::clone(&self.filter_config);
 
         // Dispatch to tool handlers on the blocking thread pool.
         // Engine operations are sync (SQLite) — must not run on the async runtime.
@@ -101,6 +105,7 @@ impl ServerHandler for MemoryMcpServer {
                 embedder.as_deref(),
                 summary_gen.as_deref(),
                 embed_dim,
+                &filter_config,
             )
         })
         .await

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use memory_engine::ResumeConfig;
 use memory_engine::bootstrap::{BootstrapConfig, KeywordExtractor};
 use memory_engine::engine::MemoryEngine;
 use memory_engine::inspect_types::{DumpFormat, FactExplanation, ReplayFilter, ReplayOrder};
@@ -15,12 +14,13 @@ use memory_engine::traits::{
 use memory_engine::types::{
     AddFactOptions, AddFactRequest, EventType, FactType, NewEvent, Outcome,
 };
+use memory_engine::ResumeConfig;
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 
 use crate::depth::{self, Depth};
 use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
-use crate::error::{ValidationError, to_mcp_error};
+use crate::error::{to_mcp_error, ValidationError};
 
 // ---------------------------------------------------------------------------
 // Tool definitions (JSON schemas)
@@ -1374,8 +1374,8 @@ fn handle_load_context(
 ) -> Result<CallToolResult, ErrorData> {
     let scope =
         get_str(&args, "scope").ok_or_else(|| ErrorData::invalid_params("missing scope", None))?;
-    let activity_limit = get_i64(&args, "activity_limit").unwrap_or(20) as usize;
-    let fact_limit = get_i64(&args, "fact_limit").unwrap_or(10) as usize;
+    let activity_limit = get_usize(&args, "activity_limit").unwrap_or(20);
+    let fact_limit = get_usize(&args, "fact_limit").unwrap_or(10);
     let depth_level = get_depth(&args);
 
     let ctx = engine

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -312,6 +312,52 @@ pub fn all_tool_definitions() -> Vec<Tool> {
                 "required": ["fact_id"]
             }),
         ),
+        // Activity stream + session lifecycle (#224)
+        tool_def(
+            "memory_record_activity",
+            "Record a tool invocation activity. Server-side filtering deduplicates, ignores formatting, and can promote significant actions to facts.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "tool": { "type": "string", "description": "Tool name that was invoked" },
+                    "args": { "description": "Tool arguments (arbitrary JSON)" },
+                    "result": { "type": "string", "description": "Tool result summary (truncated at 512 chars)" },
+                    "session_id": { "type": "string", "description": "Current session ID" },
+                    "timestamp": { "type": "string", "format": "date-time", "description": "ISO 8601 timestamp. Defaults to now." },
+                    "scope": { "type": "string", "description": "Scope path for the activity" },
+                    "outcome_class": { "type": "string", "description": "Outcome class (e.g. 'success', 'error', 'test_failure'). Default: 'success'" }
+                },
+                "required": ["tool", "session_id"]
+            }),
+        ),
+        tool_def(
+            "memory_checkpoint_session",
+            "Checkpoint the current session (last-write-wins). Called by Stop hook.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "session_id": { "type": "string", "description": "Session ID to checkpoint" },
+                    "scope": { "type": "string", "description": "Scope path (e.g. 'project:memory-engine')" },
+                    "summary": { "type": "string", "description": "Free-form session summary" },
+                    "metadata": { "description": "Arbitrary JSON metadata" }
+                },
+                "required": ["session_id"]
+            }),
+        ),
+        tool_def(
+            "memory_load_context",
+            "Load active project context for session start. Returns recent activities, last checkpoint, and relevant facts.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "scope": { "type": "string", "description": "Scope path (e.g. 'project:memory-engine')" },
+                    "activity_limit": { "type": "integer", "default": 20, "description": "Max recent activities to return" },
+                    "fact_limit": { "type": "integer", "default": 10, "description": "Max relevant facts to return" },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                },
+                "required": ["scope"]
+            }),
+        ),
     ]
 }
 
@@ -335,6 +381,7 @@ pub fn dispatch(
     embedder: Option<&HttpEmbeddingProvider>,
     summary_gen: Option<&(dyn SummaryGenerator + Send + Sync)>,
     embed_dim: usize,
+    filter_config: &memory_engine::ActivityFilterConfig,
 ) -> Result<CallToolResult, ErrorData> {
     match name {
         "memory_ingest" => handle_ingest(args, engine),
@@ -360,6 +407,10 @@ pub fn dispatch(
         // Phase 5a: Outcome tracking
         "memory_record_outcome" => handle_record_outcome(args, engine),
         "memory_outcome_counts" => handle_outcome_counts(args, engine),
+        // Activity stream + session lifecycle (#224)
+        "memory_record_activity" => handle_record_activity(args, engine, embedder, filter_config),
+        "memory_checkpoint_session" => handle_checkpoint_session(args, engine),
+        "memory_load_context" => handle_load_context(args, engine),
         _ => Err(ErrorData::invalid_params(
             format!("unknown tool: {name}"),
             None,
@@ -1249,4 +1300,87 @@ fn handle_outcome_counts(
         "negative": counts.negative,
         "neutral": counts.neutral,
     }))
+}
+
+// ---------------------------------------------------------------------------
+// Activity stream + session lifecycle (#224)
+// ---------------------------------------------------------------------------
+
+fn handle_record_activity(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+    embedder: Option<&HttpEmbeddingProvider>,
+    filter_config: &memory_engine::ActivityFilterConfig,
+) -> Result<CallToolResult, ErrorData> {
+    let tool_name =
+        get_str(&args, "tool").ok_or_else(|| ErrorData::invalid_params("missing tool", None))?;
+    let session_id = get_str(&args, "session_id")
+        .ok_or_else(|| ErrorData::invalid_params("missing session_id", None))?;
+    let tool_args = args.get("args").cloned().unwrap_or(json!({}));
+    let result_summary = get_str(&args, "result");
+    let timestamp = get_datetime(&args, "timestamp")?.unwrap_or_else(Utc::now);
+    let scope = get_str(&args, "scope");
+    let outcome_class = get_str(&args, "outcome_class");
+
+    let req = memory_engine::RecordActivityRequest {
+        tool_name,
+        args: tool_args,
+        result: result_summary,
+        session_id,
+        timestamp,
+        scope_path: scope,
+        outcome_class,
+    };
+
+    let result = engine
+        .record_activity(
+            &req,
+            embedder.map(|e| e as &dyn EmbeddingProvider),
+            filter_config,
+        )
+        .map_err(to_mcp_error)?;
+
+    ok_json(json!({
+        "activity_id": result.activity_id,
+        "was_deduplicated": result.was_deduplicated,
+        "promoted_fact_id": result.promoted_fact_id,
+        "status": result.status.to_string(),
+    }))
+}
+
+fn handle_checkpoint_session(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let session_id = get_str(&args, "session_id")
+        .ok_or_else(|| ErrorData::invalid_params("missing session_id", None))?;
+    let scope = get_str(&args, "scope");
+    let summary = get_str(&args, "summary");
+    let metadata = args.get("metadata").cloned();
+
+    engine
+        .checkpoint_session(&session_id, scope.as_deref(), summary.as_deref(), metadata)
+        .map_err(to_mcp_error)?;
+
+    ok_json(json!({
+        "session_id": session_id,
+        "checkpointed": true,
+    }))
+}
+
+fn handle_load_context(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let scope =
+        get_str(&args, "scope").ok_or_else(|| ErrorData::invalid_params("missing scope", None))?;
+    let activity_limit = get_i64(&args, "activity_limit").unwrap_or(20) as usize;
+    let fact_limit = get_i64(&args, "fact_limit").unwrap_or(10) as usize;
+    let depth_level = get_depth(&args);
+
+    let ctx = engine
+        .load_context(&scope, activity_limit, fact_limit)
+        .map_err(to_mcp_error)?;
+
+    ok_json(depth::shape_project_context(&ctx, depth_level))
 }

--- a/memory-engine-mcp/tests/depth_shaping.rs
+++ b/memory-engine-mcp/tests/depth_shaping.rs
@@ -112,6 +112,7 @@ fn get_fact_sparse() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("get_fact_sparse", body);
@@ -143,6 +144,7 @@ fn get_fact_standard() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("get_fact_standard", body);
@@ -174,6 +176,7 @@ fn get_fact_full() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("get_fact_full", body);
@@ -208,6 +211,7 @@ fn explain_fact_sparse() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("explain_fact_sparse", body);
@@ -238,6 +242,7 @@ fn explain_fact_standard() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("explain_fact_standard", body);
@@ -268,6 +273,7 @@ fn explain_fact_full() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("explain_fact_full", body);
@@ -302,6 +308,7 @@ fn query_result_sparse() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("query_result_sparse", body);
@@ -332,6 +339,7 @@ fn query_result_standard() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("query_result_standard", body);
@@ -362,6 +370,7 @@ fn query_result_full() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("query_result_full", body);
@@ -401,6 +410,7 @@ fn resume_context_sparse() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("resume_context_sparse", body);
@@ -436,6 +446,7 @@ fn resume_context_standard() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("resume_context_standard", body);
@@ -471,6 +482,7 @@ fn resume_context_full() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("resume_context_full", body);
@@ -490,6 +502,7 @@ fn list_due_sparse() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     redact(&mut body);
     insta::assert_yaml_snapshot!("list_due_sparse", body);
@@ -524,6 +537,7 @@ fn sparse_has_exactly_4_fields() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     assert_eq!(body.as_object().unwrap().len(), 4);
 }
@@ -553,6 +567,7 @@ fn standard_excludes_embedding_and_hash() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     let obj = body.as_object().unwrap();
     assert!(!obj.contains_key("embedding"));
@@ -585,6 +600,7 @@ fn full_includes_embedding_dim_and_hash() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     let obj = body.as_object().unwrap();
     assert!(obj.contains_key("content_hash"));
@@ -622,6 +638,7 @@ fn default_depth_is_standard() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     ));
     let obj = body.as_object().unwrap();
     // Standard has content + fact_type but no embedding_dim

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -77,6 +77,7 @@ async fn openai_format_embedding() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         );
         unwrap_ok(result)
     })
@@ -120,6 +121,7 @@ async fn ollama_format_embedding() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         );
         unwrap_ok(result)
     })
@@ -163,6 +165,7 @@ async fn direct_format_embedding() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         );
         unwrap_ok(result)
     })
@@ -206,6 +209,7 @@ async fn wrong_dimension_from_server() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         )
         .is_err()
     })
@@ -246,6 +250,7 @@ async fn server_500_propagates_error() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         )
         .is_err()
     })
@@ -293,6 +298,7 @@ async fn bearer_auth_sent_when_configured() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         );
         unwrap_ok(result)
     })
@@ -345,6 +351,7 @@ async fn flush_insights_with_http_embedder() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         );
         unwrap_ok(result)
     })
@@ -392,6 +399,7 @@ async fn flush_insights_partial_failure() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         );
         unwrap_ok(result)
     })
@@ -442,6 +450,7 @@ async fn query_hybrid_with_http_embedder() {
             None,
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         )
         .unwrap();
 
@@ -453,6 +462,7 @@ async fn query_hybrid_with_http_embedder() {
             Some(&provider),
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         );
         unwrap_ok(result)
     })

--- a/memory-engine-mcp/tests/query_mode_inference.rs
+++ b/memory-engine-mcp/tests/query_mode_inference.rs
@@ -108,6 +108,7 @@ fn explicit_fts_no_embedder_succeeds() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["count"].as_u64().unwrap() >= 1);
@@ -130,6 +131,7 @@ fn explicit_vector_no_embedder_no_embedding_fails() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -153,6 +155,7 @@ fn explicit_vector_with_precomputed_embedding_succeeds() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["count"].as_u64().unwrap() >= 1);
@@ -175,6 +178,7 @@ fn explicit_hybrid_no_embedder_no_embedding_fails() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -198,6 +202,7 @@ fn explicit_hybrid_with_precomputed_embedding_succeeds() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["count"].as_u64().unwrap() >= 1);
@@ -220,6 +225,7 @@ fn inferred_mode_text_only_no_embedder_falls_back_to_fts() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["count"].as_u64().unwrap() >= 1);
@@ -241,6 +247,7 @@ fn inferred_mode_embedding_only_works() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     // Should return some results via vector search
@@ -261,6 +268,7 @@ fn unknown_mode_returns_error() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -302,6 +310,7 @@ fn query_with_scope_parameters_accepted() {
             None,
             None,
             DIM,
+            &memory_engine::ActivityFilterConfig::default(),
         );
         // Should succeed (no validation error), regardless of result count
         assert!(
@@ -358,6 +367,7 @@ fn fts_with_fact_type_filter() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert_eq!(body["count"].as_u64().unwrap(), 1);

--- a/memory-engine-mcp/tests/tool_roundtrip.rs
+++ b/memory-engine-mcp/tests/tool_roundtrip.rs
@@ -92,6 +92,7 @@ fn ingest_minimal() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["event_id"].as_i64().unwrap() > 0);
@@ -114,6 +115,7 @@ fn ingest_with_all_optional_fields() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["event_id"].as_i64().unwrap() > 0);
@@ -133,6 +135,7 @@ fn ingest_invalid_event_type() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -151,6 +154,7 @@ fn ingest_missing_required_field() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -173,6 +177,7 @@ fn add_fact_with_precomputed_embedding() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["fact_id"].as_i64().unwrap() > 0);
@@ -199,6 +204,7 @@ fn add_fact_all_options() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["fact_id"].as_i64().unwrap() > 0);
@@ -218,6 +224,7 @@ fn add_fact_importance_out_of_range() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -237,6 +244,7 @@ fn add_fact_temporal_inconsistency() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -254,6 +262,7 @@ fn add_fact_wrong_embedding_dim() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -270,6 +279,7 @@ fn add_fact_no_embedder_no_embedding() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     // Should fail: no pre-computed embedding and no HttpEmbeddingProvider
     assert!(result.is_err());
@@ -322,6 +332,7 @@ fn query_fts_returns_results() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["count"].as_u64().unwrap() >= 1);
@@ -359,6 +370,7 @@ fn query_with_precomputed_embedding() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["count"].as_u64().unwrap() >= 1);
@@ -377,6 +389,7 @@ fn query_one_sided_period_rejected() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -394,6 +407,7 @@ fn query_empty_engine() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert_eq!(body["count"].as_u64().unwrap(), 0);
@@ -413,6 +427,7 @@ fn resume_context_empty_engine() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     // All tiers should be empty arrays
@@ -453,6 +468,7 @@ fn resume_context_with_pinned_fact() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(!body["pinned"].as_array().unwrap().is_empty());
@@ -465,7 +481,15 @@ fn resume_context_with_pinned_fact() {
 #[test]
 fn list_due_empty() {
     let engine = make_engine();
-    let result = tools::dispatch("memory_list_due", args(json!({})), &engine, None, None, DIM);
+    let result = tools::dispatch(
+        "memory_list_due",
+        args(json!({})),
+        &engine,
+        None,
+        None,
+        DIM,
+        &memory_engine::ActivityFilterConfig::default(),
+    );
     let body = unwrap_ok(result);
     assert_eq!(body["count"].as_u64().unwrap(), 0);
 }
@@ -484,6 +508,7 @@ fn next_due_time_empty() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body["next_due"].is_null());
@@ -519,6 +544,7 @@ fn explain_fact_existing() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert_eq!(body["fact_id"].as_i64().unwrap(), fact_id);
@@ -534,6 +560,7 @@ fn explain_fact_nonexistent() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -548,6 +575,7 @@ fn explain_fact_missing_id() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -582,6 +610,7 @@ fn get_fact_existing() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert_eq!(body["id"].as_i64().unwrap(), fact_id);
@@ -598,6 +627,7 @@ fn get_fact_nonexistent() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -616,6 +646,7 @@ fn statistics_empty_engine() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     // Should return stats even on empty engine
@@ -661,6 +692,7 @@ fn statistics_after_ingestion() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     let body = unwrap_ok(result);
     assert!(body.is_object());
@@ -684,6 +716,7 @@ fn flush_insights_no_embedder() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     // Requires embedder — should fail
     assert!(result.is_err());
@@ -699,6 +732,7 @@ fn flush_insights_missing_array() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -717,6 +751,7 @@ fn unknown_tool_returns_error() {
         None,
         None,
         DIM,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -726,12 +761,12 @@ fn unknown_tool_returns_error() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn all_tool_definitions_returns_20() {
+fn all_tool_definitions_returns_23() {
     let defs = tools::all_tool_definitions();
     assert_eq!(
         defs.len(),
-        20,
-        "expected 10 P0 + 5 P1 + 3 P2 + 2 Phase 5a tools"
+        23,
+        "expected 10 P0 + 5 P1 + 3 P2 + 2 Phase 5a + 3 activity stream tools"
     );
 }
 

--- a/memory-engine-mcp/tests/tools.rs
+++ b/memory-engine-mcp/tests/tools.rs
@@ -72,6 +72,7 @@ fn test_pin_unpin_roundtrip() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
     let v = extract_json(&result);
@@ -90,6 +91,7 @@ fn test_pin_unpin_roundtrip() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
     let v = extract_json(&result);
@@ -110,6 +112,7 @@ fn test_pin_missing_fact() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -125,7 +128,16 @@ fn test_forget_defaults() {
     let (engine, _dir) = test_engine();
     add_test_fact(&engine, "old fact");
 
-    let result = tools::dispatch("memory_forget", Map::new(), &engine, None, None, 3).unwrap();
+    let result = tools::dispatch(
+        "memory_forget",
+        Map::new(),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    )
+    .unwrap();
     let v = extract_json(&result);
     assert!(v["facts_evaluated"].is_number());
     assert!(v["facts_expired"].is_number());
@@ -142,6 +154,7 @@ fn test_forget_validation_error() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -158,6 +171,7 @@ fn test_forget_with_overrides() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
     let v = extract_json(&result);
@@ -172,7 +186,15 @@ fn test_forget_with_overrides() {
 fn test_consolidate_no_provider() {
     let (engine, _dir) = test_engine();
 
-    let result = tools::dispatch("memory_consolidate", Map::new(), &engine, None, None, 3);
+    let result = tools::dispatch(
+        "memory_consolidate",
+        Map::new(),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    );
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
@@ -191,6 +213,7 @@ fn test_consolidate_validation() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 
@@ -202,6 +225,7 @@ fn test_consolidate_validation() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -222,6 +246,7 @@ fn test_dump_state_json() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
     let v = extract_json(&result);
@@ -249,6 +274,7 @@ fn test_dump_state_custom_path() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
     let v = extract_json(&result);
@@ -265,7 +291,16 @@ fn test_dump_state_default_path() {
     add_test_fact(&engine, "fact for default dump");
 
     // No format or path → defaults to json + temp dir
-    let result = tools::dispatch("memory_dump_state", Map::new(), &engine, None, None, 3).unwrap();
+    let result = tools::dispatch(
+        "memory_dump_state",
+        Map::new(),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    )
+    .unwrap();
     let v = extract_json(&result);
     let path = v["path"].as_str().unwrap();
     assert!(path.contains("memory-dump-"));
@@ -292,6 +327,7 @@ fn test_record_outcome_and_counts() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
     let v1 = extract_json(&r1);
@@ -306,6 +342,7 @@ fn test_record_outcome_and_counts() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
 
@@ -316,6 +353,7 @@ fn test_record_outcome_and_counts() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
 
@@ -327,6 +365,7 @@ fn test_record_outcome_and_counts() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     )
     .unwrap();
     let v2 = extract_json(&r2);
@@ -347,6 +386,7 @@ fn test_record_outcome_nonexistent_fact() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }
@@ -366,6 +406,7 @@ fn test_record_outcome_invalid_variant() {
         None,
         None,
         3,
+        &memory_engine::ActivityFilterConfig::default(),
     );
     assert!(result.is_err());
 }

--- a/src/engine/activity.rs
+++ b/src/engine/activity.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use chrono::Utc;
 
-use crate::engine::activity_filter::{ActivityFilterConfig, ActivityFilterDecision, apply_filter};
+use crate::engine::activity_filter::{apply_filter, ActivityFilterConfig, ActivityFilterDecision};
 use crate::error::{MemoryError, Result};
 use crate::store::activities::ActivityStore;
 use crate::store::checkpoints::CheckpointStore;
@@ -71,16 +71,13 @@ impl MemoryEngine {
             .unwrap_or("success")
             .to_string();
 
-        // Step 3: Resolve scope.
+        // Steps 3+4: Resolve scope and insert/dedup under one lock acquisition.
+        let conn = self.write_conn()?;
         let scope_id = match req.scope_path.as_deref() {
-            Some(path) => {
-                let conn = self.write_conn()?;
-                self.ensure_scope_with_conn(&conn, path)?
-            }
+            Some(path) => self.ensure_scope_with_conn(&conn, path)?,
             None => 1, // root scope
         };
 
-        // Step 4: Insert or dedup.
         let new_activity = NewActivity {
             session_id: req.session_id.clone(),
             tool_name: req.tool_name.clone(),
@@ -93,10 +90,10 @@ impl MemoryEngine {
         };
 
         let (activity_id, was_deduplicated) = {
-            let conn = self.write_conn()?;
             let store = ActivityStore::new(&conn);
             store.insert_or_dedup(&new_activity, filter_config.dedup_window_secs)?
         };
+        drop(conn);
 
         // Step 5: Promote (only if new, not deduplicated).
         let mut promoted_fact_id = None;

--- a/src/engine/activity.rs
+++ b/src/engine/activity.rs
@@ -1,0 +1,250 @@
+//! Engine methods for activity stream and session lifecycle.
+
+use std::collections::HashSet;
+
+use chrono::Utc;
+
+use crate::engine::activity_filter::{ActivityFilterConfig, ActivityFilterDecision, apply_filter};
+use crate::error::{MemoryError, Result};
+use crate::store::activities::ActivityStore;
+use crate::store::checkpoints::CheckpointStore;
+use crate::store::facts::FactStore;
+use crate::traits::EmbeddingProvider;
+use crate::types::{
+    ActivityStatus, AddFactOptions, AddFactRequest, NewActivity, ProjectContext,
+    RecordActivityRequest, RecordActivityResult, SessionCheckpoint,
+};
+
+use super::MemoryEngine;
+
+/// Compute blake3 hex hash, truncated to 32 chars (128 bits).
+/// Same policy as `FactStore::content_hash`.
+fn args_hash(args: &serde_json::Value) -> String {
+    let canonical = serde_json::to_string(args).unwrap_or_default();
+    let hash = blake3::hash(canonical.as_bytes());
+    hash.to_hex()[..32].to_string()
+}
+
+impl MemoryEngine {
+    // --- Public API: Activity stream ---
+
+    /// Record a tool activity with server-side filtering.
+    ///
+    /// Flow:
+    /// 1. Apply ignore/promote filter (pre-storage).
+    /// 2. Compute `args_hash` (blake3, 32 hex).
+    /// 3. Resolve scope if provided.
+    /// 4. Insert or dedup at store layer.
+    /// 5. If promote AND not deduplicated: create a fact.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on write failure, or
+    /// `MemoryError::ReadOnly` if the engine is read-only.
+    pub fn record_activity(
+        &self,
+        req: &RecordActivityRequest,
+        embedder: Option<&dyn EmbeddingProvider>,
+        filter_config: &ActivityFilterConfig,
+    ) -> Result<RecordActivityResult> {
+        // Step 1: Filter decision (no locks needed).
+        let decision = apply_filter(
+            &req.tool_name,
+            &req.args,
+            req.result.as_deref(),
+            filter_config,
+        );
+        if matches!(decision, ActivityFilterDecision::Ignore) {
+            return Ok(RecordActivityResult {
+                activity_id: None,
+                was_deduplicated: false,
+                promoted_fact_id: None,
+                status: ActivityStatus::Ignored,
+            });
+        }
+
+        // Step 2: Compute args hash.
+        let hash = args_hash(&req.args);
+        let outcome = req
+            .outcome_class
+            .as_deref()
+            .unwrap_or("success")
+            .to_string();
+
+        // Step 3: Resolve scope.
+        let scope_id = match req.scope_path.as_deref() {
+            Some(path) => {
+                let conn = self.write_conn()?;
+                self.ensure_scope_with_conn(&conn, path)?
+            }
+            None => 1, // root scope
+        };
+
+        // Step 4: Insert or dedup.
+        let new_activity = NewActivity {
+            session_id: req.session_id.clone(),
+            tool_name: req.tool_name.clone(),
+            args_hash: hash,
+            args: req.args.clone(),
+            result_summary: req.result.as_ref().map(|r| truncate(r, 512).to_string()),
+            outcome_class: outcome,
+            timestamp: req.timestamp,
+            scope_id,
+        };
+
+        let (activity_id, was_deduplicated) = {
+            let conn = self.write_conn()?;
+            let store = ActivityStore::new(&conn);
+            store.insert_or_dedup(&new_activity, filter_config.dedup_window_secs)?
+        };
+
+        // Step 5: Promote (only if new, not deduplicated).
+        let mut promoted_fact_id = None;
+        let status = if was_deduplicated {
+            ActivityStatus::Deduplicated
+        } else if let ActivityFilterDecision::Promote(action) = &decision {
+            // Embed OUTSIDE the write lock.
+            if let Some(emb) = embedder {
+                match self.add_fact(
+                    &AddFactRequest {
+                        content: action.fact_content.clone(),
+                        fact_type: action.fact_type.clone(),
+                        source_event_id: None,
+                        scope: req.scope_path.clone(),
+                        opts: Some(AddFactOptions {
+                            importance: Some(action.importance),
+                            ..Default::default()
+                        }),
+                    },
+                    emb,
+                    None, // no persistence classifier
+                ) {
+                    Ok(fact_id) => {
+                        promoted_fact_id = Some(fact_id);
+                        // Update activity status to promoted.
+                        let conn = self.write_conn()?;
+                        let store = ActivityStore::new(&conn);
+                        store.update_status(
+                            activity_id,
+                            ActivityStatus::Promoted,
+                            Some(fact_id),
+                        )?;
+                        ActivityStatus::Promoted
+                    }
+                    Err(_) => {
+                        // Promotion failed (e.g., embedding error). Record as normal.
+                        ActivityStatus::Recorded
+                    }
+                }
+            } else {
+                // No embedder — skip promotion, record as normal.
+                ActivityStatus::Recorded
+            }
+        } else {
+            ActivityStatus::Recorded
+        };
+
+        Ok(RecordActivityResult {
+            activity_id: Some(activity_id),
+            was_deduplicated,
+            promoted_fact_id,
+            status,
+        })
+    }
+
+    // --- Public API: Session lifecycle ---
+
+    /// Checkpoint a session (last-write-wins upsert).
+    ///
+    /// Called by the Stop hook when a session ends or pauses.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on write failure.
+    pub fn checkpoint_session(
+        &self,
+        session_id: &str,
+        scope_path: Option<&str>,
+        summary: Option<&str>,
+        metadata: Option<serde_json::Value>,
+    ) -> Result<()> {
+        let conn = self.write_conn()?;
+
+        // Find last activity_id for this session.
+        let last_activity_id: Option<i64> = conn
+            .query_row(
+                "SELECT id FROM activities WHERE session_id = ?1 ORDER BY last_seen DESC LIMIT 1",
+                rusqlite::params![session_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(MemoryError::Database)?;
+
+        let checkpoint = SessionCheckpoint {
+            session_id: session_id.to_string(),
+            scope_path: scope_path.map(String::from),
+            summary: summary.map(String::from),
+            last_activity_id,
+            checkpoint_at: Utc::now(),
+            metadata: metadata.unwrap_or(serde_json::json!({})),
+        };
+        CheckpointStore::new(&conn).upsert(&checkpoint)
+    }
+
+    /// Load project context for session bootstrap.
+    ///
+    /// Returns recent activities, last checkpoint, and scope-filtered facts.
+    /// All queries run in a single read snapshot for consistency.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if the scope path doesn't exist.
+    pub fn load_context(
+        &self,
+        scope_path: &str,
+        activity_limit: usize,
+        fact_limit: usize,
+    ) -> Result<ProjectContext> {
+        // Resolve scope IDs from cache (short-lived read lock).
+        let scope_ids = {
+            let tree = self.scope_tree.read();
+            let id = tree
+                .resolve_path(scope_path)
+                .ok_or_else(|| MemoryError::NotFound(format!("scope path: {scope_path}")))?;
+            tree.subtree(id)
+        }; // scope_tree read lock dropped
+
+        // Single read snapshot for consistency.
+        self.with_read(|conn| {
+            let checkpoint = CheckpointStore::new(conn).get_by_scope(scope_path)?;
+            let recent_activities =
+                ActivityStore::new(conn).list_recent_by_scope(&scope_ids, activity_limit)?;
+            let relevant_facts = FactStore::new(conn, self.embed_dim).list_by_scopes_recent(
+                &scope_ids,
+                fact_limit,
+                &HashSet::new(),
+            )?;
+
+            Ok(ProjectContext {
+                scope_path: scope_path.to_string(),
+                recent_activities,
+                last_checkpoint: checkpoint,
+                relevant_facts,
+            })
+        })
+    }
+}
+
+/// Truncate a string to at most `max_len` characters, respecting UTF-8 boundaries.
+fn truncate(s: &str, max_len: usize) -> &str {
+    if s.len() <= max_len {
+        return s;
+    }
+    let mut end = max_len;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+use rusqlite::OptionalExtension;

--- a/src/engine/activity_filter.rs
+++ b/src/engine/activity_filter.rs
@@ -1,0 +1,205 @@
+//! Generic activity filtering configuration and decision logic.
+//!
+//! The core engine provides pattern-matching infrastructure. Concrete
+//! ignore/promote policies are consumer-supplied (e.g., the MCP adapter
+//! provides Claude Code-specific heuristics).
+
+use crate::types::FactType;
+
+/// Configuration for server-side activity filtering.
+///
+/// Consumers supply tool-name patterns for ignore and promote rules.
+/// The engine applies these generically — no built-in tool-name knowledge.
+#[derive(Debug, Clone)]
+pub struct ActivityFilterConfig {
+    /// Dedup window in seconds. Activities with the same
+    /// `(session_id, tool_name, args_hash, outcome_class)` within this
+    /// window are collapsed. Default: 300 (5 minutes).
+    pub dedup_window_secs: i64,
+
+    /// Tool name patterns to drop before storage.
+    /// Matching is case-insensitive substring.
+    pub ignore_patterns: Vec<String>,
+
+    /// Tool name patterns that auto-promote to facts when newly inserted
+    /// (not when deduplicated).
+    pub promote_patterns: Vec<String>,
+}
+
+impl Default for ActivityFilterConfig {
+    fn default() -> Self {
+        Self {
+            dedup_window_secs: 300,
+            ignore_patterns: Vec::new(),
+            promote_patterns: Vec::new(),
+        }
+    }
+}
+
+/// Decision from the filter pipeline (before store-level dedup).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ActivityFilterDecision {
+    /// Drop the activity — do not persist.
+    Ignore,
+    /// Persist as a normal activity record.
+    Record,
+    /// Persist and promote to a fact (only if not deduplicated).
+    Promote(PromoteAction),
+}
+
+/// Parameters for promoting an activity to a fact.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PromoteAction {
+    pub fact_content: String,
+    pub fact_type: FactType,
+    pub importance: f64,
+}
+
+/// Apply ignore and promote rules to an incoming activity.
+///
+/// Dedup is NOT handled here — it happens at the store layer via
+/// `ActivityStore::insert_or_dedup`.
+///
+/// Evaluation order: ignore first (short-circuit), then promote, else record.
+pub fn apply_filter(
+    tool_name: &str,
+    _args: &serde_json::Value,
+    result: Option<&str>,
+    config: &ActivityFilterConfig,
+) -> ActivityFilterDecision {
+    let tool_lower = tool_name.to_lowercase();
+
+    // Ignore check (case-insensitive substring match).
+    for pattern in &config.ignore_patterns {
+        if tool_lower.contains(&pattern.to_lowercase()) {
+            return ActivityFilterDecision::Ignore;
+        }
+    }
+
+    // Promote check (case-insensitive substring match).
+    for pattern in &config.promote_patterns {
+        if tool_lower.contains(&pattern.to_lowercase()) {
+            let content = format_promote_content(tool_name, result);
+            return ActivityFilterDecision::Promote(PromoteAction {
+                fact_content: content,
+                fact_type: FactType::Episodic,
+                importance: 0.7,
+            });
+        }
+    }
+
+    ActivityFilterDecision::Record
+}
+
+fn format_promote_content(tool_name: &str, result: Option<&str>) -> String {
+    match result {
+        Some(r) if !r.is_empty() => {
+            let truncated = if r.len() > 200 { &r[..200] } else { r };
+            format!("[{tool_name}] {truncated}")
+        }
+        _ => format!("[{tool_name}] (no result summary)"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_ignore(patterns: &[&str]) -> ActivityFilterConfig {
+        ActivityFilterConfig {
+            ignore_patterns: patterns.iter().map(|s| (*s).to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    fn config_with_promote(patterns: &[&str]) -> ActivityFilterConfig {
+        ActivityFilterConfig {
+            promote_patterns: patterns.iter().map(|s| (*s).to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_records_everything() {
+        let config = ActivityFilterConfig::default();
+        let decision = apply_filter("Read", &serde_json::json!({}), None, &config);
+        assert_eq!(decision, ActivityFilterDecision::Record);
+    }
+
+    #[test]
+    fn ignore_pattern_drops_matching_tool() {
+        let config = config_with_ignore(&["format", "lint"]);
+        assert_eq!(
+            apply_filter("FormatCode", &serde_json::json!({}), None, &config),
+            ActivityFilterDecision::Ignore
+        );
+        assert_eq!(
+            apply_filter("eslint_fix", &serde_json::json!({}), None, &config),
+            ActivityFilterDecision::Ignore
+        );
+        // Non-matching passes through.
+        assert_eq!(
+            apply_filter("Read", &serde_json::json!({}), None, &config),
+            ActivityFilterDecision::Record
+        );
+    }
+
+    #[test]
+    fn ignore_is_case_insensitive() {
+        let config = config_with_ignore(&["Format"]);
+        assert_eq!(
+            apply_filter("formatcode", &serde_json::json!({}), None, &config),
+            ActivityFilterDecision::Ignore
+        );
+    }
+
+    #[test]
+    fn promote_pattern_triggers_promotion() {
+        let config = config_with_promote(&["commit"]);
+        let decision = apply_filter(
+            "git_commit",
+            &serde_json::json!({}),
+            Some("feat: add feature"),
+            &config,
+        );
+        match decision {
+            ActivityFilterDecision::Promote(action) => {
+                assert!(action.fact_content.contains("git_commit"));
+                assert!(action.fact_content.contains("feat: add feature"));
+                assert_eq!(action.fact_type, FactType::Episodic);
+                assert!((action.importance - 0.7).abs() < f64::EPSILON);
+            }
+            other => panic!("expected Promote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ignore_takes_precedence_over_promote() {
+        let config = ActivityFilterConfig {
+            ignore_patterns: vec!["lint".into()],
+            promote_patterns: vec!["lint".into()],
+            ..Default::default()
+        };
+        assert_eq!(
+            apply_filter("lint_check", &serde_json::json!({}), None, &config),
+            ActivityFilterDecision::Ignore
+        );
+    }
+
+    #[test]
+    fn promote_truncates_long_results() {
+        let config = config_with_promote(&["test"]);
+        let long_result = "x".repeat(500);
+        let decision = apply_filter(
+            "test_runner",
+            &serde_json::json!({}),
+            Some(&long_result),
+            &config,
+        );
+        if let ActivityFilterDecision::Promote(action) = decision {
+            assert!(action.fact_content.len() < 250);
+        } else {
+            panic!("expected Promote");
+        }
+    }
+}

--- a/src/engine/activity_filter.rs
+++ b/src/engine/activity_filter.rs
@@ -94,7 +94,13 @@ pub fn apply_filter(
 fn format_promote_content(tool_name: &str, result: Option<&str>) -> String {
     match result {
         Some(r) if !r.is_empty() => {
-            let truncated = if r.len() > 200 { &r[..200] } else { r };
+            let truncated = if r.len() > 200 {
+                // Find the last char boundary at or before 200 bytes
+                let end = r.floor_char_boundary(200);
+                &r[..end]
+            } else {
+                r
+            };
             format!("[{tool_name}] {truncated}")
         }
         _ => format!("[{tool_name}] (no result summary)"),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -18,6 +18,7 @@ use crate::store::upcaster::UpcasterRegistry;
 use crate::traits::Reranker;
 use crate::types::{ConsolidationLevel, Fact};
 
+pub mod activity_filter;
 mod bootstrap;
 pub mod cognitive;
 mod conflict;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -18,6 +18,7 @@ use crate::store::upcaster::UpcasterRegistry;
 use crate::traits::Reranker;
 use crate::types::{ConsolidationLevel, Fact};
 
+mod activity;
 pub mod activity_filter;
 mod bootstrap;
 pub mod cognitive;

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
@@ -2,7 +2,7 @@
 source: src/inspect/dump.rs
 expression: snapshot
 ---
-schema_version: 8
+schema_version: 9
 storage_epoch: 1
 embed_dim: 4
 facts: []
@@ -16,5 +16,5 @@ scopes:
 events: []
 lineage: []
 config:
-  schema_version: "8"
+  schema_version: "9"
   storage_epoch: "1"

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
@@ -2,7 +2,7 @@
 source: src/inspect/dump.rs
 expression: snapshot
 ---
-schema_version: 8
+schema_version: 9
 storage_epoch: 1
 embed_dim: 4
 facts:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub(crate) mod store;
 #[cfg(feature = "archive")]
 pub use archive::{ArchiveManifestEntry, ArchivePolicy, ArchiveStats, ArchiveVerifyResult};
 pub use bootstrap::{BootstrapConfig, BootstrapReport, KeywordExtractor, SessionExtractor};
+pub use engine::activity_filter::{ActivityFilterConfig, ActivityFilterDecision, PromoteAction};
 pub use engine::{EngineConfig, MemoryEngine};
 pub use error::*;
 pub use inspect::types as inspect_types;

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -1,6 +1,6 @@
 //! Store operations for activity records.
 
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
 use crate::types::{Activity, ActivityStatus, NewActivity};
@@ -39,8 +39,9 @@ impl<'a> ActivityStore<'a> {
                    AND tool_name = ?2
                    AND args_hash = ?3
                    AND outcome_class = ?4
-                   AND status IN ('recorded', 'deduplicated')
-                   AND julianday(?5) - julianday(last_seen) < ?6 / 86400.0
+                   AND scope_id = ?5
+                   AND status IN ('recorded', 'deduplicated', 'promoted')
+                   AND julianday(?6) - julianday(last_seen) < ?7 / 86400.0
                  ORDER BY last_seen DESC
                  LIMIT 1",
                 params![
@@ -48,6 +49,7 @@ impl<'a> ActivityStore<'a> {
                     activity.tool_name,
                     activity.args_hash,
                     activity.outcome_class,
+                    activity.scope_id,
                     ts,
                     dedup_window_secs,
                 ],

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -151,20 +151,23 @@ impl<'a> ActivityStore<'a> {
         if scope_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders: String = scope_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-        let sql = format!(
-            "SELECT id, session_id, tool_name, args_hash, args, result_summary,
-                    outcome_class, status, occurrence_count, first_seen, last_seen,
-                    scope_id, promoted_fact_id
-             FROM activities
-             WHERE scope_id IN ({placeholders})
-             ORDER BY last_seen DESC
-             LIMIT {limit}"
-        );
-        let mut stmt = self.conn.prepare(&sql).map_err(MemoryError::Database)?;
-        let params = rusqlite::params_from_iter(scope_ids.iter());
+        let ids_json = serde_json::to_string(scope_ids).map_err(|e| {
+            MemoryError::Database(rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+        })?;
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, session_id, tool_name, args_hash, args, result_summary,
+                        outcome_class, status, occurrence_count, first_seen, last_seen,
+                        scope_id, promoted_fact_id
+                 FROM activities
+                 WHERE scope_id IN (SELECT value FROM json_each(?1))
+                 ORDER BY last_seen DESC
+                 LIMIT ?2",
+            )
+            .map_err(MemoryError::Database)?;
         let rows = stmt
-            .query_map(params, row_to_activity)
+            .query_map(params![ids_json, limit], row_to_activity)
             .map_err(MemoryError::Database)?;
         rows.collect::<std::result::Result<_, _>>()
             .map_err(MemoryError::Database)

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -64,7 +64,7 @@ impl<'a> ActivityStore<'a> {
                     "UPDATE activities
                      SET occurrence_count = ?1,
                          last_seen = ?2,
-                         status = 'deduplicated',
+                         status = CASE WHEN status = 'promoted' THEN 'promoted' ELSE 'deduplicated' END,
                          result_summary = COALESCE(?3, result_summary)
                      WHERE id = ?4",
                     params![count + 1, ts, activity.result_summary, existing_id],

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -1,0 +1,398 @@
+//! Store operations for activity records.
+
+use rusqlite::{Connection, params};
+
+use crate::error::{MemoryError, Result};
+use crate::types::{Activity, ActivityStatus, NewActivity};
+
+use super::parse_timestamp;
+
+/// Store facade for the `activities` table.
+pub struct ActivityStore<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> ActivityStore<'a> {
+    pub const fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Insert a new activity or deduplicate against an existing one.
+    ///
+    /// Dedup key: `(session_id, tool_name, args_hash, outcome_class)` within
+    /// `dedup_window_secs` of the most recent matching activity.
+    ///
+    /// Returns `(id, was_deduplicated)`.
+    pub fn insert_or_dedup(
+        &self,
+        activity: &NewActivity,
+        dedup_window_secs: i64,
+    ) -> Result<(i64, bool)> {
+        let ts = activity.timestamp.to_rfc3339();
+
+        // Check for existing activity within the dedup window.
+        let existing: Option<(i64, i64)> = self
+            .conn
+            .query_row(
+                "SELECT id, occurrence_count FROM activities
+                 WHERE session_id = ?1
+                   AND tool_name = ?2
+                   AND args_hash = ?3
+                   AND outcome_class = ?4
+                   AND status IN ('recorded', 'deduplicated')
+                   AND julianday(?5) - julianday(last_seen) < ?6 / 86400.0
+                 ORDER BY last_seen DESC
+                 LIMIT 1",
+                params![
+                    activity.session_id,
+                    activity.tool_name,
+                    activity.args_hash,
+                    activity.outcome_class,
+                    ts,
+                    dedup_window_secs,
+                ],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .map_err(MemoryError::Database)?;
+
+        if let Some((existing_id, count)) = existing {
+            self.conn
+                .execute(
+                    "UPDATE activities
+                     SET occurrence_count = ?1,
+                         last_seen = ?2,
+                         status = 'deduplicated',
+                         result_summary = COALESCE(?3, result_summary)
+                     WHERE id = ?4",
+                    params![count + 1, ts, activity.result_summary, existing_id],
+                )
+                .map_err(MemoryError::Database)?;
+            return Ok((existing_id, true));
+        }
+
+        // Insert new activity.
+        self.conn
+            .execute(
+                "INSERT INTO activities
+                 (session_id, tool_name, args_hash, args, result_summary,
+                  outcome_class, status, occurrence_count, first_seen, last_seen, scope_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'recorded', 1, ?7, ?7, ?8)",
+                params![
+                    activity.session_id,
+                    activity.tool_name,
+                    activity.args_hash,
+                    activity.args.to_string(),
+                    activity.result_summary,
+                    activity.outcome_class,
+                    ts,
+                    activity.scope_id,
+                ],
+            )
+            .map_err(MemoryError::Database)?;
+
+        let id = self.conn.last_insert_rowid();
+        Ok((id, false))
+    }
+
+    /// Get an activity by id.
+    pub fn get(&self, id: i64) -> Result<Activity> {
+        self.conn
+            .query_row(
+                "SELECT id, session_id, tool_name, args_hash, args, result_summary,
+                        outcome_class, status, occurrence_count, first_seen, last_seen,
+                        scope_id, promoted_fact_id
+                 FROM activities WHERE id = ?1",
+                params![id],
+                row_to_activity,
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    MemoryError::NotFound(format!("activity {id}"))
+                }
+                other => MemoryError::Database(other),
+            })
+    }
+
+    /// List activities for a session, most recent first.
+    pub fn list_by_session(&self, session_id: &str, limit: Option<usize>) -> Result<Vec<Activity>> {
+        let sql = match limit {
+            Some(n) => format!(
+                "SELECT id, session_id, tool_name, args_hash, args, result_summary,
+                        outcome_class, status, occurrence_count, first_seen, last_seen,
+                        scope_id, promoted_fact_id
+                 FROM activities
+                 WHERE session_id = ?1
+                 ORDER BY last_seen DESC
+                 LIMIT {n}"
+            ),
+            None => "SELECT id, session_id, tool_name, args_hash, args, result_summary,
+                            outcome_class, status, occurrence_count, first_seen, last_seen,
+                            scope_id, promoted_fact_id
+                     FROM activities
+                     WHERE session_id = ?1
+                     ORDER BY last_seen DESC"
+                .to_string(),
+        };
+        let mut stmt = self.conn.prepare(&sql).map_err(MemoryError::Database)?;
+        let rows = stmt
+            .query_map(params![session_id], row_to_activity)
+            .map_err(MemoryError::Database)?;
+        rows.collect::<std::result::Result<_, _>>()
+            .map_err(MemoryError::Database)
+    }
+
+    /// List recent activities for a set of scope IDs, most recent first.
+    ///
+    /// Uses `idx_activities_scope_recent` for efficient lookup.
+    pub fn list_recent_by_scope(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Activity>> {
+        if scope_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: String = scope_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT id, session_id, tool_name, args_hash, args, result_summary,
+                    outcome_class, status, occurrence_count, first_seen, last_seen,
+                    scope_id, promoted_fact_id
+             FROM activities
+             WHERE scope_id IN ({placeholders})
+             ORDER BY last_seen DESC
+             LIMIT {limit}"
+        );
+        let mut stmt = self.conn.prepare(&sql).map_err(MemoryError::Database)?;
+        let params = rusqlite::params_from_iter(scope_ids.iter());
+        let rows = stmt
+            .query_map(params, row_to_activity)
+            .map_err(MemoryError::Database)?;
+        rows.collect::<std::result::Result<_, _>>()
+            .map_err(MemoryError::Database)
+    }
+
+    /// Update the status of an activity and optionally link to a promoted fact.
+    pub fn update_status(
+        &self,
+        id: i64,
+        status: ActivityStatus,
+        promoted_fact_id: Option<i64>,
+    ) -> Result<()> {
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE activities SET status = ?1, promoted_fact_id = ?2 WHERE id = ?3",
+                params![status.to_string(), promoted_fact_id, id],
+            )
+            .map_err(MemoryError::Database)?;
+        if rows == 0 {
+            return Err(MemoryError::NotFound(format!("activity {id}")));
+        }
+        Ok(())
+    }
+
+    /// Count activities in a session.
+    pub fn count_by_session(&self, session_id: &str) -> Result<i64> {
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM activities WHERE session_id = ?1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .map_err(MemoryError::Database)
+    }
+}
+
+fn row_to_activity(row: &rusqlite::Row<'_>) -> rusqlite::Result<Activity> {
+    let status_str: String = row.get(7)?;
+    let status = status_str.parse::<ActivityStatus>().map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            7,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+    let args_str: String = row.get(4)?;
+    let args: serde_json::Value = serde_json::from_str(&args_str).unwrap_or_default();
+    let first_seen_str: String = row.get(9)?;
+    let last_seen_str: String = row.get(10)?;
+
+    Ok(Activity {
+        id: row.get(0)?,
+        session_id: row.get(1)?,
+        tool_name: row.get(2)?,
+        args_hash: row.get(3)?,
+        args,
+        result_summary: row.get(5)?,
+        outcome_class: row.get(6)?,
+        status,
+        occurrence_count: row.get(8)?,
+        first_seen: parse_timestamp(&first_seen_str)?,
+        last_seen: parse_timestamp(&last_seen_str)?,
+        scope_id: row.get(11)?,
+        promoted_fact_id: row.get(12)?,
+    })
+}
+
+/// Re-export for use by `rusqlite::Connection::query_row`.
+use rusqlite::OptionalExtension;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::init_schema;
+    use chrono::Utc;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn insert_new_activity() {
+        let conn = setup();
+        let store = ActivityStore::new(&conn);
+        let activity = NewActivity {
+            session_id: "sess-1".into(),
+            tool_name: "Read".into(),
+            args_hash: "abc123def456abc123def456abc123de".into(),
+            args: serde_json::json!({"path": "/foo/bar.rs"}),
+            result_summary: Some("200 lines".into()),
+            outcome_class: "success".into(),
+            timestamp: Utc::now(),
+            scope_id: 1,
+        };
+        let (id, deduped) = store.insert_or_dedup(&activity, 300).unwrap();
+        assert!(!deduped);
+        assert!(id > 0);
+
+        let fetched = store.get(id).unwrap();
+        assert_eq!(fetched.tool_name, "Read");
+        assert_eq!(fetched.occurrence_count, 1);
+        assert_eq!(fetched.status, ActivityStatus::Recorded);
+    }
+
+    #[test]
+    fn dedup_within_window() {
+        let conn = setup();
+        let store = ActivityStore::new(&conn);
+        let activity = NewActivity {
+            session_id: "sess-1".into(),
+            tool_name: "Read".into(),
+            args_hash: "abc123def456abc123def456abc123de".into(),
+            args: serde_json::json!({"path": "/foo/bar.rs"}),
+            result_summary: Some("200 lines".into()),
+            outcome_class: "success".into(),
+            timestamp: Utc::now(),
+            scope_id: 1,
+        };
+
+        let (id1, deduped1) = store.insert_or_dedup(&activity, 300).unwrap();
+        assert!(!deduped1);
+
+        let (id2, deduped2) = store.insert_or_dedup(&activity, 300).unwrap();
+        assert!(deduped2);
+        assert_eq!(id1, id2);
+
+        let fetched = store.get(id1).unwrap();
+        assert_eq!(fetched.occurrence_count, 2);
+        assert_eq!(fetched.status, ActivityStatus::Deduplicated);
+    }
+
+    #[test]
+    fn different_outcome_class_not_deduped() {
+        let conn = setup();
+        let store = ActivityStore::new(&conn);
+        let success = NewActivity {
+            session_id: "sess-1".into(),
+            tool_name: "Bash".into(),
+            args_hash: "abc123def456abc123def456abc123de".into(),
+            args: serde_json::json!({"cmd": "cargo test"}),
+            result_summary: Some("ok".into()),
+            outcome_class: "success".into(),
+            timestamp: Utc::now(),
+            scope_id: 1,
+        };
+        let failure = NewActivity {
+            outcome_class: "error".into(),
+            result_summary: Some("FAILED".into()),
+            ..success.clone()
+        };
+
+        let (id1, _) = store.insert_or_dedup(&success, 300).unwrap();
+        let (id2, deduped) = store.insert_or_dedup(&failure, 300).unwrap();
+        assert!(!deduped);
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn list_by_session() {
+        let conn = setup();
+        let store = ActivityStore::new(&conn);
+        for i in 0..5 {
+            let a = NewActivity {
+                session_id: "sess-1".into(),
+                tool_name: format!("Tool{i}"),
+                args_hash: format!("hash{i:032}"),
+                args: serde_json::json!({}),
+                result_summary: None,
+                outcome_class: "success".into(),
+                timestamp: Utc::now(),
+                scope_id: 1,
+            };
+            store.insert_or_dedup(&a, 300).unwrap();
+        }
+        let list = store.list_by_session("sess-1", Some(3)).unwrap();
+        assert_eq!(list.len(), 3);
+
+        let count = store.count_by_session("sess-1").unwrap();
+        assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn list_recent_by_scope() {
+        let conn = setup();
+        let store = ActivityStore::new(&conn);
+        for i in 0..3 {
+            let a = NewActivity {
+                session_id: "sess-1".into(),
+                tool_name: format!("Tool{i}"),
+                args_hash: format!("hash{i:032}"),
+                args: serde_json::json!({}),
+                result_summary: None,
+                outcome_class: "success".into(),
+                timestamp: Utc::now(),
+                scope_id: 1,
+            };
+            store.insert_or_dedup(&a, 300).unwrap();
+        }
+        let list = store.list_recent_by_scope(&[1], 10).unwrap();
+        assert_eq!(list.len(), 3);
+
+        let empty = store.list_recent_by_scope(&[], 10).unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn update_status() {
+        let conn = setup();
+        let store = ActivityStore::new(&conn);
+        let a = NewActivity {
+            session_id: "sess-1".into(),
+            tool_name: "Bash".into(),
+            args_hash: "abc123def456abc123def456abc123de".into(),
+            args: serde_json::json!({"cmd": "git commit"}),
+            result_summary: Some("committed".into()),
+            outcome_class: "success".into(),
+            timestamp: Utc::now(),
+            scope_id: 1,
+        };
+        let (id, _) = store.insert_or_dedup(&a, 300).unwrap();
+
+        // Test without a promoted_fact_id (fact FK would require a real fact).
+        store
+            .update_status(id, ActivityStatus::Promoted, None)
+            .unwrap();
+        let fetched = store.get(id).unwrap();
+        assert_eq!(fetched.status, ActivityStatus::Promoted);
+        assert_eq!(fetched.promoted_fact_id, None);
+    }
+}

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -1,0 +1,215 @@
+//! Store operations for session checkpoints.
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::error::{MemoryError, Result};
+use crate::types::SessionCheckpoint;
+
+use super::parse_timestamp;
+
+/// Store facade for the `session_checkpoints` table.
+pub struct CheckpointStore<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> CheckpointStore<'a> {
+    pub const fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Upsert a session checkpoint (last-write-wins per session_id).
+    pub fn upsert(&self, checkpoint: &SessionCheckpoint) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO session_checkpoints
+                 (session_id, scope_path, summary, last_activity_id, checkpoint_at, metadata)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(session_id) DO UPDATE SET
+                     scope_path = excluded.scope_path,
+                     summary = excluded.summary,
+                     last_activity_id = excluded.last_activity_id,
+                     checkpoint_at = excluded.checkpoint_at,
+                     metadata = excluded.metadata",
+                params![
+                    checkpoint.session_id,
+                    checkpoint.scope_path,
+                    checkpoint.summary,
+                    checkpoint.last_activity_id,
+                    checkpoint.checkpoint_at.to_rfc3339(),
+                    checkpoint.metadata.to_string(),
+                ],
+            )
+            .map_err(MemoryError::Database)?;
+        Ok(())
+    }
+
+    /// Get a checkpoint by session_id.
+    pub fn get(&self, session_id: &str) -> Result<Option<SessionCheckpoint>> {
+        self.conn
+            .query_row(
+                "SELECT session_id, scope_path, summary, last_activity_id, checkpoint_at, metadata
+                 FROM session_checkpoints
+                 WHERE session_id = ?1",
+                params![session_id],
+                row_to_checkpoint,
+            )
+            .optional()
+            .map_err(MemoryError::Database)
+    }
+
+    /// Get the most recent checkpoint for a scope path.
+    pub fn get_by_scope(&self, scope_path: &str) -> Result<Option<SessionCheckpoint>> {
+        self.conn
+            .query_row(
+                "SELECT session_id, scope_path, summary, last_activity_id, checkpoint_at, metadata
+                 FROM session_checkpoints
+                 WHERE scope_path = ?1
+                 ORDER BY checkpoint_at DESC
+                 LIMIT 1",
+                params![scope_path],
+                row_to_checkpoint,
+            )
+            .optional()
+            .map_err(MemoryError::Database)
+    }
+
+    /// List recent checkpoints, most recent first.
+    pub fn list_recent(&self, limit: usize) -> Result<Vec<SessionCheckpoint>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT session_id, scope_path, summary, last_activity_id, checkpoint_at, metadata
+                 FROM session_checkpoints
+                 ORDER BY checkpoint_at DESC
+                 LIMIT ?1",
+            )
+            .map_err(MemoryError::Database)?;
+        let rows = stmt
+            .query_map(params![limit as i64], row_to_checkpoint)
+            .map_err(MemoryError::Database)?;
+        rows.collect::<std::result::Result<_, _>>()
+            .map_err(MemoryError::Database)
+    }
+}
+
+fn row_to_checkpoint(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionCheckpoint> {
+    let checkpoint_at_str: String = row.get(4)?;
+    let metadata_str: String = row.get(5)?;
+    let metadata: serde_json::Value = serde_json::from_str(&metadata_str).unwrap_or_default();
+
+    Ok(SessionCheckpoint {
+        session_id: row.get(0)?,
+        scope_path: row.get(1)?,
+        summary: row.get(2)?,
+        last_activity_id: row.get(3)?,
+        checkpoint_at: parse_timestamp(&checkpoint_at_str)?,
+        metadata,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::init_schema;
+    use chrono::Utc;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn upsert_insert_and_get() {
+        let conn = setup();
+        let store = CheckpointStore::new(&conn);
+        let cp = SessionCheckpoint {
+            session_id: "sess-1".into(),
+            scope_path: Some("project:memory-engine".into()),
+            summary: Some("worked on activity stream".into()),
+            last_activity_id: None,
+            checkpoint_at: Utc::now(),
+            metadata: serde_json::json!({"tool_count": 42}),
+        };
+        store.upsert(&cp).unwrap();
+
+        let fetched = store.get("sess-1").unwrap().unwrap();
+        assert_eq!(fetched.session_id, "sess-1");
+        assert_eq!(fetched.scope_path, Some("project:memory-engine".into()));
+        assert_eq!(fetched.summary, Some("worked on activity stream".into()));
+    }
+
+    #[test]
+    fn upsert_overwrites() {
+        let conn = setup();
+        let store = CheckpointStore::new(&conn);
+        let cp1 = SessionCheckpoint {
+            session_id: "sess-1".into(),
+            scope_path: Some("project:foo".into()),
+            summary: Some("first".into()),
+            last_activity_id: None,
+            checkpoint_at: Utc::now(),
+            metadata: serde_json::json!({}),
+        };
+        store.upsert(&cp1).unwrap();
+
+        let cp2 = SessionCheckpoint {
+            summary: Some("second".into()),
+            ..cp1.clone()
+        };
+        store.upsert(&cp2).unwrap();
+
+        let fetched = store.get("sess-1").unwrap().unwrap();
+        assert_eq!(fetched.summary, Some("second".into()));
+    }
+
+    #[test]
+    fn get_by_scope() {
+        let conn = setup();
+        let store = CheckpointStore::new(&conn);
+        let cp = SessionCheckpoint {
+            session_id: "sess-1".into(),
+            scope_path: Some("project:memory-engine".into()),
+            summary: None,
+            last_activity_id: None,
+            checkpoint_at: Utc::now(),
+            metadata: serde_json::json!({}),
+        };
+        store.upsert(&cp).unwrap();
+
+        let found = store
+            .get_by_scope("project:memory-engine")
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.session_id, "sess-1");
+
+        let not_found = store.get_by_scope("project:other").unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn get_nonexistent_returns_none() {
+        let conn = setup();
+        let store = CheckpointStore::new(&conn);
+        assert!(store.get("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_recent() {
+        let conn = setup();
+        let store = CheckpointStore::new(&conn);
+        for i in 0..5 {
+            let cp = SessionCheckpoint {
+                session_id: format!("sess-{i}"),
+                scope_path: Some("project:test".into()),
+                summary: None,
+                last_activity_id: None,
+                checkpoint_at: Utc::now(),
+                metadata: serde_json::json!({}),
+            };
+            store.upsert(&cp).unwrap();
+        }
+        let list = store.list_recent(3).unwrap();
+        assert_eq!(list.len(), 3);
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! Uses WAL mode for concurrent reads during writes.
 
+pub mod activities;
 #[cfg(feature = "archive")]
 pub mod archive_manifest;
+pub mod checkpoints;
 pub mod edges;
 pub mod events;
 pub mod facts;

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -684,7 +684,7 @@ fn migrate_v8_to_v9(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_activities_session
             ON activities(session_id);
         CREATE INDEX IF NOT EXISTS idx_activities_dedup
-            ON activities(session_id, tool_name, args_hash, outcome_class);
+            ON activities(session_id, tool_name, args_hash, outcome_class, scope_id);
         CREATE INDEX IF NOT EXISTS idx_activities_scope_recent
             ON activities(scope_id, last_seen DESC);
         CREATE INDEX IF NOT EXISTS idx_activities_status

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use crate::error::{MemoryError, Result};
 
 /// Current schema version. Bump when adding migrations.
-pub(crate) const CURRENT_SCHEMA_VERSION: u32 = 8;
+pub(crate) const CURRENT_SCHEMA_VERSION: u32 = 9;
 
 /// Storage epoch — coarse-grained compatibility gate.
 ///
@@ -177,6 +177,7 @@ const MIGRATIONS: &[(MigrationFn, bool)] = &[
     (migrate_v5_to_v6, false),
     (migrate_v6_to_v7, false),
     (migrate_v7_to_v8, false),
+    (migrate_v8_to_v9, false),
 ];
 
 /// Run forward-only migrations from the current schema version to
@@ -661,6 +662,49 @@ fn migrate_v7_to_v8(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v8_to_v9(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS activities (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id       TEXT    NOT NULL,
+            tool_name        TEXT    NOT NULL,
+            args_hash        TEXT    NOT NULL,
+            args             TEXT    NOT NULL DEFAULT '{}' CHECK(json_valid(args)),
+            result_summary   TEXT,
+            outcome_class    TEXT    NOT NULL DEFAULT 'success',
+            status           TEXT    NOT NULL DEFAULT 'recorded'
+                             CHECK(status IN ('recorded', 'deduplicated', 'ignored', 'promoted')),
+            occurrence_count INTEGER NOT NULL DEFAULT 1,
+            first_seen       TEXT    NOT NULL,
+            last_seen        TEXT    NOT NULL,
+            scope_id         INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
+            promoted_fact_id INTEGER REFERENCES facts(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_activities_session
+            ON activities(session_id);
+        CREATE INDEX IF NOT EXISTS idx_activities_dedup
+            ON activities(session_id, tool_name, args_hash, outcome_class);
+        CREATE INDEX IF NOT EXISTS idx_activities_scope_recent
+            ON activities(scope_id, last_seen DESC);
+        CREATE INDEX IF NOT EXISTS idx_activities_status
+            ON activities(status);
+
+        CREATE TABLE IF NOT EXISTS session_checkpoints (
+            session_id       TEXT PRIMARY KEY,
+            scope_path       TEXT,
+            summary          TEXT,
+            last_activity_id INTEGER REFERENCES activities(id) ON DELETE SET NULL,
+            checkpoint_at    TEXT NOT NULL,
+            metadata         TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_checkpoints_scope
+            ON session_checkpoints(scope_path);",
+    )?;
+    Ok(())
+}
+
 // --- DDL constants ---
 
 const TABLES_DDL: &str = "
@@ -751,6 +795,44 @@ CREATE TABLE IF NOT EXISTS lineage (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_lineage_wisdom_fact_id
     ON lineage(wisdom_fact_id);
+
+CREATE TABLE IF NOT EXISTS activities (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id       TEXT    NOT NULL,
+    tool_name        TEXT    NOT NULL,
+    args_hash        TEXT    NOT NULL,
+    args             TEXT    NOT NULL DEFAULT '{}' CHECK(json_valid(args)),
+    result_summary   TEXT,
+    outcome_class    TEXT    NOT NULL DEFAULT 'success',
+    status           TEXT    NOT NULL DEFAULT 'recorded'
+                     CHECK(status IN ('recorded', 'deduplicated', 'ignored', 'promoted')),
+    occurrence_count INTEGER NOT NULL DEFAULT 1,
+    first_seen       TEXT    NOT NULL,
+    last_seen        TEXT    NOT NULL,
+    scope_id         INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id),
+    promoted_fact_id INTEGER REFERENCES facts(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_activities_session
+    ON activities(session_id);
+CREATE INDEX IF NOT EXISTS idx_activities_dedup
+    ON activities(session_id, tool_name, args_hash, outcome_class);
+CREATE INDEX IF NOT EXISTS idx_activities_scope_recent
+    ON activities(scope_id, last_seen DESC);
+CREATE INDEX IF NOT EXISTS idx_activities_status
+    ON activities(status);
+
+CREATE TABLE IF NOT EXISTS session_checkpoints (
+    session_id       TEXT PRIMARY KEY,
+    scope_path       TEXT,
+    summary          TEXT,
+    last_activity_id INTEGER REFERENCES activities(id) ON DELETE SET NULL,
+    checkpoint_at    TEXT NOT NULL,
+    metadata         TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata))
+);
+
+CREATE INDEX IF NOT EXISTS idx_checkpoints_scope
+    ON session_checkpoints(scope_path);
 ";
 
 const SCOPES_DDL: &str = "
@@ -1269,8 +1351,8 @@ CREATE TABLE IF NOT EXISTS config (
                 |r| r.get(0),
             )
             .unwrap();
-        // 9 original + 2 scopes indexes + 4 scope_id indexes + 4 v3 indexes + 1 archive_manifest + 1 lineage
-        assert_eq!(count, 21);
+        // 9 original + 2 scopes indexes + 4 scope_id indexes + 4 v3 indexes + 1 archive_manifest + 1 lineage + 5 activities/checkpoints
+        assert_eq!(count, 26);
     }
 
     // --- Migration framework tests ---
@@ -1281,13 +1363,13 @@ CREATE TABLE IF NOT EXISTS config (
         init_schema(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
         // migrate is a no-op on fresh DB
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
     }
 
@@ -1302,7 +1384,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
     }
 
@@ -1314,7 +1396,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
     }
 
@@ -1348,7 +1430,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
 
         // Data survived both migrations
@@ -1438,7 +1520,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
 
         // After migration: orphan scope_id fails (FK enforced)
@@ -1566,7 +1648,7 @@ CREATE TABLE IF NOT EXISTS config (
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
     }
 
@@ -1576,7 +1658,7 @@ CREATE TABLE IF NOT EXISTS config (
         init_schema(&conn).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
         conn.execute(
             "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, last_accessed, is_pinned, importance_score)
@@ -1738,7 +1820,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
     }
 
@@ -1760,7 +1842,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
 
         // Existing events get default revision = 1
@@ -1844,7 +1926,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
 
         // Event survived all migrations, got default revision
@@ -1877,7 +1959,7 @@ CREATE TABLE IF NOT EXISTS config (
         migrate(&conn, None).unwrap();
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
 
         // Existing facts have surfaced_at = NULL
@@ -2160,7 +2242,7 @@ CREATE TABLE IF NOT EXISTS config (
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
 
         // archive_manifest must exist after migration
@@ -2206,7 +2288,7 @@ CREATE TABLE IF NOT EXISTS config (
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
     }
 
@@ -2238,7 +2320,7 @@ CREATE TABLE IF NOT EXISTS config (
 
         assert_eq!(
             get_config(&conn, "schema_version").unwrap(),
-            Some("8".to_string())
+            Some(CURRENT_SCHEMA_VERSION.to_string())
         );
 
         // lineage table must exist after migration
@@ -2286,5 +2368,124 @@ CREATE TABLE IF NOT EXISTS config (
             )
             .unwrap();
         assert!(count > 0, "fresh DB should have lineage table");
+    }
+
+    /// Create a v8 schema by initing v9 and removing activity/checkpoint artifacts.
+    fn init_schema_v8(conn: &Connection) -> Result<()> {
+        init_schema(conn)?;
+        conn.execute_batch("DROP TABLE IF EXISTS session_checkpoints;")?;
+        conn.execute_batch("DROP TABLE IF EXISTS activities;")?;
+        conn.execute_batch("DROP INDEX IF EXISTS idx_activities_session;")?;
+        conn.execute_batch("DROP INDEX IF EXISTS idx_activities_dedup;")?;
+        conn.execute_batch("DROP INDEX IF EXISTS idx_activities_scope_recent;")?;
+        conn.execute_batch("DROP INDEX IF EXISTS idx_activities_status;")?;
+        conn.execute_batch("DROP INDEX IF EXISTS idx_checkpoints_scope;")?;
+        set_config(conn, "schema_version", "8")?;
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_v8_to_v9_adds_activities_and_checkpoints() {
+        let conn = open_memory().unwrap();
+        init_schema_v8(&conn).unwrap();
+
+        // Tables must NOT exist before migration
+        let tables_before: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('activities', 'session_checkpoints')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            tables_before, 0,
+            "activities/session_checkpoints should not exist before migration"
+        );
+
+        migrate(&conn, None).unwrap();
+
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap(),
+            Some(CURRENT_SCHEMA_VERSION.to_string())
+        );
+
+        // Both tables must exist after migration
+        let tables_after: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('activities', 'session_checkpoints')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            tables_after, 2,
+            "activities and session_checkpoints should exist after migration"
+        );
+
+        // Verify activities columns
+        let act_cols: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('activities')
+                 WHERE name IN ('id', 'session_id', 'tool_name', 'args_hash', 'args',
+                                'result_summary', 'outcome_class', 'status',
+                                'occurrence_count', 'first_seen', 'last_seen',
+                                'scope_id', 'promoted_fact_id')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            act_cols, 13,
+            "activities table should have 13 expected columns"
+        );
+
+        // Verify session_checkpoints columns
+        let cp_cols: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('session_checkpoints')
+                 WHERE name IN ('session_id', 'scope_path', 'summary',
+                                'last_activity_id', 'checkpoint_at', 'metadata')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            cp_cols, 6,
+            "session_checkpoints table should have 6 expected columns"
+        );
+
+        // Verify indexes (5 new)
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index'
+                 AND name IN ('idx_activities_session', 'idx_activities_dedup',
+                              'idx_activities_scope_recent', 'idx_activities_status',
+                              'idx_checkpoints_scope')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            idx_count, 5,
+            "all 5 activity/checkpoint indexes should exist"
+        );
+    }
+
+    #[test]
+    fn fresh_db_has_activities_and_checkpoints() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('activities', 'session_checkpoints')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 2,
+            "fresh DB should have activities and session_checkpoints tables"
+        );
     }
 }

--- a/src/store/snapshots/memory_engine__store__schema__tests__schema_v7.snap
+++ b/src/store/snapshots/memory_engine__store__schema__tests__schema_v7.snap
@@ -2,8 +2,23 @@
 source: src/store/schema.rs
 expression: schema
 ---
+-- index: idx_activities_dedup
+CREATE INDEX idx_activities_dedup ON activities(session_id, tool_name, args_hash, outcome_class);
+
+-- index: idx_activities_scope_recent
+CREATE INDEX idx_activities_scope_recent ON activities(scope_id, last_seen DESC);
+
+-- index: idx_activities_session
+CREATE INDEX idx_activities_session ON activities(session_id);
+
+-- index: idx_activities_status
+CREATE INDEX idx_activities_status ON activities(status);
+
 -- index: idx_archive_manifest_path
 CREATE UNIQUE INDEX idx_archive_manifest_path ON archive_manifest(pak_path);
+
+-- index: idx_checkpoints_scope
+CREATE INDEX idx_checkpoints_scope ON session_checkpoints(scope_path);
 
 -- index: idx_edges_expired
 CREATE INDEX idx_edges_expired ON edges(t_expired);
@@ -65,6 +80,9 @@ CREATE UNIQUE INDEX idx_scopes_parent_label ON scopes(parent_id, label);
 -- index: idx_summaries_scope
 CREATE INDEX idx_summaries_scope ON summaries(scope_id);
 
+-- table: activities
+CREATE TABLE activities ( id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, tool_name TEXT NOT NULL, args_hash TEXT NOT NULL, args TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(args)), result_summary TEXT, outcome_class TEXT NOT NULL DEFAULT 'success', status TEXT NOT NULL DEFAULT 'recorded' CHECK(status IN ('recorded', 'deduplicated', 'ignored', 'promoted')), occurrence_count INTEGER NOT NULL DEFAULT 1, first_seen TEXT NOT NULL, last_seen TEXT NOT NULL, scope_id INTEGER NOT NULL DEFAULT 1 REFERENCES scopes(id), promoted_fact_id INTEGER REFERENCES facts(id) );
+
 -- table: archive_manifest
 CREATE TABLE archive_manifest ( id INTEGER PRIMARY KEY AUTOINCREMENT, pak_path TEXT NOT NULL, created_at TEXT NOT NULL, fact_count INTEGER NOT NULL, edge_count INTEGER NOT NULL, fact_id_min INTEGER NOT NULL, fact_id_max INTEGER NOT NULL, t_created_min TEXT NOT NULL, t_created_max TEXT NOT NULL, size_bytes INTEGER NOT NULL, blake3_hash TEXT NOT NULL );
 
@@ -100,6 +118,9 @@ CREATE TABLE lineage ( lineage_id INTEGER PRIMARY KEY AUTOINCREMENT, wisdom_fact
 
 -- table: scopes
 CREATE TABLE scopes ( id INTEGER PRIMARY KEY AUTOINCREMENT, parent_id INTEGER REFERENCES scopes(id), label TEXT NOT NULL, depth INTEGER NOT NULL DEFAULT 0 );
+
+-- table: session_checkpoints
+CREATE TABLE session_checkpoints ( session_id TEXT PRIMARY KEY, scope_path TEXT, summary TEXT, last_activity_id INTEGER REFERENCES activities(id) ON DELETE SET NULL, checkpoint_at TEXT NOT NULL, metadata TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(metadata)) );
 
 -- table: sqlite_sequence
 CREATE TABLE sqlite_sequence(name,seq);

--- a/src/types.rs
+++ b/src/types.rs
@@ -423,6 +423,28 @@ impl Default for DreamCycleConfig {
     }
 }
 
+// --- Activity stream types ---
+
+/// Status of an activity record after server-side filtering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ActivityStatus {
+    Recorded,
+    Deduplicated,
+    Ignored,
+    Promoted,
+}
+
+impl fmt::Display for ActivityStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Recorded => write!(f, "recorded"),
+            Self::Deduplicated => write!(f, "deduplicated"),
+            Self::Ignored => write!(f, "ignored"),
+            Self::Promoted => write!(f, "promoted"),
+        }
+    }
+}
+
 impl DreamCycleConfig {
     /// Validate configuration parameters.
     ///
@@ -484,6 +506,93 @@ pub struct PromotionResult {
     pub fact_id: FactId,
     /// Database ID of the lineage record in the sidecar table.
     pub lineage_id: LineageId,
+}
+
+impl std::str::FromStr for ActivityStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "recorded" => Ok(Self::Recorded),
+            "deduplicated" => Ok(Self::Deduplicated),
+            "ignored" => Ok(Self::Ignored),
+            "promoted" => Ok(Self::Promoted),
+            other => Err(format!("unknown activity status: {other}")),
+        }
+    }
+}
+
+/// An activity record from a tool invocation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Activity {
+    pub id: i64,
+    pub session_id: String,
+    pub tool_name: String,
+    pub args_hash: String,
+    pub args: serde_json::Value,
+    pub result_summary: Option<String>,
+    pub outcome_class: String,
+    pub status: ActivityStatus,
+    pub occurrence_count: i64,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    pub scope_id: i64,
+    pub promoted_fact_id: Option<i64>,
+}
+
+/// Activity to insert (DB assigns id).
+#[derive(Debug, Clone)]
+pub struct NewActivity {
+    pub session_id: String,
+    pub tool_name: String,
+    pub args_hash: String,
+    pub args: serde_json::Value,
+    pub result_summary: Option<String>,
+    pub outcome_class: String,
+    pub timestamp: DateTime<Utc>,
+    pub scope_id: i64,
+}
+
+/// A session checkpoint (last-write-wins per session_id).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionCheckpoint {
+    pub session_id: String,
+    pub scope_path: Option<String>,
+    pub summary: Option<String>,
+    pub last_activity_id: Option<i64>,
+    pub checkpoint_at: DateTime<Utc>,
+    pub metadata: serde_json::Value,
+}
+
+/// Request to record a tool activity.
+#[derive(Debug, Clone)]
+pub struct RecordActivityRequest {
+    pub tool_name: String,
+    pub args: serde_json::Value,
+    pub result: Option<String>,
+    pub session_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub scope_path: Option<String>,
+    /// Outcome class (e.g. "success", "error", "test_failure"). Defaults to "success".
+    pub outcome_class: Option<String>,
+}
+
+/// Result of recording an activity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordActivityResult {
+    pub activity_id: Option<i64>,
+    pub was_deduplicated: bool,
+    pub promoted_fact_id: Option<i64>,
+    pub status: ActivityStatus,
+}
+
+/// Project-scoped context for session bootstrap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectContext {
+    pub scope_path: String,
+    pub recent_activities: Vec<Activity>,
+    pub last_checkpoint: Option<SessionCheckpoint>,
+    pub relevant_facts: Vec<Fact>,
 }
 
 #[cfg(test)]

--- a/tests/activity_stream_test.rs
+++ b/tests/activity_stream_test.rs
@@ -1,0 +1,147 @@
+//! Integration test: record_activity → checkpoint_session → load_context cycle.
+
+use chrono::Utc;
+use memory_engine::{ActivityFilterConfig, ActivityStatus, MemoryEngine, RecordActivityRequest};
+
+/// Minimal embedder for testing (returns zero-vector of fixed dim).
+struct ZeroEmbedder(usize);
+
+impl memory_engine::EmbeddingProvider for ZeroEmbedder {
+    fn embed(&self, _text: &str) -> memory_engine::error::Result<Vec<f32>> {
+        Ok(vec![0.0; self.0])
+    }
+}
+
+const DIM: usize = 4;
+
+fn engine() -> MemoryEngine {
+    MemoryEngine::open_memory(DIM).unwrap()
+}
+
+#[test]
+fn record_activity_stores_and_deduplicates() {
+    let engine = engine();
+    let config = ActivityFilterConfig::default();
+
+    let req = RecordActivityRequest {
+        tool_name: "Read".into(),
+        args: serde_json::json!({"path": "/foo/bar.rs"}),
+        result: Some("200 lines".into()),
+        session_id: "sess-1".into(),
+        timestamp: Utc::now(),
+        scope_path: None,
+        outcome_class: None,
+    };
+
+    let r1 = engine.record_activity(&req, None, &config).unwrap();
+    assert!(r1.activity_id.is_some());
+    assert!(!r1.was_deduplicated);
+    assert_eq!(r1.status, ActivityStatus::Recorded);
+
+    // Second call within dedup window should deduplicate.
+    let r2 = engine.record_activity(&req, None, &config).unwrap();
+    assert!(r2.was_deduplicated);
+    assert_eq!(r2.activity_id, r1.activity_id);
+    assert_eq!(r2.status, ActivityStatus::Deduplicated);
+}
+
+#[test]
+fn record_activity_ignore_drops_silently() {
+    let engine = engine();
+    let config = ActivityFilterConfig {
+        ignore_patterns: vec!["format".into()],
+        ..Default::default()
+    };
+
+    let req = RecordActivityRequest {
+        tool_name: "FormatCode".into(),
+        args: serde_json::json!({}),
+        result: None,
+        session_id: "sess-1".into(),
+        timestamp: Utc::now(),
+        scope_path: None,
+        outcome_class: None,
+    };
+
+    let result = engine.record_activity(&req, None, &config).unwrap();
+    assert!(result.activity_id.is_none());
+    assert_eq!(result.status, ActivityStatus::Ignored);
+}
+
+#[test]
+fn record_activity_promotes_to_fact() {
+    let engine = engine();
+    let embedder = ZeroEmbedder(DIM);
+    let config = ActivityFilterConfig {
+        promote_patterns: vec!["commit".into()],
+        ..Default::default()
+    };
+
+    let req = RecordActivityRequest {
+        tool_name: "git_commit".into(),
+        args: serde_json::json!({"msg": "feat: add feature"}),
+        result: Some("committed abc123".into()),
+        session_id: "sess-1".into(),
+        timestamp: Utc::now(),
+        scope_path: None,
+        outcome_class: None,
+    };
+
+    let result = engine
+        .record_activity(&req, Some(&embedder), &config)
+        .unwrap();
+    assert_eq!(result.status, ActivityStatus::Promoted);
+    assert!(result.promoted_fact_id.is_some());
+
+    // Verify the fact was actually created.
+    let fact = engine.get_fact(result.promoted_fact_id.unwrap()).unwrap();
+    assert!(fact.content.contains("git_commit"));
+    assert!(fact.content.contains("committed abc123"));
+}
+
+#[test]
+fn checkpoint_and_load_context_cycle() {
+    let engine = engine();
+    let config = ActivityFilterConfig::default();
+
+    // Create a scope first.
+    engine.ensure_scope_path("project:test").unwrap();
+
+    // Record some activities.
+    for i in 0..5 {
+        let req = RecordActivityRequest {
+            tool_name: format!("Tool{i}"),
+            args: serde_json::json!({"i": i}),
+            result: Some(format!("result {i}")),
+            session_id: "sess-1".into(),
+            timestamp: Utc::now(),
+            scope_path: Some("project:test".into()),
+            outcome_class: None,
+        };
+        engine.record_activity(&req, None, &config).unwrap();
+    }
+
+    // Checkpoint.
+    engine
+        .checkpoint_session("sess-1", Some("project:test"), Some("test session"), None)
+        .unwrap();
+
+    // Load context.
+    let ctx = engine.load_context("project:test", 10, 5).unwrap();
+    assert_eq!(ctx.scope_path, "project:test");
+    assert_eq!(ctx.recent_activities.len(), 5);
+    assert!(ctx.last_checkpoint.is_some());
+    let cp = ctx.last_checkpoint.unwrap();
+    assert_eq!(cp.session_id, "sess-1");
+    assert_eq!(cp.summary, Some("test session".into()));
+}
+
+#[test]
+fn load_context_nonexistent_scope_errors() {
+    let engine = engine();
+    let err = engine.load_context("nonexistent:scope", 10, 5).unwrap_err();
+    assert!(matches!(
+        err,
+        memory_engine::error::MemoryError::NotFound(_)
+    ));
+}


### PR DESCRIPTION
## Summary

- Add 3 new MCP endpoints: `memory_record_activity`, `memory_checkpoint_session`, `memory_load_context`
- Schema v8→v9 migration adding `activities` and `session_checkpoints` tables
- Server-side activity filtering: dedup (outcome-class-aware), ignore, and promote pipeline
- Adapter-specific Claude Code policy in `activity_policy.rs` (core stays generic)
- Full depth shaping (sparse/standard/full) for activity and context responses

Closes #224 (sub-issue of #221 umbrella). Plan: #229.

## Key Design Decisions

1. **Separate `activities` table** — not reusing `events` (different lifecycle, dedup counters)
2. **Outcome-class in dedup key** — `cargo test` pass vs fail within window are NOT collapsed
3. **Promotion gated on `was_deduplicated == false`** — prevents duplicate fact creation (Codex BLOCKER fix)
4. **Scope paths, not filesystem paths** — aligns with existing `ScopeTree` model
5. **Filtering policy in MCP adapter** — core engine is generic, adapter owns tool-name heuristics
6. **Single read snapshot** for `load_context` — consistent cross-query results

## Test plan

- [x] Schema migration test (`migrate_v8_to_v9_adds_activities_and_checkpoints`)
- [x] Fresh DB test (`fresh_db_has_activities_and_checkpoints`)
- [x] ActivityStore unit tests (insert, dedup, outcome differentiation, list, update)
- [x] CheckpointStore unit tests (upsert, overwrite, scope lookup)
- [x] Activity filter unit tests (ignore, promote, precedence, truncation)
- [x] Integration test: full record → checkpoint → load_context cycle
- [x] MCP tool count assertion updated (20 → 23)
- [x] All existing tests updated for new dispatch signature
- [x] `cargo build --workspace && cargo test --workspace && cargo clippy --workspace --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)