### PR TITLE
fix(cli): open batch-ingest target writable, not read-only

### DIFF
--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -9,7 +9,7 @@ use memory_engine::{EngineConfig, MemoryEngine};
 use memory_engine_embed::HttpEmbeddingProvider;
 use serde::{Deserialize, Serialize};
 
-use crate::db::open_engine;
+use crate::db::open_engine_writable;
 use crate::output::{OutputFormat, print_json};
 
 // ---------------------------------------------------------------------------
@@ -302,7 +302,7 @@ pub fn run(db: &Path, args: &BatchIngestArgs, format: OutputFormat) -> anyhow::R
         let config = EngineConfig::new(db.to_path_buf(), embed_dim);
         MemoryEngine::open(&config)?
     } else {
-        open_engine(db)?
+        open_engine_writable(db)?
     };
 
     // Build embedding provider


### PR DESCRIPTION
## Summary

`batch-ingest` on an **existing** database always failed: the non-`--create` path opened the engine via `open_engine`, which sets `read_only = true`, so the connection pool never acquired a write lock — yet the command writes facts via `add_facts_batch`. Only the `--create` path (writable `MemoryEngine::open`) worked.

Fix: the existing-DB branch now uses `open_engine_writable` (opens writable; also sets `backup_dir` next to the DB for WAL-safe pre-migration backups, matching the `export.rs` / `add_fact.rs` idiom).

Fixes #503

## Change
- `memory-engine-cli/src/commands/batch_ingest.rs`: `open_engine` → `open_engine_writable` (import + single call site). +3/−3, behavior-only; `--create` path untouched.

## Verification (local — this repo has no CI running build/clippy/test)
- `cargo fmt --check` ✓ · `cargo build -p memory-engine-cli` ✓ · `cargo clippy -p memory-engine-cli --all-targets` ✓ (no new warnings) · `cargo test -p memory-engine-cli` ✓ (46 tests).

## Adversarial review (2 lenses, in lieu of /super-review)
- **Correctness / regression:** LGTM — fully resolves the bug; `open_engine_writable`'s `backup_dir` only writes a backup on an actual migration (no-op for current-schema DBs).
- **Breakage / idiom:** caught a formatter-hook–induced import reorder on an adjacent line (fixed via `cargo fmt`); confirmed no missing-DB, locking, or disk-artifact regressions.

## Recommended follow-ups (out of scope — to be filed separately)
- `batch-ingest` swallows per-batch write failures into its summary and still exits `0`; a run where every batch fails would report success. This is what masked #503.
- No test exercises `run()`'s existing-DB open path (the broken one); existing tests call `ingest_from_reader` directly. A regression test needs a mock HTTP embedding server.
