### PR TITLE
chore(build): fix import-order fmt drift in temporal.rs + facts.rs (post-#531)

### DIFF
--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::graph::{EdgeData, MemoryGraph};

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::store::{


### PR DESCRIPTION
Two-line **fmt-only** hotfix. `cargo fmt --check` is red on main at `src/conflict/temporal.rs:1` and `src/store/facts.rs:1` (`use rusqlite::{params, Connection}` → caps-first `{Connection, params}`).

Cause: during #531's rebase conflict resolution the PostToolUse Edit-hook reordered the imports lowercase-first into the commit; the follow-up `cargo fmt` fixed the working tree but wasn't amended into the commit, so the working-tree-based `cargo fmt --check` passed while the merged tree carried the drift. No CI fmt gate to catch it.

Pure formatting, no logic change. `cargo build` + `cargo fmt --check` clean.