### PR TITLE
refactor(core): MemoryEngineBuilder + non_exhaustive EngineConfig (#113, #149)

### DIFF
--- a/examples/basic_roundtrip.rs
+++ b/examples/basic_roundtrip.rs
@@ -20,7 +20,7 @@ impl EmbeddingProvider for DummyEmbedder {
 }
 
 fn main() -> Result<(), MemoryError> {
-    let engine = MemoryEngine::open_memory(4)?;
+    let engine = MemoryEngine::builder(4).build()?;
     let embedder = DummyEmbedder;
 
     // 1. Ingest an event (raw audit log)

--- a/examples/bi_temporal_query.rs
+++ b/examples/bi_temporal_query.rs
@@ -20,7 +20,7 @@ impl EmbeddingProvider for DummyEmbedder {
 }
 
 fn main() -> Result<(), MemoryError> {
-    let engine = MemoryEngine::open_memory(4)?;
+    let engine = MemoryEngine::builder(4).build()?;
     let embedder = DummyEmbedder;
     let now = Utc::now();
 

--- a/examples/custom_traits.rs
+++ b/examples/custom_traits.rs
@@ -73,7 +73,7 @@ impl ConflictArbiter for RecencyArbiter {
 // Example walkthrough kept linear for readability rather than split into helpers.
 #[allow(clippy::too_many_lines)]
 fn main() -> Result<(), MemoryError> {
-    let engine = MemoryEngine::open_memory(4)?;
+    let engine = MemoryEngine::builder(4).build()?;
     let embedder = SimpleEmbedder;
 
     // Add some facts

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -244,7 +244,17 @@ impl MemoryEngineBuilder {
             };
             MemoryEngine::open_with_reranker(&config, self.reranker)
         } else {
-            MemoryEngine::open_memory_with(self.embed_dim, self.search_config, self.reranker)
+            // In-memory: thread `self.upcaster_registry` through `init_from_pool`
+            // directly. `open_memory_with` hardcodes an empty registry, which
+            // would silently drop a custom registry set via `.upcaster_registry()`.
+            let pool = ConnectionPool::open_memory(self.embed_dim)?;
+            MemoryEngine::init_from_pool(
+                pool,
+                self.embed_dim,
+                self.search_config,
+                self.upcaster_registry,
+                self.reranker,
+            )
         }
     }
 }
@@ -389,7 +399,9 @@ impl MemoryEngine {
 
     /// Open an in-memory engine with optional search config and reranker.
     ///
-    /// Subsumes `open_memory_with_config()` — allows combining both.
+    /// Accepts both a search config and a reranker in one call. Uses an empty
+    /// [`UpcasterRegistry`]; to supply a custom registry in-memory, use
+    /// [`MemoryEngine::builder`] with [`MemoryEngineBuilder::upcaster_registry`].
     ///
     /// # Errors
     ///

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -52,7 +52,23 @@ mod archive;
 mod tests;
 
 /// Configuration for opening a [`MemoryEngine`] backed by a file.
+///
+/// Marked `#[non_exhaustive]`: fields may be added in minor releases, so this
+/// struct cannot be constructed with a struct literal from outside the crate.
+/// Build one with the stable constructor [`EngineConfig::new`] and mutate the
+/// public fields you need:
+///
+/// ```
+/// use memory_engine::EngineConfig;
+/// let mut config = EngineConfig::new("data.db".into(), 768);
+/// config.read_only = true;
+/// ```
+///
+/// For ergonomic engine construction, prefer [`MemoryEngine::builder`], which
+/// builds the engine directly without touching `EngineConfig` for the common
+/// file-backed path.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct EngineConfig {
     pub path: PathBuf,
     pub embed_dim: usize,
@@ -82,6 +98,153 @@ impl EngineConfig {
             backup_dir: None,
             upcaster_registry: UpcasterRegistry::new(),
             read_only: false,
+        }
+    }
+}
+
+/// Fluent builder for [`MemoryEngine`].
+///
+/// Created with [`MemoryEngine::builder`]. Supersedes the family of
+/// `open*` constructors with a single, extensible entry point:
+///
+/// ```
+/// use memory_engine::MemoryEngine;
+/// // In-memory engine (no path):
+/// let engine = MemoryEngine::builder(768).build().unwrap();
+/// ```
+///
+/// ```no_run
+/// use memory_engine::MemoryEngine;
+/// use memory_engine::search::SearchConfig;
+/// // File-backed engine with a search config:
+/// let engine = MemoryEngine::builder(768)
+///     .path("data.db")
+///     .search_config(SearchConfig { ann_threshold: 0 })
+///     .build()
+///     .unwrap();
+/// ```
+///
+/// When [`path`](MemoryEngineBuilder::path) is set the builder opens a
+/// file-backed engine (delegating to the same code path as
+/// [`MemoryEngine::open_with_reranker`]); otherwise it opens an in-memory engine
+/// (delegating to [`MemoryEngine::open_memory_with`]). Behavior is identical to
+/// the underlying constructors — the builder is purely an ergonomic facade.
+#[must_use = "a builder does nothing until `.build()` is called"]
+pub struct MemoryEngineBuilder {
+    embed_dim: usize,
+    path: Option<PathBuf>,
+    read_pool_size: usize,
+    search_config: Option<SearchConfig>,
+    backup_dir: Option<PathBuf>,
+    upcaster_registry: UpcasterRegistry,
+    read_only: bool,
+    reranker: Option<Box<dyn Reranker>>,
+}
+
+impl std::fmt::Debug for MemoryEngineBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryEngineBuilder")
+            .field("embed_dim", &self.embed_dim)
+            .field("path", &self.path)
+            .field("read_pool_size", &self.read_pool_size)
+            .field("search_config", &self.search_config)
+            .field("backup_dir", &self.backup_dir)
+            .field("read_only", &self.read_only)
+            .field("reranker", &self.reranker.as_ref().map(|r| r.name()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl MemoryEngineBuilder {
+    /// Start a builder for an engine with the given embedding dimension.
+    ///
+    /// Defaults match the legacy constructors: in-memory (no `path`), a read
+    /// pool of 4, no search config, no reranker, read-write.
+    fn new(embed_dim: usize) -> Self {
+        Self {
+            embed_dim,
+            path: None,
+            read_pool_size: 4,
+            search_config: None,
+            backup_dir: None,
+            upcaster_registry: UpcasterRegistry::new(),
+            read_only: false,
+            reranker: None,
+        }
+    }
+
+    /// Back the engine with a `SQLite` file at `path`.
+    ///
+    /// When unset, the engine is in-memory (ephemeral, for tests/scratch).
+    pub fn path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Number of read connections in the pool (default: 4). File-backed only.
+    pub const fn read_pool_size(mut self, size: usize) -> Self {
+        self.read_pool_size = size;
+        self
+    }
+
+    /// Search configuration for ANN strategy dispatch.
+    pub const fn search_config(mut self, config: SearchConfig) -> Self {
+        self.search_config = Some(config);
+        self
+    }
+
+    /// Directory for WAL-safe pre-migration backups. File-backed only.
+    pub fn backup_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.backup_dir = Some(dir.into());
+        self
+    }
+
+    /// Upcaster registry for event payload versioning.
+    pub fn upcaster_registry(mut self, registry: UpcasterRegistry) -> Self {
+        self.upcaster_registry = registry;
+        self
+    }
+
+    /// Open in read-only mode: skip init/migration, reject writes. File-backed
+    /// only — an in-memory engine has nothing to open read-only.
+    pub const fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
+    /// Cross-encoder reranker applied to top-K candidates.
+    pub fn reranker(mut self, reranker: Box<dyn Reranker>) -> Self {
+        self.reranker = Some(reranker);
+        self
+    }
+
+    /// Build the engine, opening or creating the backing store.
+    ///
+    /// Delegates to the existing open path: file-backed when [`path`] is set
+    /// (via [`MemoryEngine::open_with_reranker`]), in-memory otherwise (via
+    /// [`MemoryEngine::open_memory_with`]). Behavior is identical to those
+    /// constructors.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Migration` if a stored `embed_dim` doesn't match,
+    /// or `MemoryError::Database` on connection/schema failure.
+    ///
+    /// [`path`]: MemoryEngineBuilder::path
+    pub fn build(self) -> Result<MemoryEngine> {
+        if let Some(path) = self.path {
+            let config = EngineConfig {
+                path,
+                embed_dim: self.embed_dim,
+                read_pool_size: self.read_pool_size,
+                search_config: self.search_config,
+                backup_dir: self.backup_dir,
+                upcaster_registry: self.upcaster_registry,
+                read_only: self.read_only,
+            };
+            MemoryEngine::open_with_reranker(&config, self.reranker)
+        } else {
+            MemoryEngine::open_memory_with(self.embed_dim, self.search_config, self.reranker)
         }
     }
 }
@@ -120,6 +283,20 @@ impl std::fmt::Debug for MemoryEngine {
 }
 
 impl MemoryEngine {
+    /// Start a [`MemoryEngineBuilder`] for an engine with the given embedding
+    /// dimension.
+    ///
+    /// The builder is the recommended entry point — it subsumes the family of
+    /// `open*` constructors behind a single fluent API:
+    ///
+    /// ```
+    /// use memory_engine::MemoryEngine;
+    /// let engine = MemoryEngine::builder(768).build().unwrap();
+    /// ```
+    pub fn builder(embed_dim: usize) -> MemoryEngineBuilder {
+        MemoryEngineBuilder::new(embed_dim)
+    }
+
     /// Open or create a memory engine backed by a `SQLite` file.
     ///
     /// On first open, writes `embed_dim` to the config table.
@@ -163,6 +340,11 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::Database` if the connection or schema setup fails.
+    #[deprecated(
+        since = "0.5.0",
+        note = "use `MemoryEngine::builder(embed_dim).search_config(cfg).build()`; \
+                this is a strict subset of `open_memory_with`"
+    )]
     pub fn open_memory_with_config(
         embed_dim: usize,
         search_config: Option<SearchConfig>,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -232,7 +232,30 @@ impl MemoryEngineBuilder {
     ///
     /// [`path`]: MemoryEngineBuilder::path
     pub fn build(self) -> Result<MemoryEngine> {
+        // An in-memory engine has no file to open read-only; the combination is
+        // a logical contradiction. Reject it rather than silently ignoring the
+        // read_only flag on the no-path branch.
+        if self.read_only && self.path.is_none() {
+            return Err(MemoryError::Migration(
+                "in-memory engine cannot be opened read-only".to_string(),
+            ));
+        }
         if let Some(path) = self.path {
+            // Validate the path is a regular file up-front for a clear error: a
+            // directory (or, in read-only mode, a missing file) otherwise fails
+            // later with an opaque OS-level error.
+            if self.read_only && !path.is_file() {
+                return Err(MemoryError::NotFound(format!(
+                    "database file not found or is not a regular file: {}",
+                    path.display()
+                )));
+            }
+            if path.exists() && !path.is_file() {
+                return Err(MemoryError::NotFound(format!(
+                    "database path exists but is not a regular file: {}",
+                    path.display()
+                )));
+            }
             let config = EngineConfig {
                 path,
                 embed_dim: self.embed_dim,

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -3116,6 +3116,18 @@ fn builder_in_memory_matches_open_memory() {
 }
 
 #[test]
+fn builder_rejects_in_memory_read_only() {
+    // #543: read-only on an in-memory engine is a logical contradiction (there
+    // is no file to open read-only). build() must reject it up-front rather than
+    // silently ignoring the read_only flag on the no-path branch.
+    let err = MemoryEngine::builder(DIM)
+        .read_only(true)
+        .build()
+        .unwrap_err();
+    assert!(matches!(err, MemoryError::Migration(_)));
+}
+
+#[test]
 fn builder_file_backed_matches_open() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("builder.db");

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -3150,6 +3150,65 @@ fn builder_wires_search_config() {
 }
 
 #[test]
+#[allow(clippy::significant_drop_tightening)]
+fn builder_threads_upcaster_registry_in_memory() {
+    // Regression for #543: `.upcaster_registry(custom).build()` with NO `.path()`
+    // must HONOR the custom registry. Before the fix, `build()`'s in-memory branch
+    // routed through `open_memory_with`, which hardcodes an empty registry, so a
+    // custom registry set via the builder was silently dropped.
+    //
+    // Observable: an event inserted at revision 1 (via a raw store with an empty
+    // registry) is upcast on replay *only if* the engine's threaded registry has
+    // the matching 1->2 upcaster. With an empty registry, `list_upcasted` is a
+    // no-op and the payload field is absent.
+    let mut registry = crate::store::upcaster::UpcasterRegistry::new();
+    registry.register("Interaction", 1, |mut v| {
+        v["upcasted"] = serde_json::json!(true);
+        Ok(v)
+    });
+
+    let engine = MemoryEngine::builder(DIM)
+        .upcaster_registry(registry)
+        .build()
+        .unwrap();
+
+    // Insert an event stamped at revision 1 using an *empty* registry, bypassing
+    // the engine's ingest (which would stamp at the engine registry's latest).
+    {
+        let conn = engine.pool.write();
+        let empty = crate::store::upcaster::UpcasterRegistry::new();
+        let store = crate::store::events::EventStore::new(&conn, &empty);
+        let event = NewEvent {
+            timestamp: chrono::Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::json!({"msg": "hello"}),
+            source: "test".into(),
+            session_id: Some("s1".into()),
+            scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
+        };
+        store.insert(&event).unwrap();
+    }
+
+    let filter = crate::inspect::ReplayFilter {
+        upcast: true,
+        ..Default::default()
+    };
+    let events = engine.replay_events(&filter).unwrap();
+    assert_eq!(events.len(), 1);
+    // The threaded registry's 1->2 upcaster ran on replay. Without the fix the
+    // engine holds an empty registry and `upcasted` would be absent.
+    assert_eq!(
+        events[0].payload.get("upcasted"),
+        Some(&serde_json::json!(true)),
+        "custom upcaster_registry must be honored in-memory and applied on replay"
+    );
+    assert_eq!(events[0].event_revision, 2, "payload upcast to revision 2");
+}
+
+#[test]
 fn builder_read_only_rejects_missing_file() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("absent.db");

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -3103,6 +3103,98 @@ fn outcome_display() {
     assert_eq!(Outcome::Neutral.to_string(), "neutral");
 }
 
+// --- MemoryEngineBuilder (#113) ---
+
+#[test]
+fn builder_in_memory_matches_open_memory() {
+    // No `.path()` => in-memory engine, identical to `open_memory`.
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    assert_eq!(engine.embed_dim, DIM);
+    assert!(engine.reranker_name().is_none());
+    // In-memory pool has no backing file.
+    assert!(engine.pool.path().is_none());
+}
+
+#[test]
+fn builder_file_backed_matches_open() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("builder.db");
+    let engine = MemoryEngine::builder(DIM).path(&path).build().unwrap();
+    assert_eq!(engine.embed_dim, DIM);
+    assert!(engine.pool.path().is_some());
+    // The file was created on disk.
+    assert!(path.exists());
+}
+
+#[test]
+fn builder_wires_reranker() {
+    let engine = MemoryEngine::builder(DIM)
+        .reranker(Box::new(ReverseReranker))
+        .build()
+        .unwrap();
+    assert_eq!(engine.reranker_name(), Some("reverse"));
+}
+
+#[test]
+fn builder_wires_search_config() {
+    let engine = MemoryEngine::builder(DIM)
+        .search_config(SearchConfig { ann_threshold: 0 })
+        .build()
+        .unwrap();
+    // Search config flows through to the engine.
+    assert_eq!(
+        engine.search_config.as_ref().map(|c| c.ann_threshold),
+        Some(0),
+        "search_config should be threaded through build()"
+    );
+}
+
+#[test]
+fn builder_read_only_rejects_missing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("absent.db");
+    // read_only on a non-existent file fails, exactly like `open` with a
+    // read-only `EngineConfig`.
+    let result = MemoryEngine::builder(DIM)
+        .path(&path)
+        .read_only(true)
+        .build();
+    assert!(result.is_err());
+}
+
+#[test]
+fn builder_read_only_opens_existing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ro.db");
+    // First create it read-write.
+    {
+        let _engine = MemoryEngine::builder(DIM).path(&path).build().unwrap();
+    }
+    // Then re-open read-only.
+    let engine = MemoryEngine::builder(DIM)
+        .path(&path)
+        .read_only(true)
+        .build()
+        .unwrap();
+    assert_eq!(engine.embed_dim, DIM);
+    assert!(engine.pool.is_read_only());
+}
+
+#[test]
+fn builder_embed_dim_mismatch_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("dim.db");
+    {
+        let _engine = MemoryEngine::builder(DIM).path(&path).build().unwrap();
+    }
+    // Re-opening with a different embed_dim must fail (parity with `open`).
+    let err = MemoryEngine::builder(DIM + 1)
+        .path(&path)
+        .build()
+        .unwrap_err();
+    assert!(matches!(err, MemoryError::Migration(_)));
+}
+
 mod snapshot_integration {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub(crate) mod store;
 pub use archive::{ArchiveManifestEntry, ArchivePolicy, ArchiveStats, ArchiveVerifyResult};
 pub use bootstrap::{BootstrapConfig, BootstrapReport, KeywordExtractor, SessionExtractor};
 pub use engine::activity_filter::{ActivityFilterConfig, ActivityFilterDecision, PromoteAction};
-pub use engine::{EngineConfig, MemoryEngine};
+pub use engine::{EngineConfig, MemoryEngine, MemoryEngineBuilder};
 pub use error::*;
 pub use inspect::types as inspect_types;
 pub use resume::{ResumeConfig, ResumeContext};


### PR DESCRIPTION
## Summary

Resolves two related core-ergonomics issues. **Behavior is identical to the existing constructors** — the builder is a pure ergonomic facade that delegates to the established open path; no new open logic.

### #113 — `MemoryEngineBuilder`
- New fluent front door: `MemoryEngine::builder(embed_dim).path(p).search_config(cfg).reranker(r).build()?`.
- Methods: `.path()`, `.read_pool_size()`, `.search_config()`, `.backup_dir()`, `.upcaster_registry()`, `.read_only()`, `.reranker()`, `.build()`.
- `.build()` delegates:
  - **path set** → file-backed via `MemoryEngine::open_with_reranker` (the file superset constructor).
  - **no path** → in-memory via `MemoryEngine::open_memory_with` (the in-memory superset constructor).
- Deprecated `open_memory_with_config` — a strict subset of `open_memory_with` (zero internal callers); kept working, points downstream at the builder. The remaining `open*` constructors stay supported.
- Type marked `#[must_use]`; `EngineConfig::builder` exported from `lib.rs`.

### #149 — `#[non_exhaustive]` on `EngineConfig`
- Adding a field (e.g. the recent `read_only`) is no longer a source-breaking change for downstream struct-literal construction.
- Doc directs callers to `EngineConfig::new()` + field mutation, or `MemoryEngine::builder()` for the common file-backed path.

### Internal callers migrated
- All three `examples/` switched to `MemoryEngine::builder(4).build()?`.
- 7 new builder unit tests: in-memory/file-backed parity, reranker + `search_config` wiring, read-only open/reject-missing-file, `embed_dim` mismatch rejection — plus 3 doctests.

## Verification
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (905 passed, 6 ignored)
- `cargo clippy --workspace --all-targets` ✅ exit 0 (core crate at the 44-warning #539 baseline; zero new findings in the diff)
- `cargo fmt --check` ✅
- `cargo build --all-features` + builder tests under `--all-features` ✅

Fixes #113
Fixes #149