### PR TITLE
refactor(retrieval): dedup scope/strategy resolution + remove infer_search_mode panic (#117, #119)

### DIFF
--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -22,6 +22,47 @@ impl MemoryEngine {
         &*self.vector_strategy
     }
 
+    /// Resolve a query's optional scope into concrete scope IDs and pair it with
+    /// the active vector search strategy.
+    ///
+    /// Returns:
+    /// - `Some((scope_ids, strategy))` — scope resolved (or absent, giving
+    ///   `scope_ids == None` for an unscoped search).
+    /// - `None` — a scope query was provided but the path does not exist.
+    ///   Callers MUST surface this as empty results rather than falling through
+    ///   to an unscoped search.
+    ///
+    /// This consolidates the scope-resolution + strategy-dispatch logic shared
+    /// by [`query`](Self::query) and [`execute_query`](Self::execute_query) (#117).
+    ///
+    /// Distinct from [`resolve_scope_ids`](Self::resolve_scope_ids), which
+    /// operates on a string path with ancestor-walk + fallback-to-root
+    /// semantics; this resolves a [`ScopeQuery`](crate::types::ScopeQuery) with
+    /// empty-on-miss semantics.
+    fn resolve_scope_and_strategy(
+        &self,
+        scope: Option<&crate::types::ScopeQuery>,
+    ) -> Option<(Option<Vec<i64>>, &dyn VectorSearchStrategy)> {
+        // Resolve scope IDs from cache (short-lived read lock).
+        // When a scope query is provided but the path doesn't exist, signal
+        // "no results" (None) instead of silently falling through to an
+        // unscoped search.
+        let scope_ids: Option<Vec<i64>> = match scope {
+            Some(sq) => {
+                // Bind the resolution before matching so the read guard is
+                // dropped promptly (short-lived read lock).
+                let resolved = self.scope_tree.read().resolve_query(sq);
+                match resolved {
+                    Some(ids) => Some(ids),
+                    None => return None, // scope doesn't exist → no results
+                }
+            }
+            None => None,
+        };
+
+        Some((scope_ids, self.active_vector_strategy()))
+    }
+
     /// Query facts using hybrid search (FTS5 + vector + RRF).
     ///
     /// # Errors
@@ -35,21 +76,12 @@ impl MemoryEngine {
     /// Panics if internal candidate de-duplication yields an inconsistent
     /// index — an invariant that should never be violated in practice.
     pub fn query(&self, query: &SearchQuery) -> Result<Vec<SearchResult>> {
-        // Resolve scope IDs from cache (short-lived read lock).
-        // When a scope query is provided but the path doesn't exist,
-        // return empty results instead of silently falling through to unscoped search.
-        let scope_ids: Option<Vec<i64>> = match &query.scope {
-            Some(sq) => {
-                let resolved = self.scope_tree.read().resolve_query(sq);
-                match resolved {
-                    Some(ids) => Some(ids),
-                    None => return Ok(vec![]), // scope doesn't exist → no results
-                }
-            }
-            None => None,
+        // Resolve scope + active vector strategy. A provided-but-missing scope
+        // yields no results rather than an unscoped search (#117).
+        let Some((scope_ids, strategy)) = self.resolve_scope_and_strategy(query.scope.as_ref())
+        else {
+            return Ok(vec![]); // scope doesn't exist → no results
         };
-
-        let strategy = self.active_vector_strategy();
 
         let (mut results, _diagnostics) = self.with_read(|conn| {
             hybrid_search(conn, query, self.embed_dim, scope_ids.as_deref(), strategy)
@@ -98,21 +130,15 @@ impl MemoryEngine {
         // --- Validation ---
         Self::validate_memory_query(query)?;
 
-        // --- Resolve scope ---
-        let scope_ids: Option<Vec<i64>> = match &query.scope {
-            Some(sq) => {
-                let resolved = self.scope_tree.read().resolve_query(sq);
-                match resolved {
-                    Some(ids) => Some(ids),
-                    None => {
-                        return Ok(QueryResponse {
-                            results: vec![],
-                            diagnostics: QueryDiagnostics::default(),
-                        });
-                    }
-                }
-            }
-            None => None,
+        // --- Resolve scope + active vector strategy ---
+        // A provided-but-missing scope yields no results rather than an
+        // unscoped search (#117).
+        let Some((scope_ids, strategy)) = self.resolve_scope_and_strategy(query.scope.as_ref())
+        else {
+            return Ok(QueryResponse {
+                results: vec![],
+                diagnostics: QueryDiagnostics::default(),
+            });
         };
 
         // --- Compute effective temporal cutoff ---
@@ -129,7 +155,13 @@ impl MemoryEngine {
         let limit = query.effective_limit();
 
         if query.has_search() {
-            self.execute_search_path(query, scope_ids.as_deref(), effective_cutoff, limit)
+            self.execute_search_path(
+                query,
+                scope_ids.as_deref(),
+                strategy,
+                effective_cutoff,
+                limit,
+            )
         } else {
             self.execute_store_path(query, scope_ids.as_deref(), effective_cutoff, limit)
         }
@@ -185,7 +217,14 @@ impl MemoryEngine {
             (true, true) => SearchMode::Hybrid,
             (true, false) => SearchMode::Fts,
             (false, true) => SearchMode::Vector,
-            (false, false) => unreachable!("has_search() should be false"),
+            // Invariant: callers gate on `has_search()`, so this arm is
+            // unreachable in correct usage. Assert it in debug/test builds to
+            // catch invariant violations, but fall back to the natural
+            // empty-query default in release rather than panicking (#119).
+            (false, false) => {
+                debug_assert!(false, "infer_search_mode called without has_search()");
+                SearchMode::Fts
+            }
         }
     }
 
@@ -198,6 +237,7 @@ impl MemoryEngine {
         &self,
         query: &MemoryQuery,
         scope_ids: Option<&[i64]>,
+        strategy: &dyn VectorSearchStrategy,
         effective_cutoff: Option<DateTime<Utc>>,
         limit: usize,
     ) -> Result<QueryResponse> {
@@ -227,8 +267,6 @@ impl MemoryEngine {
             fact_type: query.fact_type,
             scope: query.scope.clone(),
         };
-
-        let strategy = self.active_vector_strategy();
 
         let (mut results, mut diagnostics) = self.with_read(|conn| {
             hybrid_search(conn, &search_query, self.embed_dim, scope_ids, strategy)


### PR DESCRIPTION
## Summary

Two behavior-preserving changes in `src/engine/query.rs`.

### #117 — dedup scope + strategy resolution
`query()` and `execute_query()` each carried near-identical logic: read `scope_tree`, call `resolve_query`, return empty results when the scope path is missing, then dispatch the active vector search strategy. Extracted a private helper:

```rust
fn resolve_scope_and_strategy(&self, scope: Option<&ScopeQuery>)
    -> Option<(Option<Vec<i64>>, &dyn VectorSearchStrategy)>
```

- `Some((scope_ids, strategy))` — scope resolved (or absent → unscoped).
- `None` — scope path provided but missing; each caller emits its own empty value (`Ok(vec![])` for `query`, `Ok(QueryResponse{ empty })` for `execute_query`). The "None scope → empty results" semantics are **identical** to before.

The strategy is now threaded into `execute_search_path()` rather than re-resolved there, so the `#[cfg(feature = "ann")]` HNSW-vs-brute-force dispatch lives in exactly one place (`active_vector_strategy()`, called once via the new helper).

Kept deliberately distinct from the existing `resolve_scope_ids()` in `mod.rs`: that helper takes a `&str` path with ancestor-walk + fallback-to-root + `NotFound` semantics — a different contract from the `ScopeQuery` empty-on-miss path here. Merging them would change behavior.

### #119 — remove latent panic in `infer_search_mode`
The function returns `SearchMode` (not `Result`); its `(false, false)` arm used `unreachable!()`, a latent **release-build panic** if ever called without `has_search()`. Replaced with `debug_assert!(false, …)` + the natural empty-query default `SearchMode::Fts` — the invariant violation is still caught in debug/test builds, but never panics in release. Signature unchanged.

## Verification
- `cargo build --workspace` — clean
- `cargo test -p memory-engine` — **693 passed**, 5 ignored
- All **14** `execute_query_*` oracle tests pass **unmodified**
- `cargo build -p memory-engine --features ann` — clean
- `src/engine/query.rs` is clippy-clean (default + `--features ann`) and `rustfmt --check`-clean

## Out of scope / pre-existing (surfaced, not silently absorbed)
- **bootstrap.rs scope-dup (#496)** intentionally untouched — this PR is scoped to `query.rs`.
- **Pre-existing workspace clippy debt**: `cargo clippy --workspace --all-targets -- -D warnings` is **already red on `main` (63ee3c6)** — 44 findings (default) / 18 (`ann`) across `async_engine.rs`, `store/mod.rs`, `store/facts.rs`, `conflict/temporal.rs`, `bootstrap.rs`, `search/ann.rs`. None are in `query.rs`; my change adds zero new clippy findings. Fixing them would be a separate, repo-wide chore.
- **Pre-existing rustfmt edition-2024 drift**: under local rustfmt 1.9.0 (edition 2024 / `style_edition=2024`), `cargo fmt --check` flags repo-wide import-ordering drift (e.g. `params, Connection` → `Connection, params`) in files unrelated to this change. `query.rs` itself is fmt-clean. Normalizing the whole tree belongs in its own `chore(build):` PR.

Fixes #117
Fixes #119