### PR TITLE
refactor(core): centralize unscored-fact importance into Fact::UNSCORED_IMPORTANCE

### DIFF
--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -81,7 +81,7 @@ pub fn resolve_conflict(
         last_accessed: new_fact.last_accessed,
         metadata: new_fact.metadata.clone(),
         is_pinned: new_fact.is_pinned,
-        importance_score: 0.5, // placeholder — fact not yet scored; see ConflictArbiter doc
+        importance_score: crate::types::Fact::UNSCORED_IMPORTANCE,
         surfaced_at: None,
     };
 

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -54,7 +54,7 @@ pub fn global_integration(
             last_accessed: s.created_at,
             metadata: serde_json::json!({}),
             is_pinned: false,
-            importance_score: 0.5,
+            importance_score: Fact::UNSCORED_IMPORTANCE,
             surfaced_at: None,
         })
         .collect();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -74,8 +74,9 @@ pub trait ConflictArbiter: Send + Sync {
     /// When called from [`resolve_conflict`](crate::conflict::resolve_conflict),
     /// `new_fact` is a temporary [`Fact`] constructed from a [`NewFact`](crate::types::NewFact)
     /// before it has been persisted or scored. Its `importance_score` field is hardcoded
-    /// to `0.5` and does **not** reflect the fact's actual computed importance.
-    /// Implementations that branch on `new_fact.importance_score` will always see `0.5`.
+    /// to [`Fact::UNSCORED_IMPORTANCE`](crate::types::Fact::UNSCORED_IMPORTANCE) and does
+    /// **not** reflect the fact's actual computed importance. Implementations that branch on
+    /// `new_fact.importance_score` will always see that sentinel.
     /// Use `new_fact.importance` (the caller-supplied raw importance) instead if you need
     /// a signal for the incoming fact's weight.
     ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -141,6 +141,19 @@ pub struct Fact {
     pub surfaced_at: Option<DateTime<Utc>>,
 }
 
+impl Fact {
+    /// `importance_score` assigned to a transient [`Fact`] that has never been
+    /// scored — e.g. a synthetic candidate built for the
+    /// [`ConflictArbiter`](crate::traits::ConflictArbiter), or a pseudo-fact
+    /// derived during global consolidation. A neutral midpoint, deliberately
+    /// not a real computed score.
+    ///
+    /// Single source of truth: reference this constant instead of re-typing the
+    /// `0.5` literal. Arbiter implementations may compare against it to detect an
+    /// unscored candidate.
+    pub const UNSCORED_IMPORTANCE: f64 = 0.5;
+}
+
 /// A graph edge between two facts.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Edge {
@@ -828,6 +841,15 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         let back: Event = serde_json::from_str(&json).unwrap();
         assert_eq!(event, back);
+    }
+
+    #[test]
+    fn unscored_importance_sentinel_is_half() {
+        // Locks the canonical value of the unscored-fact placeholder. The two
+        // production construction sites (conflict::resolve_conflict and
+        // consolidation::global_integration) reference this constant; this is the
+        // single, deliberate place to change it.
+        assert_eq!(Fact::UNSCORED_IMPORTANCE, 0.5);
     }
 
     #[test]


### PR DESCRIPTION
**Behavior-preserving refactor.** Establishes a single source of truth for the "unscored synthetic-`Fact`" placeholder `importance_score`, which was a magic `0.5` re-typed at two production sites that must stay in sync.

### What changed
- **New constant** (`src/types.rs`): `pub const Fact::UNSCORED_IMPORTANCE: f64 = 0.5`, documented on the type it describes. It's the importance score of a transient `Fact` that has never been through scoring.
- **Two production call sites** now reference it instead of a bare literal:
  - `conflict::resolve_conflict` (`temporal.rs:84`) — the synthetic candidate `Fact` handed to the `ConflictArbiter`.
  - `consolidation::global_integration` (`global.rs:57`) — the pseudo-fact derived from cluster summaries.
- **Doc-sync** (`traits.rs`): the `ConflictArbiter` warning that documents this placeholder now links `Fact::UNSCORED_IMPORTANCE` instead of restating `0.5`, so the prose and the value can never drift.
- **Value-lock test**: `assert_eq!(Fact::UNSCORED_IMPORTANCE, 0.5)`.

### Behavior validation (for review)
- **The value is identical** (`0.5` → a const equal to `0.5`). The `ConflictArbiter` and consolidation see the exact same number, now named — no behavioral change. All existing arbiter/consolidation tests pass unchanged; that is the behavior-preservation proof.
- The constant is **`pub`** so consumer-injected `ConflictArbiter` implementations may detect an unscored candidate by name: `if new_fact.importance_score == Fact::UNSCORED_IMPORTANCE { … }`. (`cargo doc` confirms the public-trait doc-link resolves with no `private_intra_doc_links` warning.)

### Deliberately out of scope
- The ~6 **test-fixture** `0.5`s (arbitrary test data — coupling them would make a sentinel change silently rewrite unrelated test expectations).
- `FactStore::insert`'s **seed-from-`importance`** rule (`facts.rs:106`) — a different concept (real facts seed their score from base importance), not this sentinel.

### Verification
`cargo build --workspace` ✅ · `cargo test --workspace` ✅ · `cargo clippy --workspace --all-targets` ✅ · `cargo fmt --check` ✅ · `cargo doc --no-deps` ✅ (no new warnings).

Part of #505 (generalizes the `conflict/arbiter-synthetic-fact` finding, which had flagged only one of the two sites).
