### PR TITLE
refactor(core): wave-2 API-shape hardening for super-qa #506

### DIFF
--- a/docs/advanced/forgetting.md
+++ b/docs/advanced/forgetting.md
@@ -26,7 +26,7 @@ retention = 2^(-age_days / half_life)
 Returns 1.0 at age=0, 0.5 at age=half_life, 0.25 at age=2\*half_life. Age is measured from `last_accessed`, not `t_created`.
 
 ```rust
-pub fn ebbinghaus_decay(age_days: f64, half_life: f64) -> f64 {
+fn ebbinghaus_decay(age_days: f64, half_life: f64) -> f64 {
     f64::exp2(-age_days / half_life)
 }
 ```

--- a/docs/usage/inspection.md
+++ b/docs/usage/inspection.md
@@ -147,21 +147,18 @@ forgetting, or conflict resolution.
 ```rust
 use memory_engine::inspect::types::{ReplayFilter, ReplayOrder};
 
-// Replay events 10–50 with raw payloads (no upcasting)
-let filter = ReplayFilter {
-    id_range: Some((10, 50)),
-    ..Default::default()
-};
+// Replay events 10–50 with raw payloads (no upcasting).
+// `ReplayFilter` is `#[non_exhaustive]`, so construct via `default()` + fields.
+let mut filter = ReplayFilter::default();
+filter.id_range = Some((10, 50));
 let events = engine.replay_events(&filter)?;
 
 // Replay by time window with upcasted payloads
