### PR TITLE
test: cover untested branches (super-qa #505)

### DIFF
--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -356,6 +356,79 @@ mod tests {
     }
 
     #[test]
+    fn parse_openai_batch_missing_index() {
+        // Item lacks the "index" field -> the `ok_or_else` on line 60-62 fires.
+        let data = vec![
+            serde_json::json!({"index": 0, "embedding": [0.1]}),
+            serde_json::json!({"embedding": [0.2]}), // no "index"
+        ];
+        let result = HttpEmbeddingProvider::parse_openai_batch(&data, 2);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing 'index' in data item")
+        );
+    }
+
+    #[test]
+    fn parse_openai_batch_index_wrong_type() {
+        // "index" present but not a u64 -> as_u64() returns None -> error.
+        let data = vec![serde_json::json!({"index": "zero", "embedding": [0.1]})];
+        let result = HttpEmbeddingProvider::parse_openai_batch(&data, 1);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing 'index' in data item")
+        );
+    }
+
+    #[test]
+    fn parse_openai_batch_missing_embedding() {
+        // Item lacks "embedding" -> the `ok_or_else` on line 67-71 fires,
+        // reporting the index from the item.
+        let data = vec![serde_json::json!({"index": 0})];
+        let result = HttpEmbeddingProvider::parse_openai_batch(&data, 1);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot parse embedding at index 0")
+        );
+    }
+
+    #[test]
+    fn parse_openai_batch_unparseable_embedding() {
+        // "embedding" present but not an array of numbers -> from_value fails.
+        let data = vec![serde_json::json!({"index": 0, "embedding": "not-a-vec"})];
+        let result = HttpEmbeddingProvider::parse_openai_batch(&data, 1);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot parse embedding at index 0")
+        );
+    }
+
+    #[test]
+    fn parse_openai_batch_duplicate_index() {
+        // Two items share index 0, none is index 1 -> continuity check on
+        // line 78-84 fires with the "gap or duplicate" message.
+        let data = vec![
+            serde_json::json!({"index": 0, "embedding": [0.1]}),
+            serde_json::json!({"index": 0, "embedding": [0.2]}),
+        ];
+        let result = HttpEmbeddingProvider::parse_openai_batch(&data, 2);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("gap or duplicate"));
+    }
+
+    #[test]
     fn parse_ollama_batch_valid() {
         let data = vec![serde_json::json!([0.1, 0.2]), serde_json::json!([0.3, 0.4])];
         let result = HttpEmbeddingProvider::parse_ollama_batch(&data, 2).unwrap();

--- a/src/bootstrap/parse.rs
+++ b/src/bootstrap/parse.rs
@@ -194,7 +194,7 @@ pub fn parse_timestamp(s: &str) -> Option<DateTime<Utc>> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Datelike;
+    use chrono::{Datelike, Timelike};
 
     use super::*;
     use std::io::BufReader;
@@ -311,5 +311,75 @@ mod tests {
     #[test]
     fn parse_timestamp_invalid() {
         assert!(parse_timestamp("not-a-date").is_none());
+    }
+
+    #[test]
+    fn parse_timestamp_naive_no_timezone_fallback() {
+        // No timezone suffix: RFC 3339 parse fails, the naive fallback
+        // (parse.rs:185-188) takes over and interprets it as UTC.
+        let dt = parse_timestamp("2026-03-19T10:30:45").unwrap();
+        assert_eq!(dt.year(), 2026);
+        assert_eq!(dt.month(), 3);
+        assert_eq!(dt.day(), 19);
+        assert_eq!(dt.hour(), 10);
+        assert_eq!(dt.minute(), 30);
+        assert_eq!(dt.second(), 45);
+        // The naive timestamp must be promoted to the UTC zone.
+        assert_eq!(dt, parse_timestamp("2026-03-19T10:30:45Z").unwrap());
+    }
+
+    #[test]
+    fn parse_content_blocks_tool_result_string_content() {
+        // String content + is_error=true exercises the `v.is_string()` arm
+        // and the explicit is_error read (parse.rs:152-163).
+        let content = serde_json::json!([{
+            "type": "tool_result",
+            "content": "command output",
+            "is_error": true
+        }]);
+        let blocks = parse_content_blocks(&content);
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            ContentBlock::ToolResult { content, is_error } => {
+                assert_eq!(content, "command output");
+                assert!(*is_error);
+            }
+            other => panic!("expected ToolResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_content_blocks_tool_result_non_string_content_defaults_no_error() {
+        // Non-string content takes the `Some(v) => v.to_string()` arm, and
+        // a missing `is_error` defaults to false.
+        let content = serde_json::json!([{
+            "type": "tool_result",
+            "content": [{"type": "text", "text": "nested"}]
+        }]);
+        let blocks = parse_content_blocks(&content);
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            ContentBlock::ToolResult { content, is_error } => {
+                // Serialized JSON of the non-string content.
+                assert!(content.contains("nested"));
+                assert!(!*is_error, "missing is_error must default to false");
+            }
+            other => panic!("expected ToolResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_content_blocks_tool_result_missing_content_empty_string() {
+        // Absent `content` takes the `None => String::new()` arm.
+        let content = serde_json::json!([{"type": "tool_result"}]);
+        let blocks = parse_content_blocks(&content);
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            ContentBlock::ToolResult { content, is_error } => {
+                assert_eq!(content, "");
+                assert!(!*is_error);
+            }
+            other => panic!("expected ToolResult, got {other:?}"),
+        }
     }
 }

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -338,7 +338,7 @@ mod tests {
         // user:michael appears exactly once despite being in both sets.
         assert_eq!(inh.iter().filter(|&&id| id == user_id).count(), 1);
         // All four ids are unique (no duplicate from the overlap).
-        let mut sorted = inh.clone();
+        let mut sorted = inh;
         sorted.sort_unstable();
         sorted.dedup();
         assert_eq!(sorted.len(), 4, "inherited() must not emit duplicates");

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -296,6 +296,73 @@ mod tests {
     }
 
     #[test]
+    fn path_for_id_root_returns_slash() {
+        let tree = setup_tree();
+        // Root scope is the display-only "/" path (tree.rs:151-153).
+        assert_eq!(
+            tree.path_for_id(ScopeTree::root_id()),
+            Some("/".to_string())
+        );
+    }
+
+    #[test]
+    fn path_for_id_unknown_returns_none() {
+        let tree = setup_tree();
+        // ID absent from the tree short-circuits to None (tree.rs:148-150).
+        assert_eq!(tree.path_for_id(424_242), None);
+    }
+
+    #[test]
+    fn path_for_id_non_root_joins_labels() {
+        let tree = setup_tree();
+        let demo_id = tree.resolve_path("user:michael/project:demo").unwrap();
+        // Root is excluded; remaining labels are joined leaf-last.
+        assert_eq!(
+            tree.path_for_id(demo_id),
+            Some("user:michael/project:demo".to_string())
+        );
+    }
+
+    #[test]
+    fn inherited_non_leaf_dedups_self_once() {
+        let tree = setup_tree();
+        // user:michael is a NON-leaf: its subtree has 3 nodes (itself + 2
+        // projects). inherited() must add user:michael exactly once (via
+        // ancestors) and append only the descendants, exercising the
+        // `if id != scope_id` dedup branch (tree.rs:95-99).
+        let user_id = tree.resolve_path("user:michael").unwrap();
+        let inh = tree.inherited(user_id);
+        // ancestors(user) = [user, root] (2); subtree(user) = [user, demo, other]
+        // dedup user -> append demo, other => [user, root, demo, other] = 4.
+        assert_eq!(inh.len(), 4);
+        // user:michael appears exactly once despite being in both sets.
+        assert_eq!(inh.iter().filter(|&&id| id == user_id).count(), 1);
+        // All four ids are unique (no duplicate from the overlap).
+        let mut sorted = inh.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), 4, "inherited() must not emit duplicates");
+    }
+
+    #[test]
+    fn ancestors_unknown_id_returns_singleton() {
+        let tree = setup_tree();
+        // Unknown id: the while-loop pushes the id, then nodes.get fails so
+        // parent_id resolves to None and the loop ends (tree.rs:61-68).
+        let anc = tree.ancestors(999_999);
+        assert_eq!(anc, vec![999_999]);
+    }
+
+    #[test]
+    fn subtree_unknown_id_returns_singleton() {
+        let tree = setup_tree();
+        // Unknown id has no children entry, so the BFS yields just the seed
+        // (tree.rs:72-84).
+        let sub = tree.subtree(999_999);
+        assert_eq!(sub, vec![999_999]);
+    }
+
+    #[test]
     fn insert_new_node() {
         let mut tree = setup_tree();
         let node_count_before = tree.nodes.len();

--- a/src/search/ann.rs
+++ b/src/search/ann.rs
@@ -567,6 +567,42 @@ mod tests {
         }
 
         #[test]
+        fn hnsw_strategy_empty_index_returns_empty() {
+            // DB with no facts -> index_to_fact is empty, so search() hits the
+            // `n_items == 0` early return (ann.rs:248-253) before any nearest()
+            // call, returning an empty vec.
+            let conn = open_memory().unwrap();
+            init_schema(&conn).unwrap();
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+            assert_eq!(strategy.active_count(), 0);
+
+            let query = [1.0_f32, 0.0, 0.0, 0.0];
+            let results = strategy.search(&conn, &query, DIM, 5, None, None).unwrap();
+            assert!(results.is_empty(), "empty index must yield no results");
+        }
+
+        #[test]
+        fn hnsw_strategy_dim_mismatch_errors() {
+            let (conn, _ids) = setup_with_facts();
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+
+            // Query length != strategy.embed_dim -> EmbeddingDimension error
+            // before any index access (ann.rs:230-235). The `_embed_dim`
+            // parameter is intentionally ignored; the strategy's own dim wins.
+            let wrong = [1.0_f32, 0.0]; // len 2, DIM is 4
+            let err = strategy
+                .search(&conn, &wrong, DIM, 5, None, None)
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                crate::error::MemoryError::EmbeddingDimension {
+                    expected: 4,
+                    actual: 2
+                }
+            ));
+        }
+
+        #[test]
         fn hnsw_strategy_notify_expire_excludes_from_results() {
             let (conn, ids) = setup_with_facts();
             let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();

--- a/src/search/fts.rs
+++ b/src/search/fts.rs
@@ -285,6 +285,37 @@ mod tests {
         assert!(results.is_empty());
     }
 
+    #[test]
+    fn fts_search_empty_query_returns_empty() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store.insert(&make_fact("Rust language")).unwrap();
+
+        // An empty MATCH string is an FTS5 syntax error -> caught and mapped
+        // to an empty result vec (fts.rs:30-83), never an Err.
+        let results = fts_search(&conn, "", 10, None, None).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn fts_search_empty_scope_slice_matches_nothing() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store.insert(&make_fact("Rust language")).unwrap();
+
+        // Some(&[]) serializes to "[]"; the `scope_id IN (SELECT ... json_each)`
+        // subquery is empty, so no row can match (fts.rs:43-45) — distinct
+        // from None, which disables the filter entirely.
+        let scoped = fts_search(&conn, "Rust", 10, None, Some(&[])).unwrap();
+        assert!(
+            scoped.is_empty(),
+            "empty scope slice must exclude all facts"
+        );
+        // Sanity: the same query with no scope filter does find the fact.
+        let unscoped = fts_search(&conn, "Rust", 10, None, None).unwrap();
+        assert_eq!(unscoped.len(), 1);
+    }
+
     // --- fts_count_expired tests ---
 
     #[test]

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -264,6 +264,31 @@ mod tests {
         assert_eq!(results.len(), 1);
     }
 
