### PR TITLE
chore(build): fix import-order fmt drift in store/lineage.rs

### DIFF
--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::types::{LineageRecord, LineageSnapshotEntry, NewLineageRecord, PromotionProvenance};


### PR DESCRIPTION
One-line **fmt-only** hotfix. `cargo fmt --check` was red on main — `src/store/lineage.rs:1` had `use rusqlite::{params, Connection}` (lowercase-first), which edition-2024 rustfmt rejects (wants caps-first `{Connection, params}`).

Pre-existing drift from a prior super-qa auto-fix merge — the PostToolUse Edit-hook reorders imports lowercase-first, and with no CI fmt gate it landed on main. Surfaced while rebasing the #505 Wave-1 PRs (#529/#531), whose fmt gates (and Wave 2's) were reddened by it.

Pure formatting, no logic change. `cargo build -p memory-engine` + `cargo fmt --check` both clean.