### PR TITLE
docs: complete # Errors and module-doc gaps (super-qa #505)

### DIFF
--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -321,11 +321,7 @@ fn query_table_output_shows_temporal_columns() {
 
 // --- export + import roundtrip ---
 
-// NOTE: Skipped due to pre-existing library bug — restore.rs has
-// CURRENT_SCHEMA_VERSION=5 but running schema is v6 after #78/#92.
-// Re-enable once the library's restore tests are fixed.
 #[test]
-#[ignore]
 fn export_import_roundtrip() {
     let (dir, db_path) = create_test_db();
 

--- a/memory-engine-mcp/src/server.rs
+++ b/memory-engine-mcp/src/server.rs
@@ -68,7 +68,9 @@ impl ServerHandler for MemoryMcpServer {
              memory_get_fact, memory_statistics, memory_flush_insights, \
              memory_consolidate, memory_forget, memory_dump_state, \
              memory_pin_fact, memory_unpin_fact, \
-             memory_replay_events, memory_fact_history, memory_bootstrap_session. \
+             memory_replay_events, memory_fact_history, memory_bootstrap_session, \
+             memory_record_outcome, memory_outcome_counts, memory_record_activity, \
+             memory_checkpoint_session, memory_load_context. \
              Use depth=sparse|standard|full on query tools to control response verbosity.",
             )
     }

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -13,7 +13,12 @@ use crate::store::facts::FactStore;
 /// fact. Deterministic tie-break: on equal importance, the newer fact (higher id) is
 /// expired.
 ///
-/// Returns count of duplicates removed.
+/// Returns `(count, expired_ids)`: the number of duplicates removed and the
+/// ids of the facts that were expired (so the caller can update vector
+/// indexes). As a sentinel, when the active corpus exceeds the internal
+/// `MAX_DEDUP_FACTS` cap the pass is skipped and the count is `usize::MAX`
+/// with an empty id list, signaling the orchestrator NOT to advance the
+/// consolidation watermark.
 ///
 /// # Errors
 ///

--- a/src/engine/activity.rs
+++ b/src/engine/activity.rs
@@ -157,6 +157,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` on write failure.
     // `conn` (write lock) is used by both the `last_activity_id` query and the
     // final `upsert` (the return expression), so it cannot be dropped earlier

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -19,6 +19,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns errors from embedding, DB insertion, or scope resolution.
     // `conn` (write lock) legitimately spans scope resolution and the inner
     // bootstrap call (the function's return expression), so it cannot be
@@ -64,6 +65,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Io` for directory traversal failures.
     // `conn` (write lock) legitimately spans scope resolution and the inner
     // bootstrap call (the function's return expression), so it cannot be

--- a/src/engine/conflict.rs
+++ b/src/engine/conflict.rs
@@ -17,6 +17,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::NotFound` if the old fact doesn't exist.
     /// Propagates errors from the arbiter or database operations.
     pub fn resolve_conflict(

--- a/src/engine/consolidation.rs
+++ b/src/engine/consolidation.rs
@@ -12,6 +12,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Propagates errors from any consolidation pass or the `SummaryGenerator`.
     pub fn consolidate(
         &self,

--- a/src/engine/forgetting.rs
+++ b/src/engine/forgetting.rs
@@ -18,6 +18,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Conflict` if the policy is invalid.
     /// Returns `MemoryError::Database` on SQL failure.
     pub fn forget(&self, policy: &ForgetPolicy) -> Result<PruneStats> {
@@ -42,6 +43,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` if the update fails.
     pub fn pin_fact(&self, id: i64) -> Result<()> {
         let conn = self.write_conn()?;
@@ -52,6 +54,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` if the update fails.
     pub fn unpin_fact(&self, id: i64) -> Result<()> {
         let conn = self.write_conn()?;

--- a/src/engine/graph.rs
+++ b/src/engine/graph.rs
@@ -37,6 +37,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` on SQL failure.
     /// Returns `MemoryError::NotFound` if `scope` is `Some` but the path
     /// does not exist.

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -31,6 +31,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` on insert failure.
     pub fn ingest(&self, event: &NewEvent) -> Result<i64> {
         let conn = self.write_conn()?;
@@ -45,6 +46,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns errors from embedding computation, dimension validation, or DB insert.
     // `conn` (write lock) is reused by `FactStore::new(&conn).insert(..)` at the
     // block's return expression; clippy's nursery suggestion to drop it after
@@ -237,6 +239,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns errors from batch embedding, dimension validation, or DB insert.
     // `conn` (write lock) spans the whole savepoint transaction via FactStore/
     // ScopeStore wrappers that borrow it; clippy misses the transitive borrow.

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -118,8 +118,12 @@ impl MemoryEngine {
     /// Returns [`MemoryError::Io`] on filesystem failure.
     /// Returns [`MemoryError::Conflict`] if the target path resolves to the live database.
     /// Returns [`MemoryError::Database`] on SQL failure.
+    /// Returns [`MemoryError::Serialization`] for the JSON formats if snapshot
+    /// serialization fails.
     /// Returns [`MemoryError::NotImplemented`] if a compression format is used
     /// without the corresponding feature enabled.
+    /// Returns [`MemoryError::ReadOnly`] for the `Sqlite` format if the engine
+    /// was opened read-only (the `VACUUM INTO` backup acquires the write lock).
     #[allow(unreachable_patterns)] // wildcard needed for #[non_exhaustive] forward compat
     pub fn dump_state(&self, format: &crate::inspect::DumpFormat) -> Result<()> {
         match format {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -562,6 +562,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` on write failure.
     pub fn set_config(&self, key: &str, value: &str) -> Result<()> {
         let conn = self.write_conn()?;
@@ -590,6 +591,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` on insert failure.
     pub fn ensure_scope_path(&self, path: &str) -> Result<i64> {
         let conn = self.write_conn()?;

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -17,6 +17,8 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Reranker` if a configured [`Reranker`](crate::traits::Reranker)
+    /// fails or returns an invalid permutation.
     ///
     /// # Panics
     ///

--- a/src/inspect/dump.rs
+++ b/src/inspect/dump.rs
@@ -183,8 +183,10 @@ pub fn dump_json_zstd(conn: &Connection, embed_dim: usize, path: &Path) -> Resul
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Io`] on filesystem failures or
-/// [`MemoryError::Internal`] if `VACUUM INTO` fails.
+/// Returns [`MemoryError::Conflict`] if `path` resolves to the live database
+/// file (refusing to overwrite the source), [`MemoryError::Io`] on filesystem
+/// failures, or [`MemoryError::Internal`] if the database path cannot be read,
+/// `path` contains a null byte, or `VACUUM INTO` fails.
 pub fn dump_sqlite(conn: &Connection, path: &Path) -> Result<()> {
     // Detect whether this is a file-backed database.
     let db_path: String = conn

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -294,6 +294,12 @@ fn restore_edges(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
 ///
 /// Returns [`MemoryError::Database`] on any SQL failure (transaction rolls back).
 /// Returns [`MemoryError::Conflict`] if the database is not empty.
+/// Propagates the validation errors from [`validate_snapshot`]:
+/// [`MemoryError::Migration`] if the snapshot's `schema_version` is newer than
+/// supported, [`MemoryError::UnsupportedEpoch`] on a future storage epoch, and
+/// [`MemoryError::Internal`] if `embed_dim` is zero or the root scope is missing.
+/// Returns [`MemoryError::Serialization`] if a summary's `source_fact_ids`
+/// cannot be serialized to JSON.
 pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
     validate_snapshot(snapshot)?;
     assert_empty_db(conn)?;

--- a/src/resume/mod.rs
+++ b/src/resume/mod.rs
@@ -1,4 +1,5 @@
-//! Session bootstrapping: 3-tier context retrieval (identity, core, recent).
+//! Session bootstrapping: 5-tier context retrieval (pinned, high-importance,
+//! due, scope-filtered recent, KB stubs).
 
 pub mod context;
 

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -133,6 +133,8 @@ pub fn rrf_merge(fts: &[(i64, f64)], vec: &[(i64, f32)], k: u32) -> Vec<(i64, f6
 /// # Errors
 ///
 /// Returns `MemoryError::Database` on query failure.
+/// Returns `MemoryError::EmbeddingDimension` if the query embedding or a stored
+/// embedding does not match the configured dimension during vector search.
 pub fn hybrid_search(
     conn: &Connection,
     query: &SearchQuery,


### PR DESCRIPTION
**Additive rustdoc only** (plus removing one stale `#[ignore]`) — 10 findings from the super-qa #505 medium sweep (auto-fix). No runtime logic changed.

### Findings addressed
- **`# Errors` completeness:** `MemoryError::ReadOnly` across 13 write-path engine methods; `Reranker` on `query()`; `Conflict` + (newly) `Serialization` on `dump_state`/`dump_sqlite`; `validate_snapshot`-propagated variants on `restore_snapshot_into`; `EmbeddingDimension` on `hybrid_search`; `ReadOnly` on `pin_fact`/`unpin_fact`.
- **Doc/behavior mismatches:** resume module doc `3-tier` → `5-tier`; `local_dedup` return doc now documents the `(usize, Vec<i64>)` tuple + `usize::MAX` sentinel; MCP `get_info()` instructions now list all **23** registered tools (was 18).
- **Stale test gate:** removed `#[ignore]` + obsolete rationale on `export_import_roundtrip` — the cited schema bug is long-fixed; the test now passes un-ignored (CLI suite 18/18).

### Verification
- Every documented error/behavior verified against the actual code path before writing.
- Gate: `cargo build --workspace` ✅, `cargo test -p memory-engine-cli` ✅ (incl. un-ignored test), clippy + `cargo fmt --check` ✅, **zero new rustdoc warnings** (HEAD-vs-patched broken-link sets byte-identical).
- **Adversarial review** (2 lenses): *doc-accuracy* **approve-with-nits** (the one nit — `Serialization` on `dump_state` — is now incorporated), *doc-completeness-and-safety* **approve** (strictly additive; `activity.rs` touched at exactly one permitted doc line; contested `http.rs` untouched).

Part of #505.
