### PR TITLE
fix(forgetting): exempt knowledge-shaped fact types from decay (ADR-0012)

### DIFF
--- a/docs/design/adr/0012-decay-exemption-knowledge-shaped-facts.md
+++ b/docs/design/adr/0012-decay-exemption-knowledge-shaped-facts.md
@@ -1,0 +1,37 @@
+# ADR-0012: Decay Exemption for Knowledge-Shaped Fact Types
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+ADR-0006 scores every fact with the same 4-signal importance formula, using a 69-day Ebbinghaus half-life default transplanted from Memori. That default applied to **all** `FactType`s — including `Semantic` (declarative assertions) and `Procedural` (validated procedures).
+
+This is the category error the four-layer architecture exists to prevent: a paper's findings do not become less true after 69 days. In the layer mapping, Semantic facts are knowledge-shaped (Knowledge layer: persistence via supersession) and Procedural facts are wisdom-shaped (Wisdom layer: evidence-gated revision). Applying cognitive decay to them contradicts the thesis in the engine's own defaults — the 2026-06 program review flagged this as its top coherence finding (coherence:C3), and with the repository public since 2026-06-12, any reviewer reading `traits.rs` alongside the paper finds the contradiction in minutes.
+
+## Decision
+
+`ForgetPolicy` gains a `decay_exempt_types: HashSet<FactType>` field, **default `{Semantic, Procedural}`**.
+
+**Content predicate** (what makes a type exempt): a fact type belongs in the set iff its facts' truth value is independent of time-since-encoding. Declarative assertions and validated procedures qualify; episodic facts are time-indexed experience records and decay by design.
+
+Enforcement at two points:
+
+1. `compute_importance`: recency stays `1.0` for exempt types — age does not degrade a knowledge-shaped fact's score, so materialized importance stays honest for downstream consumers.
+2. `prune`: exempt types bypass the expiry filter entirely (same mechanism as `is_pinned`). This is the hard guarantee — no weight/threshold configuration can expire them. They still count in `facts_evaluated` and still get scores materialized.
+
+**Escape hatch:** an explicit `half_life_overrides` entry for a type wins over the exemption and re-enables finite-half-life decay (`ForgetPolicy::is_decay_exempt` encodes the rule). This preserves ADR-0006's documented `Procedural=365` example as valid configuration and keeps the eval suites able to exercise decay mechanics on any type.
+
+Lifecycle for exempt facts: supersession (`t_expired` via conflict resolution) and evidence-gated revision — never decay.
+
+## Alternatives Considered
+
+- **M→K promotion edge** — route knowledge-shaped facts out of the memory engine into the knowledge layer. More faithful to the four-layer story, but cross-system plumbing; deferred to the harness-integration thin slice. The exemption is compatible with adding promotion later.
+- **`f64::INFINITY` half-life override** — keeps facts inside the decay framework with a degenerate constant. Rejected as leaky: under non-default weights/thresholds an "infinite half-life" fact can still fall below `min_importance` and expire.
+
+## Consequences
+
+- Default behavior change (pre-1.0): Semantic and Procedural facts persist indefinitely unless superseded, conflict-resolved, or explicitly opted back into decay.
+- Eval/conformance suites updated: decay-mechanics scenarios now use `Episodic` subjects; the pinned=false conformance test exercises the override-wins escape hatch.
+- Episodic facts remain on the 69-day default until session-backfill telemetry fits a measured constant (#139/#140) — the transplanted value now governs only the type it can defensibly govern.
+- Storage growth for exempt types is bounded by supersession and consolidation, not decay.

--- a/docs/design/adr/index.md
+++ b/docs/design/adr/index.md
@@ -16,4 +16,5 @@ Key design decisions, documented as ADRs. Each records the context, decision, an
 0009-session-bootstrap
 0010-wisdom-revision-gate-dsl
 0011-allen-interval-algebra
+0012-decay-exemption-knowledge-shaped-facts
 ```

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -39,15 +39,21 @@ pub fn compute_importance(
     now: DateTime<Utc>,
     policy: &ForgetPolicy,
 ) -> f64 {
-    let half_life = policy
-        .half_life_overrides
-        .get(&fact.fact_type)
-        .copied()
-        .unwrap_or(policy.half_life_days);
+    // Knowledge-shaped types don't lose validity with age: recency stays 1.0.
+    // An explicit half-life override wins and re-enables decay.
+    let recency = if policy.is_decay_exempt(&fact.fact_type) {
+        1.0
+    } else {
+        let half_life = policy
+            .half_life_overrides
+            .get(&fact.fact_type)
+            .copied()
+            .unwrap_or(policy.half_life_days);
 
-    #[allow(clippy::cast_precision_loss)]
-    let age_days = (now - fact.last_accessed).num_seconds() as f64 / 86400.0;
-    let recency = ebbinghaus_decay(age_days.max(0.0), half_life);
+        #[allow(clippy::cast_precision_loss)]
+        let age_days = (now - fact.last_accessed).num_seconds() as f64 / 86400.0;
+        ebbinghaus_decay(age_days.max(0.0), half_life)
+    };
 
     // Normalization: log_base(count+1), capped at 1.0.
     // Using ln_1p for numerical accuracy near zero.
@@ -93,11 +99,13 @@ pub fn prune(
     let facts_evaluated = active_facts.len();
 
     // Score all facts before mutating, so degree values are consistent.
-    // Pinned facts are unforgettable — they bypass the decay filter entirely.
+    // Pinned facts and decay-exempt fact types are unforgettable — they
+    // bypass the expiry filter entirely (but still get scores materialized
+    // and count in `facts_evaluated`).
     let to_expire: Vec<i64> = active_facts
         .iter()
         .filter(|fact| {
-            if fact.is_pinned {
+            if fact.is_pinned || policy.is_decay_exempt(&fact.fact_type) {
                 return false;
             }
             let degree = graph.degree(fact.id);
@@ -506,5 +514,155 @@ mod tests {
         overrides.insert(FactType::Episodic, -10.0);
         policy.half_life_overrides = overrides;
         assert!(policy.validate().is_err());
+    }
+
+    /// Ancient, neglected, isolated, unpinned fact — guaranteed below any
+    /// reasonable importance threshold once its recency signal has decayed.
+    fn neglected_fact(
+        fact_type: FactType,
+        hash: &str,
+        now: DateTime<Utc>,
+    ) -> crate::types::NewFact {
+        let old_time = now - Duration::days(200);
+        crate::types::NewFact {
+            content: format!("neglected {fact_type}"),
+            content_hash: hash.into(),
+            embedding: vec![0.1; 4],
+            fact_type,
+            t_created: old_time,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            scope_id: 1,
+            importance: 0.01,
+            access_count: 0,
+            last_accessed: old_time,
+            metadata: serde_json::json!({}),
+            is_pinned: false,
+        }
+    }
+
+    #[test]
+    fn prune_exempts_knowledge_shaped_types_by_default() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let now = Utc::now();
+        let embed_dim = 4;
+        let fact_store = FactStore::new(&conn, embed_dim);
+
+        // Identical neglect across the three types; only Episodic may decay away.
+        fact_store
+            .insert(&neglected_fact(FactType::Semantic, "ks", now))
+            .unwrap();
+        fact_store
+            .insert(&neglected_fact(FactType::Procedural, "kp", now))
+            .unwrap();
+        fact_store
+            .insert(&neglected_fact(FactType::Episodic, "ke", now))
+            .unwrap();
+
+        let mut graph = MemoryGraph::new();
+        let policy = ForgetPolicy {
+            min_importance: 0.3,
+            ..ForgetPolicy::default()
+        };
+        let (stats, expired) = prune(&conn, &mut graph, &policy, embed_dim, now).unwrap();
+
+        assert_eq!(stats.facts_evaluated, 3);
+        assert_eq!(
+            stats.facts_expired, 1,
+            "only the episodic fact may expire, expired ids: {expired:?}"
+        );
+        let active = fact_store.list_active(None).unwrap();
+        let types: Vec<FactType> = active.iter().map(|f| f.fact_type.clone()).collect();
+        assert!(
+            types.contains(&FactType::Semantic),
+            "semantic must survive neglect (supersession governs it, not decay)"
+        );
+        assert!(
+            types.contains(&FactType::Procedural),
+            "procedural must survive neglect (revision governs it, not decay)"
+        );
+    }
+
+    #[test]
+    fn exempt_type_recency_does_not_decay() {
+        let now = Utc::now();
+        let policy = ForgetPolicy::default();
+
+        let ancient = Fact {
+            id: 1,
+            content: "knowledge".into(),
+            content_hash: "h".into(),
+            embedding: vec![0.1; 4],
+            fact_type: FactType::Semantic,
+            t_created: now - Duration::days(500),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            scope_id: 1,
+            importance: 0.5,
+            access_count: 5,
+            last_accessed: now - Duration::days(500),
+            metadata: serde_json::json!({}),
+            is_pinned: false,
+            importance_score: 0.5,
+            surfaced_at: None,
+        };
+        let mut fresh = ancient.clone();
+        fresh.last_accessed = now;
+
+        let ancient_importance = compute_importance(&ancient, 0, now, &policy);
+        let fresh_importance = compute_importance(&fresh, 0, now, &policy);
+        assert!(
+            (ancient_importance - fresh_importance).abs() < 1e-9,
+            "age must not change an exempt fact's importance: ancient={ancient_importance}, fresh={fresh_importance}"
+        );
+    }
+
+    #[test]
+    fn explicit_half_life_override_wins_over_exemption() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let now = Utc::now();
+        let embed_dim = 4;
+        let fact_store = FactStore::new(&conn, embed_dim);
+        fact_store
+            .insert(&neglected_fact(FactType::Semantic, "ks", now))
+            .unwrap();
+
+        let mut overrides = HashMap::new();
+        overrides.insert(FactType::Semantic, 30.0);
+        let policy = ForgetPolicy {
+            half_life_overrides: overrides,
+            min_importance: 0.3,
+            ..ForgetPolicy::default()
+        };
+
+        let mut graph = MemoryGraph::new();
+        let (stats, _) = prune(&conn, &mut graph, &policy, embed_dim, now).unwrap();
+        assert_eq!(
+            stats.facts_expired, 1,
+            "an explicit half-life override re-enables decay for an exempt type"
+        );
+    }
+
+    #[test]
+    fn default_exemption_set_and_override_interaction() {
+        let policy = ForgetPolicy::default();
+        assert!(policy.is_decay_exempt(&FactType::Semantic));
+        assert!(policy.is_decay_exempt(&FactType::Procedural));
+        assert!(!policy.is_decay_exempt(&FactType::Episodic));
+
+        let mut overridden = ForgetPolicy::default();
+        overridden
+            .half_life_overrides
+            .insert(FactType::Semantic, 30.0);
+        assert!(
+            !overridden.is_decay_exempt(&FactType::Semantic),
+            "explicit override must win over the default exemption"
+        );
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -222,7 +222,20 @@ pub struct ForgetPolicy {
     /// Base Ebbinghaus half-life in days (default: 69.0).
     pub half_life_days: f64,
     /// Per-`FactType` half-life overrides. E.g., Episodic=30, Procedural=365.
+    /// An explicit entry here wins over `decay_exempt_types`.
     pub half_life_overrides: std::collections::HashMap<crate::types::FactType, f64>,
+    /// Fact types exempt from decay-driven forgetting altogether.
+    ///
+    /// Content predicate: a type belongs here iff its facts' truth is
+    /// independent of time-since-encoding — declarative assertions
+    /// (`Semantic`) and validated procedures (`Procedural`). Such
+    /// knowledge-shaped facts are governed by supersession and conflict
+    /// resolution, never by Ebbinghaus decay; applying decay to them is the
+    /// category error the four-layer model exists to prevent. Episodic facts
+    /// are time-indexed experience records and decay by design.
+    ///
+    /// Default: `{Semantic, Procedural}`.
+    pub decay_exempt_types: std::collections::HashSet<crate::types::FactType>,
     /// Threshold below which facts are expired (default: 0.1).
     pub min_importance: f64,
     /// Weight for recency signal (Ebbinghaus decay). Default: 0.3.
@@ -240,6 +253,12 @@ impl Default for ForgetPolicy {
         Self {
             half_life_days: 69.0,
             half_life_overrides: std::collections::HashMap::new(),
+            decay_exempt_types: [
+                crate::types::FactType::Semantic,
+                crate::types::FactType::Procedural,
+            ]
+            .into_iter()
+            .collect(),
             min_importance: 0.1,
             recency_weight: 0.3,
             frequency_weight: 0.2,
@@ -250,6 +269,17 @@ impl Default for ForgetPolicy {
 }
 
 impl ForgetPolicy {
+    /// Whether `fact_type` is exempt from decay-driven forgetting.
+    ///
+    /// True iff the type is in `decay_exempt_types` and has no explicit
+    /// `half_life_overrides` entry — an explicit override wins, re-enabling
+    /// finite-half-life decay for that type.
+    #[must_use]
+    pub fn is_decay_exempt(&self, fact_type: &crate::types::FactType) -> bool {
+        self.decay_exempt_types.contains(fact_type)
+            && !self.half_life_overrides.contains_key(fact_type)
+    }
+
     /// Validate policy parameters.
     ///
     /// # Errors

--- a/tests/eval/conformance/pin_immunity.rs
+++ b/tests/eval/conformance/pin_immunity.rs
@@ -6,7 +6,7 @@
 
 use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 
-use crate::helpers::{PinByType, TestEmbedder, add_fact, aggressive_forget_policy, eval_engine};
+use crate::helpers::{add_fact, aggressive_forget_policy, eval_engine, PinByType, TestEmbedder};
 
 #[test]
 fn all_pinned_survive_aggressive_forget() {
@@ -86,12 +86,13 @@ fn persistence_classifier_auto_pins_by_type() {
         )
         .expect("add procedural fact");
 
-    // Add a Semantic fact — classifier should NOT pin it.
-    let sem_id = engine
+    // Add an Episodic fact — classifier should NOT pin it, and as a
+    // decaying type it stays forgettable (Semantic would be decay-exempt).
+    let epi_id = engine
         .add_fact(
             &AddFactRequest {
-                content: "general knowledge about servers".to_string(),
-                fact_type: FactType::Semantic,
+                content: "routine log entry about servers".to_string(),
+                fact_type: FactType::Episodic,
                 source_event_id: None,
                 scope: None,
                 opts: None,
@@ -99,18 +100,18 @@ fn persistence_classifier_auto_pins_by_type() {
             &embedder,
             Some(&classifier),
         )
-        .expect("add semantic fact");
+        .expect("add episodic fact");
 
     let proc_fact = engine.get_fact(proc_id).expect("get procedural fact");
-    let sem_fact = engine.get_fact(sem_id).expect("get semantic fact");
+    let epi_fact = engine.get_fact(epi_id).expect("get episodic fact");
 
     assert!(
         proc_fact.is_pinned,
         "Procedural fact should be auto-pinned by classifier"
     );
     assert!(
-        !sem_fact.is_pinned,
-        "Semantic fact should NOT be auto-pinned"
+        !epi_fact.is_pinned,
+        "Episodic fact should NOT be auto-pinned"
     );
 
     // Verify the pinned fact survives forget.
@@ -120,15 +121,15 @@ fn persistence_classifier_auto_pins_by_type() {
     let proc_after = engine
         .get_fact(proc_id)
         .expect("get procedural after forget");
-    let sem_after = engine.get_fact(sem_id).expect("get semantic after forget");
+    let epi_after = engine.get_fact(epi_id).expect("get episodic after forget");
 
     assert!(
         proc_after.t_expired.is_none(),
         "auto-pinned Procedural fact should survive forget"
     );
     assert!(
-        sem_after.t_expired.is_some(),
-        "unpinned Semantic fact should be expired"
+        epi_after.t_expired.is_some(),
+        "unpinned Episodic fact should be expired"
     );
 }
 
@@ -164,8 +165,14 @@ fn explicit_pinned_false_overrides_classifier() {
         "explicit pinned=false should override PersistenceClassifier"
     );
 
-    // Verify it gets expired by aggressive forget.
-    let policy = aggressive_forget_policy();
+    // Verify it gets expired by aggressive forget. Procedural is decay-exempt
+    // by default, so re-enable its decay via an explicit half-life override
+    // (an explicit override wins over the exemption) — the property under
+    // test is the pinned=false override, not persistence semantics.
+    let mut policy = aggressive_forget_policy();
+    policy
+        .half_life_overrides
+        .insert(FactType::Procedural, 69.0);
     engine.forget(&policy).expect("forget failed");
 
     let fact_after = engine.get_fact(id).expect("get fact after forget");
@@ -179,7 +186,7 @@ fn explicit_pinned_false_overrides_classifier() {
 fn unpin_allows_forgetting() {
     let engine = eval_engine();
 
-    let id = add_fact(&engine, "once pinned, now unpinned", FactType::Semantic);
+    let id = add_fact(&engine, "once pinned, now unpinned", FactType::Episodic);
     engine.pin_fact(id).expect("pin_fact");
 
     // Verify pinned.

--- a/tests/eval/quality/forgetting.rs
+++ b/tests/eval/quality/forgetting.rs
@@ -14,11 +14,11 @@ use crate::helpers::{add_fact_with_opts, days_ago, eval_engine};
 fn ebbinghaus_decay_ordering_old_before_young() {
     let engine = eval_engine();
 
-    // 120-day-old fact with 0 access
+    // 120-day-old fact with 0 access (Episodic: the decaying type)
     let old_id = add_fact_with_opts(
         &engine,
         "Old fact that should decay first due to age",
-        FactType::Semantic,
+        FactType::Episodic,
         None,
         AddFactOptions {
             importance: Some(0.3),
@@ -32,7 +32,7 @@ fn ebbinghaus_decay_ordering_old_before_young() {
     let young_id = add_fact_with_opts(
         &engine,
         "Young fact that should survive longer than old one",
-        FactType::Semantic,
+        FactType::Episodic,
         None,
         AddFactOptions {
             importance: Some(0.3),
@@ -88,7 +88,8 @@ fn half_life_override_episodic_decays_faster() {
         },
     );
 
-    // Semantic fact, also 45 days old (uses default 69-day half-life)
+    // Semantic fact, also 45 days old (decay-exempt by default: recency
+    // stays 1.0, so it survives regardless of age)
     let semantic_id = add_fact_with_opts(
         &engine,
         "Semantic fact from 45 days ago about architecture",
@@ -104,7 +105,7 @@ fn half_life_override_episodic_decays_faster() {
 
     // Computed importance scores:
     // Episodic (45d, 30d HL): 0.3*2^(-45/30) + 0 + 0 + 0.2*0.3 = 0.106 + 0.06 = ~0.166
-    // Semantic (45d, 69d HL): 0.3*2^(-45/69) + 0 + 0 + 0.2*0.3 = 0.191 + 0.06 = ~0.251
+    // Semantic (decay-exempt): 0.3*1.0 + 0 + 0 + 0.2*0.3 = 0.3 + 0.06 = ~0.36
     // Threshold between them: 0.20
     let policy = ForgetPolicy {
         half_life_overrides: overrides,
@@ -134,11 +135,11 @@ fn half_life_override_episodic_decays_faster() {
 fn importance_scoring_monotonicity() {
     let engine = eval_engine();
 
-    // High-importance fact, 60 days old
+    // High-importance fact, 60 days old (Episodic: the decaying type)
     let high_id = add_fact_with_opts(
         &engine,
         "High importance fact about critical architecture decision",
-        FactType::Semantic,
+        FactType::Episodic,
         None,
         AddFactOptions {
             importance: Some(0.9),
@@ -152,7 +153,7 @@ fn importance_scoring_monotonicity() {
     let low_id = add_fact_with_opts(
         &engine,
         "Low importance fact about minor configuration change",
-        FactType::Semantic,
+        FactType::Episodic,
         None,
         AddFactOptions {
             importance: Some(0.1),
@@ -193,10 +194,11 @@ fn pin_immunity_survives_aggressive_forget() {
     let engine = eval_engine();
 
     // Pinned fact, very old, low importance — should still survive
+    // (Episodic so that decay, not type exemption, is the survival test)
     let pinned_id = add_fact_with_opts(
         &engine,
         "Pinned fact that must never be forgotten despite age and low importance",
-        FactType::Semantic,
+        FactType::Episodic,
         None,
         AddFactOptions {
             importance: Some(0.05),
@@ -211,7 +213,7 @@ fn pin_immunity_survives_aggressive_forget() {
     let unpinned_id = add_fact_with_opts(
         &engine,
         "Unpinned fact with same low importance and old age should be forgotten",
-        FactType::Semantic,
+        FactType::Episodic,
         None,
         AddFactOptions {
             importance: Some(0.05),


### PR DESCRIPTION
## Context

`FactType::Semantic` and `FactType::Procedural` decayed under the default 69-day Ebbinghaus half-life (`traits.rs`) — the exact category error the four-layer thesis names ("a paper's findings do not become less true after 69 days"). The 2026-06 program review flagged this as its top coherence finding (coherence:C3); with the repo public, a reviewer reading the paper and the code finds the contradiction in minutes.

## Design

- `ForgetPolicy.decay_exempt_types: HashSet<FactType>`, **default `{Semantic, Procedural}`** — content predicate documented on the field and in [ADR-0012](docs/design/adr/0012-decay-exemption-knowledge-shaped-facts.md): a type is exempt iff its facts' truth is independent of time-since-encoding.
- Dual enforcement: recency pinned to `1.0` in `compute_importance` (scores stay honest) **and** hard bypass in `prune` (the guarantee — same mechanism as `is_pinned`; exempt facts still count in `facts_evaluated` and get scores materialized).
- **Override wins**: an explicit `half_life_overrides` entry re-enables decay for that type (`is_decay_exempt` encodes the rule). Keeps ADR-0006's `Procedural=365` example valid and lets eval suites exercise decay on any type.
- Lifecycle for exempt facts: supersession + conflict resolution, never decay.

## Open architectural alternative (deliberate non-goal here)

The thesis-purist fix is an **M→K promotion edge** (route knowledge-shaped facts to the knowledge layer). That's cross-system plumbing, deferred to the harness-integration thin slice (E3) and compatible with this change. Merging this PR chooses "exemption now, promotion later" — flagged so the choice is explicit.

## Test changes

TDD: `prune_exempts_knowledge_shaped_types_by_default` written first and observed red (all three neglected facts expired `[1, 2, 3]`; expected episodic-only). Six pre-existing eval/conformance tests used Semantic facts as arbitrary decay subjects; their properties (pin immunity contrast, decay ordering, importance monotonicity) are type-agnostic, so subjects moved to `Episodic`. The `pinned=false` conformance test keeps its Procedural subject via the override-wins hatch — exercising the new interaction.

## Verification

| Check | This branch | Untouched main | Attribution |
| --- | --- | --- | --- |
| `cargo test` (default features) | **623 passed, 0 failed** | 619 passed | +4 = the new tests |
| `cargo clippy --all-targets -- -D warnings` | 195 errors | 195 errors | pre-existing |
| `cargo fmt --check` | 2 files drift | same 2 files | pre-existing |
| `cargo test --all-features` | build break (`verify_archives` dup) | same | pre-existing feature-matrix issue |

🤖 Generated with [Claude Code](https://claude.com/claude-code)