-let filter = ReplayFilter {
-    since: Some(start),
-    until: Some(end),
-    upcast: true,
-    order: ReplayOrder::TimestampOrder,
-    ..Default::default()
-};
+let mut filter = ReplayFilter::default();
+filter.since = Some(start);
+filter.until = Some(end);
+filter.upcast = true;
+filter.order = ReplayOrder::TimestampOrder;
 ```
 
 ### Filter options

--- a/memory-engine-cli/src/commands/dump.rs
+++ b/memory-engine-cli/src/commands/dump.rs
@@ -76,10 +76,8 @@ fn dump_all(
 ) -> anyhow::Result<()> {
     if format == OutputFormat::Json {
         let facts = engine.list_active_facts(Some(limit))?;
-        let filter = ReplayFilter {
-            limit: Some(limit),
-            ..ReplayFilter::default()
-        };
+        let mut filter = ReplayFilter::default();
+        filter.limit = Some(limit);
         let events = engine.replay_events(&filter)?;
         let combined = serde_json::json!({
             "facts": facts,
@@ -132,10 +130,8 @@ fn dump_events(
     limit: usize,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let filter = ReplayFilter {
-        limit: Some(limit),
-        ..ReplayFilter::default()
-    };
+    let mut filter = ReplayFilter::default();
+    filter.limit = Some(limit);
     let events = engine.replay_events(&filter)?;
 
     match format {

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use memory_engine::ResumeConfig;
 use memory_engine::bootstrap::{BootstrapConfig, KeywordExtractor};
 use memory_engine::engine::MemoryEngine;
 use memory_engine::inspect_types::{DumpFormat, FactExplanation, ReplayFilter, ReplayOrder};
@@ -15,12 +14,13 @@ use memory_engine::traits::{
 use memory_engine::types::{
     AddFactOptions, AddFactRequest, EventType, FactType, NewEvent, Outcome,
 };
+use memory_engine::ResumeConfig;
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 
 use crate::depth::{self, Depth};
 use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
-use crate::error::{ValidationError, to_mcp_error};
+use crate::error::{to_mcp_error, ValidationError};
 
 // ---------------------------------------------------------------------------
 // Tool definitions (JSON schemas)
@@ -1036,6 +1036,10 @@ fn handle_forget(
     }))
 }
 
+/// Monotonic counter making default dump paths unique within a process, so
+/// concurrent dumps (e.g. parallel tests) never collide on the timestamp.
+static NEXT_DUMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 fn handle_dump_state(
     args: Map<String, Value>,
     engine: &MemoryEngine,
@@ -1070,8 +1074,12 @@ fn handle_dump_state(
             p
         }
         None => {
+            // Process id + monotonic counter so concurrent dumps (notably
+            // parallel tests) never collide on the millisecond timestamp.
+            let seq = NEXT_DUMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let timestamp = Utc::now().format("%Y%m%dT%H%M%S%3f");
-            std::env::temp_dir().join(format!("memory-dump-{timestamp}.{ext}"))
+            let pid = std::process::id();
+            std::env::temp_dir().join(format!("memory-dump-{timestamp}-{pid}-{seq}.{ext}"))
         }
     };
 
@@ -1180,16 +1188,15 @@ fn handle_replay_events(
         None => ReplayOrder::InsertionOrder,
     };
 
-    let filter = ReplayFilter {
-        since,
-        until,
-        id_range,
-        session_id,
-        event_type,
-        limit,
-        upcast,
-        order,
-    };
+    let mut filter = ReplayFilter::default();
+    filter.since = since;
+    filter.until = until;
+    filter.id_range = id_range;
+    filter.session_id = session_id;
+    filter.event_type = event_type;
+    filter.limit = limit;
+    filter.upcast = upcast;
+    filter.order = order;
 
     let events = engine.replay_events(&filter).map_err(to_mcp_error)?;
 

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use memory_engine::ResumeConfig;
 use memory_engine::bootstrap::{BootstrapConfig, KeywordExtractor};
 use memory_engine::engine::MemoryEngine;
 use memory_engine::inspect_types::{DumpFormat, FactExplanation, ReplayFilter, ReplayOrder};
@@ -14,13 +15,12 @@ use memory_engine::traits::{
 use memory_engine::types::{
     AddFactOptions, AddFactRequest, EventType, FactType, NewEvent, Outcome,
 };
-use memory_engine::ResumeConfig;
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::depth::{self, Depth};
 use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
-use crate::error::{to_mcp_error, ValidationError};
+use crate::error::{ValidationError, to_mcp_error};
 
 // ---------------------------------------------------------------------------
 // Tool definitions (JSON schemas)

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -6,9 +6,9 @@ mod cluster;
 mod dedup;
 mod global;
 
-pub use cluster::cluster_fusion;
-pub use dedup::local_dedup;
-pub use global::global_integration;
+pub(crate) use cluster::cluster_fusion;
+pub(crate) use dedup::local_dedup;
+pub(crate) use global::global_integration;
 
 use chrono::{DateTime, Utc};
 use rusqlite::Connection;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -19,9 +19,9 @@ use crate::traits::Reranker;
 use crate::types::{ConsolidationLevel, Fact};
 
 mod activity;
-pub mod activity_filter;
+pub(crate) mod activity_filter;
 mod bootstrap;
-pub mod cognitive;
+pub(crate) mod cognitive;
 mod conflict;
 mod consolidation;
 mod dormant;

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -19,7 +19,7 @@ const CONNECTIVITY_NORMALIZATION_ARG: f64 = 51.0;
 ///
 /// Returns 1.0 at `age=0`, 0.5 at `age=half_life`, 0.25 at `age=2×half_life`.
 #[must_use]
-pub fn ebbinghaus_decay(age_days: f64, half_life: f64) -> f64 {
+pub(crate) fn ebbinghaus_decay(age_days: f64, half_life: f64) -> f64 {
     f64::exp2(-age_days / half_life)
 }
 
@@ -33,7 +33,7 @@ pub fn ebbinghaus_decay(age_days: f64, half_life: f64) -> f64 {
 ///    (50 connections = full score)
 /// 4. **Base importance**: `fact.importance` — already in \[0, 1\]
 #[must_use]
-pub fn compute_importance(
+pub(crate) fn compute_importance(
     fact: &Fact,
     graph_degree: usize,
     now: DateTime<Utc>,

--- a/src/graph/memory_graph.rs
+++ b/src/graph/memory_graph.rs
@@ -39,7 +39,7 @@ impl MemoryGraph {
     }
 
     /// Ensure a node exists for the given fact id, returning its index.
-    pub fn ensure_node(&mut self, fact_id: i64) -> NodeIndex {
+    pub(crate) fn ensure_node(&mut self, fact_id: i64) -> NodeIndex {
         *self
             .node_map
             .entry(fact_id)

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -438,7 +438,7 @@ mod tests {
     use crate::store::schema::{get_config, init_schema, migrate, open_memory};
     use crate::traits::EmbeddingProvider;
     use crate::types::{AddFactRequest, FactType};
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     const DIM: usize = 4;
 
@@ -495,7 +495,7 @@ mod tests {
             scopes: vec![],
             events: vec![],
             lineage: vec![],
-            config: HashMap::new(),
+            config: BTreeMap::new(),
         };
         let err = validate_snapshot(&snapshot).unwrap_err();
         assert!(err.to_string().contains("newer than supported"));
@@ -513,7 +513,7 @@ mod tests {
             scopes: vec![],
             events: vec![],
             lineage: vec![],
-            config: HashMap::new(),
+            config: BTreeMap::new(),
         };
         let err = validate_snapshot(&snapshot).unwrap_err();
         assert!(matches!(err, MemoryError::UnsupportedEpoch { .. }));
@@ -531,7 +531,7 @@ mod tests {
             scopes: vec![],
             events: vec![],
             lineage: vec![],
-            config: HashMap::new(),
+            config: BTreeMap::new(),
         };
         let err = validate_snapshot(&snapshot).unwrap_err();
         assert!(err.to_string().contains("embed_dim is 0"));
@@ -555,7 +555,7 @@ mod tests {
             }],
             events: vec![],
             lineage: vec![],
-            config: HashMap::new(),
+            config: BTreeMap::new(),
         };
         let err = validate_snapshot(&snapshot).unwrap_err();
         assert!(err.to_string().contains("root node"));
@@ -573,7 +573,7 @@ mod tests {
             scopes: vec![],
             events: vec![],
             lineage: vec![],
-            config: HashMap::new(),
+            config: BTreeMap::new(),
         };
         validate_snapshot(&snapshot).unwrap();
     }

--- a/src/inspect/statistics.rs
+++ b/src/inspect/statistics.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use chrono::Utc;
@@ -58,7 +58,7 @@ pub fn compute_statistics(conn: &Connection, db_path: Option<&Path>) -> Result<E
 
     // Summary counts by level
     let summary_total: i64 = conn.query_row("SELECT COUNT(*) FROM summaries", [], |r| r.get(0))?;
-    let mut by_level = HashMap::new();
+    let mut by_level = BTreeMap::new();
     {
         let mut stmt = conn.prepare("SELECT level, COUNT(*) FROM summaries GROUP BY level")?;
         let rows = stmt.query_map([], |row| {

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
@@ -109,6 +109,7 @@ pub enum HistoryEventKind {
 
 /// Filter criteria for event replay.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ReplayFilter {
     pub since: Option<DateTime<Utc>>,
     pub until: Option<DateTime<Utc>>,
@@ -161,7 +162,7 @@ pub struct EngineSnapshot {
     /// Absent in pre-v8 snapshots — defaults to empty.
     #[serde(default)]
     pub lineage: Vec<LineageSnapshotEntry>,
-    pub config: HashMap<String, String>,
+    pub config: BTreeMap<String, String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -201,7 +202,7 @@ pub struct EdgeStats {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SummaryStats {
     pub total: i64,
-    pub by_level: HashMap<ConsolidationLevel, i64>,
+    pub by_level: BTreeMap<ConsolidationLevel, i64>,
 }
 
 /// Scope tree statistics.

--- a/src/scope/mod.rs
+++ b/src/scope/mod.rs
@@ -1,5 +1,5 @@
 //! Hierarchical scope tree for multi-context memory isolation.
 
-pub mod tree;
+pub(crate) mod tree;
 
 pub use tree::ScopeTree;

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -133,15 +133,15 @@ pub fn get_config(conn: &Connection, key: &str) -> Result<Option<String>> {
 /// # Errors
 ///
 /// Returns `MemoryError::Database` on query failure.
-pub fn list_config(conn: &Connection) -> Result<std::collections::HashMap<String, String>> {
-    use std::collections::HashMap;
+pub fn list_config(conn: &Connection) -> Result<std::collections::BTreeMap<String, String>> {
+    use std::collections::BTreeMap;
     let mut stmt = conn.prepare("SELECT key, value FROM config")?;
     let rows = stmt.query_map([], |row| {
         let key: String = row.get(0)?;
         let value: String = row.get(1)?;
         Ok((key, value))
     })?;
-    let mut map = HashMap::new();
+    let mut map = BTreeMap::new();
     for row in rows {
         let (key, value) = row?;
         map.insert(key, value);

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,7 +67,7 @@ impl fmt::Display for FactType {
 }
 
 /// Consolidation level for summaries.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum ConsolidationLevel {
     Local,
     Cluster,
@@ -508,8 +508,13 @@ pub struct PromotionResult {
     pub lineage_id: LineageId,
 }
 
+/// Error returned when [`ActivityStatus`] cannot be parsed from a string.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unknown activity status: {0}")]
+pub struct ParseActivityStatusError(pub String);
+
 impl std::str::FromStr for ActivityStatus {
-    type Err = String;
+    type Err = ParseActivityStatusError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
@@ -517,7 +522,7 @@ impl std::str::FromStr for ActivityStatus {
             "deduplicated" => Ok(Self::Deduplicated),
             "ignored" => Ok(Self::Ignored),
             "promoted" => Ok(Self::Promoted),
-            other => Err(format!("unknown activity status: {other}")),
+            other => Err(ParseActivityStatusError(other.to_string())),
         }
     }
 }
@@ -673,7 +678,7 @@ mod tests {
         use std::str::FromStr;
 
         let err = ActivityStatus::from_str("bogus").unwrap_err();
-        assert_eq!(err, "unknown activity status: bogus");
+        assert_eq!(err.to_string(), "unknown activity status: bogus");
         // Case-sensitivity: the matcher expects lowercase variants.
         assert!(ActivityStatus::from_str("Recorded").is_err());
         assert!(ActivityStatus::from_str("").is_err());


### PR DESCRIPTION
## Wave 2 of #506 — API-shape hardening (8 of 9 findings)

Applies the **API-shape** findings deferred from the #506 wave-1 mechanical
batch (PR #524). Branched off current `main`; all 9 findings re-verified
still-valid first (#531's #505 visibility work didn't touch these symbols).

`Closes #506` — wave-1 (#524) + wave-2 cover every mechanical and API-shape finding; the 9th (the builder) is split to its own design issue #541.

