### PR TITLE
chore(qa): wave-1 mechanical super-qa low auto-fix batch (#506)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,11 @@ Companion repos:
 cargo build                           # debug build (root crate only)
 cargo build -p memory-engine-cli      # CLI inspector binary
 cargo build -p memory-engine-mcp      # MCP server binary
+cargo build -p memory-engine-embed    # HTTP embedding provider crate
 cargo test                            # all tests (root crate only)
 cargo test -p memory-engine-cli       # CLI integration tests
 cargo test -p memory-engine-mcp       # MCP server tests
+cargo test -p memory-engine-embed     # embed crate tests
 cargo test --all-features             # with async + HNSW + compression
 cargo clippy --all-targets            # lint (pedantic + nursery)
 cargo fmt --check                     # format check
@@ -38,7 +40,7 @@ cargo test --workspace                # ALL crates' tests pass
 cargo clippy --workspace --all-targets # ALL crates lint-clean
 ```
 
-The workspace contains 3 crates: `memory-engine` (core), `memory-engine-cli`, `memory-engine-mcp`. The CLI and MCP crates consume the core's public API — changes to error variants, type definitions, or trait signatures can break them silently if only the root crate is checked.
+The workspace contains 4 crates: `memory-engine` (core), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. The CLI, MCP, and embed crates consume the core's public API — changes to error variants, type definitions, or trait signatures can break them silently if only the root crate is checked.
 
 ## Architecture
 

--- a/memory-engine-cli/src/commands/add_fact.rs
+++ b/memory-engine-cli/src/commands/add_fact.rs
@@ -6,7 +6,7 @@ use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 
 use crate::db::open_engine_writable;
 use crate::embedding::PassthroughEmbedder;
-use crate::output::{self, OutputFormat};
+use crate::output::{self, OutputFormat, parse_datetime};
 
 /// Fact type for CLI argument parsing.
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -69,12 +69,6 @@ pub struct AddFactArgs {
     source_event_id: Option<i64>,
 }
 
-fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
-    DateTime::parse_from_rfc3339(s)
-        .map(|dt| dt.with_timezone(&Utc))
-        .map_err(|e| format!("invalid RFC 3339 datetime: {e}"))
-}
-
 pub fn run(db: &Path, args: &AddFactArgs, format: OutputFormat) -> anyhow::Result<()> {
     // Parse embedding
     let embedding: Vec<f32> = serde_json::from_str(&args.embedding)
@@ -124,7 +118,7 @@ pub fn run(db: &Path, args: &AddFactArgs, format: OutputFormat) -> anyhow::Resul
 
     let req = AddFactRequest {
         content: args.content.clone(),
-        fact_type: fact_type.clone(),
+        fact_type,
         source_event_id: args.source_event_id,
         scope: args.scope.clone(),
         opts: Some(AddFactOptions {

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -119,7 +119,7 @@ fn validate_jsonl_fact(fact: &JsonlFact) -> Result<(), String> {
     Ok(())
 }
 
-fn jsonl_to_request(fact: JsonlFact, default_scope: &Option<String>) -> AddFactRequest {
+fn jsonl_to_request(fact: JsonlFact, default_scope: Option<&str>) -> AddFactRequest {
     let opts = AddFactOptions {
         importance: fact.importance,
         metadata: fact.metadata,
@@ -133,7 +133,7 @@ fn jsonl_to_request(fact: JsonlFact, default_scope: &Option<String>) -> AddFactR
         content: fact.content,
         fact_type: fact.fact_type.into(),
         source_event_id: fact.source_event_id,
-        scope: fact.scope.or_else(|| default_scope.clone()),
+        scope: fact.scope.or_else(|| default_scope.map(str::to_owned)),
         opts: Some(opts),
     }
 }
@@ -182,7 +182,7 @@ pub fn ingest_from_reader(
     reader: impl Read,
     embedder: &dyn EmbeddingProvider,
     batch_size: usize,
-    default_scope: &Option<String>,
+    default_scope: Option<&str>,
     format: OutputFormat,
 ) -> anyhow::Result<IngestSummary> {
     let start = Instant::now();
@@ -288,7 +288,17 @@ fn eprint_progress(ingested: usize, skipped: usize, start: &Instant, format: Out
 // Entry point
 // ---------------------------------------------------------------------------
 
+/// Maximum accepted `--batch-size`. Values above this would allocate an unbounded
+/// `Vec` from operator-supplied input, enabling a trivial OOM denial-of-service.
+const MAX_BATCH_SIZE: usize = 10_000;
+
 pub fn run(db: &Path, args: &BatchIngestArgs, format: OutputFormat) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        args.batch_size > 0 && args.batch_size <= MAX_BATCH_SIZE,
+        "--batch-size must be between 1 and {MAX_BATCH_SIZE}, got {}",
+        args.batch_size,
+    );
+
     // Open or create engine
     let engine = if args.create {
         let embed_dim = args
@@ -331,7 +341,7 @@ pub fn run(db: &Path, args: &BatchIngestArgs, format: OutputFormat) -> anyhow::R
         reader,
         &embedder,
         args.batch_size,
-        &args.scope,
+        args.scope.as_deref(),
         format,
     )?;
 
@@ -411,7 +421,7 @@ mod tests {
     fn jsonl_fact_to_request_mapping() {
         let line = r#"{"content":"test","fact_type":"semantic","importance":0.8,"t_valid":"2026-01-01T00:00:00Z"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        let req = jsonl_to_request(fact, &None);
+        let req = jsonl_to_request(fact, None);
         assert_eq!(req.content, "test");
         assert_eq!(req.fact_type, FactType::Semantic);
         let opts = req.opts.unwrap();
@@ -479,8 +489,7 @@ mod tests {
     fn default_scope_applied() {
         let line = r#"{"content":"test","fact_type":"semantic"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        let scope = Some("project/beam".to_string());
-        let req = jsonl_to_request(fact, &scope);
+        let req = jsonl_to_request(fact, Some("project/beam"));
         assert_eq!(req.scope, Some("project/beam".into()));
     }
 
@@ -488,8 +497,7 @@ mod tests {
     fn explicit_scope_overrides_default() {
         let line = r#"{"content":"test","fact_type":"semantic","scope":"custom"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        let scope = Some("project/beam".to_string());
-        let req = jsonl_to_request(fact, &scope);
+        let req = jsonl_to_request(fact, Some("project/beam"));
         assert_eq!(req.scope, Some("custom".into()));
     }
 
@@ -511,7 +519,7 @@ mod tests {
             input.as_bytes(),
             &FakeEmbed,
             100,
-            &None,
+            None,
             OutputFormat::Json,
         )
         .unwrap();
@@ -539,7 +547,7 @@ not valid json
             input.as_bytes(),
             &FakeEmbed,
             100,
-            &None,
+            None,
             OutputFormat::Json,
         )
         .unwrap();
@@ -565,7 +573,7 @@ not valid json
             input.as_bytes(),
             &FakeEmbed,
             100,
-            &None,
+            None,
             OutputFormat::Json,
         )
         .unwrap();
@@ -588,7 +596,7 @@ not valid json
             "".as_bytes(),
             &FakeEmbed,
             100,
-            &None,
+            None,
             OutputFormat::Json,
         );
         // Empty input = 0 ingested, 0 skipped → returns Ok (not an error)

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -6,11 +6,11 @@ use memory_engine::search::hybrid::MatchType;
 use tabled::{Table, Tabled};
 
 use crate::db::open_engine;
-use crate::output::{self, OutputFormat, truncate_str};
+use crate::output::{self, OutputFormat, parse_datetime, truncate_str};
 
 #[derive(clap::Args)]
 pub struct QueryArgs {
-    /// Search text (FTS5 full-text search)
+    /// Search text (hybrid FTS5 + vector search)
     text: String,
 
     /// Maximum results
@@ -38,12 +38,6 @@ pub struct QueryArgs {
     /// t_valid <= dt AND (t_invalid IS NULL OR t_invalid > dt).
     #[arg(long, value_parser = parse_datetime)]
     valid_at: Option<DateTime<Utc>>,
-}
-
-fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
-    DateTime::parse_from_rfc3339(s)
-        .map(|dt| dt.with_timezone(&Utc))
-        .map_err(|e| format!("invalid RFC 3339 datetime: {e}"))
 }
 
 #[derive(Tabled)]
@@ -126,6 +120,7 @@ pub fn run(db: &Path, args: &QueryArgs, format: OutputFormat) -> anyhow::Result<
                         MatchType::Vector => "VEC".into(),
                         MatchType::Both => "BOTH".into(),
                         MatchType::ImportanceRank => "RANK".into(),
+                        MatchType::Archive => "ARCHIVE".into(),
                         _ => "?".into(),
                     },
                     fact_type: format!("{:?}", r.fact.fact_type),

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -48,7 +48,7 @@ enum Commands {
         /// Fact ID
         id: i64,
     },
-    /// Search facts by text (FTS5 full-text search)
+    /// Search facts by text (hybrid FTS5 + vector search)
     Query(commands::query::QueryArgs),
     /// Export engine state to file (JSON, `SQLite`, compressed)
     Export(commands::export::ExportArgs),

--- a/memory-engine-cli/src/output.rs
+++ b/memory-engine-cli/src/output.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use clap::ValueEnum;
 
 /// Output format for CLI commands.
@@ -14,17 +15,97 @@ pub enum OutputFormat {
 
 /// Truncate a string to `max_chars` characters, appending "..." if truncated.
 /// Safe for multi-byte UTF-8 — never slices mid-character.
+///
+/// When `max_chars < 3` the suffix itself cannot fit; the returned string is at
+/// most `max_chars` characters long (taken from the beginning of `s`) with no
+/// ellipsis appended.
 pub fn truncate_str(s: &str, max_chars: usize) -> String {
     if s.chars().count() <= max_chars {
         return s.to_string();
     }
-    let truncated: String = s.chars().take(max_chars.saturating_sub(3)).collect();
+    // Not enough room for even the "..." suffix — just hard-truncate.
+    if max_chars < 3 {
+        return s.chars().take(max_chars).collect();
+    }
+    let truncated: String = s.chars().take(max_chars - 3).collect();
     format!("{truncated}...")
 }
 
+/// Parse an RFC 3339 datetime string into a `DateTime<Utc>`.
+///
+/// # Errors
+///
+/// Returns a `String` error message if the input is not a valid RFC 3339 timestamp.
+pub fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("invalid RFC 3339 datetime: {e}"))
+}
+
 /// Print a value as JSON to stdout.
+///
+/// # Errors
+///
+/// Returns an error if serialization or writing to stdout fails.
 pub fn print_json<T: serde::Serialize>(value: &T) -> anyhow::Result<()> {
     serde_json::to_writer_pretty(std::io::stdout(), value)?;
     println!();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_str_no_truncation_when_short() {
+        assert_eq!(truncate_str("hello", 10), "hello");
+        assert_eq!(truncate_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_str_appends_ellipsis() {
+        let result = truncate_str("hello world", 8);
+        assert_eq!(result, "hello...");
+        assert_eq!(result.chars().count(), 8);
+    }
+
+    #[test]
+    fn truncate_str_max_chars_less_than_3_no_overflow() {
+        // max_chars=2: result must be at most 2 chars, no "..." appended
+        let result = truncate_str("hello", 2);
+        assert!(result.chars().count() <= 2, "got: {result:?}");
+
+        let result0 = truncate_str("hello", 0);
+        assert_eq!(result0, "");
+    }
+
+    #[test]
+    fn truncate_str_exactly_3_chars() {
+        // max_chars=3 with a longer string → "..."
+        let result = truncate_str("abcdef", 3);
+        assert_eq!(result, "...");
+        assert_eq!(result.chars().count(), 3);
+    }
+
+    #[test]
+    fn truncate_str_unicode_safe() {
+        // Each emoji is multiple bytes but one char — must not panic or over-truncate
+        let s = "😀😀😀😀😀";
+        let result = truncate_str(s, 4);
+        assert_eq!(result.chars().count(), 4);
+        assert_eq!(result, "😀...");
+    }
+
+    #[test]
+    fn parse_datetime_valid_rfc3339() {
+        let dt = parse_datetime("2026-03-25T00:00:00Z").unwrap();
+        assert_eq!(dt.to_rfc3339(), "2026-03-25T00:00:00+00:00");
+    }
+
+    #[test]
+    fn parse_datetime_invalid_returns_err() {
+        assert!(parse_datetime("not-a-date").is_err());
+        assert!(parse_datetime("2026-13-01T00:00:00Z").is_err());
+    }
 }

--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -7,6 +7,21 @@ use memory_engine::traits::EmbeddingProvider;
 /// or direct (`embedding`). Supports both single and batch embedding calls.
 ///
 /// Uses `reqwest::blocking::Client` because the engine's `EmbeddingProvider` trait is sync.
+///
+/// # Examples
+///
+/// ```no_run
+/// use memory_engine_embed::HttpEmbeddingProvider;
+///
+/// let provider = HttpEmbeddingProvider::new(
+///     "http://localhost:11434/v1/embeddings".to_string(),
+///     "nomic-embed-text".to_string(),
+///     None,
+///     768,
+///     30,
+/// )
+/// .expect("failed to build HTTP client");
+/// ```
 pub struct HttpEmbeddingProvider {
     client: reqwest::blocking::Client,
     endpoint: String,
@@ -38,9 +53,7 @@ impl HttpEmbeddingProvider {
             expected_dim,
         })
     }
