### PR TITLE
refactor(core): remove SummaryGenerator::embed duplication (#116)

### DIFF
--- a/benches/lifecycle_bench.rs
+++ b/benches/lifecycle_bench.rs
@@ -57,11 +57,10 @@ impl EmbeddingProvider for ConstEmbedder {
     }
 }
 
-/// Trivial summary generator: concatenates fact content, embeds the result.
-/// Produces deterministic output without any LLM dependency.
-struct ConcatSummaryGenerator {
-    embedder: ConstEmbedder,
-}
+/// Trivial summary generator: concatenates fact content.
+/// Produces deterministic text without any LLM dependency. Summary embedding is
+/// performed by the [`ConstEmbedder`] injected into consolidation (issue #116).
+struct ConcatSummaryGenerator;
 
 impl SummaryGenerator for ConcatSummaryGenerator {
     fn summarize(&self, facts: &[Fact]) -> memory_engine::error::Result<String> {
@@ -71,10 +70,6 @@ impl SummaryGenerator for ConcatSummaryGenerator {
             .collect::<Vec<_>>()
             .join("; ");
         Ok(summary)
-    }
-
-    fn embed(&self, text: &str) -> memory_engine::error::Result<Vec<f32>> {
-        self.embedder.embed(text)
     }
 }
 
@@ -192,14 +187,13 @@ fn bench_consolidation(c: &mut Criterion) {
             b.iter_with_setup(
                 || setup_engine(n),
                 |(engine, _dir)| {
-                    let generator = ConcatSummaryGenerator {
-                        embedder: ConstEmbedder { dim: DIM },
-                    };
+                    let generator = ConcatSummaryGenerator;
+                    let embedder = ConstEmbedder { dim: DIM };
                     let config = ConsolidationConfig {
                         dedup_threshold: 0.95,
                         min_cluster_size: 3,
                     };
-                    engine.consolidate(&generator, &config).unwrap();
+                    engine.consolidate(&generator, &embedder, &config).unwrap();
                 },
             );
         });

--- a/docs/advanced/consolidation.md
+++ b/docs/advanced/consolidation.md
@@ -46,7 +46,7 @@ Expired facts have their edges cascade-expired as well, keeping the graph consis
 
 ### Pass 2: Cluster Fusion
 
-Groups active facts using greedy single-linkage clustering at a similarity threshold of 0.85 (hardcoded, lower than the dedup threshold). For each cluster meeting `min_cluster_size`, the `SummaryGenerator` produces a textual summary and embedding. These are stored as `Cluster`-level summaries.
+Groups active facts using greedy single-linkage clustering at a similarity threshold of 0.85 (hardcoded, lower than the dedup threshold). For each cluster meeting `min_cluster_size`, the `SummaryGenerator` produces a textual summary, which the `EmbeddingProvider` then embeds into the fact vector space. These are stored as `Cluster`-level summaries.
 
 Prior cluster summaries are deleted before new ones are created, making this pass idempotent.
 
