### PR TITLE
fix(embed,core): batch-embed single-format, UTF-8-safe truncation, promote logging, results_returned

### DIFF
--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -213,14 +213,35 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
         // Auto-detect response format and extract all embeddings:
         // OpenAI: { "data": [{ "index": 0, "embedding": [...] }, ...] }
         // Ollama: { "embeddings": [[...], [...]] }
+        // Single: { "embedding": [...] } (only when one text was requested)
         let embeddings = if let Some(data) = body.get("data").and_then(|d| d.as_array()) {
             Self::parse_openai_batch(data, texts.len())?
         } else if let Some(arr) = body.get("embeddings").and_then(|e| e.as_array()) {
             Self::parse_ollama_batch(arr, texts.len())?
+        } else if let Some(embedding) = body.get("embedding") {
+            // Single embedding format (e.g. Ollama's legacy `/api/embeddings`, which
+            // accepts only one prompt). Only valid when exactly one text was requested.
+            if texts.len() != 1 {
+                return Err(MemoryError::Internal(format!(
+                    "batch embedding: server returned a single 'embedding' but {} texts were requested",
+                    texts.len()
+                )));
+            }
+            let emb = serde_json::from_value::<Vec<f32>>(embedding.clone()).map_err(|_| {
+                MemoryError::Internal("batch embedding: cannot parse single 'embedding'".into())
+            })?;
+            vec![emb]
         } else {
             let body_str = serde_json::to_string(&body).unwrap_or_default();
+            // Slice on a char boundary: `body_str` may contain multibyte UTF-8 (serde_json
+            // passes non-ASCII through unescaped), so a raw byte index could split a codepoint
+            // and panic. Walk down to the nearest boundary at or below 1000.
             let truncated = if body_str.len() > 1000 {
-                format!("{}... (truncated)", &body_str[..1000])
+                let mut end = 1000;
+                while !body_str.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}... (truncated)", &body_str[..end])
             } else {
                 body_str
             };

--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -233,18 +233,7 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
             vec![emb]
         } else {
             let body_str = serde_json::to_string(&body).unwrap_or_default();
-            // Slice on a char boundary: `body_str` may contain multibyte UTF-8 (serde_json
-            // passes non-ASCII through unescaped), so a raw byte index could split a codepoint
-            // and panic. Walk down to the nearest boundary at or below 1000.
-            let truncated = if body_str.len() > 1000 {
-                let mut end = 1000;
-                while !body_str.is_char_boundary(end) {
-                    end -= 1;
-                }
-                format!("{}... (truncated)", &body_str[..end])
-            } else {
-                body_str
-            };
+            let truncated = truncate_on_char_boundary(&body_str, 1000);
             return Err(MemoryError::Internal(format!(
                 "cannot extract embeddings from batch response: {truncated}"
             )));
@@ -269,9 +258,46 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
     }
 }
 
