### PR TITLE
refactor: tighten visibility, stringly-typed->enum, non_exhaustive (super-qa #505)

### DIFF
--- a/docs/usage/bootstrapping-sessions.md
+++ b/docs/usage/bootstrapping-sessions.md
@@ -72,10 +72,9 @@ The default `KeywordExtractor` maps episode categories and outcomes to fact type
 ```rust
 # use memory_engine::error::Result;
 # use memory_engine::types::FactType;
-# use memory_engine::bootstrap::extract::{
-#     SessionExtractor, ExtractedFact, CandidateEpisode, EpisodeCategory,
+# use memory_engine::bootstrap::{
+#     SessionExtractor, ExtractedFact, CandidateEpisode, EpisodeCategory, SessionOutcome,
 # };
-# use memory_engine::bootstrap::outcome::SessionOutcome;
 #
 struct LlmExtractor {
     client: reqwest::blocking::Client,

--- a/memory-engine-cli/src/commands/add_fact.rs
+++ b/memory-engine-cli/src/commands/add_fact.rs
@@ -10,7 +10,7 @@ use crate::output::{self, OutputFormat, parse_datetime};
 
 /// Fact type for CLI argument parsing.
 #[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum FactTypeArg {
+pub(crate) enum FactTypeArg {
     Episodic,
     Semantic,
     Procedural,

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -143,11 +143,11 @@ fn jsonl_to_request(fact: JsonlFact, default_scope: Option<&str>) -> AddFactRequ
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Serialize)]
-pub struct IngestSummary {
-    pub total_ingested: usize,
-    pub total_skipped: usize,
-    pub failed_batches: usize,
-    pub elapsed_secs: f64,
+pub(crate) struct IngestSummary {
+    pub(crate) total_ingested: usize,
+    pub(crate) total_skipped: usize,
+    pub(crate) failed_batches: usize,
+    pub(crate) elapsed_secs: f64,
 }
 
 fn print_summary(summary: &IngestSummary, format: OutputFormat) -> anyhow::Result<()> {
@@ -177,7 +177,7 @@ fn print_summary(summary: &IngestSummary, format: OutputFormat) -> anyhow::Resul
 // Core ingestion logic (testable — accepts reader + embedder)
 // ---------------------------------------------------------------------------
 
-pub fn ingest_from_reader(
+pub(crate) fn ingest_from_reader(
     engine: &MemoryEngine,
     reader: impl Read,
     embedder: &dyn EmbeddingProvider,

--- a/memory-engine-cli/src/commands/dump.rs
+++ b/memory-engine-cli/src/commands/dump.rs
@@ -6,11 +6,23 @@ use tabled::{Table, Tabled};
 use crate::db::open_engine;
 use crate::output::{self, OutputFormat, truncate_str};
 
+/// What to dump from the database.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum DumpTarget {
+    /// Active facts only (default).
+    #[default]
+    Facts,
+    /// Event log only.
+    Events,
+    /// Both facts and events.
+    All,
+}
+
 #[derive(clap::Args)]
 pub struct DumpArgs {
     /// What to dump
-    #[arg(value_parser = ["facts", "events", "all"], default_value = "facts")]
-    target: String,
+    #[arg(value_enum, default_value_t = DumpTarget::Facts)]
+    target: DumpTarget,
 
     /// Maximum items
     #[arg(long, default_value = "100")]
@@ -50,11 +62,10 @@ struct EventRow {
 pub fn run(db: &Path, args: &DumpArgs, format: OutputFormat) -> anyhow::Result<()> {
     let engine = open_engine(db)?;
 
-    match args.target.as_str() {
-        "facts" => dump_facts(&engine, args.limit, format),
-        "events" => dump_events(&engine, args.limit, format),
-        "all" => dump_all(&engine, args.limit, format),
-        _ => unreachable!(),
+    match args.target {
+        DumpTarget::Facts => dump_facts(&engine, args.limit, format),
+        DumpTarget::Events => dump_events(&engine, args.limit, format),
+        DumpTarget::All => dump_all(&engine, args.limit, format),
     }
 }
 

--- a/memory-engine-cli/src/commands/export.rs
+++ b/memory-engine-cli/src/commands/export.rs
@@ -4,6 +4,25 @@ use memory_engine::inspect_types::DumpFormat;
 
 use crate::db::{open_engine, open_engine_writable};
 
+/// Serialization format for `export`.
+///
+/// The kebab-cased variant names are the stable CLI value tokens
+/// (`json`, `sqlite`, `json-gz`, `json-zst`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum ExportFormat {
+    /// Plain JSON snapshot (default).
+    #[default]
+    Json,
+    /// `SQLite` database copy (via `VACUUM INTO`).
+    Sqlite,
+    /// gzip-compressed JSON snapshot.
+    #[value(name = "json-gz")]
+    JsonGz,
+    /// zstd-compressed JSON snapshot.
+    #[value(name = "json-zst")]
+    JsonZst,
+}
+
 #[derive(clap::Args)]
 pub struct ExportArgs {
     /// Output file path
@@ -11,24 +30,23 @@ pub struct ExportArgs {
     output: PathBuf,
 
     /// Export format
-    #[arg(long, default_value = "json", value_parser = ["json", "sqlite", "json-gz", "json-zst"])]
-    export_format: String,
+    #[arg(long, value_enum, default_value_t = ExportFormat::Json)]
+    export_format: ExportFormat,
 }
 
 pub fn run(db: &Path, args: &ExportArgs) -> anyhow::Result<()> {
     // Only SQLite export needs write access (VACUUM INTO); others are read-only.
-    let engine = if args.export_format == "sqlite" {
+    let engine = if args.export_format == ExportFormat::Sqlite {
         open_engine_writable(db)?
     } else {
         open_engine(db)?
     };
 
-    let format = match args.export_format.as_str() {
-        "json" => DumpFormat::Json(args.output.clone()),
-        "sqlite" => DumpFormat::Sqlite(args.output.clone()),
-        "json-gz" => DumpFormat::JsonGzip(args.output.clone()),
-        "json-zst" => DumpFormat::JsonZstd(args.output.clone()),
-        _ => unreachable!("clap value_parser prevents unknown formats"),
+    let format = match args.export_format {
+        ExportFormat::Json => DumpFormat::Json(args.output.clone()),
+        ExportFormat::Sqlite => DumpFormat::Sqlite(args.output.clone()),
+        ExportFormat::JsonGz => DumpFormat::JsonGzip(args.output.clone()),
+        ExportFormat::JsonZst => DumpFormat::JsonZstd(args.output.clone()),
     };
 
     engine.dump_state(&format)?;

--- a/memory-engine-cli/src/commands/import.rs
+++ b/memory-engine-cli/src/commands/import.rs
@@ -22,7 +22,7 @@ pub fn run(db: &Path, args: &ImportArgs) -> anyhow::Result<()> {
 
     let embed_dim = match args.embed_dim {
         Some(dim) => dim,
-        None => peek_embed_dim(&args.snapshot).map_err(|e| {
+        None => peek_embed_dim_from_snapshot(&args.snapshot).map_err(|e| {
             anyhow::anyhow!("{e}\n\nHint: for compressed snapshots, pass --embed-dim explicitly")
         })?,
     };
@@ -39,8 +39,13 @@ pub fn run(db: &Path, args: &ImportArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Peek at a JSON snapshot file to extract `embed_dim` without loading everything.
-fn peek_embed_dim(path: &Path) -> anyhow::Result<usize> {
+/// Peek at a JSON snapshot file's header to extract `embed_dim` without
+/// loading the whole snapshot.
+///
+/// Reads only the leading `embed_dim` field of the JSON document. Distinct
+/// from the `SQLite`-`config`-table reader (`peek_embed_dim_from_db` in
+/// `crate::db`).
+fn peek_embed_dim_from_snapshot(path: &Path) -> anyhow::Result<usize> {
     #[derive(serde::Deserialize)]
     struct SnapshotHeader {
         embed_dim: usize,

--- a/memory-engine-cli/src/commands/record_outcome.rs
+++ b/memory-engine-cli/src/commands/record_outcome.rs
@@ -8,7 +8,7 @@ use crate::output::OutputFormat;
 
 /// Outcome variant for CLI argument parsing.
 #[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum OutcomeArg {
+pub(crate) enum OutcomeArg {
     Positive,
     Negative,
     Neutral,

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -2,8 +2,12 @@ use std::path::Path;
 
 use memory_engine::{EngineConfig, MemoryEngine};
 
-/// Peek `embed_dim` from an existing database's config table.
-fn peek_embed_dim(path: &Path) -> anyhow::Result<usize> {
+/// Peek `embed_dim` from an existing `SQLite` database's `config` table.
+///
+/// Opens a transient read-only connection and reads the `embed_dim` key.
+/// Distinct from the import path's snapshot-header reader (see
+/// `peek_embed_dim_from_snapshot` in `commands::import`).
+fn peek_embed_dim_from_db(path: &Path) -> anyhow::Result<usize> {
     anyhow::ensure!(
         path.is_file(),
         "database not found (or is a directory): {}",
@@ -34,7 +38,7 @@ fn peek_embed_dim(path: &Path) -> anyhow::Result<usize> {
 /// Uses the library's `read_only` config flag so the connection pool
 /// never acquires a write lock and never runs migrations.
 pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
-    let embed_dim = peek_embed_dim(path)?;
+    let embed_dim = peek_embed_dim_from_db(path)?;
     let mut config = EngineConfig::new(path.to_path_buf(), embed_dim);
     config.read_only = true;
     let engine = MemoryEngine::open(&config)?;
@@ -47,7 +51,7 @@ pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
 /// with SQLite format). Sets `backup_dir` next to the database so any
 /// schema migration creates a WAL-safe backup first.
 pub fn open_engine_writable(path: &Path) -> anyhow::Result<MemoryEngine> {
-    let embed_dim = peek_embed_dim(path)?;
+    let embed_dim = peek_embed_dim_from_db(path)?;
     let backup_dir = path.parent().map(Path::to_path_buf);
     let mut config = EngineConfig::new(path.to_path_buf(), embed_dim);
     config.backup_dir = backup_dir;

--- a/memory-engine-cli/src/embedding.rs
+++ b/memory-engine-cli/src/embedding.rs
@@ -2,12 +2,12 @@ use memory_engine::error::MemoryError;
 use memory_engine::traits::EmbeddingProvider;
 
 /// Pass-through embedder for pre-computed embeddings supplied via `--embedding`.
-pub struct PassthroughEmbedder {
+pub(crate) struct PassthroughEmbedder {
     embedding: Vec<f32>,
 }
 
 impl PassthroughEmbedder {
-    pub fn new(embedding: Vec<f32>) -> Self {
+    pub(crate) fn new(embedding: Vec<f32>) -> Self {
         Self { embedding }
     }
 }

--- a/memory-engine-cli/src/output.rs
+++ b/memory-engine-cli/src/output.rs
@@ -3,7 +3,7 @@ use clap::ValueEnum;
 
 /// Output format for CLI commands.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
-pub enum OutputFormat {
+pub(crate) enum OutputFormat {
     /// Human-readable table (default)
     #[default]
     Table,
@@ -19,7 +19,7 @@ pub enum OutputFormat {
 /// When `max_chars < 3` the suffix itself cannot fit; the returned string is at
 /// most `max_chars` characters long (taken from the beginning of `s`) with no
 /// ellipsis appended.
-pub fn truncate_str(s: &str, max_chars: usize) -> String {
+pub(crate) fn truncate_str(s: &str, max_chars: usize) -> String {
     if s.chars().count() <= max_chars {
         return s.to_string();
     }
@@ -47,7 +47,7 @@ pub fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
 /// # Errors
 ///
 /// Returns an error if serialization or writing to stdout fails.
-pub fn print_json<T: serde::Serialize>(value: &T) -> anyhow::Result<()> {
+pub(crate) fn print_json<T: serde::Serialize>(value: &T) -> anyhow::Result<()> {
     serde_json::to_writer_pretty(std::io::stdout(), value)?;
     println!();
     Ok(())

--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -40,11 +40,11 @@ impl HttpEmbeddingProvider {
         api_key: Option<String>,
         expected_dim: usize,
         timeout_secs: u64,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, MemoryError> {
         let client = reqwest::blocking::ClientBuilder::new()
             .timeout(std::time::Duration::from_secs(timeout_secs))
             .build()
-            .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+            .map_err(|e| MemoryError::Internal(format!("failed to build HTTP client: {e}")))?;
         Ok(Self {
             client,
             endpoint,

--- a/memory-engine-mcp/src/error.rs
+++ b/memory-engine-mcp/src/error.rs
@@ -61,6 +61,10 @@ pub fn to_mcp_error(err: MemoryError) -> ErrorData {
         ),
 
         MemoryError::Lineage(msg) => ErrorData::resource_not_found(format!("lineage: {msg}"), None),
+
+        // `MemoryError` is `#[non_exhaustive]`: future variants map to a
+        // generic internal error until handled explicitly above.
+        other => ErrorData::internal_error(other.to_string(), None),
     }
 }
 

