### PR TITLE
fix(security): validate backup path before VACUUM INTO interpolation (#112)

### DIFF
--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::graph::{EdgeData, MemoryGraph};

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::store::{

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -377,6 +377,17 @@ pub fn backup_before_migration(
         .to_string_lossy();
     let backup_path = backup_dir.join(format!("{db_name}.v{current_version}.bak"));
 
+    // Defense-in-depth: reject a null byte in the backup path before ANY use —
+    // the filesystem ops below and the SQL interpolation further down. A NUL
+    // would truncate the C string the OS / SQLite receives, silently changing
+    // the target path. Validate-before-use / fail-fast. Mirrors the guard in
+    // `inspect::dump::dump_sqlite`.
+    if backup_path.to_string_lossy().contains('\0') {
+        return Err(MemoryError::Migration(
+            "backup path contains null byte".to_string(),
+        ));
+    }
+
     // Remove existing backup to avoid VACUUM INTO failure on re-run
     if backup_path.exists() {
         std::fs::remove_file(&backup_path).map_err(|e| {
@@ -390,16 +401,8 @@ pub fn backup_before_migration(
     // VACUUM INTO creates a standalone, defragmented copy — WAL-safe.
     // SQLite VACUUM INTO does not support parameterized paths, so we escape
     // single quotes manually (SQLite string literal escaping: ' → '').
+    // (The path was already null-byte-validated above, before any use.)
     let escaped = backup_path.to_string_lossy().replace('\'', "''");
-    // Defense-in-depth: reject a null byte before interpolating into SQL. A NUL
-    // would truncate the C string SQLite receives, silently changing the target
-    // path the escaping was meant to pin down. Mirrors the guard in
-    // `inspect::dump::dump_sqlite`.
-    if escaped.contains('\0') {
-        return Err(MemoryError::Migration(
-            "backup path contains null byte".to_string(),
-        ));
-    }
     let sql = format!("VACUUM INTO '{escaped}'");
     conn.execute_batch(&sql)
         .map_err(|e| MemoryError::Migration(format!("backup failed: {e}")))?;

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -342,10 +342,19 @@ pub fn validate_schema_version(conn: &Connection) -> Result<()> {
 /// Uses `VACUUM INTO` which produces an atomic, consistent copy regardless
 /// of WAL state (no sidecar files to worry about).
 ///
+/// # Security
+///
+/// `backup_dir` MUST be a trusted path supplied by the consumer (it originates
+/// from `EngineConfig::backup_dir`). `VACUUM INTO` cannot parameterize its
+/// target, so the path is interpolated into SQL with single-quote escaping.
+/// The null-byte rejection below is defense-in-depth against an SQL-literal
+/// terminator slipping past the escaping — it is **not** a sandbox and does not
+/// make an untrusted path safe to pass here.
+///
 /// # Errors
 ///
-/// Returns `MemoryError::Migration` if the connection is in-memory or the
-/// backup path cannot be written to.
+/// Returns `MemoryError::Migration` if the connection is in-memory, the backup
+/// path contains a null byte, or the backup path cannot be written to.
 pub fn backup_before_migration(
     conn: &Connection,
     backup_dir: &Path,
@@ -382,6 +391,15 @@ pub fn backup_before_migration(
     // SQLite VACUUM INTO does not support parameterized paths, so we escape
     // single quotes manually (SQLite string literal escaping: ' → '').
     let escaped = backup_path.to_string_lossy().replace('\'', "''");
+    // Defense-in-depth: reject a null byte before interpolating into SQL. A NUL
+    // would truncate the C string SQLite receives, silently changing the target
+    // path the escaping was meant to pin down. Mirrors the guard in
+    // `inspect::dump::dump_sqlite`.
+    if escaped.contains('\0') {
+        return Err(MemoryError::Migration(
+            "backup path contains null byte".to_string(),
+        ));
+    }
     let sql = format!("VACUUM INTO '{escaped}'");
     conn.execute_batch(&sql)
         .map_err(|e| MemoryError::Migration(format!("backup failed: {e}")))?;
@@ -1800,6 +1818,32 @@ CREATE TABLE IF NOT EXISTS config (
             .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 1, "backup should contain the event");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn backup_rejects_null_byte_in_path() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::PathBuf;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let conn = open_connection(&db_path.to_string_lossy()).unwrap();
+        init_schema(&conn).unwrap();
+
+        // A backup_dir whose byte form embeds a NUL. The resulting backup path
+        // string carries the NUL, which must be rejected before it reaches the
+        // VACUUM INTO SQL string (where it would truncate the C path).
+        let mut bytes = dir.path().as_os_str().as_bytes().to_vec();
+        bytes.extend_from_slice(b"/sub\0dir");
+        let evil_dir = PathBuf::from(OsStr::from_bytes(&bytes));
+
+        let err = backup_before_migration(&conn, &evil_dir, 4).unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Migration(ref msg) if msg.contains("null byte")),
+            "expected null-byte rejection, got: {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Reject a backup path containing a null byte (`\0`) in
`store::schema::backup_before_migration` **before** it is interpolated into the
`VACUUM INTO '...'` SQL statement. The existing single-quote escaping is kept.

## Why (CWE-89, #112)

SQLite cannot parameterize the `VACUUM INTO` target, so the path is interpolated
into SQL text with manual single-quote escaping (`'` → `''`). That escaping
handles the SQL-literal delimiter, but a NUL byte in the path string would
truncate the C string SQLite ultimately receives — silently retargeting the
backup write past the boundary the escaping was meant to pin down. The guard
closes that gap.

This mirrors the existing **M7** null-byte guard in
`inspect::dump::dump_sqlite` (same check, `MemoryError::Migration` instead of
`Internal` to match the error type used throughout `backup_before_migration`).

A `# Security` doc section now states that `backup_dir` MUST be a trusted path
(it originates from `EngineConfig::backup_dir`); the guard is defense-in-depth,
**not** a sandbox that makes an untrusted path safe.

## Severity

The later security sweep (#500) re-rated this **INFO** because `backup_dir` is a
trusted consumer API. The change is intentionally minimal and proportionate:
one guard + one doc note + one test.

## Test

`backup_rejects_null_byte_in_path` (unix-gated) constructs a `backup_dir` whose
byte form embeds a NUL via `OsStr::from_bytes`, and asserts
`backup_before_migration` returns `MemoryError::Migration("...null byte...")`
rather than passing the path to SQLite.

## #500 sibling (dump.rs line ~215) — no change needed

`inspect::dump::dump_sqlite` already lossy-converts then null-byte-checks the
`VACUUM INTO` target (the M7 guard this PR mirrors). The `to_string_lossy` is
inherent to interpolating a `Path` into SQL text and is shared by both call
sites; there is no trivial, consistent co-fix beyond the guard that already
exists there. No follow-up required.

## Incidental

`cargo fmt` surfaced pre-existing rustfmt import-ordering drift
(`use rusqlite::{params, Connection}` → `{Connection, params}`) in
`conflict/temporal.rs` and `store/facts.rs` that was un-committed at HEAD.
Included because `cargo fmt --check` (CI gate) fails otherwise; two lines, no
behavior change.

## Gates

- `cargo build --workspace` — green
- `cargo test -p memory-engine` — 694 passed (incl. new test)
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets` (project gate, `clippy::all`=deny) — exit 0.
  Note: `-- -D warnings` promotes pre-existing `pedantic`/`nursery` warnings in
  unrelated files (`async_engine.rs`, `store/mod.rs`, etc., default level `warn`
  per `Cargo.toml [lints.clippy]`) to errors; these reproduce identically on the
  untouched base and are out of scope for this fix. This PR introduces zero
  clippy findings at any level.

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)