@@ -83,16 +83,17 @@ pub struct ConsolidationStats {
 
 ## The SummaryGenerator Trait
 
-Consumers implement `SummaryGenerator` to provide summarization and embedding logic. The engine calls this during cluster fusion and global integration:
+Consumers implement `SummaryGenerator` to provide summarization logic. The engine calls this during cluster fusion and global integration:
 
 ```rust
 pub trait SummaryGenerator {
     fn summarize(&self, facts: &[Fact]) -> Result<String>;
-    fn embed(&self, text: &str) -> Result<Vec<f32>>;
 }
 ```
 
-A typical implementation wraps an LLM call for `summarize()` and an embedding model call for `embed()`. The engine has no LLM dependency -- this is entirely consumer-provided.
+A typical implementation wraps an LLM call for `summarize()`. The engine has no LLM dependency -- this is entirely consumer-provided.
+
+Summary **embedding** is performed by the `EmbeddingProvider` passed alongside the generator into `consolidate()`, so summaries share the same vector space as the facts they summarize. The generator no longer embeds: a dedicated `SummaryGenerator::embed` once duplicated `EmbeddingProvider::embed` and was removed in favor of injecting the embedder directly into the consolidation call chain.
 
 ## Usage
 
@@ -101,7 +102,7 @@ let config = ConsolidationConfig {
     dedup_threshold: 0.92,
     min_cluster_size: 3,
 };
-let stats = engine.consolidate(&my_summary_generator, &config)?;
+let stats = engine.consolidate(&my_summary_generator, &my_embedding_provider, &config)?;
 println!(
     "deduped={}, clusters={}, global={}",
     stats.duplicates_removed, stats.clusters_created, stats.global_summaries

--- a/docs/advanced/extensibility.md
+++ b/docs/advanced/extensibility.md
@@ -52,16 +52,15 @@ The returned vector's dimension must match the `embed_dim` configured on the eng
 
 ### SummaryGenerator
 
-Called during consolidation (cluster fusion and global integration) to produce textual summaries and their embeddings:
+Called during consolidation (cluster fusion and global integration) to produce textual summaries:
 
 ```rust
 pub trait SummaryGenerator {
     fn summarize(&self, facts: &[Fact]) -> Result<String>;
-    fn embed(&self, text: &str) -> Result<Vec<f32>>;
 }
 ```
 
-The `summarize` method receives a slice of related facts (a cluster or the set of cluster summaries) and returns a textual summary. The `embed` method computes an embedding for that summary text.
+The `summarize` method receives a slice of related facts (a cluster or the set of cluster summaries) and returns a textual summary. Embedding of that summary is **not** the generator's job: the `EmbeddingProvider` passed alongside the generator into `consolidate()` embeds it, so summaries share the fact vector space. (A redundant `SummaryGenerator::embed` was removed; it merely duplicated `EmbeddingProvider::embed`.)
 
 Implementation example:
 
@@ -69,7 +68,6 @@ Implementation example:
 struct LlmSummarizer {
     client: reqwest::blocking::Client,
     api_key: String,
-    embedder: Arc<dyn EmbeddingProvider>,
 }
 
 impl SummaryGenerator for LlmSummarizer {
@@ -81,14 +79,10 @@ impl SummaryGenerator for LlmSummarizer {
         // Call LLM API...
         Ok(summary)
     }
-
-    fn embed(&self, text: &str) -> Result<Vec<f32>> {
-        self.embedder.embed(text)
-    }
 }
 ```
 
-Errors from the `SummaryGenerator` roll back the entire consolidation transaction.
+Errors from the `SummaryGenerator` (or the `EmbeddingProvider`) roll back the entire consolidation transaction.
 
 ### ConflictArbiter
 
@@ -327,7 +321,7 @@ This is a policy (parameter set), not a strategy (pluggable algorithm). See [For
 | Extension point         | Type           | When called           | Provided by                         |
 | ----------------------- | -------------- | --------------------- | ----------------------------------- |
 | `EmbeddingProvider`     | consumer trait | `add_fact()`          | Text-to-vector model                |
-| `SummaryGenerator`      | consumer trait | `consolidate()`       | Summarization + embedding           |
+| `SummaryGenerator`      | consumer trait | `consolidate()`       | Summarization (embedding via `EmbeddingProvider`) |
 | `ConflictArbiter`       | consumer trait | `resolve_conflict()`  | Resolution logic                    |
 | `PersistenceClassifier` | consumer trait | `add_fact()`          | Auto-pinning logic                  |
 | `Reranker`              | consumer trait | `query()`             | Cross-encoder reranking (Phase 4a)  |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -88,7 +88,7 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 | Method        | Signature                                                                                               | Description                                                                                                               |
 | ------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `consolidate` | `(&self, generator: &dyn SummaryGenerator, config: &ConsolidationConfig) -> Result<ConsolidationStats>` | Run three-pass consolidation: local dedup, cluster fusion, global integration. Rebuilds graph if duplicates were removed. |
+| `consolidate` | `(&self, generator: &dyn SummaryGenerator, embedder: &dyn EmbeddingProvider, config: &ConsolidationConfig) -> Result<ConsolidationStats>` | Run three-pass consolidation: local dedup, cluster fusion, global integration. The generator produces summary text; the embedder projects it into the fact vector space. Rebuilds graph if duplicates were removed. |
 
 `ConsolidationConfig` fields:
 

--- a/docs/reference/crate-layout.md
+++ b/docs/reference/crate-layout.md
@@ -37,7 +37,7 @@ memory_engine (lib.rs)
 : Consumer-implemented traits that the engine delegates to for domain-specific behavior:
 
 - `EmbeddingProvider` -- compute text embeddings (local model or API).
-- `SummaryGenerator` -- generate summaries from fact clusters, plus embed the result.
+- `SummaryGenerator` -- generate summary text from fact clusters (embedding is done by the `EmbeddingProvider` injected into `consolidate()`).
 - `ConflictArbiter` -- decide how to resolve contradicting facts (returns `CrudDecision`).
 - `PersistenceClassifier` -- decide whether a new fact should be pinned (unforgettable). Optional, default returns `false`.
   Also defines `ForgetPolicy` (Ebbinghaus parameters and signal weights), `ConsolidationConfig`, `ConsolidationStats`, `PruneStats`, `ConflictResolution`, and `CrudDecision`.
@@ -68,7 +68,7 @@ memory_engine (lib.rs)
 1. **Local dedup** -- expire near-duplicate facts (cosine similarity above threshold).
 2. **Cluster fusion** -- group related facts and generate cluster-level summaries.
 3. **Global integration** -- produce cross-cluster summaries.
-   Accepts a `SummaryGenerator` trait object and `ConsolidationConfig`.
+   Accepts a `SummaryGenerator` trait object, an `EmbeddingProvider` trait object (to embed the generated summaries), and `ConsolidationConfig`.
 
 `forgetting`
 : Ebbinghaus-based decay with multi-signal importance scoring. Computes a weighted combination of recency (exponential decay), access frequency, graph connectivity, and base importance. Facts scoring below `ForgetPolicy::min_importance` are soft-deleted (their `t_expired` is set). Returns `PruneStats`.

--- a/examples/custom_traits.rs
+++ b/examples/custom_traits.rs
@@ -48,10 +48,8 @@ impl SummaryGenerator for ConcatSummarizer {
             .join("; ");
         Ok(format!("Summary: {summary}"))
     }
-
-    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
-        SimpleEmbedder.embed(text)
-    }
+    // No `embed`: summaries are embedded by the EmbeddingProvider passed into
+    // `consolidate`, sharing the fact vector space (issue #116).
 }
 
 // --- ConflictArbiter: consumers define how to resolve contradictions ---
@@ -125,10 +123,11 @@ fn main() -> Result<(), MemoryError> {
     println!("Added 4 facts (1 duplicate)");
     println!("Active facts: {}", engine.list_active_facts(None)?.len());
 
-    // --- Consolidation: uses SummaryGenerator ---
+    // --- Consolidation: uses SummaryGenerator (text) + EmbeddingProvider (vectors) ---
     let summarizer = ConcatSummarizer;
     let stats = engine.consolidate(
         &summarizer,
+        &embedder,
         &ConsolidationConfig {
             dedup_threshold: 0.99, // high threshold to catch near-exact duplicates
             min_cluster_size: 2,

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -75,8 +75,9 @@ async fn main() -> Result<(), BoxError> {
     // Use the resolved embed_dim (from DB probe or config), not the TOML value.
     let embedder = build_embedder(&cli, &mcp_config, embed_dim)?;
 
-    // 5. Initialize summary generator (optional — requires embedder)
-    let summary_gen = build_summary_generator(&cli, &mcp_config, embedder.as_ref())?
+    // 5. Initialize summary generator (optional — text only; embedding is done
+    //    by the embedder, injected separately into consolidation per #116)
+    let summary_gen = build_summary_generator(&cli, &mcp_config)?
         .map(|sg| sg as Arc<dyn memory_engine::traits::SummaryGenerator + Send + Sync>);
 
     // 6. Construct and serve
@@ -165,12 +166,13 @@ fn load_config(cli: &Cli) -> Result<config::McpConfig, BoxError> {
 
 /// Build the summary generator from config + CLI.
 ///
-/// Requires an existing embedder — summaries must be embedded into the same
-/// vector space as facts, so the summary generator delegates `embed()` to it.
+/// The generator produces summary text only; embedding of those summaries is
+/// performed by the separately-configured embedder at consolidation time
+/// (issue #116). The `memory_consolidate` tool therefore needs *both* a summary
+/// generator and an embedder — that requirement is enforced in the tool handler.
 fn build_summary_generator(
     cli: &Cli,
     mcp_config: &config::McpConfig,
-    embedder: Option<&Arc<embedding::HttpEmbeddingProvider>>,
 ) -> Result<Option<Arc<summary::HttpSummaryGenerator>>, BoxError> {
     let base = mcp_config.summary.as_ref();
 
@@ -189,19 +191,10 @@ fn build_summary_generator(
     let timeout = base.map_or(120, |b| b.timeout_secs);
 
     match (endpoint, model) {
-        (Some(url), Some(mdl)) => {
-            let Some(emb) = embedder.cloned() else {
-                tracing::warn!(
-                    "summary generator requires embedding provider — \
-                     consolidation tool will be unavailable"
-                );
-                return Ok(None);
-            };
-            Ok(Some(Arc::new(
-                summary::HttpSummaryGenerator::new(url, mdl, api_key, emb, timeout)
-                    .map_err(|e| format!("failed to create summary generator: {e}"))?,
-            )))
-        }
+        (Some(url), Some(mdl)) => Ok(Some(Arc::new(
+            summary::HttpSummaryGenerator::new(url, mdl, api_key, timeout)
+                .map_err(|e| format!("failed to create summary generator: {e}"))?,
+        ))),
         _ => Ok(None),
     }
 }

--- a/memory-engine-mcp/src/summary.rs
+++ b/memory-engine-mcp/src/summary.rs
@@ -1,10 +1,6 @@
-use std::sync::Arc;
-
 use memory_engine::error::MemoryError;
 use memory_engine::traits::SummaryGenerator;
 use memory_engine::types::Fact;
-
-use crate::embedding::HttpEmbeddingProvider;
 
 /// Default system prompt for memory consolidation summarization.
 ///
@@ -21,14 +17,15 @@ Output only the summary text, no preamble or explanation.";
 /// Uses `reqwest::blocking::Client` because the engine's `SummaryGenerator` trait is sync.
 /// This runs inside `tokio::task::spawn_blocking` via the server's dispatch layer.
 ///
-/// Delegates `embed()` to the configured [`HttpEmbeddingProvider`] to ensure
-/// dimensional consistency between summaries and facts in the vector space.
+/// Produces summary text only. Embedding is performed by the
+/// [`HttpEmbeddingProvider`](crate::embedding::HttpEmbeddingProvider) injected
+/// separately into consolidation (issue #116 — embedding is no longer duplicated
+/// on the `SummaryGenerator` trait), so summaries share the fact vector space.
 pub struct HttpSummaryGenerator {
     client: reqwest::blocking::Client,
     endpoint: String,
     model: String,
     api_key: Option<String>,
-    embedder: Arc<HttpEmbeddingProvider>,
 }
 
 impl HttpSummaryGenerator {
@@ -39,7 +36,6 @@ impl HttpSummaryGenerator {
         endpoint: String,
         model: String,
         api_key: Option<String>,
-        embedder: Arc<HttpEmbeddingProvider>,
         timeout_secs: u64,
     ) -> Result<Self, String> {
         let client = reqwest::blocking::ClientBuilder::new()
@@ -51,7 +47,6 @@ impl HttpSummaryGenerator {
             endpoint,
             model,
             api_key,
-            embedder,
         })
     }
 }
@@ -126,11 +121,6 @@ impl SummaryGenerator for HttpSummaryGenerator {
                 serde_json::to_string(&body).unwrap_or_default()
             ))
         })
-    }
-
-    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
-        use memory_engine::traits::EmbeddingProvider;
-        self.embedder.embed(text)
     }
 }
 

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -395,7 +395,7 @@ pub fn dispatch(
         "memory_statistics" => handle_statistics(engine),
         "memory_flush_insights" => handle_flush_insights(args, engine, embedder),
         // P1 tools
-        "memory_consolidate" => handle_consolidate(args, engine, summary_gen),
+        "memory_consolidate" => handle_consolidate(args, engine, embedder, summary_gen),
         "memory_forget" => handle_forget(args, engine),
         "memory_dump_state" => handle_dump_state(args, engine),
         "memory_pin_fact" => handle_pin_fact(args, engine),
@@ -939,9 +939,13 @@ fn handle_flush_insights(
 fn handle_consolidate(
     args: Map<String, Value>,
     engine: &MemoryEngine,
+    embedder: Option<&HttpEmbeddingProvider>,
     summary_gen: Option<&(dyn SummaryGenerator + Send + Sync)>,
 ) -> Result<CallToolResult, ErrorData> {
     let generator = summary_gen.ok_or(ValidationError::NoSummaryProvider)?;
+    // Issue #116: summaries are embedded via the EmbeddingProvider, not the
+    // SummaryGenerator, so consolidation now requires an embedder too.
+    let embedder = embedder.ok_or(ValidationError::NoEmbeddingProvider)?;
 
     let dedup_threshold = get_f64(&args, "dedup_threshold").unwrap_or(0.92) as f32;
     if !(0.0..=1.0).contains(&dedup_threshold) {
@@ -965,7 +969,7 @@ fn handle_consolidate(
     };
 
     let stats = engine
-        .consolidate(generator, &config)
+        .consolidate(generator, embedder, &config)
         .map_err(to_mcp_error)?;
 
     ok_json(json!({

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -159,15 +159,21 @@ impl AsyncMemoryEngine {
     }
 
     /// Run three-pass consolidation.
+    ///
+    /// `generator` produces the summary text; `embedder` projects it into the
+    /// fact vector space (issue #116 — embedding is no longer on the generator).
     pub async fn consolidate(
         &self,
         generator: Arc<dyn SummaryGenerator + Send + Sync>,
+        embedder: Arc<dyn EmbeddingProvider + Send + Sync>,
         config: ConsolidationConfig,
     ) -> Result<ConsolidationStats> {
         let engine = self.inner.clone();
-        tokio::task::spawn_blocking(move || engine.consolidate(generator.as_ref(), &config))
-            .await
-            .map_err(join_err)?
+        tokio::task::spawn_blocking(move || {
+            engine.consolidate(generator.as_ref(), embedder.as_ref(), &config)
+        })
+        .await
+        .map_err(join_err)?
     }
 
     /// Prune stale facts.

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -72,14 +72,8 @@ pub fn cluster_fusion(
             .collect();
         let source_ids: Vec<i64> = cluster_facts.iter().map(|f| f.id).collect();
 
-        let summary_text = generator.summarize(&cluster_facts)?;
-        let summary_embedding = embedder.embed(&summary_text)?;
-        if summary_embedding.len() != embed_dim {
-            return Err(crate::error::MemoryError::EmbeddingDimension {
-                expected: embed_dim,
-                actual: summary_embedding.len(),
-            });
-        }
+        let (summary_text, summary_embedding) =
+            super::summarize_and_embed(generator, embedder, &cluster_facts, embed_dim)?;
 
         // Determine scope_id from majority vote of source facts.
         // Deterministic tie-break: lowest scope_id wins on equal counts.

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -4,7 +4,7 @@ use crate::error::Result;
 use crate::search::vector::cosine_similarity;
 use crate::store::facts::FactStore;
 use crate::store::summaries::SummaryStore;
-use crate::traits::SummaryGenerator;
+use crate::traits::{EmbeddingProvider, SummaryGenerator};
 use crate::types::{ConsolidationLevel, Fact, NewSummary};
 
 /// Cluster threshold for grouping related facts (lower than dedup threshold).
@@ -14,7 +14,8 @@ const CLUSTER_SIMILARITY_THRESHOLD: f32 = 0.85;
 ///
 /// Clears prior cluster-level summaries before creating new ones (idempotent).
 /// Groups active facts by similarity (greedy single-linkage clustering).
-/// For each cluster >= `min_cluster_size`, calls `SummaryGenerator` to create a summary.
+/// For each cluster >= `min_cluster_size`, calls `SummaryGenerator` to create a
+/// summary, then `EmbeddingProvider` to embed it into the fact vector space.
 /// Stores summaries via `SummaryStore` with `level=Cluster`.
 ///
 /// Returns number of clusters created.
@@ -22,13 +23,14 @@ const CLUSTER_SIMILARITY_THRESHOLD: f32 = 0.85;
 /// # Errors
 ///
 /// Returns `MemoryError::Database` on SQL failure, or propagates errors from
-/// the `SummaryGenerator`.
-/// Returns `MemoryError::EmbeddingDimension` if the generator returns an embedding
+/// the `SummaryGenerator` or `EmbeddingProvider`.
+/// Returns `MemoryError::EmbeddingDimension` if the embedder returns an embedding
 /// whose length does not match `embed_dim`.
 /// Returns `MemoryError::Serialization` on JSON serialization failure.
 pub fn cluster_fusion(
     conn: &Connection,
     generator: &dyn SummaryGenerator,
+    embedder: &dyn EmbeddingProvider,
     embed_dim: usize,
     min_cluster_size: usize,
 ) -> Result<usize> {
@@ -71,7 +73,7 @@ pub fn cluster_fusion(
         let source_ids: Vec<i64> = cluster_facts.iter().map(|f| f.id).collect();
 
         let summary_text = generator.summarize(&cluster_facts)?;
-        let summary_embedding = generator.embed(&summary_text)?;
+        let summary_embedding = embedder.embed(&summary_text)?;
         if summary_embedding.len() != embed_dim {
             return Err(crate::error::MemoryError::EmbeddingDimension {
                 expected: embed_dim,
@@ -156,10 +158,8 @@ mod tests {
     use crate::store::schema::{init_schema, open_memory};
     use crate::types::{FactType, NewFact};
 
-    /// Mock generator that concatenates fact contents and returns a fixed embedding.
-    struct MockGenerator {
-        embed_dim: usize,
-    }
+    /// Mock generator that concatenates fact contents.
+    struct MockGenerator;
 
     impl SummaryGenerator for MockGenerator {
         fn summarize(&self, facts: &[Fact]) -> Result<String> {
@@ -169,7 +169,14 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join(" + "))
         }
+    }
 
+    /// Mock embedder returning a fixed-dimension constant vector.
+    struct MockEmbedder {
+        embed_dim: usize,
+    }
+
+    impl EmbeddingProvider for MockEmbedder {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![0.5; self.embed_dim])
         }
@@ -214,8 +221,9 @@ mod tests {
         insert_fact(&conn, dim, "c2b", vec![0.02, 0.98, 0.0, 0.0]);
         insert_fact(&conn, dim, "c2c", vec![0.03, 0.97, 0.0, 0.0]);
 
-        let mock_gen = MockGenerator { embed_dim: dim };
-        let clusters = cluster_fusion(&conn, &mock_gen, dim, 3).unwrap();
+        let mock_gen = MockGenerator;
+        let mock_embed = MockEmbedder { embed_dim: dim };
+        let clusters = cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 3).unwrap();
         assert_eq!(clusters, 2);
 
         let summaries = SummaryStore::new(&conn, dim)
@@ -234,8 +242,9 @@ mod tests {
         insert_fact(&conn, dim, "a", vec![1.0, 0.0, 0.0, 0.0]);
         insert_fact(&conn, dim, "b", vec![0.99, 0.01, 0.0, 0.0]);
 
-        let mock_gen = MockGenerator { embed_dim: dim };
-        let clusters = cluster_fusion(&conn, &mock_gen, dim, 3).unwrap();
+        let mock_gen = MockGenerator;
+        let mock_embed = MockEmbedder { embed_dim: dim };
+        let clusters = cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 3).unwrap();
         assert_eq!(clusters, 0);
     }
 
@@ -249,8 +258,9 @@ mod tests {
         insert_fact(&conn, dim, "beta", vec![0.99, 0.01, 0.0, 0.0]);
         insert_fact(&conn, dim, "gamma", vec![0.98, 0.02, 0.0, 0.0]);
 
-        let mock_gen = MockGenerator { embed_dim: dim };
-        cluster_fusion(&conn, &mock_gen, dim, 2).unwrap();
+        let mock_gen = MockGenerator;
+        let mock_embed = MockEmbedder { embed_dim: dim };
+        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2).unwrap();
 
         let summaries = SummaryStore::new(&conn, dim)
             .list_by_level(&ConsolidationLevel::Cluster)
@@ -270,11 +280,12 @@ mod tests {
         insert_fact(&conn, dim, "y", vec![0.99, 0.01, 0.0, 0.0]);
         insert_fact(&conn, dim, "z", vec![0.98, 0.02, 0.0, 0.0]);
 
-        let mock_gen = MockGenerator { embed_dim: dim };
+        let mock_gen = MockGenerator;
+        let mock_embed = MockEmbedder { embed_dim: dim };
 
         // Run twice — should have exactly the same result
-        cluster_fusion(&conn, &mock_gen, dim, 2).unwrap();
-        cluster_fusion(&conn, &mock_gen, dim, 2).unwrap();
+        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2).unwrap();
+        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2).unwrap();
 
         let summaries = SummaryStore::new(&conn, dim)
             .list_by_level(&ConsolidationLevel::Cluster)

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -2,7 +2,7 @@ use rusqlite::Connection;
 
 use crate::error::Result;
 use crate::store::summaries::SummaryStore;
-use crate::traits::SummaryGenerator;
+use crate::traits::{EmbeddingProvider, SummaryGenerator};
 use crate::types::{ConsolidationLevel, Fact, NewSummary};
 
 /// Global integration pass.
@@ -15,13 +15,14 @@ use crate::types::{ConsolidationLevel, Fact, NewSummary};
 /// # Errors
 ///
 /// Returns `MemoryError::Database` on SQL failure, or propagates errors from
-/// the `SummaryGenerator`.
-/// Returns `MemoryError::EmbeddingDimension` if the generator returns an embedding
+/// the `SummaryGenerator` or `EmbeddingProvider`.
+/// Returns `MemoryError::EmbeddingDimension` if the embedder returns an embedding
 /// whose length does not match `embed_dim`.
 /// Returns `MemoryError::Serialization` on JSON serialization failure.
 pub fn global_integration(
     conn: &Connection,
     generator: &dyn SummaryGenerator,
+    embedder: &dyn EmbeddingProvider,
     embed_dim: usize,
 ) -> Result<usize> {
     let summary_store = SummaryStore::new(conn, embed_dim);
@@ -60,7 +61,7 @@ pub fn global_integration(
         .collect();
 
     let global_text = generator.summarize(&pseudo_facts)?;
-    let global_embedding = generator.embed(&global_text)?;
+    let global_embedding = embedder.embed(&global_text)?;
     if global_embedding.len() != embed_dim {
         return Err(crate::error::MemoryError::EmbeddingDimension {
             expected: embed_dim,
@@ -101,9 +102,8 @@ mod tests {
 
     use crate::store::schema::{init_schema, open_memory};
 
-    struct MockGenerator {
-        embed_dim: usize,
-    }
+    /// Mock generator that concatenates cluster-summary contents.
+    struct MockGenerator;
 
     impl SummaryGenerator for MockGenerator {
         fn summarize(&self, facts: &[Fact]) -> Result<String> {
@@ -113,7 +113,14 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join(" | "))
         }
+    }
 
+    /// Mock embedder returning a fixed-dimension constant vector.
+    struct MockEmbedder {
+        embed_dim: usize,
+    }
+
+    impl EmbeddingProvider for MockEmbedder {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![0.5; self.embed_dim])
         }
@@ -140,8 +147,9 @@ mod tests {
                 .unwrap();
         }
 
-        let mock_gen = MockGenerator { embed_dim: dim };
-        let count = global_integration(&conn, &mock_gen, dim).unwrap();
+        let mock_gen = MockGenerator;
+        let mock_embed = MockEmbedder { embed_dim: dim };
+        let count = global_integration(&conn, &mock_gen, &mock_embed, dim).unwrap();
         assert_eq!(count, 1);
 
         let global = store.list_by_level(&ConsolidationLevel::Global).unwrap();
@@ -160,8 +168,9 @@ mod tests {
         init_schema(&conn).unwrap();
         let dim = 4;
 
-        let mock_gen = MockGenerator { embed_dim: dim };
-        let count = global_integration(&conn, &mock_gen, dim).unwrap();
+        let mock_gen = MockGenerator;
+        let mock_embed = MockEmbedder { embed_dim: dim };
+        let count = global_integration(&conn, &mock_gen, &mock_embed, dim).unwrap();
         assert_eq!(count, 0);
     }
 
@@ -183,11 +192,12 @@ mod tests {
             })
             .unwrap();
 
-        let mock_gen = MockGenerator { embed_dim: dim };
+        let mock_gen = MockGenerator;
+        let mock_embed = MockEmbedder { embed_dim: dim };
 
         // Run twice
-        global_integration(&conn, &mock_gen, dim).unwrap();
-        global_integration(&conn, &mock_gen, dim).unwrap();
+        global_integration(&conn, &mock_gen, &mock_embed, dim).unwrap();
+        global_integration(&conn, &mock_gen, &mock_embed, dim).unwrap();
 
         let global = store.list_by_level(&ConsolidationLevel::Global).unwrap();
         assert_eq!(global.len(), 1); // Not 2

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -60,14 +60,8 @@ pub fn global_integration(
         })
         .collect();
 
-    let global_text = generator.summarize(&pseudo_facts)?;
-    let global_embedding = embedder.embed(&global_text)?;
-    if global_embedding.len() != embed_dim {
-        return Err(crate::error::MemoryError::EmbeddingDimension {
-            expected: embed_dim,
-            actual: global_embedding.len(),
-        });
-    }
+    let (global_text, global_embedding) =
+        super::summarize_and_embed(generator, embedder, &pseudo_facts, embed_dim)?;
 
     // Collect all source fact ids from all cluster summaries.
     // Pre-size to avoid repeated reallocations: flat_map has no upper-bound hint.

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -15,7 +15,7 @@ use rusqlite::Connection;
 
 use crate::error::Result;
 use crate::store::schema::{get_config, set_config};
-use crate::traits::{ConsolidationConfig, ConsolidationStats, SummaryGenerator};
+use crate::traits::{ConsolidationConfig, ConsolidationStats, EmbeddingProvider, SummaryGenerator};
 
 /// Orchestrate all 3 consolidation passes atomically.
 ///
@@ -24,18 +24,25 @@ use crate::traits::{ConsolidationConfig, ConsolidationStats, SummaryGenerator};
 /// 3. Global integration — summarize all clusters into one global summary
 ///
 /// All passes run within a single transaction. On any failure (including
-/// `SummaryGenerator` errors), the entire consolidation is rolled back.
+/// `SummaryGenerator` or `EmbeddingProvider` errors), the entire consolidation
+/// is rolled back.
 ///
 /// Reads `last_consolidated_at` from config to scope dedup.
 /// Updates `last_consolidated_at` after successful completion.
 ///
+/// `generator` produces the summary text; `embedder` projects that text into
+/// the fact vector space (issue #116 — embedding is no longer duplicated on the
+/// generator trait).
+///
 /// # Errors
 ///
-/// Propagates errors from any pass or the `SummaryGenerator`.
+/// Propagates errors from any pass, the `SummaryGenerator`, or the
+/// `EmbeddingProvider`.
 /// Returns `MemoryError::Migration` if `last_consolidated_at` in config cannot be parsed.
 pub fn consolidate(
     conn: &Connection,
     generator: &dyn SummaryGenerator,
+    embedder: &dyn EmbeddingProvider,
     embed_dim: usize,
     config: &ConsolidationConfig,
 ) -> Result<(ConsolidationStats, Vec<i64>)> {
@@ -57,8 +64,9 @@ pub fn consolidate(
     let dedup_skipped = duplicates_removed == usize::MAX;
     let duplicates_removed = if dedup_skipped { 0 } else { duplicates_removed };
 
-    let clusters_created = cluster_fusion(&tx, generator, embed_dim, config.min_cluster_size)?;
-    let global_summaries = global_integration(&tx, generator, embed_dim)?;
+    let clusters_created =
+        cluster_fusion(&tx, generator, embedder, embed_dim, config.min_cluster_size)?;
+    let global_summaries = global_integration(&tx, generator, embedder, embed_dim)?;
 
     // Only advance the watermark if dedup actually ran. When skipped, facts
     // ingested during the over-cap period must be retried on the next run.

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -16,6 +16,33 @@ use rusqlite::Connection;
 use crate::error::Result;
 use crate::store::schema::{get_config, set_config};
 use crate::traits::{ConsolidationConfig, ConsolidationStats, EmbeddingProvider, SummaryGenerator};
+use crate::types::Fact;
+
+/// Summarize a slice of facts and embed the resulting summary text, validating
+/// the embedding dimension. Shared by cluster fusion and global integration so
+/// the summarize → embed → dimension-check sequence cannot diverge (issue #116:
+/// embedding now flows through the injected `EmbeddingProvider`).
+///
+/// # Errors
+///
+/// Propagates `SummaryGenerator` / `EmbeddingProvider` errors; returns
+/// `MemoryError::EmbeddingDimension` when the embedding length != `embed_dim`.
+pub(crate) fn summarize_and_embed(
+    generator: &dyn SummaryGenerator,
+    embedder: &dyn EmbeddingProvider,
+    facts: &[Fact],
+    embed_dim: usize,
+) -> Result<(String, Vec<f32>)> {
+    let text = generator.summarize(facts)?;
+    let embedding = embedder.embed(&text)?;
+    if embedding.len() != embed_dim {
+        return Err(crate::error::MemoryError::EmbeddingDimension {
+            expected: embed_dim,
+            actual: embedding.len(),
+        });
+    }
+    Ok((text, embedding))
+}
 
 /// Orchestrate all 3 consolidation passes atomically.
 ///

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -6,7 +6,8 @@ use crate::search::hybrid::{SearchQuery, SearchResult};
 use crate::store::facts::FactStore;
 use crate::store::lineage::LineageStore;
 use crate::traits::{
-    ConsolidationConfig, ConsolidationStats, ForgetPolicy, PruneStats, SummaryGenerator,
+    ConsolidationConfig, ConsolidationStats, EmbeddingProvider, ForgetPolicy, PruneStats,
+    SummaryGenerator,
 };
 use crate::types::{CycleReport, Fact, NewFact, NewLineageRecord, PromoteRequest, PromotionResult};
 
@@ -69,6 +70,8 @@ impl<'a> DreamContext<'a> {
     /// Run engine-internal consolidation (dedup → cluster → global summaries).
     ///
     /// Delegates to `MemoryEngine::consolidate()`, which manages its own locks.
+    /// `generator` produces the summary text; `embedder` projects it into the
+    /// fact vector space (issue #116).
     ///
     /// # Errors
     ///
@@ -76,9 +79,10 @@ impl<'a> DreamContext<'a> {
     pub fn consolidate(
         &self,
         generator: &dyn SummaryGenerator,
+        embedder: &dyn EmbeddingProvider,
         config: &ConsolidationConfig,
     ) -> Result<ConsolidationStats> {
-        self.engine.consolidate(generator, config)
+        self.engine.consolidate(generator, embedder, config)
     }
 
     /// Run Ebbinghaus decay + pruning on stale facts.

--- a/src/engine/consolidation.rs
+++ b/src/engine/consolidation.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::graph::MemoryGraph;
-use crate::traits::{ConsolidationConfig, ConsolidationStats, SummaryGenerator};
+use crate::traits::{ConsolidationConfig, ConsolidationStats, EmbeddingProvider, SummaryGenerator};
 
 #[cfg(feature = "ann")]
 use crate::search::strategy::VectorSearchStrategy;
@@ -10,19 +10,30 @@ use super::MemoryEngine;
 impl MemoryEngine {
     /// Run three-pass consolidation: local dedup, cluster fusion, global integration.
     ///
+    /// `generator` produces the summary text for each cluster and the global
+    /// pass; `embedder` projects that text into the fact vector space. Embedding
+    /// is no longer duplicated on the `SummaryGenerator` trait (issue #116).
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Propagates errors from any consolidation pass or the `SummaryGenerator`.
+    /// Propagates errors from any consolidation pass, the `SummaryGenerator`, or
+    /// the `EmbeddingProvider`.
     pub fn consolidate(
         &self,
         generator: &dyn SummaryGenerator,
+        embedder: &dyn EmbeddingProvider,
         config: &ConsolidationConfig,
     ) -> Result<ConsolidationStats> {
         let (stats, expired_ids) = {
             let conn = self.write_conn()?;
-            let (stats, expired_ids) =
-                crate::consolidation::consolidate(&conn, generator, self.embed_dim, config)?;
+            let (stats, expired_ids) = crate::consolidation::consolidate(
+                &conn,
+                generator,
+                embedder,
+                self.embed_dim,
+                config,
+            )?;
 
             // Rebuild graph inside write lock — dedup may have expired facts and their edges
             if stats.duplicates_removed > 0 {

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -29,9 +29,6 @@ impl SummaryGenerator for MockGen {
             .collect::<Vec<_>>()
             .join("; "))
     }
-    fn embed(&self, _: &str) -> Result<Vec<f32>> {
-        Ok(vec![0.1; DIM])
-    }
 }
 
 struct FixedArbiter {
@@ -206,7 +203,9 @@ fn consolidate_deduplicates_similar_facts() {
         dedup_threshold: 0.90,
         min_cluster_size: 10, // high threshold so no clusters form
     };
-    let stats = engine.consolidate(&MockGen, &config).unwrap();
+    let stats = engine
+        .consolidate(&MockGen, &MockEmbedder { dim: DIM }, &config)
+        .unwrap();
     assert_eq!(stats.duplicates_removed, 1);
 
     let active = engine.list_active_facts(None).unwrap();
@@ -230,8 +229,12 @@ fn consolidate_is_idempotent() {
         min_cluster_size: 10,
     };
 
-    let _stats1 = engine.consolidate(&MockGen, &config).unwrap();
-    let stats2 = engine.consolidate(&MockGen, &config).unwrap();
+    let _stats1 = engine
+        .consolidate(&MockGen, &MockEmbedder { dim: DIM }, &config)
+        .unwrap();
+    let stats2 = engine
+        .consolidate(&MockGen, &MockEmbedder { dim: DIM }, &config)
+        .unwrap();
 
     // Second run should find 0 new duplicates
     assert_eq!(stats2.duplicates_removed, 0);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -44,6 +44,12 @@ pub trait EmbeddingProvider: Send + Sync {
 ///
 /// Used by consolidation to merge related facts into higher-level summaries.
 ///
+/// Summaries are embedded by the [`EmbeddingProvider`] passed alongside the
+/// generator into [`consolidate`](crate::engine::MemoryEngine::consolidate), so
+/// summary text shares the same vector space as the facts it summarizes. The
+/// generator only produces text — it never embeds (issue #116: embedding lived
+/// here as a duplicate of [`EmbeddingProvider::embed`]).
+///
 /// Requires `Send + Sync`: summary generators are shared across the engine's
 /// worker threads alongside the other consumer providers.
 pub trait SummaryGenerator: Send + Sync {
@@ -53,13 +59,6 @@ pub trait SummaryGenerator: Send + Sync {
     ///
     /// Returns an error if summarization fails.
     fn summarize(&self, facts: &[Fact]) -> Result<String>;
-
-    /// Compute an embedding for the given text.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if embedding computation fails.
-    fn embed(&self, text: &str) -> Result<Vec<f32>>;
 }
 
 /// Trait for arbitrating conflicts between contradicting facts (Phase 2).
@@ -627,9 +626,6 @@ mod tests {
         impl SummaryGenerator for Dummy {
             fn summarize(&self, _facts: &[Fact]) -> crate::error::Result<String> {
                 Ok(String::new())
-            }
-            fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
-                Ok(vec![0.0])
             }
         }
         let _: &dyn SummaryGenerator = &Dummy;

--- a/tests/eval/conformance/fact_lifecycle.rs
+++ b/tests/eval/conformance/fact_lifecycle.rs
@@ -6,7 +6,9 @@
 use memory_engine::traits::ConsolidationConfig;
 use memory_engine::types::FactType;
 
-use crate::helpers::{MockSummaryGenerator, add_fact, aggressive_forget_policy, eval_engine};
+use crate::helpers::{
+    MockSummaryGenerator, TestEmbedder, add_fact, aggressive_forget_policy, eval_engine,
+};
 
 #[test]
 fn same_content_produces_identical_content_hash() {
@@ -66,7 +68,7 @@ fn dedup_consolidation_expires_one_duplicate() {
     };
 
     let stats = engine
-        .consolidate(&generator, &config)
+        .consolidate(&generator, &TestEmbedder, &config)
         .expect("consolidate failed");
     assert!(
         stats.duplicates_removed > 0,

--- a/tests/eval/helpers.rs
+++ b/tests/eval/helpers.rs
@@ -52,7 +52,8 @@ impl EmbeddingProvider for TestEmbedder {
 // MockSummaryGenerator — deterministic summarization
 // ---------------------------------------------------------------------------
 
-/// Mock summarizer: joins fact content with "; " and embeds via blake3.
+/// Mock summarizer: joins fact content with "; ". Summary embedding is performed
+/// by the [`TestEmbedder`] injected separately into consolidation (issue #116).
 pub struct MockSummaryGenerator;
 
 impl SummaryGenerator for MockSummaryGenerator {
@@ -62,10 +63,6 @@ impl SummaryGenerator for MockSummaryGenerator {
             .map(|f| f.content.as_str())
             .collect::<Vec<_>>()
             .join("; "))
-    }
-
-    fn embed(&self, text: &str) -> Result<Vec<f32>> {
-        TestEmbedder.embed(text)
     }
 }
 

--- a/tests/eval/quality/consolidation.rs
+++ b/tests/eval/quality/consolidation.rs
@@ -10,7 +10,7 @@
 use memory_engine::traits::ConsolidationConfig;
 use memory_engine::types::FactType;
 
-use crate::helpers::{MockSummaryGenerator, add_fact, add_scoped_fact, eval_engine};
+use crate::helpers::{MockSummaryGenerator, TestEmbedder, add_fact, add_scoped_fact, eval_engine};
 
 /// Insert 5 pairs of exact-duplicate facts. Identical text produces identical
 /// blake3 embeddings, giving cosine similarity = 1.0.
@@ -47,7 +47,7 @@ fn dedup_removes_exact_duplicates() {
     };
 
     let stats = engine
-        .consolidate(&generator, &config)
+        .consolidate(&generator, &TestEmbedder, &config)
         .expect("consolidate failed");
 
     assert!(
@@ -92,7 +92,7 @@ fn cluster_fusion_creates_clusters() {
     };
 
     let stats = engine
-        .consolidate(&generator, &config)
+        .consolidate(&generator, &TestEmbedder, &config)
         .expect("consolidate failed");
 
     assert!(
@@ -115,7 +115,7 @@ fn consolidation_is_idempotent() {
 
     // First pass
     let stats1 = engine
-        .consolidate(&generator, &config)
+        .consolidate(&generator, &TestEmbedder, &config)
         .expect("first consolidate failed");
     assert!(
         stats1.duplicates_removed > 0,
@@ -124,7 +124,7 @@ fn consolidation_is_idempotent() {
 
     // Second pass: no additional dedup expected
     let stats2 = engine
-        .consolidate(&generator, &config)
+        .consolidate(&generator, &TestEmbedder, &config)
         .expect("second consolidate failed");
     assert_eq!(
         stats2.duplicates_removed, 0,
@@ -151,7 +151,7 @@ fn cluster_and_global_summary_scoping() {
     };
 
     let stats = engine
-        .consolidate(&generator, &config)
+        .consolidate(&generator, &TestEmbedder, &config)
         .expect("consolidate failed");
 
     // With identical embeddings, a cluster should form


### PR DESCRIPTION
## Summary

`SummaryGenerator::embed` duplicated `EmbeddingProvider::embed` — every consumer implemented embedding twice, and the two could silently diverge into different vector spaces. This removes `embed` from the `SummaryGenerator` trait (generator now produces summary **text** only) and threads an `&dyn EmbeddingProvider` through the consolidation call chain so summaries are embedded by the same provider that embeds facts.

## Trait change

```rust
// before
pub trait SummaryGenerator: Send + Sync {
    fn summarize(&self, facts: &[Fact]) -> Result<String>;
    fn embed(&self, text: &str) -> Result<Vec<f32>>;   // removed — duplicated EmbeddingProvider::embed
}
// after
pub trait SummaryGenerator: Send + Sync {
    fn summarize(&self, facts: &[Fact]) -> Result<String>;
}
```

## New `consolidate` signature

The embedder is injected explicitly at every layer:

```text
MemoryEngine::consolidate(&self, generator, embedder, config)
CognitiveEngine (DreamContext)::consolidate(&self, generator, embedder, config)
AsyncMemoryEngine::consolidate(generator: Arc<…>, embedder: Arc<dyn EmbeddingProvider + Send + Sync>, config)
consolidation::consolidate(conn, generator, embedder, embed_dim, config)
  → cluster_fusion(conn, generator, embedder, embed_dim, min_cluster_size)
  → global_integration(conn, generator, embedder, embed_dim)
```

`cluster_fusion` / `global_integration` now call `embedder.embed(&summary_text)` instead of `generator.embed(...)`.

## Consumer + test updates

- **MCP server**: `memory_consolidate` pulls the embedder from the dispatch layer (guards `ValidationError::NoEmbeddingProvider`). `HttpSummaryGenerator` drops the `embedder` field it only held to satisfy the removed method; `build_summary_generator` no longer depends on an embedder.
- **Mocks** (engine tests, eval helpers, bench, example, trait doctests): `embed` impls removed; consolidate call sites pass a separate embedder (split `MockGenerator` / `MockEmbedder` where needed).
- **Docs**: `consolidation.md`, `extensibility.md`, `api.md`, `crate-layout.md` updated to the new trait + signature. ADRs and frozen design plans left as historical record.

## #495 status

`global.rs` builds a `Vec<Fact>` of pseudo-facts to satisfy `summarize(&[Fact])`, cloning embeddings unnecessarily (one of 8 grouped low/info findings in #495). Left as a **follow-up**: it is a perf concern orthogonal to this trait change, and fixing it here would only partially close the umbrella issue. The trait change does not worsen it.

## Gates

- `cargo build --workspace` + `--all-features` — pass
- `cargo test --workspace` — pass (the flaky `memory-engine-mcp` `test_dump_state_json` is a pre-existing parallel temp-file race, unrelated to this change; passes in isolation and on re-run)
- `cargo clippy --workspace --all-targets` — exit 0, **zero new findings** vs `main` (per-file warning-count diff empty; 44 pre-existing pedantic/nursery warnings tracked in #539)
- `cargo fmt --check` — clean (out-of-scope #539 drift in `conflict/temporal.rs` + `store/facts.rs` left untouched)

Fixes #116. Resolves newer-sweep LOW #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)