### PR TITLE
fix(core): snap embed_batch error truncation to a UTF-8 char boundary

### DIFF
--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -219,11 +219,7 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
             Self::parse_ollama_batch(arr, texts.len())?
         } else {
             let body_str = serde_json::to_string(&body).unwrap_or_default();
-            let truncated = if body_str.len() > 1000 {
-                format!("{}... (truncated)", &body_str[..1000])
-            } else {
-                body_str
-            };
+            let truncated = truncate_on_char_boundary(&body_str, 1000);
             return Err(MemoryError::Internal(format!(
                 "cannot extract embeddings from batch response: {truncated}"
             )));
@@ -248,9 +244,47 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
     }
 }
 
+/// Truncate `s` to at most `max` bytes for an error message, snapping the cut
+/// down to the nearest UTF-8 char boundary.
+///
+/// `serde_json::to_string` emits non-ASCII as raw UTF-8, so a serialized
+/// response body can contain multibyte codepoints. Slicing at a raw byte index
+/// that lands inside one panics; this walks the index down to a boundary first.
+/// Byte 0 is always a boundary, so the loop terminates.
+fn truncate_on_char_boundary(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}... (truncated)", &s[..end])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_snaps_down_to_char_boundary() {
+        // A 4-byte emoji at bytes 998..1002 straddles the byte-1000 cut.
+        // A raw `&s[..1000]` slice would panic; the helper must snap to 998.
+        let mut s = "a".repeat(998);
+        s.push('\u{1F600}'); // emoji, 4 bytes: indices 998, 999, 1000, 1001
+        s.push_str(&"b".repeat(50));
+        assert!(s.len() > 1000);
+        let out = truncate_on_char_boundary(&s, 1000);
+        assert!(out.ends_with("... (truncated)"));
+        assert!(out.starts_with(&"a".repeat(998)));
+        // Emoji dropped (boundary snapped below it); no panic, valid UTF-8 out.
+        assert!(!out.contains('\u{1F600}'));
+    }
+
+    #[test]
+    fn truncate_leaves_short_strings_unchanged() {
+        assert_eq!(truncate_on_char_boundary("short body", 1000), "short body");
+    }
 
     #[test]
     fn parse_openai_batch_valid() {


### PR DESCRIPTION
## Fix the multibyte-UTF-8 truncation panic in `embed_batch`

Closes #526.

`HttpEmbeddingProvider::embed_batch` built its "unrecognized response" error
message by slicing the serialized body at a fixed **byte** index:

```rust
let truncated = format!("{}... (truncated)", &body_str[..1000]);
```

`serde_json::to_string` passes non-ASCII through as raw UTF-8, so when a
multibyte codepoint straddles byte 1000 the slice is not on a char boundary
and **panics** (`byte index 1000 is not a char boundary`).

### Change

- Extract `truncate_on_char_boundary(s, max)` — snaps the cut **down** to the
  nearest UTF-8 boundary (byte 0 is always a boundary, so it terminates).
- Route the `embed_batch` error path through it.
- Regression test: a 4-byte codepoint placed at bytes 998–1001 so byte 1000
  lands mid-codepoint (panics on the old code, snaps to 998 on the new) + a
  short-string passthrough test.

### Verification

- `cargo test -p memory-engine-embed` — 7 passed, incl. the 2 new tests
- `cargo clippy --workspace --all-targets` — 0 deny
- `cargo fmt` — clean

Found off-script during #506 wave-1 work; filed and fixed separately per the
collateral-issue convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
