### PR TITLE
S0.5 (#45): secrets/PII redaction gate for session import

### DIFF
--- a/docs/audits/S0.5-redaction-gate.md
+++ b/docs/audits/S0.5-redaction-gate.md
@@ -11,45 +11,111 @@ and is a HARD prerequisite — non-negotiable, reviewed by the owner (#51) befor
 ## What it does
 
 `redact_text(text) -> (redacted, findings)` and `redact_entries(entries) -> (redacted, RedactionReport)`.
-Detection is **dependency-free**. Tokens are split on whitespace **and** JSON/assignment
-punctuation (`" ' { } [ ] ( ) : , ; =`) so a secret embedded in `"token":"ghp_…"` or
-`key=secret` is isolated — `.`/`@`/`/`/`-`/`_`/`+` are kept (they live inside emails, JWTs,
-base64, provider tokens). Each token is classified:
+Detection is **dependency-free**. Rather than splitting on a blanket delimiter set, the gate
+runs a **multi-detector span scanner**: each detector finds redaction spans over the raw text,
+non-overlapping spans are collected in priority order (earlier detectors win over the same
+character range), and the string is rebuilt replacing each span with `[REDACTED:<rule>]`.
+All indices are char-based to avoid panics on multibyte text. Non-secret characters are
+preserved byte-exact.
 
-1. **Provider-token prefixes** (gitleaks-style): `AKIA…` (AWS), `ghp_…`/`github_pat_…` (GitHub),
-   `sk-…` (OpenAI), `AIza…` (Google), `xoxb-`/`xoxp-` (Slack), `-----BEGIN…PRIVATE KEY`, `eyJ…` (JWT).
-2. **Email** PII (`local@domain.tld` shape, exactly one `@`, Unicode-aware local part).
-3. **High Shannon entropy** tokens: length ≥ 20, secret-like charset (base64/hex/url-safe with
-   digits or specials), entropy ≥ **4.3** bits/char — above uniform hex (4.0, so git SHAs are
-   not unstably redacted), below base64/alnum secrets (~6.0) — catches arbitrary keys the prefix
-   rules miss.
+### Detectors (in priority order)
 
-Each finding is replaced in place with `[REDACTED:<rule>]` (non-secret text + whitespace
-preserved exactly), and tallied into a `RedactionReport`. `report.coverage_lines()` is the
-**auditable coverage report** for the #51 review (entries scanned, total redactions, per-rule
-counts). Redaction is idempotent (`[REDACTED:*]` placeholders are not re-redacted).
+1. **provider-prefix** — for each `(rule, prefix)` in `SECRET_PREFIXES`, finds every occurrence
+   that is at a **token boundary** (text start, or preceded by whitespace or a structural/URL
+   char from `PREFIX_BOUNDARY_CHARS`: `"'` `` ` `` `(){}[]:,;=<>?&/@`). This prevents `sk-`
+   from matching inside `task-force` or `risk-`. From the prefix end, extends over the secret
+   body = maximal run of `[alphanumeric ._-+/=]`, so `SG.xxx.yyy` and `eyJ...eyJ...sig` are
+   captured whole. A match is kept only if the captured token is ≥ `MIN_PREFIXED_SECRET_LEN`
+   (20) chars, and the dot-structured prefixes (`SG.`, `eyJ`) additionally require an embedded
+   `.` — so ordinary words like bare `SG.` / `eyJournal` do NOT fire. Special-case
+   `-----BEGIN`: redacts to end of line (preserving a trailing `\r` as the terminator).
+   Prefixes: `AKIA` (AWS), `ghp_` / `github_pat_` (GitHub), `sk-` (OpenAI), `AIza` (Google),
+   `xoxb-` / `xoxp-` (Slack), `-----BEGIN` (private-key header), `eyJ` (JWT), `SG.` (SendGrid).
+
+2. **url-credential** — finds `://`; within the authority (up to the next `/`, `?`, `#`,
+   whitespace, or end), if it contains `user:pass@host`, redacts the password = substring
+   between the **first** `:` after `://` and the **last** `@` in the authority. A password
+   containing `@` (e.g. `amqp://guest:p@ss-w0rd@rabbit.local`) is therefore fully captured.
+   Rule: `connection-string-password`.
+
+3. **email** — scans for `local@domain` where local = `[alnum ._%+-]+`, domain = `[alnum .-]+`
+   that **contains at least one `.`** and ends in a 2+-char alphabetic TLD. `admin@localhost`
+   and `pkg@v1` do NOT match. `user2024@example.com` matches as `email`, not as
+   `connection-string-password`. Rule: `email`.
+
+4. **hex-in-context (context-gated)** — only redacts a hex run of ≥ 32 `[0-9a-fA-F]` chars
+   when the **word immediately preceding** it (separated only by assignment punctuation /
+   quotes / whitespace) is a secret-indicator key. The trailing word is split on `_`, so
+   `api_key` / `access_token` gate via their `key` / `token` component, while ordinary words
+   like `monkey` / `authentic` and filenames like `key.rs` do NOT. Key components
+   (case-insensitive): `secret token key apikey password passwd pwd auth credential cred`.
+   Bare hex (git SHA-1s, SHA-256 checksums, MD5 digests with no adjacent key) is left
+   untouched. Rule: `hex-secret`.
+
+5. **high-entropy** — splits still-unclaimed text on whitespace and structural punctuation
+   (`"'` `` ` `` `{}[]():,;=` — **not** `.` or `/`, which appear inside secrets), and redacts
+   tokens with len ≥ 20, secret-like charset (`[alnum +/=_-]` with at least one digit or
+   special), and Shannon entropy ≥ 4.3 bits/char. 4.3 sits above uniform hex (log₂16 = 4.0)
+   and well below base64/alnum secrets (~6.0). Rule: `high-entropy`.
+
+Each finding is replaced in place with `[REDACTED:<rule>]` and tallied into a `RedactionReport`.
+`report.coverage_lines()` is the **auditable coverage report** for the #51 review.
+Redaction is idempotent (`[REDACTED:*]` placeholders are not re-redacted).
 
 ## Verification
 
-15 unit tests (`src/bootstrap/redact.rs` `#[cfg(test)]`): each prefix rule, email, high-entropy
-token, prose-untouched, whitespace preservation, Shannon-entropy values, report tallies,
-idempotency, **JSON-embedded secrets, `key=value` assignment, JWT, multibyte/no-panic, empty,
-multi-finding**. `cargo test --lib bootstrap::redact`; clippy `-D warnings` + nightly fmt clean.
+38 unit tests (`src/bootstrap/redact.rs` `#[cfg(test)]`):
 
-## Residuals + #51 review items
+- **Provider prefixes**: each of AWS, GitHub PAT, OpenAI (`sk-`), private-key header.
+- **Boundary rule**: `sk-` does not match inside `task-force` / `risk-`.
+- **SendGrid** (`SG.<22>.<43>`): prefix fires, body extends over dots.
+- **JWT** (`eyJ...`): prefix fires, captures header + body.
+- **URL-credential basic** (`postgres://user:s3cr3tPass1@db.host.com`): password redacted as `connection-string-password`, not `email`.
+- **URL-credential @ in password** (`amqp://guest:p@ss-w0rd@rabbit.local`): full password captured.
+- **URL-embedded GitHub PAT** (`https://x:ghp_...@github.com`): PAT not leaked.
+- **Email** (`craig@example.com`): redacted as `email`.
+- **Email with digit in local** (`user2024@example.com`): redacts as `email`, not `connection-string-password`.
+- **Angle-bracket email** (`<user@example.com>`): email extracted and redacted.
+- **`admin@localhost`** / **`pkg@v1`**: NOT redacted (no domain dot / no TLD).
+- **Bare git SHA-1** (40-char hex, no key): NOT redacted (`assert_eq!(out, input)`).
+- **Bare SHA-256** (64-char hex, no key): NOT redacted (`assert_eq!(out, input)`).
+- **Hex after `api_key=`**: redacted as `hex-secret`.
+- **Hex after `secret: `**: redacted as `hex-secret`.
+- **Short hex** (< 32 chars): NOT redacted.
+- **High-entropy token**: redacted.
+- **`key=value` assignment**: key name survives, value redacted.
+- **Prose untouched** (`assert_eq!(out, prose)` — fully restored).
+- **Version string** (`version 1.2.3`): not redacted.
+- **File path** (`see src/foo/bar.rs`): not redacted.
+- **Plain HTTPS URL** (`https://example.com`): not redacted.
+- **Hyphenated prose** (`task-force`, `risk-free`): not redacted.
+- **Whitespace + non-secrets**: preserved byte-exact.
+- **JSON-embedded secrets**: `"token":"ghp_..."` / `"email":"a@b.com"` both caught.
+- **Idempotency**: double-redaction produces no new findings.
+- **Report tallies**: `entries_scanned`, `total`, per-rule counts correct.
+- **Multiple findings one line**: both caught.
+- **Shannon entropy values**: 0-bit (empty), 0-bit (uniform), 2-bit (4 distinct).
+- **Multibyte no-panic**: Unicode prose around email doesn't panic.
+- **Empty input**: clean.
 
-JSON/assignment/JWT embedding is now handled (review fix). Remaining residuals for the #51
-review to weigh before wiring into the import path:
+`cargo test redact`: 38 passed. `cargo +nightly fmt --check`: clean. `cargo clippy --all-targets`: no issues.
 
-- **Connection-string passwords** (`postgres://user:pass@host`): the `:` split isolates `user`
-  but `pass@host` stays joined; a long password is caught by entropy, a short one is missed.
-- **Private-key BODY**: only the `-----BEGIN` header matches by rule; PEM body lines are caught
-  incidentally by entropy (long base64), with a possible ragged-tail gap. A stateful
-  `BEGIN…END` block redactor would be more robust.
-- **Short secrets** (< 20 chars) with no known prefix are uncatchable by design (entropy needs
-  length) — a deliberate false-positive/false-negative tradeoff.
+## Known limitations
+
+- **Bare hex secrets** (a long key stored bare, no `key=` / `secret:` context on the same line)
+  are **not caught** by the hex-in-context detector. They may be caught by the high-entropy
+  detector if the token is ≥ 20 chars and mixed enough (pure hex entropy = 4.0 < threshold 4.3,
+  so a bare uniform hex token will slip through). Deferred to #51's regex/gitleaks upgrade.
+- **Arbitrary embedded secrets** with no known prefix, no context key, and entropy below 4.3
+  (short or low-entropy tokens) are not caught. Deferred to #51.
 - **PII beyond email** (IPs, phone numbers, names) is not covered — scope decision for #51.
-- **Tuning** the entropy threshold (4.3) and min length (20) against the real corpus — the
-  coverage report is the instrument.
+- **Private-key body**: only the `-----BEGIN` header line is redacted by rule; PEM body lines
+  are caught incidentally by high-entropy (long base64), with a possible ragged-tail gap.
+
+## Residuals for #51
+
+- Tune entropy threshold (4.3) and min length (20) against the real corpus — the coverage
+  report is the instrument.
+- Consider stateful `BEGIN…END` block redaction for PEM bodies.
 - **Wiring**: when ratified, call `redact_entries` in front of `bootstrap_directory` (or
   pre-redact the `.jsonl` on disk). Deliberately not wired yet.

--- a/docs/audits/S0.5-redaction-gate.md
+++ b/docs/audits/S0.5-redaction-gate.md
@@ -1,0 +1,45 @@
+# S0.5 (#45) — Secrets/PII redaction gate
+
+**Status:** built + verified (build-only; **not wired into `bootstrap_session`** — owner reviews in #51 before any backfill). **Module:** `src/bootstrap/redact.rs`.
+
+## Why
+
+The B3 backfill (#53) imports 9 months of dev-session `.jsonl` into ME/KB. Those sessions
+contain credentials, tokens, and personal data. This gate sits **in front of** any bulk import
+and is a HARD prerequisite — non-negotiable, reviewed by the owner (#51) before backfill runs.
+
+## What it does
+
+`redact_text(text) -> (redacted, findings)` and `redact_entries(entries) -> (redacted, RedactionReport)`.
+Detection is **dependency-free**, over whitespace-delimited tokens:
+
+1. **Provider-token prefixes** (gitleaks-style): `AKIA…` (AWS), `ghp_…`/`github_pat_…` (GitHub),
+   `sk-…` (OpenAI), `AIza…` (Google), `xoxb-`/`xoxp-` (Slack), `-----BEGIN…PRIVATE KEY`.
+2. **Email** PII (`local@domain.tld` shape).
+3. **High Shannon entropy** tokens: length ≥ 20, secret-like charset (base64/hex/url-safe with
+   digits or specials), entropy ≥ 4.0 bits/char — catches arbitrary keys/secrets the prefix
+   rules miss.
+
+Each finding is replaced in place with `[REDACTED:<rule>]` (non-secret text + whitespace
+preserved exactly), and tallied into a `RedactionReport`. `report.coverage_lines()` is the
+**auditable coverage report** for the #51 review (entries scanned, total redactions, per-rule
+counts). Redaction is idempotent (`[REDACTED:*]` placeholders are not re-redacted).
+
+## Verification
+
+Nine unit tests (`src/bootstrap/redact.rs` `#[cfg(test)]`): each prefix rule, email, high-entropy
+token, prose-left-untouched, whitespace preservation, Shannon-entropy values, report tallies,
+idempotency. `cargo test --lib bootstrap::redact`; clippy `-D warnings` + nightly fmt clean.
+
+## v1 scope + #51 review items
+
+This is a **v1** (prefix + email + entropy). For the #51 review, decide whether to upgrade to a
+full regex/gitleaks rule set before backfill:
+
+- **`key = value` assignment patterns** (e.g. `password=…`, `secret: …`) are only caught when the
+  value is itself high-entropy; a weak/short secret in an assignment is missed.
+- **JWT structure** (`eyJ….….…`) is caught by entropy if long enough, not by a dedicated rule.
+- **Tuning** the entropy threshold (4.0 bits/char) and min length (20) against the real corpus to
+  trade false positives vs misses — the coverage report is the instrument for that.
+- **Wiring**: when ratified, call `redact_entries` in front of `bootstrap_directory` (or pre-redact
+  the `.jsonl` on disk). Deliberately not wired yet.

--- a/docs/audits/S0.5-redaction-gate.md
+++ b/docs/audits/S0.5-redaction-gate.md
@@ -11,13 +11,17 @@ and is a HARD prerequisite — non-negotiable, reviewed by the owner (#51) befor
 ## What it does
 
 `redact_text(text) -> (redacted, findings)` and `redact_entries(entries) -> (redacted, RedactionReport)`.
-Detection is **dependency-free**, over whitespace-delimited tokens:
+Detection is **dependency-free**. Tokens are split on whitespace **and** JSON/assignment
+punctuation (`" ' { } [ ] ( ) : , ; =`) so a secret embedded in `"token":"ghp_…"` or
+`key=secret` is isolated — `.`/`@`/`/`/`-`/`_`/`+` are kept (they live inside emails, JWTs,
+base64, provider tokens). Each token is classified:
 
 1. **Provider-token prefixes** (gitleaks-style): `AKIA…` (AWS), `ghp_…`/`github_pat_…` (GitHub),
-   `sk-…` (OpenAI), `AIza…` (Google), `xoxb-`/`xoxp-` (Slack), `-----BEGIN…PRIVATE KEY`.
-2. **Email** PII (`local@domain.tld` shape).
+   `sk-…` (OpenAI), `AIza…` (Google), `xoxb-`/`xoxp-` (Slack), `-----BEGIN…PRIVATE KEY`, `eyJ…` (JWT).
+2. **Email** PII (`local@domain.tld` shape, exactly one `@`, Unicode-aware local part).
 3. **High Shannon entropy** tokens: length ≥ 20, secret-like charset (base64/hex/url-safe with
-   digits or specials), entropy ≥ 4.0 bits/char — catches arbitrary keys/secrets the prefix
+   digits or specials), entropy ≥ **4.3** bits/char — above uniform hex (4.0, so git SHAs are
+   not unstably redacted), below base64/alnum secrets (~6.0) — catches arbitrary keys the prefix
    rules miss.
 
 Each finding is replaced in place with `[REDACTED:<rule>]` (non-secret text + whitespace
@@ -27,19 +31,25 @@ counts). Redaction is idempotent (`[REDACTED:*]` placeholders are not re-redacte
 
 ## Verification
 
-Nine unit tests (`src/bootstrap/redact.rs` `#[cfg(test)]`): each prefix rule, email, high-entropy
-token, prose-left-untouched, whitespace preservation, Shannon-entropy values, report tallies,
-idempotency. `cargo test --lib bootstrap::redact`; clippy `-D warnings` + nightly fmt clean.
+15 unit tests (`src/bootstrap/redact.rs` `#[cfg(test)]`): each prefix rule, email, high-entropy
+token, prose-untouched, whitespace preservation, Shannon-entropy values, report tallies,
+idempotency, **JSON-embedded secrets, `key=value` assignment, JWT, multibyte/no-panic, empty,
+multi-finding**. `cargo test --lib bootstrap::redact`; clippy `-D warnings` + nightly fmt clean.
 
-## v1 scope + #51 review items
+## Residuals + #51 review items
 
-This is a **v1** (prefix + email + entropy). For the #51 review, decide whether to upgrade to a
-full regex/gitleaks rule set before backfill:
+JSON/assignment/JWT embedding is now handled (review fix). Remaining residuals for the #51
+review to weigh before wiring into the import path:
 
-- **`key = value` assignment patterns** (e.g. `password=…`, `secret: …`) are only caught when the
-  value is itself high-entropy; a weak/short secret in an assignment is missed.
-- **JWT structure** (`eyJ….….…`) is caught by entropy if long enough, not by a dedicated rule.
-- **Tuning** the entropy threshold (4.0 bits/char) and min length (20) against the real corpus to
-  trade false positives vs misses — the coverage report is the instrument for that.
-- **Wiring**: when ratified, call `redact_entries` in front of `bootstrap_directory` (or pre-redact
-  the `.jsonl` on disk). Deliberately not wired yet.
+- **Connection-string passwords** (`postgres://user:pass@host`): the `:` split isolates `user`
+  but `pass@host` stays joined; a long password is caught by entropy, a short one is missed.
+- **Private-key BODY**: only the `-----BEGIN` header matches by rule; PEM body lines are caught
+  incidentally by entropy (long base64), with a possible ragged-tail gap. A stateful
+  `BEGIN…END` block redactor would be more robust.
+- **Short secrets** (< 20 chars) with no known prefix are uncatchable by design (entropy needs
+  length) — a deliberate false-positive/false-negative tradeoff.
+- **PII beyond email** (IPs, phone numbers, names) is not covered — scope decision for #51.
+- **Tuning** the entropy threshold (4.3) and min length (20) against the real corpus — the
+  coverage report is the instrument.
+- **Wiring**: when ratified, call `redact_entries` in front of `bootstrap_directory` (or
+  pre-redact the `.jsonl` on disk). Deliberately not wired yet.

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -8,6 +8,7 @@ pub mod filter;
 pub mod metrics;
 pub mod outcome;
 pub mod parse;
+pub mod redact;
 
 use std::io::BufRead;
 use std::path::Path;
@@ -26,6 +27,7 @@ pub use extract::{ExtractedFact, KeywordExtractor, SessionExtractor};
 pub use filter::{CandidateEpisode, ConversationTurn, EpisodeCategory, ToolCallRecord};
 pub use metrics::{BootstrapConfig, BootstrapReport, PrewarmMetrics};
 pub use outcome::{OutcomeSignals, SessionOutcome};
+pub use redact::{Finding, RedactionReport, redact_entries, redact_text, shannon_entropy};
 
 /// Bootstrap one session from a JSONL reader into the memory engine.
 ///

--- a/src/bootstrap/redact.rs
+++ b/src/bootstrap/redact.rs
@@ -1,0 +1,289 @@
+//! Secrets/PII redaction gate (#45 S0.5).
+//!
+//! Sits in **front** of any bulk import of session `.jsonl` into ME/KB: 9 months of
+//! dev sessions contain credentials, tokens and personal data. This is a HARD
+//! prerequisite for the B3 backfill (#53) and is reviewed by the owner (#51) before
+//! any backfill runs — so it is **build-only** here and is *not* wired into
+//! `bootstrap_session` yet.
+//!
+//! Detection is dependency-free and operates on whitespace-delimited tokens, via
+//! (1) known provider-token prefixes (gitleaks-style), (2) email PII, and (3) high
+//! Shannon-entropy tokens (arbitrary secrets/keys).
+//! Each finding is replaced with `[REDACTED:<rule>]` and tallied into an auditable
+//! [`RedactionReport`]. (v1: #51 may upgrade to full regex/gitleaks rule sets, e.g.
+//! `key = value` assignment patterns and JWT structure.)
+
+use std::collections::{BTreeMap, HashMap};
+
+/// Known secret-token prefixes: (rule name, literal prefix). gitleaks-style.
+const SECRET_PREFIXES: &[(&str, &str)] = &[
+    ("aws-access-key", "AKIA"),
+    ("github-pat", "ghp_"),
+    ("github-fine-pat", "github_pat_"),
+    ("openai-key", "sk-"),
+    ("google-api-key", "AIza"),
+    ("slack-token", "xoxb-"),
+    ("slack-token", "xoxp-"),
+    ("private-key-header", "-----BEGIN"),
+];
+
+/// A token is a high-entropy secret candidate only if at least this long.
+const HIGH_ENTROPY_MIN_LEN: usize = 20;
+/// Shannon entropy threshold (bits/char) above which a token-shaped string is redacted.
+const HIGH_ENTROPY_BITS: f64 = 4.0;
+
+/// One redaction: the rule that fired and the (now-removed) token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    pub rule: String,
+    pub token: String,
+}
+
+/// Auditable tally of what was redacted — the report the owner reviews in #51.
+#[derive(Debug, Clone, Default)]
+pub struct RedactionReport {
+    pub by_rule: BTreeMap<String, usize>,
+    pub total: usize,
+    pub entries_scanned: usize,
+}
+
+impl RedactionReport {
+    fn record(&mut self, rule: &str) {
+        *self.by_rule.entry(rule.to_owned()).or_default() += 1;
+        self.total += 1;
+    }
+
+    /// Human-readable coverage lines for the audit report.
+    #[must_use]
+    pub fn coverage_lines(&self) -> Vec<String> {
+        let mut lines = vec![format!(
+            "scanned {} entries, redacted {} secrets/PII",
+            self.entries_scanned, self.total
+        )];
+        lines.extend(
+            self.by_rule
+                .iter()
+                .map(|(rule, n)| format!("  {rule}: {n}")),
+        );
+        lines
+    }
+}
+
+/// Shannon entropy of `s` in bits per character.
+#[must_use]
+pub fn shannon_entropy(s: &str) -> f64 {
+    let n = s.chars().count();
+    if n == 0 {
+        return 0.0;
+    }
+    let mut counts: HashMap<char, usize> = HashMap::new();
+    for c in s.chars() {
+        *counts.entry(c).or_default() += 1;
+    }
+    // Counts are tiny (token length); usize -> f64 cannot lose precision here.
+    #[allow(clippy::cast_precision_loss)]
+    let n_f = n as f64;
+    #[allow(clippy::cast_precision_loss)]
+    counts
+        .values()
+        .map(|&c| {
+            let p = c as f64 / n_f;
+            -p * p.log2()
+        })
+        .sum()
+}
+
+/// True iff `token` looks like an email address (PII).
+fn is_email(token: &str) -> bool {
+    let Some(at) = token.find('@') else {
+        return false;
+    };
+    let (local, domain) = (&token[..at], &token[at + 1..]);
+    !local.is_empty()
+        && domain.contains('.')
+        && !domain.starts_with('.')
+        && !domain.ends_with('.')
+        && token
+            .chars()
+            .all(|c| c.is_alphanumeric() || "._%+-@".contains(c))
+}
+
+/// True iff `token` uses a secret-like charset (base64/hex/url-safe with some digits
+/// or specials) — so plain prose words are not flagged as high-entropy.
+fn looks_like_secret_charset(token: &str) -> bool {
+    let charset_ok = token
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || "+/=_-".contains(c));
+    let has_digit = token.chars().any(|c| c.is_ascii_digit());
+    let has_special = token.chars().any(|c| "+/=_-".contains(c));
+    charset_ok && (has_digit || has_special)
+}
+
+/// Classify a token; returns the rule name if it is a secret/PII, else None.
+fn classify(token: &str) -> Option<&'static str> {
+    for (rule, prefix) in SECRET_PREFIXES {
+        if token.starts_with(prefix) {
+            return Some(rule);
+        }
+    }
+    if is_email(token) {
+        return Some("email");
+    }
+    if token.len() >= HIGH_ENTROPY_MIN_LEN
+        && looks_like_secret_charset(token)
+        && shannon_entropy(token) >= HIGH_ENTROPY_BITS
+    {
+        return Some("high-entropy");
+    }
+    None
+}
+
+fn flush_token(token: &mut String, out: &mut String, findings: &mut Vec<Finding>) {
+    if token.is_empty() {
+        return;
+    }
+    if let Some(rule) = classify(token) {
+        out.push_str("[REDACTED:");
+        out.push_str(rule);
+        out.push(']');
+        findings.push(Finding {
+            rule: rule.to_owned(),
+            token: std::mem::take(token),
+        });
+    } else {
+        out.push_str(token);
+        token.clear();
+    }
+}
+
+/// Redact secrets/PII from `text`, preserving all non-secret characters + whitespace.
+///
+/// Returns the redacted text and the findings (secret tokens removed).
+#[must_use]
+pub fn redact_text(text: &str) -> (String, Vec<Finding>) {
+    let mut out = String::with_capacity(text.len());
+    let mut findings: Vec<Finding> = Vec::new();
+    let mut token = String::new();
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            flush_token(&mut token, &mut out, &mut findings);
+            out.push(ch);
+        } else {
+            token.push(ch);
+        }
+    }
+    flush_token(&mut token, &mut out, &mut findings);
+    (out, findings)
+}
+
+/// Redact a sequence of session entries (raw `.jsonl` lines or extracted text),
+/// returning the redacted entries and an auditable coverage report.
+#[must_use]
+pub fn redact_entries(entries: &[String]) -> (Vec<String>, RedactionReport) {
+    let mut report = RedactionReport::default();
+    let mut redacted = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let (clean, findings) = redact_text(entry);
+        report.entries_scanned += 1;
+        for finding in &findings {
+            report.record(&finding.rule);
+        }
+        redacted.push(clean);
+    }
+    (redacted, report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_provider_prefixes() {
+        for (token, rule) in [
+            ("AKIAIOSFODNN7EXAMPLE", "aws-access-key"),
+            ("ghp_0123456789abcdefghij0123456789abcdef", "github-pat"),
+            ("sk-abcdefghijklmnopqrstuvwxyz0123", "openai-key"),
+        ] {
+            let (out, findings) = redact_text(&format!("token is {token} end"));
+            assert!(out.contains("[REDACTED:"), "{token} not redacted: {out}");
+            assert_eq!(findings.len(), 1);
+            assert_eq!(findings[0].rule, rule);
+            assert!(!out.contains(token));
+            assert!(out.contains("token is") && out.contains("end"));
+        }
+    }
+
+    #[test]
+    fn redacts_private_key_header() {
+        let (out, findings) = redact_text("-----BEGIN RSA PRIVATE KEY-----");
+        assert!(out.contains("[REDACTED:private-key-header]"));
+        assert_eq!(findings[0].rule, "private-key-header");
+    }
+
+    #[test]
+    fn redacts_email() {
+        let (out, findings) = redact_text("contact craig@example.com please");
+        assert!(out.contains("[REDACTED:email]"));
+        assert!(!out.contains("craig@example.com"));
+        assert_eq!(findings[0].rule, "email");
+        assert!(out.contains("contact") && out.contains("please"));
+    }
+
+    #[test]
+    fn redacts_high_entropy_token() {
+        let secret = "aGVsbG8x9Zk3Qw7Lp2Rt5Yv8Bn1Cx4Df6"; // len>20, mixed case+digits
+        let (out, findings) = redact_text(&format!("the token {secret} here"));
+        assert!(out.contains("[REDACTED:high-entropy]"), "got: {out}");
+        assert_eq!(findings[0].rule, "high-entropy");
+        assert!(!out.contains(secret));
+    }
+
+    #[test]
+    fn leaves_prose_untouched() {
+        let prose = "The quick brown fox jumps over the lazy dog repeatedly today.";
+        let (out, findings) = redact_text(prose);
+        assert_eq!(out, prose);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn preserves_whitespace_and_nonsecrets() {
+        let text = "a\n  b\tc";
+        let (out, _) = redact_text(text);
+        assert_eq!(out, text);
+    }
+
+    #[test]
+    fn entropy_basic() {
+        assert_eq!(shannon_entropy(""), 0.0);
+        assert_eq!(shannon_entropy("aaaa"), 0.0); // single symbol -> 0 bits
+        assert!((shannon_entropy("abcd") - 2.0).abs() < 1e-9); // 4 distinct -> log2(4) = 2
+    }
+
+    #[test]
+    fn report_tallies_by_rule() {
+        let entries = [
+            "email me at a@b.com".to_owned(),
+            "aws AKIAIOSFODNN7EXAMPLE here".to_owned(),
+            "nothing secret here".to_owned(),
+        ];
+        let (redacted, report) = redact_entries(&entries);
+        assert_eq!(report.entries_scanned, 3);
+        assert_eq!(report.total, 2);
+        assert_eq!(report.by_rule.get("email"), Some(&1));
+        assert_eq!(report.by_rule.get("aws-access-key"), Some(&1));
+        assert_eq!(redacted[2], "nothing secret here");
+    }
+
+    #[test]
+    fn idempotent_placeholders_not_re_redacted() {
+        let text = "the token aGVsbG8x9Zk3Qw7Lp2Rt5Yv8Bn1Cx4Df6 and a@b.com";
+        let (once, _) = redact_text(text);
+        let (twice, findings2) = redact_text(&once);
+        assert_eq!(once, twice, "redaction must be idempotent");
+        assert!(
+            findings2.is_empty(),
+            "[REDACTED:*] placeholders must not be re-redacted"
+        );
+    }
+}

--- a/src/bootstrap/redact.rs
+++ b/src/bootstrap/redact.rs
@@ -25,12 +25,27 @@ const SECRET_PREFIXES: &[(&str, &str)] = &[
     ("slack-token", "xoxb-"),
     ("slack-token", "xoxp-"),
     ("private-key-header", "-----BEGIN"),
+    ("jwt", "eyJ"), // base64url of `{"` — catches JWTs whose internal `.` breaks entropy
 ];
 
 /// A token is a high-entropy secret candidate only if at least this long.
 const HIGH_ENTROPY_MIN_LEN: usize = 20;
 /// Shannon entropy threshold (bits/char) above which a token-shaped string is redacted.
-const HIGH_ENTROPY_BITS: f64 = 4.0;
+/// 4.3 sits above uniform hex (log2 16 = 4.0, so git SHAs are not unstably redacted) and
+/// well below base64/alnum secrets (~6.0 / ~5.95).
+const HIGH_ENTROPY_BITS: f64 = 4.3;
+
+/// Non-whitespace delimiters that also split tokens, so secrets embedded in JSON /
+/// `key=value` / `key: value` / quoted strings are isolated and classified — not hidden
+/// inside `"token":"ghp_..."`. `.`/`@`/`/`/`-`/`_`/`+` are NOT delimiters (they appear
+/// inside emails, JWTs, base64 and provider tokens).
+const PUNCT_DELIMITERS: &[char] = &[
+    '"', '\'', '`', '{', '}', '[', ']', '(', ')', ':', ',', ';', '=',
+];
+
+fn is_delimiter(ch: char) -> bool {
+    ch.is_whitespace() || PUNCT_DELIMITERS.contains(&ch)
+}
 
 /// One redaction: the rule that fired and the (now-removed) token.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,10 +110,12 @@ pub fn shannon_entropy(s: &str) -> f64 {
 
 /// True iff `token` looks like an email address (PII).
 fn is_email(token: &str) -> bool {
-    let Some(at) = token.find('@') else {
+    if token.matches('@').count() != 1 {
+        return false; // exactly one '@' (rejects `a@b@c` and non-emails)
+    }
+    let Some((local, domain)) = token.split_once('@') else {
         return false;
     };
-    let (local, domain) = (&token[..at], &token[at + 1..]);
     !local.is_empty()
         && domain.contains('.')
         && !domain.starts_with('.')
@@ -156,8 +173,10 @@ fn flush_token(token: &mut String, out: &mut String, findings: &mut Vec<Finding>
     }
 }
 
-/// Redact secrets/PII from `text`, preserving all non-secret characters + whitespace.
+/// Redact secrets/PII from `text`, preserving all non-secret characters + delimiters.
 ///
+/// Tokens are split on whitespace AND JSON/assignment punctuation (see [`is_delimiter`]),
+/// so a secret embedded in `"token":"ghp_..."` or `key=secret` is isolated and classified.
 /// Returns the redacted text and the findings (secret tokens removed).
 #[must_use]
 pub fn redact_text(text: &str) -> (String, Vec<Finding>) {
@@ -165,7 +184,7 @@ pub fn redact_text(text: &str) -> (String, Vec<Finding>) {
     let mut findings: Vec<Finding> = Vec::new();
     let mut token = String::new();
     for ch in text.chars() {
-        if ch.is_whitespace() {
+        if is_delimiter(ch) {
             flush_token(&mut token, &mut out, &mut findings);
             out.push(ch);
         } else {
@@ -285,5 +304,66 @@ mod tests {
             findings2.is_empty(),
             "[REDACTED:*] placeholders must not be re-redacted"
         );
+    }
+
+    #[test]
+    fn redacts_secrets_embedded_in_json() {
+        let line = r#"{"token":"ghp_0123456789abcdefghij0123456789abcdef","email":"a@b.com"}"#;
+        let (out, findings) = redact_text(line);
+        assert!(
+            !out.contains("ghp_0123456789abcdefghij0123456789abcdef"),
+            "json token leaked: {out}"
+        );
+        assert!(!out.contains("a@b.com"), "json email leaked: {out}");
+        let rules: Vec<&str> = findings.iter().map(|f| f.rule.as_str()).collect();
+        assert!(
+            rules.contains(&"github-pat") && rules.contains(&"email"),
+            "rules: {rules:?}"
+        );
+        assert!(
+            out.contains("\"token\":") && out.contains("\"email\":"),
+            "json structure lost"
+        );
+    }
+
+    #[test]
+    fn redacts_assignment_value_keeping_key() {
+        let (out, findings) = redact_text("api_key=Xk9Lp2Rt5Yv8Bn1Cx4Df6Qw7Zz0Aa");
+        assert!(
+            out.starts_with("api_key="),
+            "key name should survive: {out}"
+        );
+        assert!(out.contains("[REDACTED:high-entropy]"), "got: {out}");
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn redacts_jwt_via_prefix() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N";
+        let (out, findings) = redact_text(&format!("Authorization: Bearer {jwt}"));
+        assert!(out.contains("[REDACTED:jwt]"), "got: {out}");
+        assert!(!out.contains(jwt));
+        assert_eq!(findings.iter().filter(|f| f.rule == "jwt").count(), 1);
+    }
+
+    #[test]
+    fn empty_input() {
+        let (out, findings) = redact_text("");
+        assert_eq!(out, "");
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn multibyte_tokens_no_panic() {
+        // Non-ASCII tokens around an email must not panic and must survive.
+        let (out, _) = redact_text("café résumé señor@example.com déjà");
+        assert!(out.contains("[REDACTED:email]"), "got: {out}");
+        assert!(out.contains("café") && out.contains("déjà"));
+    }
+
+    #[test]
+    fn multiple_findings_one_line() {
+        let (_out, findings) = redact_text("aws AKIAIOSFODNN7EXAMPLE and email a@b.com");
+        assert_eq!(findings.len(), 2);
     }
 }

--- a/src/bootstrap/redact.rs
+++ b/src/bootstrap/redact.rs
@@ -6,14 +6,22 @@
 //! any backfill runs — so it is **build-only** here and is *not* wired into
 //! `bootstrap_session` yet.
 //!
-//! Detection is dependency-free and operates on whitespace-delimited tokens, via
-//! (1) known provider-token prefixes (gitleaks-style), (2) email PII, and (3) high
-//! Shannon-entropy tokens (arbitrary secrets/keys).
-//! Each finding is replaced with `[REDACTED:<rule>]` and tallied into an auditable
-//! [`RedactionReport`]. (v1: #51 may upgrade to full regex/gitleaks rule sets, e.g.
-//! `key = value` assignment patterns and JWT structure.)
+//! Detection is dependency-free and uses a **multi-detector span scanner**: each
+//! detector finds redaction spans over the raw text, non-overlapping spans are
+//! collected in priority order (earlier detectors win), and the string is rebuilt
+//! replacing each span with `[REDACTED:<rule>]`. Char indices are used throughout
+//! to avoid panics on multibyte text.
+//!
+//! Detectors (in priority order):
+//! 1. **provider-prefix** — known secret-token prefixes at a token boundary.
+//! 2. **url-credential** — `user:password@host` inside a URL authority.
+//! 3. **email** — `local@domain.tld` PII.
+//! 4. **hex-in-context** — long hex run preceded by a secret-indicator key.
+//! 5. **high-entropy** — arbitrary long tokens with high Shannon entropy.
 
 use std::collections::{BTreeMap, HashMap};
+
+// ── Constants ────────────────────────────────────────────────────────────────
 
 /// Known secret-token prefixes: (rule name, literal prefix). gitleaks-style.
 const SECRET_PREFIXES: &[(&str, &str)] = &[
@@ -25,29 +33,61 @@ const SECRET_PREFIXES: &[(&str, &str)] = &[
     ("slack-token", "xoxb-"),
     ("slack-token", "xoxp-"),
     ("private-key-header", "-----BEGIN"),
-    ("jwt", "eyJ"), // base64url of `{"` — catches JWTs whose internal `.` breaks entropy
+    ("jwt", "eyJ"), // base64url of `{"` — catches JWTs
+    ("sendgrid", "SG."),
 ];
 
-/// A token is a high-entropy secret candidate only if at least this long.
-const HIGH_ENTROPY_MIN_LEN: usize = 20;
-/// Shannon entropy threshold (bits/char) above which a token-shaped string is redacted.
-/// 4.3 sits above uniform hex (log2 16 = 4.0, so git SHAs are not unstably redacted) and
-/// well below base64/alnum secrets (~6.0 / ~5.95).
-const HIGH_ENTROPY_BITS: f64 = 4.3;
+/// Characters that constitute a "structural boundary" for the provider-prefix
+/// detector: a prefix is only a match if it is at the text start, or preceded
+/// by whitespace or one of these structural chars.
+const PREFIX_BOUNDARY_CHARS: &[char] = &[
+    '"', '\'', '`', '(', ')', '{', '}', '[', ']', ':', ',', ';', '=', '<', '>', '?', '&', '/', '@',
+];
 
-/// Non-whitespace delimiters that also split tokens, so secrets embedded in JSON /
-/// `key=value` / `key: value` / quoted strings are isolated and classified — not hidden
-/// inside `"token":"ghp_..."`. `.`/`@`/`/`/`-`/`_`/`+` are NOT delimiters (they appear
-/// inside emails, JWTs, base64 and provider tokens).
-const PUNCT_DELIMITERS: &[char] = &[
+/// Characters that are valid inside a provider-token body (extends into the
+/// secret after the prefix).
+const TOKEN_BODY_CHARS: &[char] = &['.', '_', '-', '+', '/', '='];
+
+/// Characters on which the high-entropy detector splits tokens.
+/// Intentionally does NOT include `.` or `/` (those appear inside secrets).
+const ENTROPY_SPLIT_CHARS: &[char] = &[
     '"', '\'', '`', '{', '}', '[', ']', '(', ')', ':', ',', ';', '=',
 ];
 
-fn is_delimiter(ch: char) -> bool {
-    ch.is_whitespace() || PUNCT_DELIMITERS.contains(&ch)
-}
+/// Secret-indicator keywords that gate the hex-in-context detector (case-insensitive).
+const HEX_CONTEXT_KEYS: &[&str] = &[
+    // Base identifier components: a trailing key like `api_key` / `access_token` gates the
+    // hex via its `key` / `token` component (the word is split on `_`), but ordinary words
+    // such as `monkey` / `authentic` do not.
+    "secret",
+    "token",
+    "key",
+    "apikey",
+    "password",
+    "passwd",
+    "pwd",
+    "auth",
+    "credential",
+    "cred",
+];
 
-/// One redaction: the rule that fired and the (now-removed) token.
+/// Minimum hex run length to be considered a secret (when context-gated).
+const HEX_SECRET_MIN_LEN: usize = 32;
+
+/// Minimum length of a prefix-detected token (prefix + body). Rejects bare/short matches
+/// that fire on ordinary words (e.g. `SG.`, `eyJournal`); real provider tokens are long
+/// (AWS `AKIA` + 16 = 20 is the shortest).
+const MIN_PREFIXED_SECRET_LEN: usize = 20;
+
+/// Minimum token length for the high-entropy detector.
+const HIGH_ENTROPY_MIN_LEN: usize = 20;
+
+/// Shannon entropy threshold (bits/char) for the high-entropy detector.
+const HIGH_ENTROPY_BITS: f64 = 4.3;
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/// One redaction: the rule that fired and the (now-removed) secret text.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Finding {
     pub rule: String,
@@ -84,6 +124,8 @@ impl RedactionReport {
     }
 }
 
+// ── Shannon entropy (public — used by tests) ─────────────────────────────────
+
 /// Shannon entropy of `s` in bits per character.
 #[must_use]
 pub fn shannon_entropy(s: &str) -> f64 {
@@ -95,7 +137,6 @@ pub fn shannon_entropy(s: &str) -> f64 {
     for c in s.chars() {
         *counts.entry(c).or_default() += 1;
     }
-    // Counts are tiny (token length); usize -> f64 cannot lose precision here.
     #[allow(clippy::cast_precision_loss)]
     let n_f = n as f64;
     #[allow(clippy::cast_precision_loss)]
@@ -108,25 +149,280 @@ pub fn shannon_entropy(s: &str) -> f64 {
         .sum()
 }
 
-/// True iff `token` looks like an email address (PII).
-fn is_email(token: &str) -> bool {
-    if token.matches('@').count() != 1 {
-        return false; // exactly one '@' (rejects `a@b@c` and non-emails)
-    }
-    let Some((local, domain)) = token.split_once('@') else {
-        return false;
-    };
-    !local.is_empty()
-        && domain.contains('.')
-        && !domain.starts_with('.')
-        && !domain.ends_with('.')
-        && token
-            .chars()
-            .all(|c| c.is_alphanumeric() || "._%+-@".contains(c))
+// ── Span type ────────────────────────────────────────────────────────────────
+
+/// A half-open byte range `[start, end)` in the original text together with the
+/// rule name.  All indices are **byte** offsets into the UTF-8 string (produced
+/// from char positions), and are always kept on char boundaries.
+#[derive(Debug)]
+struct Span {
+    start: usize, // byte offset
+    end: usize,   // byte offset (exclusive)
+    rule: &'static str,
 }
 
-/// True iff `token` uses a secret-like charset (base64/hex/url-safe with some digits
-/// or specials) — so plain prose words are not flagged as high-entropy.
+/// Returns true if `[a_start, a_end)` overlaps with any span in `spans`.
+fn overlaps(spans: &[Span], a_start: usize, a_end: usize) -> bool {
+    spans.iter().any(|s| a_start < s.end && a_end > s.start)
+}
+
+// ── Detector 1: provider-prefix ──────────────────────────────────────────────
+
+fn is_prefix_boundary(text: &str, byte_pos: usize) -> bool {
+    if byte_pos == 0 {
+        return true;
+    }
+    // Walk backwards one char
+    let preceding = &text[..byte_pos];
+    if let Some(ch) = preceding.chars().next_back() {
+        return ch.is_whitespace() || PREFIX_BOUNDARY_CHARS.contains(&ch);
+    }
+    true
+}
+
+fn detect_provider_prefix(text: &str, spans: &mut Vec<Span>) {
+    for &(rule, prefix) in SECRET_PREFIXES {
+        let mut search_start = 0;
+        while search_start < text.len() {
+            let Some(rel) = text[search_start..].find(prefix) else {
+                break;
+            };
+            let match_start = search_start + rel;
+
+            // Boundary check
+            if !is_prefix_boundary(text, match_start) {
+                search_start = match_start + 1;
+                continue;
+            }
+
+            // Special case: -----BEGIN — redact to end of line
+            let match_end = if prefix == "-----BEGIN" {
+                let rest = &text[match_start..];
+                let mut line_end = rest.find('\n').unwrap_or(rest.len());
+                // Keep \r\n as the line terminator — don't swallow a trailing CR.
+                if line_end > 0 && rest.as_bytes()[line_end - 1] == b'\r' {
+                    line_end -= 1;
+                }
+                match_start + line_end
+            } else {
+                // Extend over the token body: alnum + TOKEN_BODY_CHARS
+                let body_start = match_start + prefix.len();
+                let mut end = body_start;
+                for ch in text[body_start..].chars() {
+                    if ch.is_alphanumeric() || TOKEN_BODY_CHARS.contains(&ch) {
+                        end += ch.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
+                end
+            };
+
+            // Reject bare/short matches that fire on ordinary words (`SG.`, `eyJournal`):
+            // real provider tokens are long, and the dot-structured prefixes (`SG.`, `eyJ`)
+            // must actually exhibit their dotted multi-segment structure.
+            if prefix != "-----BEGIN" {
+                let captured = &text[match_start..match_end];
+                if captured.len() < MIN_PREFIXED_SECRET_LEN
+                    || (matches!(prefix, "SG." | "eyJ") && !captured.contains('.'))
+                {
+                    search_start = match_start + 1;
+                    continue;
+                }
+            }
+
+            if !overlaps(spans, match_start, match_end) {
+                spans.push(Span {
+                    start: match_start,
+                    end: match_end,
+                    rule,
+                });
+            }
+            search_start = match_start + 1;
+        }
+    }
+}
+
+// ── Detector 2: url-credential ───────────────────────────────────────────────
+
+fn detect_url_credential(text: &str, spans: &mut Vec<Span>) {
+    let mut search_start = 0;
+    while search_start < text.len() {
+        let Some(rel) = text[search_start..].find("://") else {
+            break;
+        };
+        let authority_start = search_start + rel + 3; // after "://"
+
+        // Authority ends at the next '/', '?', '#', whitespace, or end
+        let authority_text = &text[authority_start..];
+        let authority_len = authority_text
+            .find(|c: char| c == '/' || c == '?' || c == '#' || c.is_whitespace())
+            .unwrap_or(authority_text.len());
+        let authority = &authority_text[..authority_len];
+
+        // Need 'user:pass@host' — must contain '@' AND first ':' before last '@'
+        if let Some(at_pos) = authority.rfind('@') {
+            let before_at = &authority[..at_pos];
+            if let Some(colon_pos) = before_at.find(':') {
+                // password = between first ':' and last '@'
+                let pass_start = authority_start + colon_pos + 1;
+                let pass_end = authority_start + at_pos;
+                if pass_start < pass_end && !overlaps(spans, pass_start, pass_end) {
+                    spans.push(Span {
+                        start: pass_start,
+                        end: pass_end,
+                        rule: "connection-string-password",
+                    });
+                }
+            }
+        }
+
+        search_start = authority_start + authority_len + 1;
+    }
+}
+
+// ── Detector 3: email ────────────────────────────────────────────────────────
+
+/// True if `ch` is valid in an email local-part.
+fn is_email_local(ch: char) -> bool {
+    ch.is_alphanumeric() || "._%+-".contains(ch)
+}
+
+/// True if `ch` is valid in an email domain.
+fn is_email_domain(ch: char) -> bool {
+    ch.is_alphanumeric() || ".-".contains(ch)
+}
+
+fn detect_email(text: &str, spans: &mut Vec<Span>) {
+    // Find each '@' and expand left (local-part) and right (domain).
+    let chars: Vec<(usize, char)> = text.char_indices().collect();
+    for (at_idx, &(at_byte, ch)) in chars.iter().enumerate() {
+        if ch != '@' {
+            continue;
+        }
+
+        // Expand left for local-part
+        let mut local_start_idx = at_idx;
+        while local_start_idx > 0 && is_email_local(chars[local_start_idx - 1].1) {
+            local_start_idx -= 1;
+        }
+        let local = &text[chars[local_start_idx].0..at_byte];
+        if local.is_empty() {
+            continue;
+        }
+
+        // Expand right for domain
+        let domain_start_idx = at_idx + 1;
+        let mut domain_end_idx = domain_start_idx;
+        while domain_end_idx < chars.len() && is_email_domain(chars[domain_end_idx].1) {
+            domain_end_idx += 1;
+        }
+        let domain_end_byte = if domain_end_idx < chars.len() {
+            chars[domain_end_idx].0
+        } else {
+            text.len()
+        };
+        let domain = &text[at_byte + 1..domain_end_byte];
+
+        // Validate: domain must contain at least one '.' and end in 2+ alpha TLD
+        if !domain.contains('.') {
+            continue;
+        }
+        let tld = domain.rsplit('.').next().unwrap_or("");
+        if tld.len() < 2 || !tld.chars().all(|c| c.is_ascii_alphabetic()) {
+            continue;
+        }
+
+        let span_start = chars[local_start_idx].0;
+        let span_end = domain_end_byte;
+
+        if !overlaps(spans, span_start, span_end) {
+            spans.push(Span {
+                start: span_start,
+                end: span_end,
+                rule: "email",
+            });
+        }
+    }
+}
+
+// ── Detector 4: hex-in-context ───────────────────────────────────────────────
+
+/// True if `ch` is a hex digit.
+const fn is_hex(ch: char) -> bool {
+    ch.is_ascii_hexdigit()
+}
+
+/// True iff the WORD immediately preceding the hex run is a secret-indicator key.
+///
+/// Word-adjacency (separated only by assignment punctuation / quotes / whitespace), NOT a
+/// line-wide substring scan: so `monkey <hex>`, `authentic <hex>`, and
+/// `key.rs: ... points to <hex>` do NOT gate (the bare hex / git SHA is preserved), while
+/// `api_key=<hex>`, `secret: <hex>`, and `"token":"<hex>"` do. The trailing word is split
+/// on `_`, so `api_key` / `access_token` gate via their `key` / `token` component.
+fn has_hex_context_key(line: &str, hex_start_in_line: usize) -> bool {
+    let prefix = &line[..hex_start_in_line];
+    let trimmed = prefix.trim_end_matches(|c: char| c.is_whitespace() || "=:\"'`".contains(c));
+    let word_len: usize = trimmed
+        .chars()
+        .rev()
+        .take_while(|&c| c.is_alphanumeric() || c == '_')
+        .map(char::len_utf8)
+        .sum();
+    if word_len == 0 {
+        return false;
+    }
+    let word = trimmed[trimmed.len() - word_len..].to_ascii_lowercase();
+    word.split('_').any(|part| HEX_CONTEXT_KEYS.contains(&part))
+}
+
+fn detect_hex_in_context(text: &str, spans: &mut Vec<Span>) {
+    // Process line by line so we can check context within the same line.
+    let mut line_start_byte = 0;
+    for line in text.split('\n') {
+        let chars: Vec<(usize, char)> = line.char_indices().collect();
+        let mut i = 0;
+        while i < chars.len() {
+            if !is_hex(chars[i].1) {
+                i += 1;
+                continue;
+            }
+            // Find end of hex run
+            let hex_start_local = chars[i].0; // byte offset within line
+            let mut j = i;
+            while j < chars.len() && is_hex(chars[j].1) {
+                j += 1;
+            }
+            let hex_end_local = if j < chars.len() {
+                chars[j].0
+            } else {
+                line.len()
+            };
+            let run_len = j - i; // number of hex chars
+
+            if run_len >= HEX_SECRET_MIN_LEN && has_hex_context_key(line, hex_start_local) {
+                let span_start = line_start_byte + hex_start_local;
+                let span_end = line_start_byte + hex_end_local;
+                if !overlaps(spans, span_start, span_end) {
+                    spans.push(Span {
+                        start: span_start,
+                        end: span_end,
+                        rule: "hex-secret",
+                    });
+                }
+            }
+            i = j;
+        }
+        line_start_byte += line.len() + 1; // +1 for the '\n'
+    }
+}
+
+// ── Detector 5: high-entropy ─────────────────────────────────────────────────
+
+fn is_entropy_split(ch: char) -> bool {
+    ch.is_whitespace() || ENTROPY_SPLIT_CHARS.contains(&ch)
+}
+
 fn looks_like_secret_charset(token: &str) -> bool {
     let charset_ok = token
         .chars()
@@ -136,63 +432,95 @@ fn looks_like_secret_charset(token: &str) -> bool {
     charset_ok && (has_digit || has_special)
 }
 
-/// Classify a token; returns the rule name if it is a secret/PII, else None.
-fn classify(token: &str) -> Option<&'static str> {
-    for (rule, prefix) in SECRET_PREFIXES {
-        if token.starts_with(prefix) {
-            return Some(rule);
+fn detect_high_entropy(text: &str, spans: &mut Vec<Span>) {
+    // Walk byte-by-byte splitting on entropy-split chars, collecting token ranges.
+    let mut tok_start: Option<usize> = None;
+    let chars: Vec<(usize, char)> = text.char_indices().collect();
+    let flush = |tok_start: usize, tok_end: usize, spans: &mut Vec<Span>| {
+        let token = &text[tok_start..tok_end];
+        if token.chars().count() >= HIGH_ENTROPY_MIN_LEN
+            && looks_like_secret_charset(token)
+            && shannon_entropy(token) >= HIGH_ENTROPY_BITS
+            && !overlaps(spans, tok_start, tok_end)
+        {
+            spans.push(Span {
+                start: tok_start,
+                end: tok_end,
+                rule: "high-entropy",
+            });
+        }
+    };
+
+    for &(byte_pos, ch) in &chars {
+        if is_entropy_split(ch) {
+            if let Some(start) = tok_start.take() {
+                flush(start, byte_pos, spans);
+            }
+        } else if tok_start.is_none() {
+            tok_start = Some(byte_pos);
         }
     }
-    if is_email(token) {
-        return Some("email");
+    if let Some(start) = tok_start {
+        flush(start, text.len(), spans);
     }
-    if token.len() >= HIGH_ENTROPY_MIN_LEN
-        && looks_like_secret_charset(token)
-        && shannon_entropy(token) >= HIGH_ENTROPY_BITS
-    {
-        return Some("high-entropy");
-    }
-    None
 }
 
-fn flush_token(token: &mut String, out: &mut String, findings: &mut Vec<Finding>) {
-    if token.is_empty() {
-        return;
-    }
-    if let Some(rule) = classify(token) {
+// ── Span collection + string reconstruction ───────────────────────────────────
+
+/// Run all detectors in priority order; collect non-overlapping spans.
+fn collect_spans(text: &str) -> Vec<Span> {
+    let mut spans: Vec<Span> = Vec::new();
+    detect_provider_prefix(text, &mut spans);
+    detect_url_credential(text, &mut spans);
+    detect_email(text, &mut spans);
+    detect_hex_in_context(text, &mut spans);
+    detect_high_entropy(text, &mut spans);
+    // Sort by start position for reconstruction.
+    spans.sort_by_key(|s| s.start);
+    spans
+}
+
+/// Rebuild `text` replacing each span with `[REDACTED:<rule>]`.
+///
+/// Spans must be sorted and non-overlapping (invariant guaranteed by
+/// `collect_spans`).
+fn rebuild(text: &str, spans: &[Span]) -> (String, Vec<Finding>) {
+    let mut out = String::with_capacity(text.len());
+    let mut findings = Vec::new();
+    let mut cursor = 0usize;
+    for span in spans {
+        // Preserve everything before this span
+        out.push_str(&text[cursor..span.start]);
+        // Emit placeholder
         out.push_str("[REDACTED:");
-        out.push_str(rule);
+        out.push_str(span.rule);
         out.push(']');
         findings.push(Finding {
-            rule: rule.to_owned(),
-            token: std::mem::take(token),
+            rule: span.rule.to_owned(),
+            token: text[span.start..span.end].to_owned(),
         });
-    } else {
-        out.push_str(token);
-        token.clear();
+        cursor = span.end;
     }
+    out.push_str(&text[cursor..]);
+    (out, findings)
 }
 
-/// Redact secrets/PII from `text`, preserving all non-secret characters + delimiters.
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Redact secrets/PII from `text`, preserving all non-secret characters
+/// byte-exact.
 ///
-/// Tokens are split on whitespace AND JSON/assignment punctuation (see [`is_delimiter`]),
-/// so a secret embedded in `"token":"ghp_..."` or `key=secret` is isolated and classified.
-/// Returns the redacted text and the findings (secret tokens removed).
+/// Returns the redacted text and the list of findings (each secret that was
+/// replaced).  Redaction is idempotent: a `[REDACTED:*]` placeholder is never
+/// re-redacted.
 #[must_use]
 pub fn redact_text(text: &str) -> (String, Vec<Finding>) {
-    let mut out = String::with_capacity(text.len());
-    let mut findings: Vec<Finding> = Vec::new();
-    let mut token = String::new();
-    for ch in text.chars() {
-        if is_delimiter(ch) {
-            flush_token(&mut token, &mut out, &mut findings);
-            out.push(ch);
-        } else {
-            token.push(ch);
-        }
-    }
-    flush_token(&mut token, &mut out, &mut findings);
-    (out, findings)
+    // Idempotency: text that only contains placeholders is a no-op.
+    // The detectors naturally avoid re-redacting because:
+    //  - `[REDACTED:...]` does not match any prefix, email, hex, or entropy rule.
+    // No special guard needed; the invariant holds by construction.
+    let spans = collect_spans(text);
+    rebuild(text, &spans)
 }
 
 /// Redact a sequence of session entries (raw `.jsonl` lines or extracted text),
@@ -212,9 +540,13 @@ pub fn redact_entries(entries: &[String]) -> (Vec<String>, RedactionReport) {
     (redacted, report)
 }
 
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Provider prefixes ─────────────────────────────────────────────────────
 
     #[test]
     fn redacts_provider_prefixes() {
@@ -225,7 +557,7 @@ mod tests {
         ] {
             let (out, findings) = redact_text(&format!("token is {token} end"));
             assert!(out.contains("[REDACTED:"), "{token} not redacted: {out}");
-            assert_eq!(findings.len(), 1);
+            assert_eq!(findings.len(), 1, "expected 1 finding for {token}");
             assert_eq!(findings[0].rule, rule);
             assert!(!out.contains(token));
             assert!(out.contains("token is") && out.contains("end"));
@@ -235,18 +567,242 @@ mod tests {
     #[test]
     fn redacts_private_key_header() {
         let (out, findings) = redact_text("-----BEGIN RSA PRIVATE KEY-----");
-        assert!(out.contains("[REDACTED:private-key-header]"));
+        assert!(out.contains("[REDACTED:private-key-header]"), "got: {out}");
         assert_eq!(findings[0].rule, "private-key-header");
     }
 
     #[test]
+    fn prefix_does_not_match_inside_word() {
+        // `sk-` must NOT fire inside `task-force` or `risk-free`.
+        for text in ["the task-force and risk-free disk", "task-sk-nope"] {
+            let (out, findings) = redact_text(text);
+            let has_sk = findings.iter().any(|f| f.rule == "openai-key");
+            assert!(!has_sk, "sk- matched inside word in: {text:?} → {out}");
+        }
+    }
+
+    // ── SendGrid + JWT ────────────────────────────────────────────────────────
+
+    #[test]
+    fn sendgrid_token_redacted() {
+        // SG.<22alnum>.<43alnum> — the SG. prefix fires, body extends over dots/alnum.
+        let key22 = "b".repeat(6) + "1C2D3E4F5G6H7I8J";
+        let key43 = "a".repeat(10) + "B3x9Lp2Rt5Yv8Bn1Cx4Df6Qw7Zz0AaXkYm";
+        let token = format!("SG.{key22}.{key43}");
+        let (out, findings) = redact_text(&format!("api_key={token}"));
+        assert!(!out.contains(&token), "SendGrid token leaked: {out}");
+        assert!(
+            !findings.is_empty(),
+            "expected at least one finding for SendGrid token"
+        );
+    }
+
+    #[test]
+    fn jwt_redacted_via_prefix() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N";
+        let (out, findings) = redact_text(&format!("Authorization: Bearer {jwt}"));
+        assert!(out.contains("[REDACTED:jwt]"), "got: {out}");
+        assert!(!out.contains("eyJhbGciOiJIUzI1NiJ9"), "JWT header leaked");
+        assert!(
+            findings.iter().any(|f| f.rule == "jwt"),
+            "no jwt finding; findings: {findings:?}"
+        );
+    }
+
+    // ── URL-credential ────────────────────────────────────────────────────────
+
+    #[test]
+    fn url_credential_basic() {
+        let (out, findings) = redact_text("postgres://user:s3cr3tPass1@db.host.com:5432/mydb");
+        assert!(
+            !out.contains("s3cr3tPass1"),
+            "connection-string password leaked: {out}"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.rule == "connection-string-password"),
+            "not categorised as connection-string-password; findings: {findings:?}"
+        );
+        assert!(
+            !findings.iter().any(|f| f.rule == "email"),
+            "password mis-categorised as email; findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn url_credential_password_with_at_sign() {
+        // Password contains a literal '@' — must still be fully redacted.
+        let url = "amqp://guest:p@ss-w0rd@rabbit.local";
+        let (out, findings) = redact_text(url);
+        assert!(!out.contains("p@ss-w0rd"), "password with @ leaked: {out}");
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.rule == "connection-string-password"),
+            "not categorised as connection-string-password; findings: {findings:?}"
+        );
+        assert!(
+            !findings.iter().any(|f| f.rule == "email"),
+            "was mis-categorised as email; findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn url_embedded_github_pat_redacted() {
+        // ghp_ token embedded in a URL is caught by provider-prefix detector.
+        let pat = "ghp_0123456789abcdefghij0123456789abcdef";
+        let url = format!("https://x:{pat}@github.com/repo.git");
+        let (out, findings) = redact_text(&url);
+        assert!(!out.contains(pat), "URL-embedded ghp_ token leaked: {out}");
+        // The URL-credential detector fires on the password range, which contains
+        // the ghp_ token.  The provider-prefix or url-credential rule fires.
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.rule == "github-pat" || f.rule == "connection-string-password"),
+            "no finding for URL-embedded PAT; findings: {findings:?}"
+        );
+    }
+
+    // ── Email ─────────────────────────────────────────────────────────────────
+
+    #[test]
     fn redacts_email() {
         let (out, findings) = redact_text("contact craig@example.com please");
-        assert!(out.contains("[REDACTED:email]"));
-        assert!(!out.contains("craig@example.com"));
+        assert!(out.contains("[REDACTED:email]"), "got: {out}");
+        assert!(!out.contains("craig@example"));
         assert_eq!(findings[0].rule, "email");
         assert!(out.contains("contact") && out.contains("please"));
     }
+
+    #[test]
+    fn email_with_digit_in_local_part() {
+        // user2024@example.com must redact as email, NOT connection-string-password.
+        let (out, findings) = redact_text("send to user2024@example.com today");
+        assert!(out.contains("[REDACTED:email]"), "got: {out}");
+        assert!(!out.contains("user2024@example.com"), "email leaked: {out}");
+        assert!(
+            findings.iter().any(|f| f.rule == "email"),
+            "not categorised as email; findings: {findings:?}"
+        );
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.rule == "connection-string-password"),
+            "wrongly categorised as connection-string-password; findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn angle_bracket_email_redacted() {
+        // `<user@example.com>` — angle brackets are boundary chars for the email detector.
+        let (out, findings) = redact_text("From: <user@example.com> in header");
+        assert!(
+            !out.contains("user@example"),
+            "angle-bracket email leaked: {out}"
+        );
+        assert!(
+            findings.iter().any(|f| f.rule == "email"),
+            "no email finding; findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn localhost_not_email() {
+        // admin@localhost has no dot in domain — must NOT redact.
+        let text = "user admin@localhost here";
+        let (out, findings) = redact_text(text);
+        assert_eq!(out, text, "admin@localhost should not be redacted: {out}");
+        assert!(
+            !findings.iter().any(|f| f.rule == "email"),
+            "admin@localhost wrongly flagged as email"
+        );
+    }
+
+    #[test]
+    fn bare_version_not_email() {
+        // pkg@v1 has no dot in domain — must NOT redact.
+        let text = "install pkg@v1 now";
+        let (out, findings) = redact_text(text);
+        assert_eq!(out, text, "pkg@v1 should not be redacted: {out}");
+        assert!(
+            !findings.iter().any(|f| f.rule == "email"),
+            "pkg@v1 wrongly flagged"
+        );
+    }
+
+    // ── Hex-in-context ────────────────────────────────────────────────────────
+
+    #[test]
+    fn bare_git_sha1_not_redacted() {
+        // A bare 40-char SHA-1 in prose (no secret-indicator key) must NOT be redacted.
+        let sha1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        assert_eq!(sha1.len(), 40);
+        let text = format!("commit {sha1} merged");
+        let (out, findings) = redact_text(&text);
+        assert_eq!(out, text, "bare git SHA-1 should not be redacted: {out}");
+        assert!(
+            !findings.iter().any(|f| f.rule == "hex-secret"),
+            "bare SHA-1 wrongly flagged as hex-secret"
+        );
+    }
+
+    #[test]
+    fn bare_sha256_not_redacted() {
+        // A bare 64-char SHA-256 in prose must NOT be redacted.
+        let sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert_eq!(sha256.len(), 64);
+        let text = format!("checksum: {sha256}");
+        let (out, findings) = redact_text(&text);
+        assert_eq!(out, text, "bare SHA-256 should not be redacted: {out}");
+        assert!(
+            !findings.iter().any(|f| f.rule == "hex-secret"),
+            "bare SHA-256 wrongly flagged as hex-secret"
+        );
+    }
+
+    #[test]
+    fn hex_after_api_key_is_redacted() {
+        // Same hex, but after `api_key=` — must redact as hex-secret.
+        let hex32 = "a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6";
+        assert_eq!(hex32.len(), 32);
+        let (out, findings) = redact_text(&format!("api_key={hex32}"));
+        assert!(!out.contains(hex32), "hex after api_key= leaked: {out}");
+        assert!(
+            findings.iter().any(|f| f.rule == "hex-secret"),
+            "no hex-secret finding; findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn hex_after_secret_key_is_redacted() {
+        // `secret: <64-char hex>` — must redact as hex-secret.
+        let hex64 = "a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6";
+        assert_eq!(hex64.len(), 64);
+        let (out, findings) = redact_text(&format!("secret: {hex64}"));
+        assert!(!out.contains(hex64), "hex after 'secret:' leaked: {out}");
+        assert!(
+            findings.iter().any(|f| f.rule == "hex-secret"),
+            "no hex-secret finding; findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn fix2_short_hex_not_redacted() {
+        // Short hex strings (CSS colors, short hashes) must NOT be caught.
+        for short in ["a3f1b2", "deadbeef", "cafebabe0000dead"] {
+            let text = format!("color=#{short} or id={short}");
+            let (out, findings) = redact_text(&text);
+            assert_eq!(out, text, "short hex {short} should not be redacted");
+            assert!(
+                !findings.iter().any(|f| f.rule == "hex-secret"),
+                "short hex {short} was incorrectly redacted"
+            );
+        }
+    }
+
+    // ── High-entropy ──────────────────────────────────────────────────────────
 
     #[test]
     fn redacts_high_entropy_token() {
@@ -258,12 +814,54 @@ mod tests {
     }
 
     #[test]
+    fn redacts_assignment_value_keeping_key() {
+        let (out, findings) = redact_text("api_key=Xk9Lp2Rt5Yv8Bn1Cx4Df6Qw7Zz0Aa");
+        assert!(
+            out.starts_with("api_key="),
+            "key name should survive: {out}"
+        );
+        assert!(out.contains("[REDACTED:high-entropy]"), "got: {out}");
+        assert_eq!(findings.len(), 1);
+    }
+
+    // ── Prose untouched ───────────────────────────────────────────────────────
+
+    #[test]
     fn leaves_prose_untouched() {
         let prose = "The quick brown fox jumps over the lazy dog repeatedly today.";
-        let (out, findings) = redact_text(prose);
-        assert_eq!(out, prose);
-        assert!(findings.is_empty());
+        let (out, _findings) = redact_text(prose);
+        assert_eq!(out, prose, "prose was modified: {out}");
     }
+
+    #[test]
+    fn version_string_not_redacted() {
+        let text = "version 1.2.3";
+        let (out, _) = redact_text(text);
+        assert_eq!(out, text, "version string should not be redacted");
+    }
+
+    #[test]
+    fn file_path_not_redacted() {
+        let text = "see src/foo/bar.rs";
+        let (out, _) = redact_text(text);
+        assert_eq!(out, text, "file path should not be redacted");
+    }
+
+    #[test]
+    fn plain_https_url_not_redacted() {
+        let text = "visit https://example.com for docs";
+        let (out, _) = redact_text(text);
+        assert_eq!(out, text, "plain URL should not be redacted");
+    }
+
+    #[test]
+    fn hyphenated_words_not_redacted() {
+        let text = "the task-force and risk-free disk";
+        let (out, _) = redact_text(text);
+        assert_eq!(out, text, "hyphenated prose should not be redacted");
+    }
+
+    // ── Structural preservation ───────────────────────────────────────────────
 
     #[test]
     fn preserves_whitespace_and_nonsecrets() {
@@ -273,11 +871,57 @@ mod tests {
     }
 
     #[test]
-    fn entropy_basic() {
-        assert_eq!(shannon_entropy(""), 0.0);
-        assert_eq!(shannon_entropy("aaaa"), 0.0); // single symbol -> 0 bits
-        assert!((shannon_entropy("abcd") - 2.0).abs() < 1e-9); // 4 distinct -> log2(4) = 2
+    fn redacts_secrets_embedded_in_json() {
+        let line = r#"{"token":"ghp_0123456789abcdefghij0123456789abcdef","email":"a@b.com"}"#;
+        let (out, findings) = redact_text(line);
+        assert!(
+            !out.contains("ghp_0123456789abcdefghij0123456789abcdef"),
+            "json token leaked: {out}"
+        );
+        assert!(!out.contains("a@b"), "json email leaked: {out}");
+        let rules: Vec<&str> = findings.iter().map(|f| f.rule.as_str()).collect();
+        assert!(
+            rules.contains(&"github-pat") && rules.contains(&"email"),
+            "rules: {rules:?}"
+        );
+        assert!(
+            out.contains("\"token\":") && out.contains("\"email\":"),
+            "json structure lost"
+        );
     }
+
+    // ── Multibyte + empty ─────────────────────────────────────────────────────
+
+    #[test]
+    fn multibyte_tokens_no_panic() {
+        // Non-ASCII tokens around an email must not panic and must survive.
+        let (out, _) = redact_text("café résumé señor@example.com déjà");
+        assert!(out.contains("[REDACTED:email]"), "got: {out}");
+        assert!(out.contains("café") && out.contains("déjà"));
+    }
+
+    #[test]
+    fn empty_input() {
+        let (out, findings) = redact_text("");
+        assert_eq!(out, "");
+        assert!(findings.is_empty());
+    }
+
+    // ── Idempotency ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn idempotent_placeholders_not_re_redacted() {
+        let text = "the token aGVsbG8x9Zk3Qw7Lp2Rt5Yv8Bn1Cx4Df6 and a@b.com";
+        let (once, _) = redact_text(text);
+        let (twice, findings2) = redact_text(&once);
+        assert_eq!(once, twice, "redaction must be idempotent");
+        assert!(
+            findings2.is_empty(),
+            "[REDACTED:*] placeholders must not be re-redacted"
+        );
+    }
+
+    // ── Reports ───────────────────────────────────────────────────────────────
 
     #[test]
     fn report_tallies_by_rule() {
@@ -295,75 +939,88 @@ mod tests {
     }
 
     #[test]
-    fn idempotent_placeholders_not_re_redacted() {
-        let text = "the token aGVsbG8x9Zk3Qw7Lp2Rt5Yv8Bn1Cx4Df6 and a@b.com";
-        let (once, _) = redact_text(text);
-        let (twice, findings2) = redact_text(&once);
-        assert_eq!(once, twice, "redaction must be idempotent");
-        assert!(
-            findings2.is_empty(),
-            "[REDACTED:*] placeholders must not be re-redacted"
-        );
-    }
-
-    #[test]
-    fn redacts_secrets_embedded_in_json() {
-        let line = r#"{"token":"ghp_0123456789abcdefghij0123456789abcdef","email":"a@b.com"}"#;
-        let (out, findings) = redact_text(line);
-        assert!(
-            !out.contains("ghp_0123456789abcdefghij0123456789abcdef"),
-            "json token leaked: {out}"
-        );
-        assert!(!out.contains("a@b.com"), "json email leaked: {out}");
-        let rules: Vec<&str> = findings.iter().map(|f| f.rule.as_str()).collect();
-        assert!(
-            rules.contains(&"github-pat") && rules.contains(&"email"),
-            "rules: {rules:?}"
-        );
-        assert!(
-            out.contains("\"token\":") && out.contains("\"email\":"),
-            "json structure lost"
-        );
-    }
-
-    #[test]
-    fn redacts_assignment_value_keeping_key() {
-        let (out, findings) = redact_text("api_key=Xk9Lp2Rt5Yv8Bn1Cx4Df6Qw7Zz0Aa");
-        assert!(
-            out.starts_with("api_key="),
-            "key name should survive: {out}"
-        );
-        assert!(out.contains("[REDACTED:high-entropy]"), "got: {out}");
-        assert_eq!(findings.len(), 1);
-    }
-
-    #[test]
-    fn redacts_jwt_via_prefix() {
-        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N";
-        let (out, findings) = redact_text(&format!("Authorization: Bearer {jwt}"));
-        assert!(out.contains("[REDACTED:jwt]"), "got: {out}");
-        assert!(!out.contains(jwt));
-        assert_eq!(findings.iter().filter(|f| f.rule == "jwt").count(), 1);
-    }
-
-    #[test]
-    fn empty_input() {
-        let (out, findings) = redact_text("");
-        assert_eq!(out, "");
-        assert!(findings.is_empty());
-    }
-
-    #[test]
-    fn multibyte_tokens_no_panic() {
-        // Non-ASCII tokens around an email must not panic and must survive.
-        let (out, _) = redact_text("café résumé señor@example.com déjà");
-        assert!(out.contains("[REDACTED:email]"), "got: {out}");
-        assert!(out.contains("café") && out.contains("déjà"));
-    }
-
-    #[test]
     fn multiple_findings_one_line() {
         let (_out, findings) = redact_text("aws AKIAIOSFODNN7EXAMPLE and email a@b.com");
         assert_eq!(findings.len(), 2);
+    }
+
+    // ── Shannon entropy ───────────────────────────────────────────────────────
+
+    #[test]
+    fn entropy_basic() {
+        assert!(shannon_entropy("").abs() < f64::EPSILON);
+        assert!(shannon_entropy("aaaa").abs() < f64::EPSILON);
+        assert!((shannon_entropy("abcd") - 2.0).abs() < 1e-9);
+    }
+
+    // ── Precision-fix regressions (re-verify pass: bare-prefix + substring-hex FPs) ──
+
+    #[test]
+    fn bare_sg_prefix_in_prose_not_redacted() {
+        for prose in [
+            "The org SG. handles the message.",
+            "Region: SG.1 latency ok",
+            "as shown in FIG. 3 and SG.2",
+        ] {
+            let (out, findings) = redact_text(prose);
+            assert!(
+                !findings.iter().any(|f| f.rule == "sendgrid"),
+                "bare SG. wrongly redacted in {prose:?}: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn eyj_word_not_redacted() {
+        let (out, findings) = redact_text("the keyword eyJournal is not a jwt");
+        assert!(
+            !findings.iter().any(|f| f.rule == "jwt"),
+            "ordinary word eyJournal wrongly redacted: {out}"
+        );
+    }
+
+    #[test]
+    fn real_sendgrid_and_jwt_still_redacted() {
+        // The structure/length gate must NOT suppress genuine tokens.
+        let sg = format!("SG.{}.{}", "a".repeat(22), "b".repeat(43));
+        let (_o1, f1) = redact_text(&format!("key={sg}"));
+        assert!(
+            f1.iter().any(|f| f.rule == "sendgrid"),
+            "real SendGrid missed"
+        );
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N";
+        let (_o2, f2) = redact_text(&format!("Bearer {jwt}"));
+        assert!(f2.iter().any(|f| f.rule == "jwt"), "real JWT missed");
+    }
+
+    #[test]
+    fn bare_hex_with_unrelated_key_substring_not_redacted() {
+        let sha = "a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0"; // 40-char SHA-1
+        // `monkey` contains "key", `key.rs` mentions a key — but neither is the WORD
+        // adjacent to the hex, so the bare SHA must survive (no data loss).
+        for line in [
+            format!("monkey {sha} bars"),
+            format!("modified key.rs: now points to {sha}"),
+            format!("authentic {sha} ok"),
+        ] {
+            let (out, findings) = redact_text(&line);
+            assert!(
+                !findings.iter().any(|f| f.rule == "hex-secret"),
+                "bare hex wrongly redacted in {line:?}: {out}"
+            );
+            assert!(out.contains(sha), "bare SHA must survive: {out}");
+        }
+    }
+
+    #[test]
+    fn hex_with_adjacent_key_still_redacted() {
+        let sha = "a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0";
+        for line in [format!("api_key={sha}"), format!("secret: {sha}")] {
+            let (out, findings) = redact_text(&line);
+            assert!(
+                findings.iter().any(|f| f.rule == "hex-secret"),
+                "context-gated hex missed in {line:?}: {out}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## S0.5 (#45) — Secrets/PII redaction gate

A verified, **dependency-free** redaction gate that sits in front of any bulk import of session `.jsonl` into ME/KB — a HARD prerequisite for the B3 backfill, reviewed by the owner (#51) before backfill. **Build-only: not wired into `bootstrap_session` yet.**

### What
`src/bootstrap/redact.rs` — `redact_text` / `redact_entries`. Over whitespace-delimited tokens:
- **provider-token prefixes** (gitleaks-style): AWS `AKIA…`, GitHub `ghp_`/`github_pat_`, OpenAI `sk-`, Google `AIza`, Slack `xox[bp]-`, `-----BEGIN…PRIVATE KEY`
- **email** PII
- **high Shannon entropy** (len ≥ 20, secret-like charset, ≥ 4.0 bits/char) — catches arbitrary keys the prefixes miss

Findings → `[REDACTED:<rule>]` in place (non-secret text + whitespace preserved exactly); `redact_entries` returns a `RedactionReport` whose `coverage_lines()` is the **auditable coverage report** for #51. Idempotent.

### Scope (v1)
prefix + email + entropy. #51 may upgrade to full regex/gitleaks rules (`key=value` assignments, JWT structure) and tune the entropy threshold against the real corpus — see `docs/audits/S0.5-redaction-gate.md`. Deliberately not wired into the import path until ratified.

### Gates
9 unit tests (`cargo test --lib bootstrap::redact`); clippy `-D warnings` + nightly `cargo fmt --check` clean. No engine behavior changed.

Addresses dutiona/autonomous-agent-project#45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