-}
 
-impl HttpEmbeddingProvider {
     /// Parse OpenAI batch response: `data` array with `index` + `embedding` fields.
     /// Sorts by `index` to handle out-of-order responses.
     fn parse_openai_batch(
@@ -57,9 +70,17 @@ impl HttpEmbeddingProvider {
         // Extract (index, embedding) pairs
         let mut pairs: Vec<(usize, Vec<f32>)> = Vec::with_capacity(expected_count);
         for item in data {
-            let idx = item.get("index").and_then(|v| v.as_u64()).ok_or_else(|| {
-                MemoryError::Internal("batch embedding: missing 'index' in data item".into())
-            })? as usize;
+            let idx = item
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| {
+                    MemoryError::Internal("batch embedding: missing 'index' in data item".into())
+                })
+                .and_then(|n| {
+                    usize::try_from(n).map_err(|_| {
+                        MemoryError::Internal(format!("batch embedding: index {n} overflows usize"))
+                    })
+                })?;
 
             let embedding = item
                 .get("embedding")
@@ -110,6 +131,26 @@ impl HttpEmbeddingProvider {
             })
             .collect()
     }
+
+    /// Validate that an embedding has the expected dimension and contains no NaN/Inf values.
+    ///
+    /// `idx` is included in the error message when validating a batch element; pass `None`
+    /// for single-embedding validation.
+    fn validate_embedding(&self, emb: &[f32], idx: Option<usize>) -> Result<(), MemoryError> {
+        if emb.len() != self.expected_dim {
+            return Err(MemoryError::EmbeddingDimension {
+                expected: self.expected_dim,
+                actual: emb.len(),
+            });
+        }
+        if emb.iter().any(|v| v.is_nan() || v.is_infinite()) {
+            return Err(MemoryError::Internal(match idx {
+                Some(i) => format!("embedding at index {i} contains NaN or Inf"),
+                None => "embedding contains NaN or Inf".into(),
+            }));
+        }
+        Ok(())
+    }
 }
 
 impl EmbeddingProvider for HttpEmbeddingProvider {
@@ -142,13 +183,13 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
         // Auto-detect response format:
         // OpenAI: { "data": [{ "embedding": [...] }] }
         // Ollama: { "embeddings": [[...]] }
-        let embedding = if let Some(data) = body.get("data") {
-            data.get(0)
+        let embedding = if let Some(data) = body.get("data").and_then(|d| d.as_array()) {
+            data.first()
                 .and_then(|d| d.get("embedding"))
                 .and_then(|e| serde_json::from_value::<Vec<f32>>(e.clone()).ok())
-        } else if let Some(embeddings) = body.get("embeddings") {
+        } else if let Some(embeddings) = body.get("embeddings").and_then(|e| e.as_array()) {
             embeddings
-                .get(0)
+                .first()
                 .and_then(|e| serde_json::from_value::<Vec<f32>>(e.clone()).ok())
         } else if let Some(embedding) = body.get("embedding") {
             // Single embedding format
@@ -164,18 +205,7 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
             ))
         })?;
 
-        if embedding.len() != self.expected_dim {
-            return Err(MemoryError::EmbeddingDimension {
-                expected: self.expected_dim,
-                actual: embedding.len(),
-            });
-        }
-
-        if embedding.iter().any(|v| v.is_nan() || v.is_infinite()) {
-            return Err(MemoryError::Internal(
-                "embedding contains NaN or Inf".into(),
-            ));
-        }
+        self.validate_embedding(&embedding, None)?;
 
         Ok(embedding)
     }
@@ -239,19 +269,9 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
             )));
         };
 
-        // Validate all dimensions
+        // Validate all dimensions and NaN/Inf
         for (i, emb) in embeddings.iter().enumerate() {
-            if emb.len() != self.expected_dim {
-                return Err(MemoryError::EmbeddingDimension {
-                    expected: self.expected_dim,
-                    actual: emb.len(),
-                });
-            }
-            if emb.iter().any(|v| v.is_nan() || v.is_infinite()) {
-                return Err(MemoryError::Internal(format!(
-                    "embedding at index {i} contains NaN or Inf"
-                )));
-            }
+            self.validate_embedding(emb, Some(i))?;
         }
 
         Ok(embeddings)
@@ -354,5 +374,78 @@ mod tests {
                 .to_string()
                 .contains("expected 3 results, got 1")
         );
