### PR TITLE
fix(storage): reject non-file backup paths in restore_sqlite (#191)

### DIFF
--- a/src/engine/restore.rs
+++ b/src/engine/restore.rs
@@ -106,7 +106,8 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::Conflict` if the target path already exists.
-    /// Returns `MemoryError::NotFound` if the backup file doesn't exist.
+    /// Returns `MemoryError::NotFound` if the backup path is not an existing
+    /// regular file (missing, or a directory / other non-file).
     /// Returns `MemoryError::EmbeddingDimension` on dimension mismatch.
     pub fn restore_sqlite(backup_path: &Path, config: &EngineConfig) -> Result<Self> {
         if config.path.exists() {
@@ -114,9 +115,13 @@ impl MemoryEngine {
                 "target database path already exists".into(),
             ));
         }
-        if !backup_path.exists() {
+        // Use `is_file()` (not `exists()`): a directory passed as the backup
+        // source would pass an `exists()` guard and then fail deep inside
+        // `std::fs::copy` with a confusing OS-level error. `is_file()` rejects
+        // directories and other non-regular files up front with a clear message.
+        if !backup_path.is_file() {
             return Err(MemoryError::NotFound(format!(
-                "backup file: {}",
+                "backup file is not a regular file: {}",
                 backup_path.display()
             )));
         }

--- a/tests/restore_roundtrip_test.rs
+++ b/tests/restore_roundtrip_test.rs
@@ -191,6 +191,46 @@ fn restore_sqlite_fails_if_backup_missing() {
     assert!(err.to_string().contains("backup file"));
 }
 
+/// Regression for #191: a directory passed as the backup source must be
+/// rejected by the `is_file()` guard with a precise `NotFound` ("not a regular
+/// file") error, *before* `std::fs::copy` runs. With the old `exists()` guard
+/// the directory passed the check and `copy` later failed with a confusing
+/// OS-level I/O error.
+#[test]
+fn restore_sqlite_fails_if_backup_is_directory() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // The backup "source" is a directory, not a file.
+    let backup_dir = dir.path().join("a_directory");
+    std::fs::create_dir(&backup_dir).unwrap();
+
+    let target_path = dir.path().join("target.db");
+    let config = EngineConfig::new(target_path.clone(), DIM);
+
+    let err = MemoryEngine::restore_sqlite(&backup_dir, &config).unwrap_err();
+
+    // Must be the precise pre-copy guard error, not a copy/I/O error.
+    assert!(
+        matches!(err, memory_engine::error::MemoryError::NotFound(_)),
+        "expected NotFound, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("backup file") && msg.contains("not a regular file"),
+        "expected a 'not a regular file' message, got: {msg}"
+    );
+    assert!(
+        !msg.contains("I/O error"),
+        "must not surface a raw copy/I/O error, got: {msg}"
+    );
+
+    // The guard fired before any copy, so no orphan target file was created.
+    assert!(
+        !target_path.exists(),
+        "target file should not have been created when the guard rejects the source"
+    );
+}
+
 #[cfg(feature = "compress-gzip")]
 #[test]
 fn gzip_json_restore_roundtrip() {


### PR DESCRIPTION
## #191 — `restore_sqlite` should reject non-file backup paths

`restore_sqlite` guarded the backup **source** with `!backup_path.exists()`. A directory path passes that guard and then fails deep inside `std::fs::copy` with an opaque OS-level error. Switched to `is_file()` for a precise up-front rejection.

### Scope

- `src/engine/restore.rs` — `restore_sqlite` source guard `exists()` → `is_file()` + clearer "not a regular file" message. The two `config.path.exists()` **target** checks are a different, correct semantic and were intentionally left untouched.
- `tests/restore_roundtrip_test.rs` — `restore_sqlite_fails_if_backup_is_directory` regression test (asserts a precise `NotFound` "not a regular file" error, _not_ a copy error, and no orphan target file).

### Gates

- `cargo build --workspace` ✓
- `cargo test -p memory-engine` ✓ (restore suite green, incl. existing `..._backup_missing`)
- clippy — project gate (`clippy::all = deny`) ✓; restore.rs adds **zero** findings
- fmt ✓ on changed files

> Pre-existing `clippy -D warnings` debt and rustfmt import-order drift on base `63ee3c6` are **out of scope** (filed separately) — this change contributes zero new findings, verified via `git stash` on the clean base.

Fixes #191