+/// Truncate `s` to at most `max` bytes for an error message, snapping the cut
+/// down to the nearest UTF-8 char boundary.
+///
+/// `serde_json::to_string` emits non-ASCII as raw UTF-8, so a serialized
+/// response body can contain multibyte codepoints. Slicing at a raw byte index
+/// that lands inside one panics; this walks the index down to a boundary first.
+/// Byte 0 is always a boundary, so the loop terminates.
+fn truncate_on_char_boundary(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}... (truncated)", &s[..end])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_snaps_down_to_char_boundary() {
+        // A 4-byte emoji at bytes 998..1002 straddles the byte-1000 cut.
+        // A raw `&body_str[..1000]` slice would panic; the helper snaps to 998.
+        let mut s = "a".repeat(998);
+        s.push('\u{1F600}'); // emoji, 4 bytes: indices 998, 999, 1000, 1001
+        s.push_str(&"b".repeat(50));
+        assert!(s.len() > 1000);
+        let out = truncate_on_char_boundary(&s, 1000);
+        assert!(out.ends_with("... (truncated)"));
+        assert!(out.starts_with(&"a".repeat(998)));
+        assert!(!out.contains('\u{1F600}'));
+    }
+
+    #[test]
+    fn truncate_leaves_short_strings_unchanged() {
+        assert_eq!(truncate_on_char_boundary("short body", 1000), "short body");
+    }
 
     #[test]
     fn parse_openai_batch_valid() {

--- a/src/engine/activity.rs
+++ b/src/engine/activity.rs
@@ -128,8 +128,14 @@ impl MemoryEngine {
                         drop(conn);
                         ActivityStatus::Promoted
                     }
-                    Err(_) => {
-                        // Promotion failed (e.g., embedding error). Record as normal.
+                    Err(e) => {
+                        // Promotion failed (e.g., embedding error). Record as
+                        // normal, but surface the failure so it is not silent.
+                        tracing::warn!(
+                            activity_id,
+                            error = %e,
+                            "activity promotion to fact failed; recording without promotion"
+                        );
                         ActivityStatus::Recorded
                     }
                 }

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -246,6 +246,7 @@ pub fn hybrid_search(
 
     let diagnostics = QueryDiagnostics {
         candidates_before_filter: ranked_count,
+        results_returned: results.len(),
         fts_candidates: fts_candidate_count,
         vector_candidates: vec_candidate_count,
         ..QueryDiagnostics::default()


### PR DESCRIPTION
## Summary

Three correctness fixes from the `/super-qa` audit (#504), each adversarially reviewed (3 independent lenses, in lieu of `/super-review`).

### Fixes
1. **embed — `embed_batch` single-format + UTF-8-safe truncation** (`memory-engine-embed/src/http.rs`)
   - Adds an `else if body.get("embedding")` branch handling a top-level single `{"embedding":[...]}` response (e.g. Ollama's legacy `/api/embeddings`), gated on a single-text request (a multi-text batch collapsing to one embedding is a server contract violation → hard error). Mirrors the existing single-`embed()` path. **Purely additive** — branch order (`data` → `embeddings` → `embedding`) keeps array responses on their existing branches.
   - Replaces `&body_str[..1000]` (raw byte index → **panics** if byte 1000 splits a multibyte UTF-8 codepoint) with a char-boundary-safe truncation. This is the error/diagnostic path, exactly where odd encodings appear.
2. **core/activity — surface silent promotion failure** (`src/engine/activity.rs`)
   - `record_activity`'s promotion `Err(_)` arm silently swallowed the error. Now binds it and emits `tracing::warn!(activity_id, error = %e, …)`. The intentional fallback to `ActivityStatus::Recorded` is preserved.
3. **retrieval/hybrid — set `results_returned`** (`src/search/hybrid.rs`)
   - `QueryDiagnostics::results_returned` was documented but never assigned (fell through to `default()` = 0). Now set to `results.len()`.
   - _Nuance:_ on the engine's public query path this field is authoritatively (re)computed at `query.rs:255` after post-filters/truncation. This fix corrects the value observed by **direct callers of the `pub fn hybrid_search`** (re-exported as `memory_engine::search::hybrid_search`), where it was stuck at 0.

The `clippy::explicit_counter_loop` finding (`scopes.rs`) was already resolved upstream — no change needed.

Fixes #504

## Verification (local — no CI runs build/clippy/test in this repo)
`cargo fmt --check` ✓ · `cargo build --workspace --all-features` ✓ · `cargo clippy --workspace --all-targets` ✓ (0 new warnings; 122 pre-existing, tracked under #516) · `cargo test --workspace` ✓ (840 passed).

## Adversarial review (3 lenses, in lieu of /super-review)
- **Correctness:** LGTM — empty-batch guard, char-boundary termination/underflow, branch order verified.
- **Idiom + feature-axis:** LGTM — clippy-clean; `..default()` FRU compiles archive-on/off; `tracing` valid + idiomatic.
- **Breakage + judgment:** LGTM — embed branch additive & non-mis-routing; char-boundary unbreakable; surfaced the `results_returned` public-path nuance above.

## Optional follow-ups (LOW, out of scope)
- `http.rs`: single `embed()` is lenient on a malformed `embedding` value (`.ok()` fallthrough) while the new batch branch is strict (hard error). Behavior-equivalent; could be made symmetric.
- `activity.rs`: on promotion failure the activity row's persisted DB status isn't updated to `Recorded` (only the in-memory return value). Pre-existing; this PR only added logging.