### Visibility narrowing (0 external blast radius — verified across all 4 crates)
- `engine`: `activity_filter`, `cognitive` → `pub(crate)`
- `scope`: `tree` → `pub(crate)`
- `graph`: `ensure_node` → `pub(crate)`
- `consolidation`: pass-fn re-exports → `pub(crate) use`
- `forgetting`: `ebbinghaus_decay`, `compute_importance` → `pub(crate)`

### API hardening
- `inspect::ReplayFilter` gains `#[non_exhaustive]`; the **3 external construction
  sites** (cli ×2, mcp ×1) switch from struct-literal to default-then-mutate.
- `ActivityStatus::FromStr::Err`: `String` → typed `ParseActivityStatusError` (thiserror).

### Determinism
- snapshot `config` + summary `by_level`: `HashMap` → `BTreeMap` (deterministic
  serialization order); `ConsolidationLevel` gains `PartialOrd/Ord` (BTreeMap key);
  producers in `statistics.rs` and `store::schema::list_config` updated.

### ⚠️ F1 (telescoping-constructors → builder) — DEFERRED
The 9th finding wants the 5 `MemoryEngine::open*` constructors replaced by a
builder. Blast radius: **`open_memory` alone has 263 call sites** (overwhelmingly
tests). That's a disproportionate, design-laden change for a severity-low smell —
it warrants its own design issue + PR, not a fold-in here. **Filed as #541**
(`type:refactor` + `status:needs-design`); #506's auto-fix batch is complete without it.

### Incidental (Tier-1 collateral)
Made the MCP default dump path unique (pid + atomic counter) — fixes a
**pre-existing parallel-test race** in `test_dump_state_default_path` (passed
serially, flaked under parallel execution; the dump-path code is untouched by the
wave-2 findings). Not a #506 finding.

### Gate — all green (deterministic)
`fmt`; `build/test/clippy --workspace` (flake fixed, ran 2× clean); `build/test/clippy --all-features`.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)