--- a/memory-engine-mcp/src/server.rs
+++ b/memory-engine-mcp/src/server.rs
@@ -20,11 +20,11 @@ use crate::tools;
 /// All tool calls are dispatched to `tokio::task::spawn_blocking` via the engine's
 /// internal connection pool. The server holds an `Arc<MemoryEngine>` for thread-safe sharing.
 pub struct MemoryMcpServer {
-    pub engine: Arc<MemoryEngine>,
-    pub embedder: Option<Arc<HttpEmbeddingProvider>>,
-    pub summary_gen: Option<Arc<dyn SummaryGenerator + Send + Sync>>,
-    pub embed_dim: usize,
-    pub filter_config: Arc<ActivityFilterConfig>,
+    pub(crate) engine: Arc<MemoryEngine>,
+    pub(crate) embedder: Option<Arc<HttpEmbeddingProvider>>,
+    pub(crate) summary_gen: Option<Arc<dyn SummaryGenerator + Send + Sync>>,
+    pub(crate) embed_dim: usize,
+    pub(crate) filter_config: Arc<ActivityFilterConfig>,
 }
 
 impl MemoryMcpServer {

--- a/src/archive/pak.rs
+++ b/src/archive/pak.rs
@@ -100,6 +100,7 @@ impl<W: Write> Write for HashingWriter<'_, W> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::archive::types::CURRENT_PAK_VERSION;
     use chrono::Utc;
 
     /// Write an `ArchivePak` as zstd-compressed JSON (test convenience wrapper).
@@ -112,7 +113,7 @@ mod tests {
 
     fn empty_pak() -> ArchivePak {
         ArchivePak {
-            pak_version: 1,
+            pak_version: CURRENT_PAK_VERSION,
             engine_schema_version: 7,
             embed_dim: 3,
             created_at: Utc::now(),
@@ -128,7 +129,7 @@ mod tests {
         write_pak(&empty_pak(), &pak_path).unwrap();
         assert!(pak_path.exists());
         let restored = read_pak(&pak_path).unwrap();
-        assert_eq!(restored.pak_version, 1);
+        assert_eq!(restored.pak_version, CURRENT_PAK_VERSION);
         assert_eq!(restored.embed_dim, 3);
         assert!(restored.facts.is_empty());
     }

--- a/src/archive/types.rs
+++ b/src/archive/types.rs
@@ -4,6 +4,12 @@ use std::path::PathBuf;
 
 use crate::types::{Edge, Fact};
 
+/// Current on-disk format version written into every new `.pak` file.
+///
+/// Bump this when the `.pak` payload layout changes in a way that requires
+/// version-gated reading. The value is stamped into [`ArchivePak::pak_version`].
+pub const CURRENT_PAK_VERSION: u32 = 1;
+
 /// Contents of a `.pak` archive file — zstd-compressed JSON.
 ///
 /// Contains only facts and edges; events stay in the live DB
@@ -85,7 +91,7 @@ mod tests {
     #[test]
     fn archive_pak_roundtrip_serde() {
         let pak = ArchivePak {
-            pak_version: 1,
+            pak_version: CURRENT_PAK_VERSION,
             engine_schema_version: 7,
             embed_dim: 3,
             created_at: Utc::now(),
@@ -94,7 +100,7 @@ mod tests {
         };
         let json = serde_json::to_string(&pak).unwrap();
         let restored: ArchivePak = serde_json::from_str(&json).unwrap();
-        assert_eq!(restored.pak_version, 1);
+        assert_eq!(restored.pak_version, CURRENT_PAK_VERSION);
         assert_eq!(restored.embed_dim, 3);
     }
 }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -3,12 +3,12 @@
 //! Pipeline: JSONL → parse → reconstruct turns → classify outcome → keyword pre-filter
 //! → extract facts → ingest marker event + add facts.
 
-pub mod extract;
-pub mod filter;
-pub mod metrics;
-pub mod outcome;
-pub mod parse;
-pub mod redact;
+pub(crate) mod extract;
+pub(crate) mod filter;
+pub(crate) mod metrics;
+pub(crate) mod outcome;
+pub(crate) mod parse;
+pub(crate) mod redact;
 
 use std::io::BufRead;
 use std::path::Path;

--- a/src/bootstrap/parse.rs
+++ b/src/bootstrap/parse.rs
@@ -25,6 +25,12 @@ pub enum EntryType {
 }
 
 /// A single line from a Claude Code JSONL session file.
+///
+/// Several fields (`cwd`, `git_branch`, `data`) mirror the on-disk JSONL schema
+/// for round-trip fidelity but are not consumed by the current pipeline; they
+/// are retained as deserialization targets and documentation of the wire
+/// format. The `#[allow(dead_code)]` is scoped to those fields and surfaced
+/// only because the module is `pub(crate)`.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionEntry {
@@ -34,19 +40,23 @@ pub struct SessionEntry {
     pub timestamp: Option<String>,
     pub uuid: Option<String>,
     pub parent_uuid: Option<String>,
+    #[allow(dead_code)] // schema field, parsed but not yet consumed
     pub cwd: Option<String>,
+    #[allow(dead_code)] // schema field, parsed but not yet consumed
     pub git_branch: Option<String>,
     #[serde(default)]
     pub message: Option<MessagePayload>,
     #[serde(default)]
     pub tool_use_result: Option<ToolUseResult>,
     #[serde(default)]
+    #[allow(dead_code)] // schema field, parsed but not yet consumed
     pub data: Option<serde_json::Value>,
 }
 
 /// Message payload attached to user/assistant entries.
 #[derive(Debug, Clone, Deserialize)]
 pub struct MessagePayload {
+    #[allow(dead_code)] // schema field; role is inferred from `EntryType` instead
     pub role: Option<String>,
     pub content: Option<serde_json::Value>,
 }
@@ -70,7 +80,11 @@ pub enum ContentBlock {
         input: serde_json::Value,
     },
     ToolResult {
+        // Captured from the wire but not yet inspected by the filter, which
+        // only needs to know a tool-result block is present.
+        #[allow(dead_code)]
         content: String,
+        #[allow(dead_code)]
         is_error: bool,
     },
     Thinking(String),

--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
 use crate::graph::{EdgeData, MemoryGraph};
@@ -8,10 +8,29 @@ use crate::store::facts::FactStore;
 use crate::traits::{ConflictArbiter, ConflictResolution, CrudDecision};
 use crate::types::{NewEdge, NewFact};
 
-/// Relation type for edges created when facts supplement each other.
-const RELATION_SUPPLEMENTS: &str = "supplements";
-/// Relation type for edges created when facts contradict each other.
-const RELATION_CONTRADICTS: &str = "contradicts";
+/// Edge relation kinds emitted by conflict resolution.
+///
+/// Closed set replacing the previous stringly-typed constants. Each variant
+/// maps to a fixed on-wire / DB string via [`EdgeRelation::as_str`]; those
+/// string values are the stable persisted representation and must not change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EdgeRelation {
+    /// Facts coexist and supplement each other (`CrudDecision::Add`).
+    Supplements,
+    /// New fact contradicts and supersedes the old one (`CrudDecision::Update`).
+    Contradicts,
+}
+
+impl EdgeRelation {
+    /// On-wire / DB string for this relation. Stable — do not change.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Supplements => "supplements",
+            Self::Contradicts => "contradicts",
+        }
+    }
+}
+
 /// Default weight for conflict resolution edges.
 const DEFAULT_EDGE_WEIGHT: f64 = 1.0;
 
@@ -83,12 +102,11 @@ pub fn resolve_conflict(
             let new_id = FactStore::new(&tx, embed_dim).insert(new_fact)?;
 
             // Create "supplements" edge: new → old
-            let relation = RELATION_SUPPLEMENTS.to_string();
             let edge_store = EdgeStore::new(&tx);
             let edge_id = edge_store.insert(&NewEdge {
                 source_fact_id: new_id,
                 target_fact_id: old_fact_id,
-                relation_type: relation.clone(),
+                relation_type: EdgeRelation::Supplements.as_str().to_string(),
                 weight: DEFAULT_EDGE_WEIGHT,
                 scope_id: new_fact.scope_id,
                 t_created: now,
@@ -103,7 +121,7 @@ pub fn resolve_conflict(
                 old_fact_id,
                 EdgeData {
                     edge_id,
-                    relation_type: relation,
+                    relation_type: EdgeRelation::Supplements.as_str().to_string(),
                     weight: DEFAULT_EDGE_WEIGHT,
                 },
             );
@@ -131,11 +149,10 @@ pub fn resolve_conflict(
             let new_id = FactStore::new(&tx, embed_dim).insert(new_fact)?;
 
             // Create "contradicts" edge: new → old
-            let relation = RELATION_CONTRADICTS.to_string();
             let edge_id = edge_store.insert(&NewEdge {
                 source_fact_id: new_id,
                 target_fact_id: old_fact_id,
-                relation_type: relation.clone(),
+                relation_type: EdgeRelation::Contradicts.as_str().to_string(),
                 weight: DEFAULT_EDGE_WEIGHT,
                 scope_id: new_fact.scope_id,
                 t_created: now,
@@ -151,7 +168,7 @@ pub fn resolve_conflict(
                 old_fact_id,
                 EdgeData {
                     edge_id,
-                    relation_type: relation,
+                    relation_type: EdgeRelation::Contradicts.as_str().to_string(),
                     weight: DEFAULT_EDGE_WEIGHT,
                 },
             );

--- a/src/engine/archive.rs
+++ b/src/engine/archive.rs
@@ -12,6 +12,7 @@ use chrono::Utc;
 use crate::archive::pak::{hash_file, verify_pak, write_pak_and_hash};
 use crate::archive::types::{
     ArchiveManifestEntry, ArchivePak, ArchivePolicy, ArchiveStats, ArchiveVerifyResult,
+    CURRENT_PAK_VERSION,
 };
 use crate::error::{MemoryError, Result};
 use crate::store::archive_manifest::ArchiveManifestStore;
@@ -176,7 +177,7 @@ impl MemoryEngine {
     /// Build the `.pak` payload.
     fn build_pak(&self, facts: &[Fact], edges: &[Edge]) -> ArchivePak {
         ArchivePak {
-            pak_version: 1,
+            pak_version: CURRENT_PAK_VERSION,
             engine_schema_version: CURRENT_SCHEMA_VERSION,
             embed_dim: self.embed_dim,
             created_at: Utc::now(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,9 @@
 /// Errors returned by the memory engine.
+///
+/// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
+/// downstream `match` expressions must include a wildcard (`_`) arm.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum MemoryError {
     #[error("not found: {0}")]
     NotFound(String),

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -16,21 +16,36 @@ pub struct ScopeTree {
 }
 
 impl ScopeTree {
-    /// Build tree from all scopes in the database.
-    pub fn load(conn: &Connection) -> Result<Self> {
-        let store = ScopeStore::new(conn);
-        let all = store.list_all()?;
+    /// Build the `(nodes, children)` index maps from a node iterator.
+    ///
+    /// Shared by [`ScopeTree::load`] (from the DB) and
+    /// [`ScopeTree::from_snapshot`] (from a serialized snapshot): both insert
+    /// each node into `nodes` by id and register it under its parent's
+    /// `children` list.
+    fn build_index<I>(node_iter: I) -> (HashMap<i64, ScopeNode>, HashMap<i64, Vec<i64>>)
+    where
+        I: IntoIterator<Item = ScopeNode>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let iter = node_iter.into_iter();
+        let mut nodes = HashMap::with_capacity(iter.len());
+        let mut children: HashMap<i64, Vec<i64>> = HashMap::new();
 
-        let mut nodes = HashMap::with_capacity(all.len());
-        let mut children: HashMap<i64, Vec<i64>> = HashMap::with_capacity(all.len());
-
-        for node in all {
+        for node in iter {
             if let Some(pid) = node.parent_id {
                 children.entry(pid).or_default().push(node.id);
             }
             nodes.insert(node.id, node);
         }
 
+        (nodes, children)
+    }
+
+    /// Build tree from all scopes in the database.
+    pub fn load(conn: &Connection) -> Result<Self> {
+        let store = ScopeStore::new(conn);
+        let all = store.list_all()?;
+        let (nodes, children) = Self::build_index(all);
         Ok(Self { nodes, children })
     }
 
@@ -180,16 +195,7 @@ impl ScopeTree {
 
     /// Rebuild tree from a snapshot (same logic as `load` but from snapshot data).
     pub(crate) fn from_snapshot(snap: &crate::engine::snapshot::ScopeTreeSnapshot) -> Self {
-        let mut nodes = HashMap::with_capacity(snap.nodes.len());
-        let mut children: HashMap<i64, Vec<i64>> = HashMap::with_capacity(snap.nodes.len());
-
-        for node in &snap.nodes {
-            if let Some(pid) = node.parent_id {
-                children.entry(pid).or_default().push(node.id);
-            }
-            nodes.insert(node.id, node.clone());
-        }
-
+        let (nodes, children) = Self::build_index(snap.nodes.iter().cloned());
         Self { nodes, children }
     }
 }

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -13,7 +13,7 @@ pub struct ActivityStore<'a> {
 }
 
 impl<'a> ActivityStore<'a> {
-    pub const fn new(conn: &'a Connection) -> Self {
+    pub(crate) const fn new(conn: &'a Connection) -> Self {
         Self { conn }
     }
 

--- a/src/store/archive_manifest.rs
+++ b/src/store/archive_manifest.rs
@@ -12,7 +12,7 @@ pub struct ArchiveManifestStore<'a> {
 impl<'a> ArchiveManifestStore<'a> {
     /// Create a new `ArchiveManifestStore` borrowing the given connection.
     #[must_use]
-    pub const fn new(conn: &'a Connection) -> Self {
+    pub(crate) const fn new(conn: &'a Connection) -> Self {
         Self { conn }
     }
 

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -13,7 +13,7 @@ pub struct CheckpointStore<'a> {
 }
 
 impl<'a> CheckpointStore<'a> {
-    pub const fn new(conn: &'a Connection) -> Self {
+    pub(crate) const fn new(conn: &'a Connection) -> Self {
         Self { conn }
     }
 

--- a/src/store/edges.rs
+++ b/src/store/edges.rs
@@ -30,7 +30,7 @@ fn row_to_edge(row: &rusqlite::Row<'_>) -> rusqlite::Result<Edge> {
 impl<'a> EdgeStore<'a> {
     /// Create a new `EdgeStore` borrowing the given connection.
     #[must_use]
-    pub const fn new(conn: &'a Connection) -> Self {
+    pub(crate) const fn new(conn: &'a Connection) -> Self {
         Self { conn }
     }
 

--- a/src/store/events.rs
+++ b/src/store/events.rs
@@ -109,7 +109,7 @@ fn row_to_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
 impl<'a> EventStore<'a> {
     /// Create a new `EventStore` borrowing the given connection and upcaster registry.
     #[must_use]
-    pub const fn new(conn: &'a Connection, registry: &'a UpcasterRegistry) -> Self {
+    pub(crate) const fn new(conn: &'a Connection, registry: &'a UpcasterRegistry) -> Self {
         Self { conn, registry }
     }
 

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 
 use crate::error::{MemoryError, Result};
 use crate::store::{
@@ -12,6 +12,17 @@ pub struct FactStore<'a> {
     conn: &'a Connection,
     embed_dim: usize,
 }
+
+/// The full ordered column list selected by every fact-reading query.
+///
+/// Centralized so the projection stays in lockstep with [`row_to_fact`], which
+/// reads columns by name. The column set and order are identical to the
+/// previous per-query literals (only inter-column whitespace is normalized;
+/// `SQLite` ignores it, so the queries are behaviorally unchanged).
+const FACT_COLUMNS: &str = "id, content, content_hash, embedding, fact_type, \
+     t_created, t_expired, t_valid, t_invalid, \
+     source_event_id, importance, access_count, last_accessed, metadata, scope_id, \
+     is_pinned, importance_score, surfaced_at";
 
 pub const fn fact_type_to_str(ft: &FactType) -> &'static str {
     match ft {
@@ -40,7 +51,7 @@ fn content_hash(content: &str) -> String {
 impl<'a> FactStore<'a> {
     /// Create a new `FactStore` borrowing the given connection.
     #[must_use]
-    pub const fn new(conn: &'a Connection, embed_dim: usize) -> Self {
+    pub(crate) const fn new(conn: &'a Connection, embed_dim: usize) -> Self {
         Self { conn, embed_dim }
     }
 
@@ -104,13 +115,9 @@ impl<'a> FactStore<'a> {
     ///
     /// Returns `MemoryError::NotFound` if the id doesn't exist.
     pub fn get(&self, id: i64) -> Result<Fact> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts WHERE id = ?1",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts WHERE id = ?1"))?;
         let dim = self.embed_dim;
         let mut rows = stmt.query_map(params![id], |row| row_to_fact(row, dim))?;
         match rows.next() {
@@ -129,11 +136,7 @@ impl<'a> FactStore<'a> {
     ///
     /// Returns `MemoryError::Database` on query failure.
     pub fn list_active(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
-        let base = "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts WHERE t_expired IS NULL";
+        let base = format!("SELECT {FACT_COLUMNS} FROM facts WHERE t_expired IS NULL");
         let limit_i64: i64 = limit.map_or(-1, |n| i64::try_from(n).unwrap_or(i64::MAX));
         let sql = format!("{base} LIMIT ?1");
         let mut stmt = self.conn.prepare(&sql)?;
@@ -156,16 +159,12 @@ impl<'a> FactStore<'a> {
     /// Returns `MemoryError::Database` on query failure.
     pub fn list_active_at(&self, valid_at: DateTime<Utc>) -> Result<Vec<Fact>> {
         let valid_at_str = valid_at.to_rfc3339();
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL
                AND (t_valid IS NULL OR t_valid <= ?1)
-               AND (t_invalid IS NULL OR t_invalid > ?1)",
-        )?;
+               AND (t_invalid IS NULL OR t_invalid > ?1)"
+        ))?;
         let dim = self.embed_dim;
         let rows = stmt.query_map(params![valid_at_str], |row| row_to_fact(row, dim))?;
         let mut facts = Vec::new();
@@ -211,11 +210,7 @@ impl<'a> FactStore<'a> {
         };
 
         let sql = format!(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts
+            "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL
                AND is_pinned = 0
                AND importance_score < ?1
@@ -301,16 +296,12 @@ impl<'a> FactStore<'a> {
     pub fn list_by_scope_importance(&self, scope_id: i64, limit: usize) -> Result<Vec<Fact>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         let dim = self.embed_dim;
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL AND scope_id = ?1
              ORDER BY importance DESC
-             LIMIT ?2",
-        )?;
+             LIMIT ?2"
+        ))?;
         let rows = stmt.query_map(params![scope_id, limit_i64], |row| row_to_fact(row, dim))?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(MemoryError::Database)
@@ -334,19 +325,15 @@ impl<'a> FactStore<'a> {
         let exclude_json = serde_json::to_string(&exclude_ids.iter().copied().collect::<Vec<_>>())
             .expect("serialize exclude_ids");
         let dim = self.embed_dim;
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
                AND importance >= ?2
                AND id NOT IN (SELECT value FROM json_each(?3))
              ORDER BY importance DESC
-             LIMIT ?4",
-        )?;
+             LIMIT ?4"
+        ))?;
         let rows = stmt.query_map(
             params![scope_json, min_importance, exclude_json, limit_i64],
             |row| row_to_fact(row, dim),
@@ -358,11 +345,8 @@ impl<'a> FactStore<'a> {
     /// List active pinned (unforgettable) facts, optionally filtered by scope.
     /// Pass empty slice to get all pinned facts across all scopes.
     pub fn list_pinned(&self, scope_ids: &[i64]) -> Result<Vec<Fact>> {
-        let base = "SELECT id, content, content_hash, embedding, fact_type,
-                        t_created, t_expired, t_valid, t_invalid,
-                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                        is_pinned, importance_score, surfaced_at
-                 FROM facts WHERE t_expired IS NULL AND is_pinned = 1";
+        let base =
+            format!("SELECT {FACT_COLUMNS} FROM facts WHERE t_expired IS NULL AND is_pinned = 1");
         let dim = self.embed_dim;
         if scope_ids.is_empty() {
             let sql = format!("{base} ORDER BY importance_score DESC");
@@ -387,13 +371,11 @@ impl<'a> FactStore<'a> {
     /// Excludes facts where `t_invalid <= now` (bi-temporally invalidated).
     pub fn list_due(&self, now: DateTime<Utc>, scope_ids: &[i64]) -> Result<Vec<Fact>> {
         let now_str = now.to_rfc3339();
-        let base = "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts
+        let base = format!(
+            "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL AND t_valid IS NOT NULL AND t_valid <= ?1
-             AND (t_invalid IS NULL OR t_invalid > ?1)";
+             AND (t_invalid IS NULL OR t_invalid > ?1)"
+        );
         let sql = if scope_ids.is_empty() {
             format!("{base} ORDER BY t_valid ASC")
         } else {
@@ -508,13 +490,9 @@ impl<'a> FactStore<'a> {
     ///
     /// Returns `MemoryError::Database` on SQL failure.
     pub fn list_all(&self) -> Result<Vec<Fact>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts ORDER BY id ASC",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts ORDER BY id ASC"))?;
         let dim = self.embed_dim;
         let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
@@ -535,13 +513,9 @@ impl<'a> FactStore<'a> {
     where
         F: FnMut(Fact) -> Result<()>,
     {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts ORDER BY id ASC",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts ORDER BY id ASC"))?;
         let dim = self.embed_dim;
         let mut rows = stmt.query([])?;
         while let Some(row) = rows.next()? {
@@ -574,13 +548,11 @@ impl<'a> FactStore<'a> {
             .expect("serialize exclude_ids");
         let dim = self.embed_dim;
 
-        let base = "SELECT id, content, content_hash, embedding, fact_type,
-                        t_created, t_expired, t_valid, t_invalid,
-                        source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                        is_pinned, importance_score, surfaced_at
-                 FROM facts
+        let base = format!(
+            "SELECT {FACT_COLUMNS} FROM facts
                  WHERE t_expired IS NULL AND importance_score >= ?1
-                   AND id NOT IN (SELECT value FROM json_each(?2))";
+                   AND id NOT IN (SELECT value FROM json_each(?2))"
+        );
 
         if scope_ids.is_empty() {
             let sql = format!("{base} ORDER BY importance_score DESC LIMIT ?3");
@@ -676,18 +648,14 @@ impl<'a> FactStore<'a> {
         let exclude_json = serde_json::to_string(&exclude_ids.iter().copied().collect::<Vec<_>>())
             .expect("serialize exclude_ids");
         let dim = self.embed_dim;
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
                AND id NOT IN (SELECT value FROM json_each(?2))
              ORDER BY t_created DESC
-             LIMIT ?3",
-        )?;
+             LIMIT ?3"
+        ))?;
         let rows = stmt.query_map(params![scope_json, exclude_json, limit_i64], |row| {
             row_to_fact(row, dim)
         })?;
@@ -744,11 +712,7 @@ impl<'a> FactStore<'a> {
 
         let where_clause = conditions.join(" AND ");
         let sql = format!(
-            "SELECT id, content, content_hash, embedding, fact_type,
-                    t_created, t_expired, t_valid, t_invalid,
-                    source_event_id, importance, access_count, last_accessed, metadata, scope_id,
-                    is_pinned, importance_score, surfaced_at
-             FROM facts
+            "SELECT {FACT_COLUMNS} FROM facts
              WHERE {where_clause}
              ORDER BY importance_score DESC"
         );

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -12,7 +12,7 @@ pub struct LineageStore<'a> {
 impl<'a> LineageStore<'a> {
     /// Create a new `LineageStore` borrowing the given connection.
     #[must_use]
-    pub const fn new(conn: &'a Connection) -> Self {
+    pub(crate) const fn new(conn: &'a Connection) -> Self {
         Self { conn }
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2,18 +2,18 @@
 //!
 //! Uses WAL mode for concurrent reads during writes.
 
-pub mod activities;
+pub(crate) mod activities;
 #[cfg(feature = "archive")]
-pub mod archive_manifest;
-pub mod checkpoints;
-pub mod edges;
-pub mod events;
-pub mod facts;
-pub mod lineage;
-pub mod schema;
-pub mod scopes;
-pub mod summaries;
-pub mod upcaster;
+pub(crate) mod archive_manifest;
+pub(crate) mod checkpoints;
+pub(crate) mod edges;
+pub(crate) mod events;
+pub(crate) mod facts;
+pub(crate) mod lineage;
+pub(crate) mod schema;
+pub(crate) mod scopes;
+pub(crate) mod summaries;
+pub(crate) mod upcaster;
 
 pub use scopes::ScopeStore;
 pub use upcaster::UpcasterRegistry;

--- a/src/store/scopes.rs
+++ b/src/store/scopes.rs
@@ -10,7 +10,7 @@ pub struct ScopeStore<'a> {
 
 #[allow(dead_code)] // complete CRUD API — not all methods called through engine facade yet
 impl<'a> ScopeStore<'a> {
-    pub const fn new(conn: &'a Connection) -> Self {
+    pub(crate) const fn new(conn: &'a Connection) -> Self {
         Self { conn }
     }
 

--- a/src/store/summaries.rs
+++ b/src/store/summaries.rs
@@ -35,7 +35,7 @@ pub struct SummaryStore<'a> {
 impl<'a> SummaryStore<'a> {
     /// Create a new `SummaryStore` borrowing the given connection.
     #[must_use]
-    pub const fn new(conn: &'a Connection, embed_dim: usize) -> Self {
+    pub(crate) const fn new(conn: &'a Connection, embed_dim: usize) -> Self {
         Self { conn, embed_dim }
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,7 +8,10 @@ use crate::types::Fact;
 ///
 /// Consumers implement this to integrate their embedding model (local or API).
 /// The engine calls `embed` during `add_fact` to compute the embedding vector.
-pub trait EmbeddingProvider {
+///
+/// Requires `Send + Sync`: providers are shared across the engine's worker
+/// threads (`spawn_blocking` connection pool, async facade).
+pub trait EmbeddingProvider: Send + Sync {
     /// Compute an embedding vector for the given text.
     ///
     /// # Errors
@@ -40,7 +43,10 @@ pub trait EmbeddingProvider {
 /// Trait for generating summaries from fact clusters (Phase 2).
 ///
 /// Used by consolidation to merge related facts into higher-level summaries.
-pub trait SummaryGenerator {
+///
+/// Requires `Send + Sync`: summary generators are shared across the engine's
+/// worker threads alongside the other consumer providers.
+pub trait SummaryGenerator: Send + Sync {
     /// Generate a textual summary from a slice of facts.
     ///
     /// # Errors
@@ -57,7 +63,10 @@ pub trait SummaryGenerator {
 }
 
 /// Trait for arbitrating conflicts between contradicting facts (Phase 2).
-pub trait ConflictArbiter {
+///
+/// Requires `Send + Sync`: arbiters are shared across the engine's worker
+/// threads alongside the other consumer providers.
+pub trait ConflictArbiter: Send + Sync {
     /// Decide how to resolve a conflict between an existing and a new fact.
     ///
     /// # Warning: `importance_score` on `new_fact` is a placeholder
@@ -100,7 +109,10 @@ pub enum CrudDecision {
 /// Classifiers should only rely on `content`, `fact_type`, `importance`
 /// (caller hint), and `metadata` — not on `id`, `scope_id`,
 /// `importance_score`, or `access_count`.
-pub trait PersistenceClassifier {
+///
+/// Requires `Send + Sync`: classifiers are shared across the engine's worker
+/// threads alongside the other consumer providers.
+pub trait PersistenceClassifier: Send + Sync {
     /// Decide if a fact should be pinned (never forgotten).
     fn should_pin(&self, fact: &Fact) -> bool {
         let _ = fact;

--- a/tests/bootstrap_dryrun.rs
+++ b/tests/bootstrap_dryrun.rs
@@ -13,13 +13,13 @@
 //! Hermetic: in-memory engine + zero-vector embedder. No network, no Ollama,
 //! no GPU contention (S0 is build-only). See `docs/audits/S0.3-bootstrap-audit.md`.
 
-use std::cell::RefCell;
+use std::sync::Mutex;
 
 use chrono::{DateTime, Datelike, Utc};
-use memory_engine::bootstrap::extract::KeywordExtractor;
-use memory_engine::bootstrap::metrics::BootstrapConfig;
 use memory_engine::traits::PersistenceClassifier;
-use memory_engine::{EmbeddingProvider, Fact, MemoryEngine, MemoryError};
+use memory_engine::{
+    BootstrapConfig, EmbeddingProvider, Fact, KeywordExtractor, MemoryEngine, MemoryError,
+};
 
 /// Zero-vector embedder (dim 4) — retrieval is irrelevant to this audit.
 struct TestEmbedder;
@@ -33,12 +33,13 @@ impl EmbeddingProvider for TestEmbedder {
 /// i.e. every bootstrapped fact — with its (backdated) `t_created` intact.
 #[derive(Default)]
 struct RecordingClassifier {
-    seen: RefCell<Vec<(String, DateTime<Utc>)>>,
+    seen: Mutex<Vec<(String, DateTime<Utc>)>>,
 }
 impl PersistenceClassifier for RecordingClassifier {
     fn should_pin(&self, fact: &Fact) -> bool {
         self.seen
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .push((fact.content.clone(), fact.t_created));
         false
     }
@@ -208,7 +209,7 @@ fn dryrun_yield_backdate_idempotency_no_dedup() {
         total_facts += report.facts_created;
     }
     println!("TOTAL facts (first pass) = {total_facts}");
-    for (content, t) in recorder.seen.borrow().iter() {
+    for (content, t) in recorder.seen.lock().unwrap().iter() {
         let snippet: String = content.chars().take(90).collect();
         println!("  fact t_created={t} content={snippet:?}");
     }
@@ -221,7 +222,7 @@ fn dryrun_yield_backdate_idempotency_no_dedup() {
     );
 
     // --- Idempotency: re-run all five, expect skips + zero new facts ---
-    let facts_before_rerun = recorder.seen.borrow().len();
+    let facts_before_rerun = recorder.seen.lock().unwrap().len();
     for jsonl in &sessions {
         let report = engine
             .bootstrap_session(
@@ -241,14 +242,14 @@ fn dryrun_yield_backdate_idempotency_no_dedup() {
         );
     }
     assert_eq!(
-        recorder.seen.borrow().len(),
+        recorder.seen.lock().unwrap().len(),
         facts_before_rerun,
         "skipped sessions must create no facts"
     );
 
     // --- Backdating: every t_created is the historical session time (2024/2025),
     //     never Utc::now() (2026+). ---
-    let seen = recorder.seen.borrow();
+    let seen = recorder.seen.lock().unwrap();
     assert!(!seen.is_empty(), "recorder should have captured facts");
     let now = Utc::now();
     for (content, t) in seen.iter() {

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -2,9 +2,9 @@
 
 use std::io::Cursor;
 
-use memory_engine::bootstrap::extract::KeywordExtractor;
-use memory_engine::bootstrap::metrics::BootstrapConfig;
-use memory_engine::{EmbeddingProvider, MemoryEngine, MemoryError};
+use memory_engine::{
+    BootstrapConfig, EmbeddingProvider, KeywordExtractor, MemoryEngine, MemoryError,
+};
 
 /// Dummy embedder for testing — returns a fixed-length zero vector.
 struct TestEmbedder;


### PR DESCRIPTION
**14 behavior-preserving structural refactors** (+1 finding confirmed already-resolved) from the super-qa #505 medium sweep (auto-fix). Full `--workspace --all-features` gate green.

### Findings addressed
- **`MemoryError` → `#[non_exhaustive]`** + the one cross-crate exhaustive match (`mcp::error::to_mcp_error`) gains a wildcard arm. No other external match exists.
- **Consumer traits gain `: Send + Sync`** (`EmbeddingProvider`, `SummaryGenerator`, `ConflictArbiter`, `PersistenceClassifier`; `Reranker` already had it). One test mock switched `RefCell`→`Mutex`; all other impls already satisfy the bound.
- **Stringly-typed → closed enums:** CLI dump `target` & export `format` (clap `ValueEnum`), conflict relation constants (`EdgeRelation`). Wire/DB/CLI string tokens preserved **byte-for-byte**; `unreachable!()` guards removed.
- **`HttpEmbeddingProvider::new` → `Result<Self, MemoryError>`** (was `Result<Self, String>`).
- **Named constants:** `CURRENT_PAK_VERSION`, `FACT_COLUMNS` (the 13× repeated SELECT list; column set/order byte-identical).
- **Visibility tightening → `pub(crate)`:** bootstrap submodules, CLI binary-crate items, `MemoryMcpServer` fields, **and the store submodules + 9 store-wrapper constructors** (see note). Plus: duplicated scope-tree build loop extracted into a shared helper; the two clashing `peek_embed_dim` fns renamed by I/O semantics (`_from_db` / `_from_snapshot`).

### Notes
- **`store/refactoring-over-broad-pub-stores` was completed in this PR by the orchestrator.** The implementation agent miscounted its list and skipped it; I finished it (11 submodules + 9 internal constructors → `pub(crate)`), deliberately leaving `UpcasterRegistry::new()` `pub` since that type is publicly re-exported at the crate root (tightening it would be a real API change the finding didn't intend). `store` is already `pub(crate) mod` at lib root, so this is intra-crate hygiene with zero external-API impact.
- **`store/dead-code` was already-resolved** — `activities::get`/`checkpoints::get` are `#[cfg(test)]` test helpers, not dead code; deleting them would break passing tests. Left as-is.

### Verification
- Gate (isolated worktree off `236538e`): `cargo build --workspace --all-features` ✅, `cargo test --workspace --all-features` ✅, `cargo clippy --workspace --all-targets --all-features` ✅, `cargo fmt --check` ✅.
- **Adversarial review** (3 lenses): *api-breakage* **approve** (verified `#[non_exhaustive]`/`Send+Sync`/visibility break nothing across all crates + integration tests), *behavior-preservation* **approve-with-nits**, *compile-correctness* **approve**.

### Caveats for reviewers (accepted, non-blocking)
1. **Error-message text change:** `HttpEmbeddingProvider::new`'s failure message gains an `internal error: ` prefix (from `MemoryError::Internal`'s `Display`). No test asserts it; flagged for any downstream log/alert matchers.
2. **CLI `--help` rendering:** the `ValueEnum`s change how clap renders accepted values in `--help`/invalid-value errors. Accepted **tokens are byte-identical**; only help text differs.
3. **Warn-level `clippy::redundant_pub_crate`** noise from the `pub(crate)` tightening (nursery = warn in the workspace lint policy; gate stays green).

### Collateral (filed separately, NOT in this PR)
`memory-engine-mcp`'s `test_dump_state_default_path` is a pre-existing parallelism flake (shared `std::env::temp_dir` + timestamp filename) — confirmed unrelated to this refactor (reproduces on stash). Will be filed as its own `type:test`/`area:mcp` issue.

Part of #505.