+    #[test]
+    fn vector_search_empty_scope_slice_matches_nothing() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        store
+            .insert(&make_fact_with_embedding(
+                "fact one",
+                vec![1.0, 0.0, 0.0, 0.0],
+            ))
+            .unwrap();
+
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        // Some(&[]) serializes to "[]"; the json_each subquery is empty so the
+        // `scope_id IN (...)` predicate excludes every fact (vector.rs:61-63),
+        // unlike None which disables the filter.
+        let scoped = vector_search(&conn, &query, DIM, 10, None, Some(&[])).unwrap();
+        assert!(
+            scoped.is_empty(),
+            "empty scope slice must exclude all facts"
+        );
+        // Sanity: with no scope filter the fact is found.
+        let unscoped = vector_search(&conn, &query, DIM, 10, None, None).unwrap();
+        assert_eq!(unscoped.len(), 1);
+    }
+
     mod proptest_cosine {
         use super::*;
         use proptest::prelude::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -625,6 +625,60 @@ mod tests {
         assert_eq!(ActivityStatus::Promoted.to_string(), "promoted");
     }
 
+    // --- ActivityStatus::from_str round-trip + error path ---
+
+    #[test]
+    fn activity_status_from_str_all_known_variants() {
+        use std::str::FromStr;
+
+        assert_eq!(
+            ActivityStatus::from_str("recorded").unwrap(),
+            ActivityStatus::Recorded
+        );
+        assert_eq!(
+            ActivityStatus::from_str("deduplicated").unwrap(),
+            ActivityStatus::Deduplicated
+        );
+        assert_eq!(
+            ActivityStatus::from_str("ignored").unwrap(),
+            ActivityStatus::Ignored
+        );
+        assert_eq!(
+            ActivityStatus::from_str("promoted").unwrap(),
+            ActivityStatus::Promoted
+        );
+    }
+
+    #[test]
+    fn activity_status_from_str_round_trips_with_display() {
+        use std::str::FromStr;
+
+        for status in [
+            ActivityStatus::Recorded,
+            ActivityStatus::Deduplicated,
+            ActivityStatus::Ignored,
+            ActivityStatus::Promoted,
+        ] {
+            let rendered = status.to_string();
+            assert_eq!(
+                ActivityStatus::from_str(&rendered).unwrap(),
+                status,
+                "Display->from_str round-trip failed for {status:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn activity_status_from_str_unknown_is_error() {
+        use std::str::FromStr;
+
+        let err = ActivityStatus::from_str("bogus").unwrap_err();
+        assert_eq!(err, "unknown activity status: bogus");
+        // Case-sensitivity: the matcher expects lowercase variants.
+        assert!(ActivityStatus::from_str("Recorded").is_err());
+        assert!(ActivityStatus::from_str("").is_err());
+    }
+
     // --- Phase 5a type tests ---
 
     #[test]


### PR DESCRIPTION
**23 additive unit tests** across 7 files, covering branches flagged uncovered by the super-qa #505 medium sweep (auto-fix). **No production code changed.**

### Findings addressed
| Area | Branch now covered |
|---|---|
| bootstrap | `parse_timestamp` naive (no-TZ) fallback; `ContentBlock::ToolResult` all 3 content arms |
| core | `ActivityStatus::from_str` (all variants + error + case-sensitivity + round-trip) |
| embed | 5 `parse_openai_batch` error branches (test module only; `parse_openai_batch` untouched) |
| scope | `path_for_id` root/unknown; `inherited()` non-leaf dedup; `ancestors`/`subtree` unknown-id singleton |
| retrieval | FTS empty query; FTS/vector `Some(&[])` empty-scope slice; HNSW empty-index + dim-mismatch (`--features ann`) |

### Verification
- Gate: `cargo test -p memory-engine` ✅, `--features ann --lib` ✅ (601 passed), `cargo test -p memory-engine-embed` ✅, clippy + `cargo fmt --check` ✅.
- **Adversarial review** (2 lenses): *test-validity* **approve** (each test provably reaches its named branch — e.g. empty-FTS-query confirmed to raise the `fts5: syntax error` caught path via a SQLite probe; HNSW tests correctly `#[cfg(feature=ann)]`-gated), *coverage-adequacy* **approve** (specific error-struct/string assertions, not bare `is_err()`).

### Declined nits (documented, non-blocking)
- A suggested `fts_count_expired` empty-query sibling test — **already covered** by the existing `fts_count_expired_syntax_error_returns_zero` (empty `""` routes through the identical fallback).
- A cosmetic test-name note for `parse_openai_batch_index_wrong_type` (a present-but-non-`u64` index intentionally shares the "missing index" path) — left to avoid churn in the contested `http.rs`.

Part of #505.