+    }
+
+    #[test]
+    fn embed_batch_empty_input_returns_empty_vec() {
+        // embed_batch short-circuits on empty input without making any HTTP call.
+        let provider = HttpEmbeddingProvider::new(
+            "http://127.0.0.1:0/v1/embeddings".to_string(),
+            "test-model".to_string(),
+            None,
+            768,
+            5,
+        )
+        .expect("client build should not fail");
+
+        let result = provider
+            .embed_batch(&[])
+            .expect("empty batch should succeed");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn validate_embedding_dimension_mismatch() {
+        let provider = HttpEmbeddingProvider::new(
+            "http://127.0.0.1:0/v1/embeddings".to_string(),
+            "test-model".to_string(),
+            None,
+            3,
+            5,
+        )
+        .expect("client build should not fail");
+
+        let err = provider.validate_embedding(&[0.1, 0.2], None).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::EmbeddingDimension {
+                expected: 3,
+                actual: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_embedding_nan_rejected() {
+        let provider = HttpEmbeddingProvider::new(
+            "http://127.0.0.1:0/v1/embeddings".to_string(),
+            "test-model".to_string(),
+            None,
+            2,
+            5,
+        )
+        .expect("client build should not fail");
+
+        let err = provider
+            .validate_embedding(&[0.1, f32::NAN], None)
+            .unwrap_err();
+        assert!(err.to_string().contains("NaN"));
+    }
+
+    #[test]
+    fn validate_embedding_inf_rejected() {
+        let provider = HttpEmbeddingProvider::new(
+            "http://127.0.0.1:0/v1/embeddings".to_string(),
+            "test-model".to_string(),
+            None,
+            2,
+            5,
+        )
+        .expect("client build should not fail");
+
+        let err = provider
+            .validate_embedding(&[0.1, f32::INFINITY], None)
+            .unwrap_err();
+        assert!(err.to_string().contains("Inf"));
     }
 }

--- a/memory-engine-embed/src/lib.rs
+++ b/memory-engine-embed/src/lib.rs
@@ -1,3 +1,24 @@
+//! HTTP embedding provider for `memory-engine`.
+//!
+//! Implements [`memory_engine::traits::EmbeddingProvider`] by calling an
+//! OpenAI-compatible `/v1/embeddings` endpoint (OpenAI, Ollama, and any
+//! compatible server).
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use memory_engine_embed::HttpEmbeddingProvider;
+//!
+//! let provider = HttpEmbeddingProvider::new(
+//!     "http://localhost:11434/v1/embeddings".to_string(),
+//!     "nomic-embed-text".to_string(),
+//!     None,   // no API key needed for local Ollama
+//!     768,    // expected embedding dimension
+//!     30,     // HTTP timeout in seconds
+//! )
+//! .expect("failed to build HTTP client");
+//! ```
+
 mod http;
 
 pub use http::HttpEmbeddingProvider;

--- a/memory-engine-mcp/Cargo.toml
+++ b/memory-engine-mcp/Cargo.toml
@@ -22,7 +22,6 @@ path = "tests/tools.rs"
 [dependencies]
 memory-engine = { path = "..", features = ["async"] }
 rmcp = { version = "1", features = ["server", "transport-io"] }
-schemars = { version = "1", features = ["chrono04"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -2,14 +2,13 @@ use memory_engine::ResumeContext;
 use memory_engine::inspect_types::{FactExplanation, FactHistory};
 use memory_engine::search::hybrid::{QueryDiagnostics, SearchResult};
 use memory_engine::types::{Activity, Event, Fact, ProjectContext, SessionCheckpoint};
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 /// Tiered retrieval depth for MCP responses.
 ///
 /// Controls how much detail is included in tool results to manage token budget.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Depth {
     /// ~15 tokens/fact: id, truncated content, importance_score, scope_path.
@@ -130,6 +129,10 @@ pub fn shape_explanation(explanation: &FactExplanation, depth: Depth) -> Value {
         }),
         Depth::Full => {
             // Full: serialize the entire explanation including source_event.
+            // On the rare serialization failure (e.g. non-finite float in a
+            // nested field), we log the error and return JSON null rather than
+            // propagating — the MCP call still succeeds with a degraded result,
+            // which is preferable to an unrecoverable tool error for the caller.
             serde_json::to_value(explanation).unwrap_or_else(|e| {
                 tracing::error!("failed to serialize FactExplanation: {e}");
                 json!(null)

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -452,10 +452,12 @@ fn get_datetime(args: &Map<String, Value>, key: &str) -> Result<Option<DateTime<
     }
 }
 
-fn get_depth(args: &Map<String, Value>) -> Depth {
-    args.get("depth")
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .unwrap_or_default()
+fn get_depth(args: &Map<String, Value>) -> Result<Depth, ErrorData> {
+    match args.get("depth") {
+        None | Some(Value::Null) => Ok(Depth::default()),
+        Some(v) => serde_json::from_value(v.clone())
+            .map_err(|e| ErrorData::invalid_params(format!("invalid depth: {e}"), None)),
+    }
 }
 
 /// Parse an embedding from a JSON value, returning an error if present but malformed.
@@ -633,7 +635,7 @@ fn handle_query(
     engine: &MemoryEngine,
     embedder: Option<&HttpEmbeddingProvider>,
 ) -> Result<CallToolResult, ErrorData> {
-    let depth_level = get_depth(&args);
+    let depth_level = get_depth(&args)?;
 
     let mut query = memory_engine::MemoryQuery::new();
 
@@ -743,7 +745,7 @@ fn handle_resume_context(
     args: Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let depth_level = get_depth(&args);
+    let depth_level = get_depth(&args)?;
 
     let config = ResumeConfig {
         scope_path: get_str(&args, "scope"),
@@ -765,7 +767,7 @@ fn handle_list_due(
     args: Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let depth_level = get_depth(&args);
+    let depth_level = get_depth(&args)?;
     let scope = get_str(&args, "scope");
 
     let facts = engine
@@ -798,7 +800,7 @@ fn handle_explain_fact(
 ) -> Result<CallToolResult, ErrorData> {
     let fact_id = get_i64(&args, "fact_id")
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
-    let depth_level = get_depth(&args);
+    let depth_level = get_depth(&args)?;
 
     let explanation: FactExplanation = engine.explain_fact(fact_id).map_err(to_mcp_error)?;
     let shaped = depth::shape_explanation(&explanation, depth_level);
@@ -812,7 +814,7 @@ fn handle_get_fact(
 ) -> Result<CallToolResult, ErrorData> {
     let fact_id = get_i64(&args, "fact_id")
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
-    let depth_level = get_depth(&args);
+    let depth_level = get_depth(&args)?;
 
     let fact = engine.get_fact(fact_id).map_err(to_mcp_error)?;
     let shaped = depth::shape_fact(&fact, depth_level, None);
@@ -1127,7 +1129,7 @@ fn handle_replay_events(
     args: Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let depth_level = get_depth(&args);
+    let depth_level = get_depth(&args)?;
 
     let since = get_datetime(&args, "since")?;
     let until = get_datetime(&args, "until")?;
@@ -1205,7 +1207,7 @@ fn handle_fact_history(
 ) -> Result<CallToolResult, ErrorData> {
     let fact_id = get_i64(&args, "fact_id")
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
-    let depth_level = get_depth(&args);
+    let depth_level = get_depth(&args)?;
 
     let history = engine.fact_history(fact_id).map_err(to_mcp_error)?;
     let shaped = depth::shape_fact_history(&history, depth_level);
@@ -1372,7 +1374,7 @@ fn handle_load_context(
         get_str(&args, "scope").ok_or_else(|| ErrorData::invalid_params("missing scope", None))?;
     let activity_limit = get_usize(&args, "activity_limit").unwrap_or(20);
     let fact_limit = get_usize(&args, "fact_limit").unwrap_or(10);
-    let depth_level = get_depth(&args);
+    let depth_level = get_depth(&args)?;
 
     let ctx = engine
         .load_context(&scope, activity_limit, fact_limit)

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -26,7 +26,7 @@ use crate::error::{ValidationError, to_mcp_error};
 // Tool definitions (JSON schemas)
 // ---------------------------------------------------------------------------
 
-/// Returns all tool definitions (P0 + P1) with JSON schemas.
+/// Returns all tool definitions (P0, P1, P2, Phase 5) with JSON schemas.
 pub fn all_tool_definitions() -> Vec<Tool> {
     vec![
         tool_def(
@@ -453,13 +453,8 @@ fn get_datetime(args: &Map<String, Value>, key: &str) -> Result<Option<DateTime<
 }
 
 fn get_depth(args: &Map<String, Value>) -> Depth {
-    get_str(args, "depth")
-        .and_then(|s| match s.as_str() {
-            "sparse" => Some(Depth::Sparse),
-            "standard" => Some(Depth::Standard),
-            "full" => Some(Depth::Full),
-            _ => None,
-        })
+    args.get("depth")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default()
 }
 
@@ -1137,7 +1132,8 @@ fn handle_replay_events(
     let since = get_datetime(&args, "since")?;
     let until = get_datetime(&args, "until")?;
 
-    // Both-or-neither validation (like period_start/period_end in handle_query)
+    // Ordering validation: when both bounds are provided, since must not exceed until.
+    // Either bound may be omitted independently (open-ended range).
     if let (Some(s), Some(u)) = (since, until) {
         if s > u {
             return Err(ErrorData::invalid_params("since must be <= until", None));

--- a/src/archive/pak.rs
+++ b/src/archive/pak.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
@@ -8,27 +9,23 @@ use crate::error::{MemoryError, Result};
 /// Maximum decompressed `.pak` size (4 GiB) — prevents decompression bombs.
 const MAX_PAK_DECOMPRESSED_SIZE: u64 = 4 * 1024 * 1024 * 1024;
 
-/// Write an `ArchivePak` as zstd-compressed JSON (convenience wrapper).
-///
-/// Thin wrapper over [`write_pak_and_hash`] for callers that don't need the hash.
-// Used in unit tests below; restore tooling will also use this.
-#[allow(dead_code)]
-pub fn write_pak(pak: &ArchivePak, path: &Path) -> Result<()> {
-    write_pak_and_hash(pak, path)?;
-    Ok(())
-}
-
 /// Write a `.pak` file and return its blake3 hash.
 /// Hash is computed during write (no TOCTOU). Atomic write via tmp+rename.
 pub fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
     let tmp_path = path.with_extension("pak.tmp");
 
-    let file = fs::File::create(&tmp_path).map_err(|e| {
-        MemoryError::Archive(format!(
-            "failed to create temp pak file {}: {e}",
-            tmp_path.display()
-        ))
-    })?;
+    // O_EXCL: atomic creation — fails if the tmp file already exists, preventing
+    // symlink/TOCTOU attacks on the predictable temp path.
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp_path)
+        .map_err(|e| {
+            MemoryError::Archive(format!(
+                "failed to create temp pak file {}: {e}",
+                tmp_path.display()
+            ))
+        })?;
 
     let mut hasher = blake3::Hasher::new();
     let hashing_writer = HashingWriter {
@@ -104,6 +101,14 @@ impl<W: Write> Write for HashingWriter<'_, W> {
 mod tests {
     use super::*;
     use chrono::Utc;
+
+    /// Write an `ArchivePak` as zstd-compressed JSON (test convenience wrapper).
+    ///
+    /// Thin wrapper over [`write_pak_and_hash`] for callers that don't need the hash.
+    fn write_pak(pak: &ArchivePak, path: &std::path::Path) -> crate::error::Result<()> {
+        write_pak_and_hash(pak, path)?;
+        Ok(())
+    }
 
     fn empty_pak() -> ArchivePak {
         ArchivePak {

--- a/src/archive/types.rs
+++ b/src/archive/types.rs
@@ -78,7 +78,7 @@ mod tests {
         let policy = ArchivePolicy::default();
         let now = Utc::now();
         let diff = now - policy.expired_before;
-        assert!(diff.num_days() == 30 || diff.num_days() == 29);
+        assert_eq!(diff.num_days(), 30);
         assert_eq!(policy.min_facts, 100);
     }
 

--- a/src/bootstrap/extract.rs
+++ b/src/bootstrap/extract.rs
@@ -89,7 +89,7 @@ impl SessionExtractor for KeywordExtractor {
             content,
             fact_type,
             importance,
-            category: episode.category.clone(),
+            category: episode.category,
             metadata,
         }])
     }
@@ -219,8 +219,9 @@ mod tests {
 
         // "User: " prefix is 6 chars, so total > 2000
         assert!(facts[0].content.ends_with("..."));
-        // The truncated content (minus the "..." suffix) must be <= 2000 chars.
-        assert!(facts[0].content.len() <= 2003 + 3);
+        // The implementation truncates to MAX_LEN=2000 chars then appends "...",
+        // so the total length must be exactly MAX_LEN + 3 = 2003 at most.
+        assert!(facts[0].content.len() <= 2003);
     }
 
     #[test]

--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -36,7 +36,7 @@ pub struct ToolCallRecord {
 }
 
 /// Category of a noteworthy episode detected by keyword pre-filter.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EpisodeCategory {
     Bug,
     Decision,

--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 #[derive(Debug, Clone)]
 pub struct BootstrapConfig {
     /// Scope path to ingest facts into (e.g., `"project:memory-engine"`).
+    /// `None` falls back to the root scope.
     pub scope: Option<String>,
     /// Maximum turns to process per session. `0` = no limit.
     pub max_turns: usize,

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -36,8 +36,8 @@ pub use redact::{Finding, RedactionReport, redact_entries, redact_text, shannon_
 ///
 /// # Errors
 ///
-/// Returns errors from the engine (DB, embedding, scope resolution) or
-/// extraction failures. Malformed JSONL lines are skipped with `tracing::warn`.
+/// Returns errors from the engine (DB, embedding) or extraction failures.
+/// Malformed JSONL lines are skipped with `tracing::warn`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn bootstrap_session_inner(
     conn: &Connection,
@@ -110,8 +110,12 @@ pub(crate) fn bootstrap_session_inner(
             // ROLLBACK TO restores the savepoint but keeps it open —
             // we must RELEASE to close it and avoid leaving the writer
             // in an open transaction.
-            let _ = conn.execute_batch("ROLLBACK TO bootstrap");
-            let _ = conn.execute_batch("RELEASE bootstrap");
+            if let Err(rb_err) = conn.execute_batch("ROLLBACK TO bootstrap") {
+                tracing::warn!(error = %rb_err, "savepoint ROLLBACK TO bootstrap failed");
+            }
+            if let Err(rel_err) = conn.execute_batch("RELEASE bootstrap") {
+                tracing::warn!(error = %rel_err, "savepoint RELEASE bootstrap (after rollback) failed");
+            }
             Err(e)
         }
     }
@@ -182,8 +186,7 @@ fn bootstrap_within_savepoint(
         SessionOutcome::Indeterminate => report.outcome_counts.indeterminate += 1,
     }
 
-    // Update marker event payload with outcome
-    // (We don't update the already-inserted event; outcome is in fact metadata)
+    // Outcome is stored in fact metadata rather than updating the marker event.
 
     // --- Keyword pre-filter ---
     let candidates = filter::keyword_prefilter(&turns, session_id);
@@ -221,7 +224,7 @@ fn bootstrap_within_savepoint(
                     content: fact.content.clone(),
                     content_hash: String::new(),
                     embedding: embedding.clone(),
-                    fact_type: fact.fact_type.clone(),
+                    fact_type: fact.fact_type,
                     t_created: effective_created,
                     t_expired: None,
                     t_valid: None,
@@ -243,7 +246,7 @@ fn bootstrap_within_savepoint(
                 content: fact.content.clone(),
                 content_hash: String::new(),
                 embedding,
-                fact_type: fact.fact_type.clone(),
+                fact_type: fact.fact_type,
                 t_created: effective_created,
                 t_expired: None,
                 t_valid: None,
@@ -344,4 +347,57 @@ pub(crate) fn bootstrap_directory_inner(
     }
 
     Ok(aggregate)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::store::upcaster::UpcasterRegistry;
+
+    /// A no-op embedder used when we know embedding will never be called.
+    struct NeverCalledEmbedder;
+    impl crate::traits::EmbeddingProvider for NeverCalledEmbedder {
+        fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
+            panic!("embed() must not be called in this test");
+        }
+    }
+
+    /// JSONL with two valid entries but neither carries a `sessionId`.
+    #[test]
+    fn bootstrap_valid_jsonl_no_session_id_returns_empty_report() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let registry = UpcasterRegistry::new();
+
+        let jsonl = r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}
+"#;
+        let reader = Cursor::new(jsonl);
+        let config = BootstrapConfig::default();
+        let extractor = extract::KeywordExtractor;
+
+        let report = bootstrap_session_inner(
+            &conn,
+            4,
+            &registry,
+            reader,
+            &NeverCalledEmbedder,
+            &extractor,
+            &config,
+            None,
+            1, // root scope id
+        )
+        .expect("bootstrap_session_inner should succeed");
+
+        // Early-exit path: entries parsed but nothing processed.
+        assert!(report.entries_parsed > 0, "expected entries to be parsed");
+        assert_eq!(
+            report.sessions_processed, 0,
+            "no session should be processed"
+        );
+        assert_eq!(report.facts_created, 0);
+    }
 }

--- a/src/bootstrap/outcome.rs
+++ b/src/bootstrap/outcome.rs
@@ -488,4 +488,37 @@ mod tests {
         assert!(!has_short_sha("abc12")); // only 5 hex chars
         assert!(!has_short_sha("xyz"));
     }
+
+    #[test]
+    fn detect_tests_passed_pytest_branch() {
+        // Exercises the `pytest` + `passed` heuristic path in detect_tests_passed.
+        let tc = ToolCallRecord {
+            tool_name: "Bash".into(),
+            input: serde_json::json!({"command": "pytest"}),
+            stdout: Some("pytest collected 5 items\n5 passed in 0.12s".into()),
+            stderr: None,
+            is_error: false,
+            interrupted: false,
+        };
+        let turns = vec![make_turn("run tests", "running pytest", vec![tc])];
+        let (outcome, signals) = classify_outcome(&turns);
+        assert_eq!(signals.tests_passed, TestOutcome::Passed);
+        assert_eq!(outcome, SessionOutcome::Success);
+    }
+
+    #[test]
+    fn detect_commit_via_master_branch_in_stdout() {
+        // Exercises the `[master` pattern in detect_commit.
+        let tc = ToolCallRecord {
+            tool_name: "Bash".into(),
+            input: serde_json::json!({"command": "git commit -m 'fix: something'"}),
+            stdout: Some("[master abc1234] fix: something\n 1 file changed".into()),
+            stderr: None,
+            is_error: false,
+            interrupted: false,
+        };
+        let turns = vec![make_turn("commit", "ok", vec![tc])];
+        let (_, signals) = classify_outcome(&turns);
+        assert!(signals.has_commit);
+    }
 }

--- a/src/bootstrap/outcome.rs
+++ b/src/bootstrap/outcome.rs
@@ -173,7 +173,10 @@ fn detect_tests_passed(turns: &[super::filter::ConversationTurn]) -> bool {
                 if lower.contains("passed") && (lower.contains("test") || lower.contains("tests")) {
                     return true;
                 }
-                if lower.contains("pytest") && (lower.contains("passed") || lower.contains(" ok")) {
+                // A `pytest` + `passed` line is already caught by the generic
+                // `passed && test` branch above (`pytest` contains `test`), so this
+                // branch only adds the pytest-specific ` ok` summary form.
+                if lower.contains("pytest") && lower.contains(" ok") {
                     return true;
                 }
             }
@@ -491,11 +494,13 @@ mod tests {
 
     #[test]
     fn detect_tests_passed_pytest_branch() {
-        // Exercises the `pytest` + `passed` heuristic path in detect_tests_passed.
+        // Isolates the pytest-specific branch (`pytest` + ` ok`): the stdout
+        // deliberately omits "passed" so the earlier `passed && test` branch
+        // cannot fire first (note "pytest" itself contains "test").
         let tc = ToolCallRecord {
             tool_name: "Bash".into(),
             input: serde_json::json!({"command": "pytest"}),
-            stdout: Some("pytest collected 5 items\n5 passed in 0.12s".into()),
+            stdout: Some("pytest collected 5 items\n5 ok in 0.12s".into()),
             stderr: None,
             is_error: false,
             interrupted: false,
@@ -508,11 +513,13 @@ mod tests {
 
     #[test]
     fn detect_commit_via_master_branch_in_stdout() {
-        // Exercises the `[master` pattern in detect_commit.
+        // Isolates the `[master` stdout pattern: the input command is NOT
+        // `git commit` (so the command branch is skipped) and the SHA is <7 hex
+        // (so `has_short_sha` cannot fire) — only `[master` can satisfy it here.
         let tc = ToolCallRecord {
             tool_name: "Bash".into(),
-            input: serde_json::json!({"command": "git commit -m 'fix: something'"}),
-            stdout: Some("[master abc1234] fix: something\n 1 file changed".into()),
+            input: serde_json::json!({"command": "make release"}),
+            stdout: Some("[master ab12] release: cut version\n 1 file changed".into()),
             stderr: None,
             is_error: false,
             interrupted: false,

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -50,7 +50,7 @@ pub fn resolve_conflict(
         content: new_fact.content.clone(),
         content_hash: new_fact.content_hash.clone(),
         embedding: new_fact.embedding.clone(),
-        fact_type: new_fact.fact_type.clone(),
+        fact_type: new_fact.fact_type,
         t_created: new_fact.t_created,
         t_expired: new_fact.t_expired,
         t_valid: new_fact.t_valid,
@@ -62,7 +62,7 @@ pub fn resolve_conflict(
         last_accessed: new_fact.last_accessed,
         metadata: new_fact.metadata.clone(),
         is_pinned: new_fact.is_pinned,
-        importance_score: 0.5,
+        importance_score: 0.5, // placeholder — fact not yet scored; see ConflictArbiter doc
         surfaced_at: None,
     };
 
@@ -76,16 +76,19 @@ pub fn resolve_conflict(
         }),
 
         CrudDecision::Add => {
+            // unchecked_transaction: no outer transaction exists; we own the connection
+            // exclusively at this call site, so there is no risk of nesting.
             let tx = conn.unchecked_transaction()?;
 
             let new_id = FactStore::new(&tx, embed_dim).insert(new_fact)?;
 
             // Create "supplements" edge: new → old
+            let relation = RELATION_SUPPLEMENTS.to_string();
             let edge_store = EdgeStore::new(&tx);
             let edge_id = edge_store.insert(&NewEdge {
                 source_fact_id: new_id,
                 target_fact_id: old_fact_id,
-                relation_type: RELATION_SUPPLEMENTS.to_string(),
+                relation_type: relation.clone(),
                 weight: DEFAULT_EDGE_WEIGHT,
                 scope_id: new_fact.scope_id,
                 t_created: now,
@@ -100,7 +103,7 @@ pub fn resolve_conflict(
                 old_fact_id,
                 EdgeData {
                     edge_id,
-                    relation_type: RELATION_SUPPLEMENTS.to_string(),
+                    relation_type: relation,
                     weight: DEFAULT_EDGE_WEIGHT,
                 },
             );
@@ -113,6 +116,8 @@ pub fn resolve_conflict(
         }
 
         CrudDecision::Update => {
+            // unchecked_transaction: no outer transaction exists; we own the connection
+            // exclusively at this call site, so there is no risk of nesting.
             let tx = conn.unchecked_transaction()?;
 
             // Expire + invalidate old fact (bi-temporal)
@@ -126,10 +131,11 @@ pub fn resolve_conflict(
             let new_id = FactStore::new(&tx, embed_dim).insert(new_fact)?;
 
             // Create "contradicts" edge: new → old
+            let relation = RELATION_CONTRADICTS.to_string();
             let edge_id = edge_store.insert(&NewEdge {
                 source_fact_id: new_id,
                 target_fact_id: old_fact_id,
-                relation_type: RELATION_CONTRADICTS.to_string(),
+                relation_type: relation.clone(),
                 weight: DEFAULT_EDGE_WEIGHT,
                 scope_id: new_fact.scope_id,
                 t_created: now,
@@ -139,7 +145,16 @@ pub fn resolve_conflict(
             tx.commit()?;
 
             // Update in-memory graph: remove expired edges, add new one
-            rebuild_graph_for_fact(graph, old_fact_id, new_id, edge_id);
+            graph.remove_edges_by_fact(old_fact_id);
+            graph.add_edge(
+                new_id,
+                old_fact_id,
+                EdgeData {
+                    edge_id,
+                    relation_type: relation,
+                    weight: DEFAULT_EDGE_WEIGHT,
+                },
+            );
 
             Ok(ConflictResolution {
                 decision: CrudDecision::Update,
@@ -149,6 +164,8 @@ pub fn resolve_conflict(
         }
 
         CrudDecision::Delete => {
+            // unchecked_transaction: no outer transaction exists; we own the connection
+            // exclusively at this call site, so there is no risk of nesting.
             let tx = conn.unchecked_transaction()?;
 
             // Expire + invalidate old fact
@@ -161,7 +178,7 @@ pub fn resolve_conflict(
             tx.commit()?;
 
             // Remove edges from in-memory graph
-            remove_edges_for_fact(graph, old_fact_id);
+            graph.remove_edges_by_fact(old_fact_id);
 
             Ok(ConflictResolution {
                 decision: CrudDecision::Delete,
@@ -183,27 +200,6 @@ fn expire_and_invalidate(conn: &Connection, fact_id: i64, now: DateTime<Utc>) ->
         return Err(MemoryError::NotFound(format!("fact {fact_id}")));
     }
     Ok(())
-}
-
-/// Rebuild the in-memory graph after an Update conflict resolution.
-///
-/// Removes all edges involving the old fact, then adds the new "contradicts" edge.
-fn rebuild_graph_for_fact(graph: &mut MemoryGraph, old_fact_id: i64, new_id: i64, edge_id: i64) {
-    remove_edges_for_fact(graph, old_fact_id);
-    graph.add_edge(
-        new_id,
-        old_fact_id,
-        EdgeData {
-            edge_id,
-            relation_type: RELATION_CONTRADICTS.to_string(),
-            weight: DEFAULT_EDGE_WEIGHT,
-        },
-    );
-}
-
-/// Remove all edges from the in-memory graph that involve a given fact id.
-fn remove_edges_for_fact(graph: &mut MemoryGraph, fact_id: i64) {
-    graph.remove_edges_by_fact(fact_id);
 }
 
 #[cfg(test)]

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -23,6 +23,9 @@ const CLUSTER_SIMILARITY_THRESHOLD: f32 = 0.85;
 ///
 /// Returns `MemoryError::Database` on SQL failure, or propagates errors from
 /// the `SummaryGenerator`.
+/// Returns `MemoryError::EmbeddingDimension` if the generator returns an embedding
+/// whose length does not match `embed_dim`.
+/// Returns `MemoryError::Serialization` on JSON serialization failure.
 pub fn cluster_fusion(
     conn: &Connection,
     generator: &dyn SummaryGenerator,
@@ -69,6 +72,12 @@ pub fn cluster_fusion(
 
         let summary_text = generator.summarize(&cluster_facts)?;
         let summary_embedding = generator.embed(&summary_text)?;
+        if summary_embedding.len() != embed_dim {
+            return Err(crate::error::MemoryError::EmbeddingDimension {
+                expected: embed_dim,
+                actual: summary_embedding.len(),
+            });
+        }
 
         // Determine scope_id from majority vote of source facts.
         // Deterministic tie-break: lowest scope_id wins on equal counts.

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -5,6 +5,7 @@ use crate::error::Result;
 use crate::search::vector::cosine_similarity;
 use crate::store::edges::EdgeStore;
 use crate::store::facts::FactStore;
+use crate::types::Fact;
 
 /// Local deduplication pass.
 ///
@@ -18,6 +19,7 @@ use crate::store::facts::FactStore;
 /// # Errors
 ///
 /// Returns `MemoryError::Database` on SQL failure.
+/// Returns `MemoryError::NotFound` if a fact to expire or update no longer exists.
 pub fn local_dedup(
     conn: &Connection,
     embed_dim: usize,
@@ -95,12 +97,7 @@ pub fn local_dedup(
                 } else {
                     (new_fact, &candidate)
                 };
-                if loser.importance > survivor.importance {
-                    fact_store.update_importance(survivor.id, loser.importance)?;
-                }
-                if loser.importance_score > survivor.importance_score {
-                    fact_store.update_importance_score(survivor.id, loser.importance_score)?;
-                }
+                inherit_max_importance(&fact_store, survivor, loser)?;
 
                 // If the new_fact itself was expired, stop comparing it
                 if expire_id == new_fact.id {
@@ -112,6 +109,20 @@ pub fn local_dedup(
 
     let expired_vec: Vec<i64> = expired_ids.into_iter().collect();
     Ok((duplicates_removed, expired_vec))
+}
+
+/// Inherit the higher importance values from `loser` into `survivor`.
+///
+/// Called after a dedup merge to ensure the surviving fact retains the
+/// maximum base importance and `importance_score` across the merged pair.
+fn inherit_max_importance(fact_store: &FactStore<'_>, survivor: &Fact, loser: &Fact) -> Result<()> {
+    if loser.importance > survivor.importance {
+        fact_store.update_importance(survivor.id, loser.importance)?;
+    }
+    if loser.importance_score > survivor.importance_score {
+        fact_store.update_importance_score(survivor.id, loser.importance_score)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -386,5 +397,17 @@ mod tests {
             "expected importance_score 0.8, got {}",
             active[0].importance_score
         );
+    }
+
+    #[test]
+    fn empty_db_dedup_is_noop() {
+        let (conn, dim) = setup();
+        // No facts in the DB — dedup must return (0, []) without error.
+        let (removed, expired) = local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+        assert_eq!(removed, 0);
+        assert!(expired.is_empty());
+
+        let store = FactStore::new(&conn, dim);
+        assert!(store.list_active(None).unwrap().is_empty());
     }
 }

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -16,6 +16,9 @@ use crate::types::{ConsolidationLevel, Fact, NewSummary};
 ///
 /// Returns `MemoryError::Database` on SQL failure, or propagates errors from
 /// the `SummaryGenerator`.
+/// Returns `MemoryError::EmbeddingDimension` if the generator returns an embedding
+/// whose length does not match `embed_dim`.
+/// Returns `MemoryError::Serialization` on JSON serialization failure.
 pub fn global_integration(
     conn: &Connection,
     generator: &dyn SummaryGenerator,
@@ -58,12 +61,23 @@ pub fn global_integration(
 
     let global_text = generator.summarize(&pseudo_facts)?;
     let global_embedding = generator.embed(&global_text)?;
+    if global_embedding.len() != embed_dim {
+        return Err(crate::error::MemoryError::EmbeddingDimension {
+            expected: embed_dim,
+            actual: global_embedding.len(),
+        });
+    }
 
-    // Collect all source fact ids from all cluster summaries
-    let all_source_ids: Vec<i64> = cluster_summaries
+    // Collect all source fact ids from all cluster summaries.
+    // Pre-size to avoid repeated reallocations: flat_map has no upper-bound hint.
+    let total_source_ids: usize = cluster_summaries
         .iter()
-        .flat_map(|s| s.source_fact_ids.iter().copied())
-        .collect();
+        .map(|s| s.source_fact_ids.len())
+        .sum();
+    let mut all_source_ids: Vec<i64> = Vec::with_capacity(total_source_ids);
+    for s in &cluster_summaries {
+        all_source_ids.extend_from_slice(&s.source_fact_ids);
+    }
 
     // Global summaries are intentionally root-scoped (scope_id=1).
     // They aggregate across all cluster-level summaries regardless of
@@ -134,7 +148,10 @@ mod tests {
         assert_eq!(global.len(), 1);
         assert!(global[0].content.contains("cluster 0"));
         assert!(global[0].content.contains("cluster 2"));
-        assert_eq!(global[0].source_fact_ids, vec![0, 1, 2]);
+        // Order-independent: global summary must contain all three source IDs.
+        let mut got = global[0].source_fact_ids.clone();
+        got.sort_unstable();
+        assert_eq!(got, vec![0, 1, 2]);
     }
 
     #[test]

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -32,6 +32,7 @@ use crate::traits::{ConsolidationConfig, ConsolidationStats, SummaryGenerator};
 /// # Errors
 ///
 /// Propagates errors from any pass or the `SummaryGenerator`.
+/// Returns `MemoryError::Migration` if `last_consolidated_at` in config cannot be parsed.
 pub fn consolidate(
     conn: &Connection,
     generator: &dyn SummaryGenerator,

--- a/src/engine/activity.rs
+++ b/src/engine/activity.rs
@@ -106,7 +106,7 @@ impl MemoryEngine {
                 match self.add_fact(
                     &AddFactRequest {
                         content: action.fact_content.clone(),
-                        fact_type: action.fact_type.clone(),
+                        fact_type: action.fact_type,
                         source_event_id: None,
                         scope: req.scope_path.clone(),
                         opts: Some(AddFactOptions {

--- a/src/engine/archive.rs
+++ b/src/engine/archive.rs
@@ -32,7 +32,9 @@ impl MemoryEngine {
     ///
     /// # Panics
     ///
-    /// Cannot panic in practice — the `.pak` path is always constructed with a filename.
+    /// Panics if the constructed `.pak` path has no filename component.
+    /// This cannot happen in practice because the path is always built as
+    /// `archive_dir.join("archive-<timestamp>.pak")`.
     ///
     /// # Errors
     ///

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -1,10 +1,29 @@
+use rusqlite::Connection;
+
 use crate::error::Result;
-use crate::store::scopes::ScopeStore;
 use crate::traits::{EmbeddingProvider, PersistenceClassifier};
 
 use super::MemoryEngine;
 
 impl MemoryEngine {
+    // --- Internal helpers ---
+
+    /// Resolve (or create) the scope for a bootstrap config, returning its ID.
+    ///
+    /// When `config.scope` is `Some(path)`, ensures the path exists in the DB
+    /// and inserts the node into the in-memory scope tree cache.
+    /// When `None`, returns 1 (root scope).
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from `ScopeStore::ensure_path` or `ScopeStore::get`.
+    fn ensure_bootstrap_scope(&self, conn: &Connection, scope: Option<&str>) -> Result<i64> {
+        match scope {
+            Some(path) => self.ensure_scope_with_conn(conn, path),
+            None => Ok(1),
+        }
+    }
+
     // --- Public API: Bootstrap ---
 
     /// Bootstrap a single JSONL session log into historical memory.
@@ -34,16 +53,7 @@ impl MemoryEngine {
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
         let conn = self.write_conn()?;
-        let scope_id = match &config.scope {
-            Some(path) => {
-                let scope_store = ScopeStore::new(&conn);
-                let id = scope_store.ensure_path(path)?;
-                let node = scope_store.get(id)?;
-                self.scope_tree.write().insert(node);
-                id
-            }
-            None => 1,
-        };
+        let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
         crate::bootstrap::bootstrap_session_inner(
             &conn,
             self.embed_dim,
@@ -79,16 +89,7 @@ impl MemoryEngine {
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
         let conn = self.write_conn()?;
-        let scope_id = match &config.scope {
-            Some(path) => {
-                let scope_store = ScopeStore::new(&conn);
-                let id = scope_store.ensure_path(path)?;
-                let node = scope_store.get(id)?;
-                self.scope_tree.write().insert(node);
-                id
-            }
-            None => 1,
-        };
+        let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
         crate::bootstrap::bootstrap_directory_inner(
             &conn,
             self.embed_dim,

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -60,7 +60,7 @@ impl<'a> DreamContext<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::NotFound` if no active fact with this ID exists.
+    /// Returns `MemoryError::NotFound` if no fact with this ID exists.
     pub fn get_fact(&self, id: i64) -> Result<Fact> {
         self.engine
             .with_read(|conn| FactStore::new(conn, self.engine.embed_dim).get(id))
@@ -191,7 +191,7 @@ impl MemoryEngine {
             content: req.content.clone(),
             content_hash: String::new(), // FactStore::insert computes this via blake3
             embedding: req.embedding.clone(),
-            fact_type: req.fact_type.clone(),
+            fact_type: req.fact_type,
             t_created: now,
             t_expired: None,
             t_valid: None,

--- a/src/engine/graph.rs
+++ b/src/engine/graph.rs
@@ -63,6 +63,7 @@ impl MemoryEngine {
         }
 
         let now = Utc::now();
+        let relation = Self::CO_SESSION_RELATION.to_string();
         let mut new_edges: Vec<(i64, i64, i64)> = Vec::new(); // (edge_id, src, tgt)
 
         {
@@ -84,7 +85,7 @@ impl MemoryEngine {
                             let edge_id = edge_store.insert(&NewEdge {
                                 source_fact_id: src,
                                 target_fact_id: tgt,
-                                relation_type: Self::CO_SESSION_RELATION.to_string(),
+                                relation_type: relation.clone(),
                                 weight: Self::CO_SESSION_WEIGHT,
                                 scope_id: Self::CO_SESSION_SCOPE_ID,
                                 t_created: now,
@@ -109,7 +110,7 @@ impl MemoryEngine {
                     tgt,
                     EdgeData {
                         edge_id,
-                        relation_type: Self::CO_SESSION_RELATION.to_string(),
+                        relation_type: relation.clone(),
                         weight: Self::CO_SESSION_WEIGHT,
                     },
                 );

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -73,7 +73,7 @@ impl MemoryEngine {
                     content: req.content.clone(),
                     content_hash: String::new(),
                     embedding: embedding.clone(),
-                    fact_type: req.fact_type.clone(),
+                    fact_type: req.fact_type,
                     t_created: effective_created,
                     t_expired: None,
                     t_valid: opts.t_valid,
@@ -110,7 +110,7 @@ impl MemoryEngine {
                 content: req.content.clone(),
                 content_hash: String::new(), // FactStore::insert computes this via blake3
                 embedding,
-                fact_type: req.fact_type.clone(),
+                fact_type: req.fact_type,
                 t_created: effective_created,
                 t_expired: None,
                 t_valid: opts.t_valid,
@@ -160,7 +160,7 @@ impl MemoryEngine {
                             content: entry.content.clone(),
                             content_hash: String::new(),
                             embedding: embedding.clone(),
-                            fact_type: entry.fact_type.clone(),
+                            fact_type: entry.fact_type,
                             t_created: effective_created,
                             t_expired: None,
                             t_valid: opts.t_valid,
@@ -238,6 +238,8 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns errors from batch embedding, dimension validation, or DB insert.
+    /// Returns `MemoryError::Internal` if the embedder returns a different
+    /// number of embeddings than input entries.
     // `conn` (write lock) spans the whole savepoint transaction via FactStore/
     // ScopeStore wrappers that borrow it; clippy misses the transitive borrow.
     #[allow(clippy::significant_drop_tightening)]
@@ -294,7 +296,7 @@ impl MemoryEngine {
                         content: entry.content.clone(),
                         content_hash: String::new(), // FactStore::insert computes via blake3
                         embedding: embedding.clone(),
-                        fact_type: entry.fact_type.clone(),
+                        fact_type: entry.fact_type,
                         t_created: *effective_created,
                         t_expired: None,
                         t_valid: opts.t_valid,

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -12,6 +12,16 @@ use crate::types::Fact;
 use super::{MemoryEngine, fact_overlaps_period, fact_to_search_result, passes_temporal_cutoff};
 
 impl MemoryEngine {
+    /// Return the active vector search strategy: HNSW when available and
+    /// populated, brute-force cosine otherwise.
+    fn active_vector_strategy(&self) -> &dyn VectorSearchStrategy {
+        #[cfg(feature = "ann")]
+        if self.should_use_hnsw() {
+            return self.hnsw_strategy.as_ref().unwrap() as &dyn VectorSearchStrategy;
+        }
+        &*self.vector_strategy
+    }
+
     /// Query facts using hybrid search (FTS5 + vector + RRF).
     ///
     /// # Errors
@@ -37,14 +47,7 @@ impl MemoryEngine {
             None => None,
         };
 
-        #[cfg(feature = "ann")]
-        let strategy: &dyn VectorSearchStrategy = if self.should_use_hnsw() {
-            self.hnsw_strategy.as_ref().unwrap()
-        } else {
-            &*self.vector_strategy
-        };
-        #[cfg(not(feature = "ann"))]
-        let strategy: &dyn VectorSearchStrategy = &*self.vector_strategy;
+        let strategy = self.active_vector_strategy();
 
         let (mut results, _diagnostics) = self.with_read(|conn| {
             hybrid_search(conn, query, self.embed_dim, scope_ids.as_deref(), strategy)
@@ -174,7 +177,7 @@ impl MemoryEngine {
     /// Infer search mode from available inputs (D7).
     fn infer_search_mode(query: &MemoryQuery) -> SearchMode {
         if let Some(ref mode) = query.search_mode {
-            return mode.clone();
+            return *mode;
         }
         match (query.text.is_some(), query.embedding.is_some()) {
             (true, true) => SearchMode::Hybrid,
@@ -219,18 +222,11 @@ impl MemoryEngine {
             limit,
             rerank_depth: None,
             valid_at: search_cutoff,
-            fact_type: query.fact_type.clone(),
+            fact_type: query.fact_type,
             scope: query.scope.clone(),
         };
 
-        #[cfg(feature = "ann")]
-        let strategy: &dyn VectorSearchStrategy = if self.should_use_hnsw() {
-            self.hnsw_strategy.as_ref().unwrap()
-        } else {
-            &*self.vector_strategy
-        };
-        #[cfg(not(feature = "ann"))]
-        let strategy: &dyn VectorSearchStrategy = &*self.vector_strategy;
+        let strategy = self.active_vector_strategy();
 
         let (mut results, mut diagnostics) = self.with_read(|conn| {
             hybrid_search(conn, &search_query, self.embed_dim, scope_ids, strategy)

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -8,12 +8,12 @@ use crate::store::facts::FactStore;
 use crate::traits::{ForgetPolicy, PruneStats};
 use crate::types::Fact;
 
-/// Normalization ceiling for access frequency: ln(100+1).
-/// 100 accesses = full score.
-const FREQUENCY_NORMALIZATION_CEILING: f64 = 101.0;
-/// Normalization ceiling for graph connectivity: ln(50+1).
-/// 50 connections = full score.
-const CONNECTIVITY_NORMALIZATION_CEILING: f64 = 51.0;
+/// Argument to `ln()` for access-frequency normalization: 100 + 1.
+/// Gives `ln(101)` as the divisor so that 100 accesses produce a full score of 1.0.
+const FREQUENCY_NORMALIZATION_ARG: f64 = 101.0;
+/// Argument to `ln()` for graph-connectivity normalization: 50 + 1.
+/// Gives `ln(51)` as the divisor so that 50 connections produce a full score of 1.0.
+const CONNECTIVITY_NORMALIZATION_ARG: f64 = 51.0;
 
 /// Ebbinghaus forgetting curve: retention = 2^(-age/half_life).
 ///
@@ -59,10 +59,10 @@ pub fn compute_importance(
     // Using ln_1p for numerical accuracy near zero.
     #[allow(clippy::cast_precision_loss)]
     let frequency =
-        (f64::ln_1p(fact.access_count as f64) / FREQUENCY_NORMALIZATION_CEILING.ln()).min(1.0);
+        (f64::ln_1p(fact.access_count as f64) / FREQUENCY_NORMALIZATION_ARG.ln()).min(1.0);
     #[allow(clippy::cast_precision_loss)]
     let connectivity =
-        (f64::ln_1p(graph_degree as f64) / CONNECTIVITY_NORMALIZATION_CEILING.ln()).min(1.0);
+        (f64::ln_1p(graph_degree as f64) / CONNECTIVITY_NORMALIZATION_ARG.ln()).min(1.0);
 
     policy
         .recency_weight
@@ -80,6 +80,12 @@ pub fn compute_importance(
 /// and removes edges from the in-memory graph to keep it consistent.
 ///
 /// All mutations happen in a single transaction.
+///
+/// # Returns
+///
+/// A tuple of `(PruneStats, Vec<i64>)` where:
+/// - `PruneStats` contains aggregate counts (`facts_evaluated`, `facts_expired`).
+/// - `Vec<i64>` is the list of fact IDs that were soft-deleted during this run.
 ///
 /// # Errors
 ///
@@ -575,7 +581,7 @@ mod tests {
             "only the episodic fact may expire, expired ids: {expired:?}"
         );
         let active = fact_store.list_active(None).unwrap();
-        let types: Vec<FactType> = active.iter().map(|f| f.fact_type.clone()).collect();
+        let types: Vec<FactType> = active.iter().map(|f| f.fact_type).collect();
         assert!(
             types.contains(&FactType::Semantic),
             "semantic must survive neglect (supersession governs it, not decay)"

--- a/src/graph/memory_graph.rs
+++ b/src/graph/memory_graph.rs
@@ -61,16 +61,19 @@ impl MemoryGraph {
         self.graph.add_edge(s, t, data);
     }
 
-    /// Remove all edges associated with the given `SQLite` edge id.
+    /// Remove the edge with the given `SQLite` edge id.
+    ///
+    /// Edge ids are unique (one `SQLite` row → one petgraph edge), so this
+    /// scans O(E) and removes at most one edge. Short-circuits after the
+    /// first match.
     ///
     /// Used after expiring an edge in `SQLite` to keep the graph in sync.
     pub fn remove_edge_by_id(&mut self, edge_id: i64) {
-        let to_remove: Vec<_> = self
+        if let Some(ei) = self
             .graph
             .edge_indices()
-            .filter(|&ei| self.graph[ei].edge_id == edge_id)
-            .collect();
-        for ei in to_remove {
+            .find(|&ei| self.graph[ei].edge_id == edge_id)
+        {
             self.graph.remove_edge(ei);
         }
     }
@@ -193,14 +196,12 @@ impl MemoryGraph {
 
         let mut graph = Self::new();
         for edge in &active_edges {
-            graph.add_edge(
+            graph.add_edges_from_iter(
                 edge.source_fact_id,
                 edge.target_fact_id,
-                EdgeData {
-                    edge_id: edge.id,
-                    relation_type: edge.relation_type.clone(),
-                    weight: edge.weight,
-                },
+                edge.id,
+                &edge.relation_type,
+                edge.weight,
             );
         }
 
@@ -235,17 +236,35 @@ impl MemoryGraph {
     pub(crate) fn from_snapshot(snap: &crate::engine::snapshot::GraphSnapshot) -> Self {
         let mut graph = Self::new();
         for edge in &snap.edges {
-            graph.add_edge(
+            graph.add_edges_from_iter(
                 edge.source,
                 edge.target,
-                EdgeData {
-                    edge_id: edge.edge_id,
-                    relation_type: edge.relation_type.clone(),
-                    weight: edge.weight,
-                },
+                edge.edge_id,
+                &edge.relation_type,
+                edge.weight,
             );
         }
         graph
+    }
+
+    /// Shared edge-insertion kernel used by `load_from_db` and `from_snapshot`.
+    fn add_edges_from_iter(
+        &mut self,
+        source: i64,
+        target: i64,
+        edge_id: i64,
+        relation_type: &str,
+        weight: f64,
+    ) {
+        self.add_edge(
+            source,
+            target,
+            EdgeData {
+                edge_id,
+                relation_type: relation_type.to_owned(),
+                weight,
+            },
+        );
     }
 }
 

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -55,6 +55,12 @@ pub fn explain_fact(
 /// snapshot if a concurrent writer commits between the graph traversal and the
 /// DB read. This is acceptable for an informational/debugging API — the
 /// explanation is best-effort, not transactionally consistent.
+///
+/// # Errors
+///
+/// Returns [`MemoryError::NotFound`] if the fact (or its source event) does not exist.
+/// Returns [`MemoryError::Migration`] if the source event cannot be upcasted.
+/// Returns [`MemoryError::Database`] on SQL failure.
 pub(crate) fn explain_fact_with_graph_context(
     conn: &Connection,
     scope_tree: &ScopeTree,
@@ -98,7 +104,8 @@ fn determine_state(fact: &Fact, now: DateTime<Utc>) -> FactState {
         return FactState::Pinned;
     }
     if let Some(t_valid) = fact.t_valid {
-        if t_valid <= now && (fact.t_invalid.is_none() || fact.t_invalid.unwrap() > now) {
+        let not_yet_invalid = fact.t_invalid.is_none_or(|t_inv| t_inv > now);
+        if t_valid <= now && not_yet_invalid {
             return FactState::Due {
                 t_valid,
                 surfaced_at: fact.surfaced_at,
@@ -135,14 +142,15 @@ pub(crate) fn build_graph_context(graph: &crate::graph::MemoryGraph, fact_id: i6
     let degree = graph.degree(fact_id);
     // Use connected_component to get ALL neighbors (in + out), consistent with degree.
     // `neighbors()` only returns outgoing, which would be inconsistent with degree.
-    let mut neighbor_ids: Vec<i64> = if graph.has_node(fact_id) {
+    let has_node = graph.has_node(fact_id);
+    let mut neighbor_ids: Vec<i64> = if has_node {
         let component = graph.connected_component(fact_id);
         component.into_iter().filter(|&id| id != fact_id).collect()
     } else {
         Vec::new()
     };
     neighbor_ids.sort_unstable();
-    let component_size = neighbor_ids.len() + usize::from(graph.has_node(fact_id));
+    let component_size = neighbor_ids.len() + usize::from(has_node);
     GraphContext {
         degree,
         neighbor_ids,

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -67,7 +67,8 @@ const MAX_SNAPSHOT_SIZE: u64 = 4 * 1024 * 1024 * 1024;
 /// - [`MemoryError::Io`] on file access failure.
 /// - [`MemoryError::Serialization`] on malformed JSON.
 /// - [`MemoryError::NotImplemented`] if compression detected but feature disabled.
-/// - [`MemoryError::Internal`] if the file exceeds 4 GiB.
+/// - [`MemoryError::Internal`] if the file exceeds 4 GiB or if zstd decoder
+///   initialization fails.
 pub fn read_snapshot(path: &Path) -> Result<EngineSnapshot> {
     // Open the file once and perform all checks on the handle to avoid TOCTOU.
     let mut file = File::open(path)?;
@@ -307,11 +308,11 @@ pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Re
         tx.execute("DELETE FROM scopes", [])?;
 
         // 2. Insert scopes (sorted by depth then id to satisfy parent FK).
-        let mut scopes = snapshot.scopes.clone();
-        scopes.sort_by_key(|s| (s.depth, s.id));
+        let mut scope_idx: Vec<usize> = (0..snapshot.scopes.len()).collect();
+        scope_idx.sort_by_key(|&i| (snapshot.scopes[i].depth, snapshot.scopes[i].id));
         let mut stmt =
             tx.prepare("INSERT INTO scopes (id, parent_id, label, depth) VALUES (?1, ?2, ?3, ?4)")?;
-        for scope in &scopes {
+        for scope in scope_idx.into_iter().map(|i| &snapshot.scopes[i]) {
             stmt.execute(rusqlite::params![
                 scope.id,
                 scope.parent_id,
@@ -369,36 +370,37 @@ pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Re
     reset_autoincrement(
         &tx,
         "scopes",
-        &snapshot.scopes.iter().map(|s| s.id).collect::<Vec<_>>(),
+        snapshot.scopes.iter().map(|s| s.id).max().unwrap_or(0),
     )?;
     reset_autoincrement(
         &tx,
         "events",
-        &snapshot.events.iter().map(|e| e.id).collect::<Vec<_>>(),
+        snapshot.events.iter().map(|e| e.id).max().unwrap_or(0),
     )?;
     reset_autoincrement(
         &tx,
         "facts",
-        &snapshot.facts.iter().map(|f| f.id).collect::<Vec<_>>(),
+        snapshot.facts.iter().map(|f| f.id).max().unwrap_or(0),
     )?;
     reset_autoincrement(
         &tx,
         "edges",
-        &snapshot.edges.iter().map(|e| e.id).collect::<Vec<_>>(),
+        snapshot.edges.iter().map(|e| e.id).max().unwrap_or(0),
     )?;
     reset_autoincrement(
         &tx,
         "summaries",
-        &snapshot.summaries.iter().map(|s| s.id).collect::<Vec<_>>(),
+        snapshot.summaries.iter().map(|s| s.id).max().unwrap_or(0),
     )?;
     reset_autoincrement(
         &tx,
         "lineage",
-        &snapshot
+        snapshot
             .lineage
             .iter()
             .map(|l| l.lineage_id)
-            .collect::<Vec<_>>(),
+            .max()
+            .unwrap_or(0),
     )?;
 
     // 10. Commit.
@@ -410,8 +412,7 @@ pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Re
 ///
 /// `sqlite_sequence` is auto-created by `SQLite` for AUTOINCREMENT tables but
 /// has no unique constraint on `name`, so we use DELETE + INSERT.
-fn reset_autoincrement(conn: &Connection, table: &str, ids: &[i64]) -> Result<()> {
-    let max_id = ids.iter().copied().max().unwrap_or(0);
+fn reset_autoincrement(conn: &Connection, table: &str, max_id: i64) -> Result<()> {
     conn.execute(
         "DELETE FROM sqlite_sequence WHERE name = ?1",
         rusqlite::params![table],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //!
 //! - `SQLite` WAL for event log, facts, and FTS5
 //! - Pure Rust brute-force vector similarity (cosine)
+//! - Optional HNSW approximate nearest-neighbour index (`ann` feature)
 //!
 //! ## Threading
 //!
@@ -54,8 +55,43 @@ pub use inspect::types as inspect_types;
 pub use resume::{ResumeConfig, ResumeContext};
 pub use search::{MemoryQuery, QueryDiagnostics, QueryResponse};
 pub use store::UpcasterRegistry;
-pub use traits::{DreamCycle, EmbeddingProvider, InsightStream, Reranker};
+pub use traits::{
+    ConflictArbiter, ConflictResolution, ConsolidationConfig, ConsolidationStats, CrudDecision,
+    DreamCycle, EmbeddingProvider, ForgetPolicy, InsightStream, PersistenceClassifier, PruneStats,
+    Reranker, SummaryGenerator,
+};
 pub use types::*;
 
 // Phase 5a cognitive pipeline re-exports
 pub use engine::cognitive::DreamContext;
+
+#[cfg(test)]
+mod tests {
+    /// Smoke-test: verify that re-exported types are reachable from the crate root.
+    /// If any re-export is removed or renamed, this test will fail to compile.
+    #[test]
+    fn reexports_are_accessible() {
+        // traits
+        fn _accepts_embedding_provider(_: &dyn crate::EmbeddingProvider) {}
+        fn _accepts_summary_generator(_: &dyn crate::SummaryGenerator) {}
+        fn _accepts_conflict_arbiter(_: &dyn crate::ConflictArbiter) {}
+        fn _accepts_persistence_classifier(_: &dyn crate::PersistenceClassifier) {}
+        fn _accepts_reranker(_: &dyn crate::Reranker) {}
+        fn _accepts_insight_stream(_: &dyn crate::InsightStream) {}
+        fn _accepts_dream_cycle(_: &dyn crate::DreamCycle) {}
+
+        // trait types
+        let _ = std::mem::size_of::<crate::CrudDecision>();
+        let _ = std::mem::size_of::<crate::ConsolidationConfig>();
+        let _ = std::mem::size_of::<crate::ConsolidationStats>();
+        let _ = std::mem::size_of::<crate::PruneStats>();
+        let _ = std::mem::size_of::<crate::ConflictResolution>();
+        let _ = std::mem::size_of::<crate::ForgetPolicy>();
+
+        // core types
+        let _ = std::mem::size_of::<crate::FactType>();
+        let _ = std::mem::size_of::<crate::Fact>();
+        let _ = std::mem::size_of::<crate::EngineConfig>();
+        let _ = std::mem::size_of::<crate::MemoryEngine>();
+    }
+}

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -85,19 +85,24 @@ impl ConnectionPool {
     /// # Errors
     ///
     /// Returns `MemoryError::Database` if any connection or schema setup fails.
+    /// Returns `MemoryError::Migration` if the schema version cannot be determined
+    /// or the stored version is newer than the compiled-in maximum.
+    /// Returns `MemoryError::UnsupportedEpoch` if the database was written by a
+    /// future version of the engine.
     pub fn open(
         path: &Path,
         embed_dim: usize,
         read_pool_size: usize,
         backup_dir: Option<&Path>,
     ) -> Result<Self> {
-        let write_conn = open_connection(&path.to_string_lossy())?;
+        let path_str = path.to_string_lossy();
+        let write_conn = open_connection(&path_str)?;
         init_schema(&write_conn)?;
         migrate(&write_conn, backup_dir)?;
 
         let mut read_conns = Vec::with_capacity(read_pool_size);
         for _ in 0..read_pool_size {
-            let conn = open_connection(&path.to_string_lossy())?;
+            let conn = open_connection(&path_str)?;
             conn.execute_batch("PRAGMA query_only = ON")
                 .map_err(MemoryError::Database)?;
             read_conns.push(conn);
@@ -140,11 +145,12 @@ impl ConnectionPool {
     /// read-write open. This constructor validates schema compatibility without
     /// running `init_schema()` or `migrate()`.
     ///
-    /// All connections have `PRAGMA query_only = ON`, including the internal slot
-    /// used for cache loading during initialization.
+    /// All connections are opened with `SQLITE_OPEN_READ_ONLY`, which enforces
+    /// read-only access at the OS level. No `PRAGMA query_only` is set.
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::Database` if any connection or pragma setup fails.
     /// Returns `MemoryError::Migration` if the file does not exist, the schema
     /// is uninitialized, or the schema needs migration.
     /// Returns `MemoryError::UnsupportedEpoch` if the DB epoch is from the future.
@@ -160,12 +166,13 @@ impl ConnectionPool {
         }
 
         // Open with SQLITE_OPEN_READ_ONLY — no file creation, no WAL mutation
-        let conn = open_connection_read_only(&path.to_string_lossy())?;
+        let path_str = path.to_string_lossy();
+        let conn = open_connection_read_only(&path_str)?;
         validate_schema_version(&conn)?;
 
         let mut read_conns = Vec::with_capacity(read_pool_size);
         for _ in 0..read_pool_size {
-            let c = open_connection_read_only(&path.to_string_lossy())?;
+            let c = open_connection_read_only(&path_str)?;
             read_conns.push(c);
         }
 
@@ -367,5 +374,36 @@ mod tests {
     fn pool_not_read_only_by_default() {
         let pool = ConnectionPool::open_memory(4).unwrap();
         assert!(!pool.is_read_only());
+    }
+
+    #[test]
+    fn pool_path_accessor() {
+        // In-memory: path() returns None
+        let mem_pool = ConnectionPool::open_memory(4).unwrap();
+        assert!(mem_pool.path().is_none());
+
+        // File-backed: path() returns the path used to open the pool
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pool = ConnectionPool::open(&db_path, 4, 1, None).unwrap();
+        assert_eq!(pool.path(), Some(db_path.as_path()));
+    }
+
+    #[test]
+    fn pool_open_with_backup_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let backup_dir = dir.path().join("backups");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+
+        // Opening with a backup_dir must succeed and produce a usable pool
+        let pool = ConnectionPool::open(&db_path, 4, 1, Some(&backup_dir)).unwrap();
+        assert!(pool.is_file_backed());
+        assert!(!pool.is_read_only());
+
+        let r = pool.read();
+        let v = get_config(&r, "schema_version").unwrap();
+        drop(r);
+        assert!(v.is_some());
     }
 }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,6 +1,6 @@
 //! Bounded connection pool: N read connections + 1 exclusive write connection.
 //!
-//! Uses `parking_lot::Mutex` for the write lock and a bounded channel for readers.
+//! Uses `parking_lot::Mutex` + `Condvar` for both the write lock and the reader pool.
 
 mod connection_pool;
 

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -49,7 +49,7 @@ pub struct ResumeContext {
     pub high_importance: Vec<Fact>,
     /// Future-memory facts whose `t_valid` has arrived.
     pub due: Vec<Fact>,
-    /// Most recent facts from active scope.
+    /// Most recent facts from active scopes.
     pub recent: Vec<Fact>,
     /// Placeholder: KB reference URIs for Phase 5.
     pub kb_stubs: Vec<String>,
@@ -57,15 +57,35 @@ pub struct ResumeContext {
 
 /// Retrieve tiered context for resuming a session.
 ///
-/// Five tiers, mutually exclusive (no fact appears in multiple tiers):
+/// Four fact tiers, mutually exclusive (no fact appears in multiple tiers):
 ///
 /// 1. **Pinned** — all pinned facts (always present, cross-scope)
 /// 2. **High-importance** — top-N by materialized `importance_score`
 /// 3. **Due** — active facts with `t_valid <= now` (future memory surfacing)
-/// 4. **Scope-filtered recent** — newest by `t_created` from active scope
-/// 5. **KB stubs** — placeholder `Vec<String>` for Phase 5
+/// 4. **Scope-filtered recent** — newest by `t_created` from active scopes
+///
+/// Plus `kb_stubs` — placeholder `Vec<String>` for Phase 5 (not a fact tier).
 ///
 /// Takes pre-resolved scope IDs to avoid holding cache locks across DB access.
+///
+/// # Errors
+///
+/// Returns [`crate::error::MemoryError`] if any underlying store query fails.
+///
+/// # Examples
+///
+/// This is a crate-internal helper; callers use the public
+/// [`MemoryEngine::resume_context`](crate::MemoryEngine::resume_context).
+/// The example is illustrative (`ignore`d) because `resume` is a `pub(crate)`
+/// module — a compiled doctest cannot reach it from outside the crate.
+///
+/// ```ignore
+/// use crate::resume::{ResumeConfig, resume_context};
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let config = ResumeConfig::default();
+/// let ctx = resume_context(&conn, &[1], 384, &config).unwrap();
+/// ```
 pub fn resume_context(
     conn: &Connection,
     scope_ids: &[i64],
@@ -149,6 +169,46 @@ mod tests {
             metadata: serde_json::json!({}),
             is_pinned: false,
         }
+    }
+
+    #[test]
+    fn resume_config_serde_roundtrip() {
+        let config = ResumeConfig {
+            scope_path: Some("agents/assistant".into()),
+            now: Utc::now(),
+            pinned_cap: 25,
+            high_importance_cap: 15,
+            high_importance_min: 0.6,
+            due_cap: 5,
+            recent_cap: 8,
+        };
+        let json = serde_json::to_string(&config).expect("serialize ResumeConfig");
+        let restored: ResumeConfig = serde_json::from_str(&json).expect("deserialize ResumeConfig");
+        assert_eq!(config.scope_path, restored.scope_path);
+        assert_eq!(config.pinned_cap, restored.pinned_cap);
+        assert_eq!(config.high_importance_cap, restored.high_importance_cap);
+        assert_eq!(config.due_cap, restored.due_cap);
+        assert_eq!(config.recent_cap, restored.recent_cap);
+        assert!((config.high_importance_min - restored.high_importance_min).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resume_context_serde_roundtrip() {
+        let ctx = ResumeContext {
+            pinned: vec![],
+            high_importance: vec![],
+            due: vec![],
+            recent: vec![],
+            kb_stubs: vec!["kb://some/stub".into()],
+        };
+        let json = serde_json::to_string(&ctx).expect("serialize ResumeContext");
+        let restored: ResumeContext =
+            serde_json::from_str(&json).expect("deserialize ResumeContext");
+        assert_eq!(ctx.kb_stubs, restored.kb_stubs);
+        assert!(restored.pinned.is_empty());
+        assert!(restored.high_importance.is_empty());
+        assert!(restored.due.is_empty());
+        assert!(restored.recent.is_empty());
     }
 
     #[test]

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -22,7 +22,7 @@ impl ScopeTree {
         let all = store.list_all()?;
 
         let mut nodes = HashMap::with_capacity(all.len());
-        let mut children: HashMap<i64, Vec<i64>> = HashMap::new();
+        let mut children: HashMap<i64, Vec<i64>> = HashMap::with_capacity(all.len());
 
         for node in all {
             if let Some(pid) = node.parent_id {
@@ -34,16 +34,19 @@ impl ScopeTree {
         Ok(Self { nodes, children })
     }
 
+    /// Root scope id (database-assigned, always 1).
+    pub(crate) const ROOT_ID: i64 = 1;
+
     /// Root scope id (always 1).
     #[must_use]
     pub const fn root_id() -> i64 {
-        1
+        Self::ROOT_ID
     }
 
     /// Resolve a path string to a `scope_id` (read-only, no creation).
     /// Returns `None` if any segment is missing.
     pub fn resolve_path(&self, path: &str) -> Option<i64> {
-        let mut current = 1i64; // start at root
+        let mut current = Self::ROOT_ID; // start at root
         for segment in path.split('/') {
             let segment = segment.trim();
             if segment.is_empty() {
@@ -178,7 +181,7 @@ impl ScopeTree {
     /// Rebuild tree from a snapshot (same logic as `load` but from snapshot data).
     pub(crate) fn from_snapshot(snap: &crate::engine::snapshot::ScopeTreeSnapshot) -> Self {
         let mut nodes = HashMap::with_capacity(snap.nodes.len());
-        let mut children: HashMap<i64, Vec<i64>> = HashMap::new();
+        let mut children: HashMap<i64, Vec<i64>> = HashMap::with_capacity(snap.nodes.len());
 
         for node in &snap.nodes {
             if let Some(pid) = node.parent_id {
@@ -305,6 +308,38 @@ mod tests {
         tree.insert(new_node);
         assert_eq!(tree.nodes.len(), node_count_before + 1);
         assert!(tree.children.get(&1).unwrap().contains(&999));
+    }
+
+    #[test]
+    fn node_count_matches_inserted_nodes() {
+        let tree = setup_tree();
+        // root + user:michael + project:demo + project:other = 4
+        assert_eq!(tree.node_count(), 4);
+    }
+
+    #[test]
+    fn node_count_empty_tree() {
+        let tree = ScopeTree {
+            nodes: HashMap::new(),
+            children: HashMap::new(),
+        };
+        assert_eq!(tree.node_count(), 0);
+    }
+
+    #[test]
+    fn max_depth_returns_deepest_node() {
+        let tree = setup_tree();
+        // root=depth 0, user:michael=depth 1, project:demo/other=depth 2
+        assert_eq!(tree.max_depth(), 2);
+    }
+
+    #[test]
+    fn max_depth_empty_tree() {
+        let tree = ScopeTree {
+            nodes: HashMap::new(),
+            children: HashMap::new(),
+        };
+        assert_eq!(tree.max_depth(), 0);
     }
 
     mod proptest_scope {

--- a/src/search/ann.rs
+++ b/src/search/ann.rs
@@ -72,6 +72,7 @@ struct HnswInner {
 const OVERFETCH_FACTOR: usize = 3;
 const DEFAULT_EF_SEARCH: usize = 100;
 const MAX_WIDEN_ATTEMPTS: usize = 3;
+const HNSW_SEED: u64 = 42;
 
 impl HnswStrategy {
     /// Number of active (non-tombstoned) items in the index.
@@ -94,7 +95,6 @@ impl HnswStrategy {
     pub fn build_from_db(conn: &Connection, embed_dim: usize) -> Result<Self> {
         use rand::SeedableRng;
 
-        const HNSW_SEED: u64 = 42;
         let mut index: Hnsw<CosineMetric, Vec<f32>, SmallRng, 16, 32> = Hnsw::new_params_and_prng(
             CosineMetric,
             hnsw::Params::new().ef_construction(200),
@@ -177,7 +177,6 @@ impl HnswStrategy {
     ) -> Result<Self> {
         use rand::SeedableRng;
 
-        const HNSW_SEED: u64 = 42;
         let mut index: Hnsw<CosineMetric, Vec<f32>, SmallRng, 16, 32> = Hnsw::new_params_and_prng(
             CosineMetric,
             hnsw::Params::new().ef_construction(200),
@@ -235,7 +234,7 @@ impl VectorSearchStrategy for HnswStrategy {
         }
 
         let mut ef = DEFAULT_EF_SEARCH;
-        let mut overfetch = limit * OVERFETCH_FACTOR;
+        let mut overfetch = limit.saturating_mul(OVERFETCH_FACTOR);
         let mut results = Vec::new();
         let query_vec = query_embedding.to_vec();
 
@@ -291,8 +290,8 @@ impl VectorSearchStrategy for HnswStrategy {
             }
             // Widen both search accuracy and candidate count so aggressive
             // filters don't exhaust the same small candidate set each retry.
-            ef *= 2;
-            overfetch *= 2;
+            ef = ef.saturating_mul(2);
+            overfetch = overfetch.saturating_mul(2);
         }
 
         // If HNSW widening couldn't satisfy, fall back to brute-force.
@@ -357,8 +356,10 @@ fn check_fact_filters(
     fact_type: Option<&FactType>,
     scope_ids: Option<&[i64]>,
 ) -> Result<bool> {
+    use crate::search::serialize_scope_ids;
     use crate::store::facts::fact_type_to_str;
 
+    let scope_json = serialize_scope_ids(scope_ids)?;
     let exists: bool = conn.query_row(
         "SELECT EXISTS(
             SELECT 1 FROM facts
@@ -367,11 +368,7 @@ fn check_fact_filters(
             AND (?2 IS NULL OR fact_type = ?2)
             AND (?3 IS NULL OR scope_id IN (SELECT value FROM json_each(?3)))
         )",
-        rusqlite::params![
-            fact_id,
-            fact_type.map(fact_type_to_str),
-            scope_ids.map(|ids| serde_json::to_string(ids).expect("scope_ids serialization")),
-        ],
+        rusqlite::params![fact_id, fact_type.map(fact_type_to_str), scope_json,],
         |row| row.get(0),
     )?;
 

--- a/src/search/fts.rs
+++ b/src/search/fts.rs
@@ -1,6 +1,7 @@
 use rusqlite::Connection;
 
 use crate::error::Result;
+use crate::search::serialize_scope_ids;
 use crate::store::facts::fact_type_to_str;
 use crate::types::FactType;
 
@@ -47,7 +48,7 @@ pub fn fts_search(
 
     let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
     let fact_type_str: Option<&str> = fact_type.map(fact_type_to_str);
-    let scope_ids_json: Option<String> = scope_ids.map(serde_json::to_string).transpose()?;
+    let scope_ids_json = serialize_scope_ids(scope_ids)?;
 
     // FTS5 syntax errors surface at query_map execution time, not at prepare time.
     // They are indistinguishable from other rusqlite::Error variants at the type level,
@@ -108,7 +109,7 @@ pub fn fts_count_expired(
     )?;
 
     let fact_type_str: Option<&str> = fact_type.map(fact_type_to_str);
-    let scope_ids_json: Option<String> = scope_ids.map(serde_json::to_string).transpose()?;
+    let scope_ids_json = serialize_scope_ids(scope_ids)?;
 
     match stmt.query_row(
         rusqlite::params![query, fact_type_str, scope_ids_json],

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -10,7 +10,7 @@ use crate::store::facts::FactStore;
 use crate::types::{Fact, FactType};
 
 /// How to combine search sources.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchMode {
     Fts,
     Vector,
@@ -19,7 +19,7 @@ pub enum SearchMode {
 
 /// Which source(s) contributed to a result.
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum MatchType {
     Fts,
     Vector,
@@ -101,6 +101,12 @@ pub struct QueryResponse {
     pub results: Vec<SearchResult>,
     pub diagnostics: QueryDiagnostics,
 }
+
+/// Default RRF smoothing constant (Cormack & Clarke, 2009).
+///
+/// k=60 is the value recommended in the original RRF paper and widely adopted
+/// in practice. It controls rank-score attenuation: larger k = slower decay.
+pub const RRF_K: u32 = 60;
 
 /// Reciprocal Rank Fusion merge of two ranked result lists.
 ///
@@ -192,7 +198,7 @@ pub fn hybrid_search(
                 fts_results.iter().map(|r| (r.fact_id, r.score)).collect();
             let vec_pairs: Vec<(i64, f32)> =
                 vec_results.iter().map(|r| (r.fact_id, r.score)).collect();
-            rrf_merge(&fts_pairs, &vec_pairs, 60)
+            rrf_merge(&fts_pairs, &vec_pairs, RRF_K)
         }
     };
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -12,9 +12,28 @@ pub mod vector;
 pub use ann::HnswStrategy;
 pub use fts::{FtsResult, fts_count_expired, fts_search};
 pub use hybrid::{
-    MatchType, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult,
+    MatchType, QueryDiagnostics, QueryResponse, RRF_K, SearchMode, SearchQuery, SearchResult,
     hybrid_search, rrf_merge,
 };
 pub use query::MemoryQuery;
 pub use strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
 pub use vector::{VectorResult, cosine_similarity, vector_search};
+
+/// Serialize an optional scope-ID slice to a JSON string for use as a SQL
+/// parameter in `json_each(?N)` expressions.
+///
+/// Returns `None` when `scope_ids` is `None` (no scope filter), letting SQL
+/// treat the parameter as NULL and skip the filter clause.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Serialization` if `serde_json::to_string` fails,
+/// which cannot happen for `&[i64]` in practice.
+pub(crate) fn serialize_scope_ids(
+    scope_ids: Option<&[i64]>,
+) -> crate::error::Result<Option<String>> {
+    scope_ids
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(crate::error::MemoryError::Serialization)
+}

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -1,6 +1,7 @@
 use rusqlite::{Connection, params};
 
 use crate::error::Result;
+use crate::search::serialize_scope_ids;
 use crate::store::deserialize_embedding;
 use crate::store::facts::fact_type_to_str;
 use crate::types::FactType;
@@ -53,7 +54,7 @@ pub fn vector_search(
     }
 
     let ft_str: Option<&str> = fact_type.map(fact_type_to_str);
-    let scope_json: Option<String> = scope_ids.map(serde_json::to_string).transpose()?;
+    let scope_json = serialize_scope_ids(scope_ids)?;
 
     let mut stmt = conn.prepare(
         "SELECT id, embedding FROM facts
@@ -309,6 +310,15 @@ mod tests {
                 let sim = cosine_similarity(&a[..len], &b[..len]);
                 prop_assert!((-1.0 - 1e-5..=1.0 + 1e-5).contains(&sim),
                     "cosine similarity {sim} out of [-1, 1] bounds");
+            }
+
+            /// Anti-parallel vectors (v and -v) must yield cosine similarity of -1.0.
+            #[test]
+            fn antiparallel_vectors_equal_minus_one(v in nonzero_vec(64)) {
+                let neg: Vec<f32> = v.iter().map(|&x| -x).collect();
+                let sim = cosine_similarity(&v, &neg);
+                prop_assert!((sim - (-1.0)).abs() < 1e-5,
+                    "anti-parallel vectors should give -1.0, got {sim}");
             }
         }
     }

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -132,10 +132,11 @@ impl<'a> ActivityStore<'a> {
                  FROM activities
                  WHERE session_id = ?1
                  ORDER BY last_seen DESC";
-        let sql = limit.map_or_else(|| base.to_string(), |n| format!("{base} LIMIT {n}"));
+        let limit_i64: i64 = limit.map_or(-1, |n| i64::try_from(n).unwrap_or(i64::MAX));
+        let sql = format!("{base} LIMIT ?2");
         let mut stmt = self.conn.prepare(&sql).map_err(MemoryError::Database)?;
         let rows = stmt
-            .query_map(params![session_id], row_to_activity)
+            .query_map(params![session_id, limit_i64], row_to_activity)
             .map_err(MemoryError::Database)?;
         rows.collect::<std::result::Result<_, _>>()
             .map_err(MemoryError::Database)
@@ -207,7 +208,7 @@ impl<'a> ActivityStore<'a> {
 }
 
 fn row_to_activity(row: &rusqlite::Row<'_>) -> rusqlite::Result<Activity> {
-    let status_str: String = row.get(7)?;
+    let status_str: String = row.get("status")?;
     let status = status_str.parse::<ActivityStatus>().map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(
             7,
@@ -215,25 +216,31 @@ fn row_to_activity(row: &rusqlite::Row<'_>) -> rusqlite::Result<Activity> {
             Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
         )
     })?;
-    let args_str: String = row.get(4)?;
-    let args: serde_json::Value = serde_json::from_str(&args_str).unwrap_or_default();
-    let first_seen_str: String = row.get(9)?;
-    let last_seen_str: String = row.get(10)?;
+    let args_str: String = row.get("args")?;
+    let args: serde_json::Value = serde_json::from_str(&args_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+    let first_seen_str: String = row.get("first_seen")?;
+    let last_seen_str: String = row.get("last_seen")?;
 
     Ok(Activity {
-        id: row.get(0)?,
-        session_id: row.get(1)?,
-        tool_name: row.get(2)?,
-        args_hash: row.get(3)?,
+        id: row.get("id")?,
+        session_id: row.get("session_id")?,
+        tool_name: row.get("tool_name")?,
+        args_hash: row.get("args_hash")?,
         args,
-        result_summary: row.get(5)?,
-        outcome_class: row.get(6)?,
+        result_summary: row.get("result_summary")?,
+        outcome_class: row.get("outcome_class")?,
         status,
-        occurrence_count: row.get(8)?,
+        occurrence_count: row.get("occurrence_count")?,
         first_seen: parse_timestamp(&first_seen_str)?,
         last_seen: parse_timestamp(&last_seen_str)?,
-        scope_id: row.get(11)?,
-        promoted_fact_id: row.get(12)?,
+        scope_id: row.get("scope_id")?,
+        promoted_fact_id: row.get("promoted_fact_id")?,
     })
 }
 

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -106,7 +106,13 @@ impl<'a> CheckpointStore<'a> {
 fn row_to_checkpoint(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionCheckpoint> {
     let checkpoint_at_str: String = row.get(4)?;
     let metadata_str: String = row.get(5)?;
-    let metadata: serde_json::Value = serde_json::from_str(&metadata_str).unwrap_or_default();
+    let metadata: serde_json::Value = serde_json::from_str(&metadata_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            5,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
 
     Ok(SessionCheckpoint {
         session_id: row.get(0)?,

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -134,10 +134,11 @@ impl<'a> FactStore<'a> {
                     source_event_id, importance, access_count, last_accessed, metadata, scope_id,
                     is_pinned, importance_score, surfaced_at
              FROM facts WHERE t_expired IS NULL";
-        let sql = limit.map_or_else(|| base.to_owned(), |n| format!("{base} LIMIT {n}"));
+        let limit_i64: i64 = limit.map_or(-1, |n| i64::try_from(n).unwrap_or(i64::MAX));
+        let sql = format!("{base} LIMIT ?1");
         let mut stmt = self.conn.prepare(&sql)?;
         let dim = self.embed_dim;
-        let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
+        let rows = stmt.query_map(params![limit_i64], |row| row_to_fact(row, dim))?;
         let mut facts = Vec::new();
         for row in rows {
             facts.push(row?);

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
 use crate::types::{LineageRecord, LineageSnapshotEntry, NewLineageRecord, PromotionProvenance};

--- a/src/store/upcaster.rs
+++ b/src/store/upcaster.rs
@@ -52,7 +52,7 @@ impl UpcasterRegistry {
     /// The latest revision for this event type is automatically tracked as
     /// `max(current_latest, from_revision + 1)`.
     pub fn register(&mut self, event_type: &str, from_revision: u16, func: UpcasterFn) {
-        let target = from_revision + 1;
+        let target = from_revision.saturating_add(1);
         self.upcasters
             .insert((event_type.to_string(), from_revision), func);
         let current = self.latest.entry(event_type.to_string()).or_insert(1);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -60,6 +60,16 @@ pub trait SummaryGenerator {
 pub trait ConflictArbiter {
     /// Decide how to resolve a conflict between an existing and a new fact.
     ///
+    /// # Warning: `importance_score` on `new_fact` is a placeholder
+    ///
+    /// When called from [`resolve_conflict`](crate::conflict::resolve_conflict),
+    /// `new_fact` is a temporary [`Fact`] constructed from a [`NewFact`](crate::types::NewFact)
+    /// before it has been persisted or scored. Its `importance_score` field is hardcoded
+    /// to `0.5` and does **not** reflect the fact's actual computed importance.
+    /// Implementations that branch on `new_fact.importance_score` will always see `0.5`.
+    /// Use `new_fact.importance` (the caller-supplied raw importance) instead if you need
+    /// a signal for the incoming fact's weight.
+    ///
     /// # Errors
     ///
     /// Returns an error if arbitration fails.

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,7 +49,7 @@ pub struct OutcomeCounts {
 }
 
 /// Type of fact (`CoALA` mapping: Episodic, Semantic, Procedural).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum FactType {
     Episodic,
     Semantic,
@@ -598,6 +598,32 @@ pub struct ProjectContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- Display impl tests ---
+
+    #[test]
+    fn display_impls_all_variants() {
+        // Outcome
+        assert_eq!(Outcome::Positive.to_string(), "positive");
+        assert_eq!(Outcome::Negative.to_string(), "negative");
+        assert_eq!(Outcome::Neutral.to_string(), "neutral");
+
+        // FactType
+        assert_eq!(FactType::Episodic.to_string(), "episodic");
+        assert_eq!(FactType::Semantic.to_string(), "semantic");
+        assert_eq!(FactType::Procedural.to_string(), "procedural");
+
+        // ConsolidationLevel
+        assert_eq!(ConsolidationLevel::Local.to_string(), "local");
+        assert_eq!(ConsolidationLevel::Cluster.to_string(), "cluster");
+        assert_eq!(ConsolidationLevel::Global.to_string(), "global");
+
+        // ActivityStatus
+        assert_eq!(ActivityStatus::Recorded.to_string(), "recorded");
+        assert_eq!(ActivityStatus::Deduplicated.to_string(), "deduplicated");
+        assert_eq!(ActivityStatus::Ignored.to_string(), "ignored");
+        assert_eq!(ActivityStatus::Promoted.to_string(), "promoted");
+    }
 
     // --- Phase 5a type tests ---
 

--- a/tests/eval/helpers.rs
+++ b/tests/eval/helpers.rs
@@ -126,7 +126,7 @@ impl CorpusBuilder {
             let id = engine.add_fact(
                 &AddFactRequest {
                     content: fact.content.to_string(),
-                    fact_type: fact.fact_type.clone(),
+                    fact_type: fact.fact_type,
                     source_event_id: None,
                     scope: fact.scope.map(String::from),
                     opts,


### PR DESCRIPTION
## Wave 1 of #506 — mechanical super-qa low auto-fixes

Applies the **mechanical, behavior-preserving** subset of the 114
`super-qa` "auto-fix: low" findings in #506. This is **wave 1 of 2** —
the API-shape findings are deferred to a follow-up PR (see below), so
this PR `Refs #506` rather than closing it.

### How it was dispatched

17 **file-disjoint module buckets** (by finding-ID prefix), one agent
each, so parallel workers never edit the same file. Each agent verified
the finding against the real code before applying (super-qa emits false
positives), then a single-workspace compile surfaced the cross-cutting
breakage no individual bucket could see.

### Outcome (115 findings triaged)

| Status | Count |
|---|---|
| Applied | 92 |
| Already fixed upstream | 10 |
| False positive (verified) | 3 |
| Deferred to wave 2 | 7 |
| Skipped — needs coordinated/API change | 2 |
| Cross-bucket handoff | 1 |

**Categories applied:** correctness (lineage `json_each` parameterisation,
saturating upcaster arithmetic, DB-JSON error propagation), docs
(`# Errors`/`# Panics` sections, backticks, stale-comment fixes), perf
(`Copy` derives, pre-sized `Vec`s, hoisted allocations), modern-rust
(`try_from` over lossy `as`, named column access, bound `LIMIT` params),
and ~15 new unit/doc tests.

### Cross-cutting repairs (surfaced by the workspace gate)

- `FactType`/`SearchMode` gaining `Copy` rippled `clone_on_copy` across 8
  modules → cleared via a *scoped* `clippy --fix` (pre-existing pedantic
  warnings left untouched, per the repo's `pedantic = warn` policy).
- The bootstrap scope-dedup helper collided with an existing
  `ensure_scope_with_conn` → now **delegates** instead of duplicating.
- The lineage `Serialization` error took a `String`, not `serde_json::Error`.
- The resume doctest referenced the `pub(crate)` `resume` module from an
  external-crate doctest context → marked illustrative (`ignore`); a
  runnable example is wave-2 work, once `ResumeConfig` is re-exported.

### Deferred to wave 2 (a separate PR that completes the #506 batch)

The 7 visibility / builder / `non_exhaustive` carve-outs, plus 2
cross-module changes (`HashMap`→`BTreeMap` snapshot determinism, `FromStr`
typed error). These are genuine API-shape changes that warrant their own
review.

### Off-script discovery (collateral issue to be filed)

An agent found a real latent panic in `embed_batch`'s error path
(`&body_str[..1000]` can split a multibyte UTF-8 codepoint). Not in #506,
so it'll be filed separately rather than smuggled in here.

### Verification gate — all green

| Check | Result |
|---|---|
| `fmt` | clean |
| `build/test/clippy --workspace` | ✅ 600 tests, 0 deny |
| `build/test/clippy --all-features` | ✅ 618 tests, 0 deny |

Refs #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

