### PR TITLE
perf: hoist per-iteration allocation and recompute (super-qa #505)

### DIFF
--- a/src/archive/search.rs
+++ b/src/archive/search.rs
@@ -41,6 +41,9 @@ pub fn search_archives(
     let mut all_results: Vec<SearchResult> = Vec::new();
     let mut paks_scanned = 0usize;
 
+    // Pre-compute the lowercased query once; it is invariant across all facts.
+    let query_text_lower = query.text.as_ref().map(|text| text.to_lowercase());
+
     for entry in manifest_entries {
         let pak_path = archive_dir.join(&entry.pak_path);
         // Path traversal guard: ensure resolved path stays inside archive_dir
@@ -66,8 +69,8 @@ pub fn search_archives(
             let mut matched = false;
 
             // Text matching — simple case-insensitive substring
-            if let Some(ref text) = query.text {
-                if fact.content.to_lowercase().contains(&text.to_lowercase()) {
+            if let Some(ref text_lower) = query_text_lower {
+                if fact.content.to_lowercase().contains(text_lower) {
                     score += 1.0;
                     matched = true;
                 }

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -103,18 +103,18 @@ pub fn prune(
     // decay-exempt fact types are unforgettable — they bypass the expiry
     // filter entirely (but still get scores materialized and count in
     // `facts_evaluated`).
-    let scored: Vec<(i64, f64)> = active_facts
+    let scored: Vec<f64> = active_facts
         .iter()
         .map(|fact| {
             let degree = graph.degree(fact.id);
-            (fact.id, compute_importance(fact, degree, now, policy))
+            compute_importance(fact, degree, now, policy)
         })
         .collect();
 
     let to_expire: Vec<i64> = active_facts
         .iter()
         .zip(&scored)
-        .filter_map(|(fact, &(_, score))| {
+        .filter_map(|(fact, &score)| {
             if fact.is_pinned || policy.is_decay_exempt(&fact.fact_type) {
                 return None;
             }
@@ -128,8 +128,8 @@ pub fn prune(
 
     // Materialize importance scores for all active facts (reusing the
     // scores computed above).
-    for &(fact_id, score) in &scored {
-        fact_store.update_importance_score(fact_id, score)?;
+    for (fact, &score) in active_facts.iter().zip(&scored) {
+        fact_store.update_importance_score(fact.id, score)?;
     }
 
     // Expire low-importance unpinned facts

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -98,31 +98,38 @@ pub fn prune(
     let active_facts = fact_store.list_active(None)?;
     let facts_evaluated = active_facts.len();
 
-    // Score all facts before mutating, so degree values are consistent.
-    // Pinned facts and decay-exempt fact types are unforgettable — they
-    // bypass the expiry filter entirely (but still get scores materialized
-    // and count in `facts_evaluated`).
+    // Score all facts once before mutating, so degree values are consistent
+    // and importance is computed a single time per fact. Pinned facts and
+    // decay-exempt fact types are unforgettable — they bypass the expiry
+    // filter entirely (but still get scores materialized and count in
+    // `facts_evaluated`).
+    let scored: Vec<(i64, f64)> = active_facts
+        .iter()
+        .map(|fact| {
+            let degree = graph.degree(fact.id);
+            (fact.id, compute_importance(fact, degree, now, policy))
+        })
+        .collect();
+
     let to_expire: Vec<i64> = active_facts
         .iter()
-        .filter(|fact| {
+        .zip(&scored)
+        .filter_map(|(fact, &(_, score))| {
             if fact.is_pinned || policy.is_decay_exempt(&fact.fact_type) {
-                return false;
+                return None;
             }
-            let degree = graph.degree(fact.id);
-            compute_importance(fact, degree, now, policy) < policy.min_importance
+            (score < policy.min_importance).then_some(fact.id)
         })
-        .map(|f| f.id)
         .collect();
 
     let tx = conn.unchecked_transaction()?;
     let fact_store = FactStore::new(&tx, embed_dim);
     let edge_store = EdgeStore::new(&tx);
 
-    // Materialize importance scores for all active facts
-    for fact in &active_facts {
-        let degree = graph.degree(fact.id);
-        let score = compute_importance(fact, degree, now, policy);
-        fact_store.update_importance_score(fact.id, score)?;
+    // Materialize importance scores for all active facts (reusing the
+    // scores computed above).
+    for &(fact_id, score) in &scored {
+        fact_store.update_importance_score(fact_id, score)?;
     }
 
     // Expire low-importance unpinned facts


### PR DESCRIPTION
Two **behavior-preserving** performance fixes from the super-qa #505 medium sweep (auto-fix).

### Findings addressed
- **`archive/performance-to-lowercase-per-fact`** (`src/archive/search.rs`): the lowercased query string was re-allocated on every fact in the per-`.pak` inner loop. Now computed once before the loop into `query_text_lower`. Drops query lowercasing from O(total facts) to O(1) allocations.
- **`forgetting/perf-double-compute-importance`** (`src/forgetting/policy.rs`): `compute_importance` + `graph.degree` ran **twice** per unpinned fact (once in the `to_expire` filter closure, once in the materialize loop). Now computed once into a reused `scored` Vec; the expire decision and score materialization both read from it.

Results are **identical** — only allocation/compute counts change.

### Verification
- Gate (in an isolated worktree off `236538e`): `cargo build -p memory-engine --features archive` ✅, `cargo test -p memory-engine [--features archive]` ✅ (679 passed), `cargo clippy --features archive --all-targets` ✅, `cargo fmt --check` ✅.
- **Adversarial review** (2 lenses, in-house subagents — no external quota):
  - *result-equivalence*: **approve** — proved no hoisted value can differ between iterations (`query` is an immutable borrow; no `graph` mutation between the two original compute sites; `zip(&scored)` is index-aligned and keys off `fact.id`).
  - *perf-validity*: **approve** — real wins, no new clones/allocations, no borrow-scope regression.

Part of #505.
