### PR TITLE
feat(bootstrap): author-seeded denylist closes redaction gaps (#51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ docs/plans/*-drafts/
 scripts/github-pm/state.json
 scripts/github-pm/backups/
 scripts/github-pm/manifests/open-issues.json
+
+# redaction denylist — real secret literals for the #51/#53 backfill gate.
+# NEVER commit. Default path that ME_REDACT_DENYLIST_FILE may point at; the
+# loader (bootstrap::load_secret_denylist) accepts any path, so a denylist kept
+# elsewhere is the caller's responsibility to keep ignored.
+.secrets-denylist

--- a/docs/audits/S0.5-redaction-gate.md
+++ b/docs/audits/S0.5-redaction-gate.md
@@ -105,17 +105,69 @@ Redaction is idempotent (`[REDACTED:*]` placeholders are not re-redacted).
 - **Bare hex secrets** (a long key stored bare, no `key=` / `secret:` context on the same line)
   are **not caught** by the hex-in-context detector. They may be caught by the high-entropy
   detector if the token is ≥ 20 chars and mixed enough (pure hex entropy = 4.0 < threshold 4.3,
-  so a bare uniform hex token will slip through). Deferred to #51's regex/gitleaks upgrade.
+  so a bare uniform hex token will slip through). **Mitigated** by the author-seeded denylist
+  (see below) for the controlled corpus.
 - **Arbitrary embedded secrets** with no known prefix, no context key, and entropy below 4.3
-  (short or low-entropy tokens) are not caught. Deferred to #51.
-- **PII beyond email** (IPs, phone numbers, names) is not covered — scope decision for #51.
+  (short or low-entropy tokens) are not caught by the signature detectors. **Mitigated** by the
+  author-seeded denylist.
+- **PII beyond email** (IPs, phone numbers, names) is not covered — out of scope for the
+  controlled single-author corpus.
 - **Private-key body**: only the `-----BEGIN` header line is redacted by rule; PEM body lines
   are caught incidentally by high-entropy (long base64), with a possible ragged-tail gap.
 
-## Residuals for #51
+## #51 review gate — RATIFIED DECISION (2026-06-15)
 
-- Tune entropy threshold (4.3) and min length (20) against the real corpus — the coverage
-  report is the instrument.
+**Decision: accept the residual signature gaps for the controlled 9-month single-author
+dev-session corpus, with this documented risk statement, _and_ close them with an
+author-seeded known-secret denylist.** (Owner-ratified; chosen over a gitleaks/regex
+ruleset upgrade.)
+
+### Why not a gitleaks/regex upgrade
+
+The two headline gaps above are **information-theoretically unclosable by any
+signature/regex ruleset** without unacceptable false positives:
+
+- A bare hex run is indistinguishable from a SHA-1/SHA-256/MD5 checksum, a git object
+  ID, or a content hash. Any rule aggressive enough to redact a bare-hex _secret_ also
+  redacts every git SHA and checksum in the corpus → mass over-redaction → it **corrupts
+  the very corpus the benchmark measures**. gitleaks does not flag bare hex by default for
+  exactly this reason.
+- An arbitrary low-entropy token with no prefix and no context key carries no signal at
+  all; nothing short of knowing the value can distinguish it from ordinary text.
+
+A gitleaks/regex upgrade would add value only as **more provider prefixes** (Stripe,
+Twilio, GCP service-account JSON, …) — those are cheaply addable to `SECRET_PREFIXES`
+without a runtime dependency, and do **not** require importing gitleaks. It would **not**
+close the headline gaps. (`.gitleaks.toml` in the repo root is for git-history scanning,
+a separate concern from this import gate.)
+
+### What closes the gap for a _controlled_ corpus: author-seeded denylist
+
+Because the corpus is a single author's own 9 months of sessions, the **secret-holder is
+known and can enumerate their own secrets**. Detector 0 (`detect_denylist`, priority over
+all signature rules) matches each author-supplied literal exactly — catching bare-hex and
+low-entropy secrets that carry no signal, with near-zero false positives. The denylist
+values are supplied **at runtime from a gitignored source and are never committed** to this
+crate; only fake fixtures live in `#[cfg(test)]`. A `DENYLIST_MIN_LEN = 4` guard prevents a
+stray short/blank line in the source from nuking the corpus.
+
+### Residual risk after this decision
+
+- A real secret that is (a) not a known provider prefix, (b) not URL/context/email/high-
+  entropy detectable, **and** (c) not enumerated in the author's denylist will pass through.
+  For a single-author corpus this is bounded by the author's recall of their own secrets;
+  the `report.coverage_lines()` manual review is the backstop.
+- Scope is explicitly the **private, local** ME/KB research store for the benchmark — not a
+  public release. The threat model is "secrets leaking into a local research artifact," not
+  adversarial exfiltration.
+
+## Residuals for #51 / hand-off to #53
+
+- The coverage report (`report.coverage_lines()`) is the instrument: run it over the real
+  corpus during the #53 backfill and inspect manually. Tune entropy threshold (4.3) and min
+  length (20) against what it surfaces.
+- Optionally extend `SECRET_PREFIXES` with additional provider prefixes (cheap, no FPs).
 - Consider stateful `BEGIN…END` block redaction for PEM bodies.
-- **Wiring**: when ratified, call `redact_entries` in front of `bootstrap_directory` (or
-  pre-redact the `.jsonl` on disk). Deliberately not wired yet.
+- **Wiring**: `redact_entries_with_denylist(entries, &denylist)` / `redact_text_with_denylist`
+  are exported and ready. #53's backfill harness loads the denylist from the gitignored source
+  (see `bootstrap::load_secret_denylist`) and calls them in front of any bulk import.

--- a/docs/audits/S0.5-redaction-gate.md
+++ b/docs/audits/S0.5-redaction-gate.md
@@ -146,10 +146,15 @@ a separate concern from this import gate.)
 Because the corpus is a single author's own 9 months of sessions, the **secret-holder is
 known and can enumerate their own secrets**. Detector 0 (`detect_denylist`, priority over
 all signature rules) matches each author-supplied literal exactly — catching bare-hex and
-low-entropy secrets that carry no signal, with near-zero false positives. The denylist
-values are supplied **at runtime from a gitignored source and are never committed** to this
-crate; only fake fixtures live in `#[cfg(test)]`. A `DENYLIST_MIN_LEN = 4` guard prevents a
-stray short/blank line in the source from nuking the corpus.
+low-entropy secrets that carry no signal, with near-zero false positives. Overlapping
+enumerated secrets are **merged into maximal spans** so a longer secret's tail can never
+leak, and matches inside an existing `[REDACTED:...]` placeholder are skipped (idempotent
+re-runs). The denylist values are supplied **at runtime** from a file named by
+`ME_REDACT_DENYLIST_FILE`; only the path enters the environment, the values live in the
+file alone, and that file must be kept out of version control (caller's responsibility —
+`.secrets-denylist` is a pre-`.gitignore`d default). Only fake fixtures live in
+`#[cfg(test)]`. A `DENYLIST_MIN_LEN = 4` **byte** guard prevents a stray short/blank line
+from nuking the corpus.
 
 ### Residual risk after this decision
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -27,7 +27,10 @@ pub use extract::{ExtractedFact, KeywordExtractor, SessionExtractor};
 pub use filter::{CandidateEpisode, ConversationTurn, EpisodeCategory, ToolCallRecord};
 pub use metrics::{BootstrapConfig, BootstrapReport, PrewarmMetrics};
 pub use outcome::{OutcomeSignals, SessionOutcome};
-pub use redact::{Finding, RedactionReport, redact_entries, redact_text, shannon_entropy};
+pub use redact::{
+    DENYLIST_ENV_VAR, Finding, RedactionReport, load_secret_denylist, redact_entries,
+    redact_entries_with_denylist, redact_text, redact_text_with_denylist, shannon_entropy,
+};
 
 /// Bootstrap one session from a JSONL reader into the memory engine.
 ///

--- a/src/bootstrap/redact.rs
+++ b/src/bootstrap/redact.rs
@@ -74,6 +74,11 @@ const HEX_CONTEXT_KEYS: &[&str] = &[
 /// Minimum hex run length to be considered a secret (when context-gated).
 const HEX_SECRET_MIN_LEN: usize = 32;
 
+/// Minimum length of an author-supplied denylist literal to be honored. Guards
+/// against a stray short/blank line in the (gitignored) denylist source matching
+/// everywhere and nuking the corpus. The author's real secrets are far longer.
+const DENYLIST_MIN_LEN: usize = 4;
+
 /// Minimum length of a prefix-detected token (prefix + body). Rejects bare/short matches
 /// that fire on ordinary words (e.g. `SG.`, `eyJournal`); real provider tokens are long
 /// (AWS `AKIA` + 16 = 20 is the shortest).
@@ -164,6 +169,43 @@ struct Span {
 /// Returns true if `[a_start, a_end)` overlaps with any span in `spans`.
 fn overlaps(spans: &[Span], a_start: usize, a_end: usize) -> bool {
     spans.iter().any(|s| a_start < s.end && a_end > s.start)
+}
+
+// ── Detector 0: author-seeded denylist (highest priority) ─────────────────────
+
+/// Redact every occurrence of each author-supplied known-secret literal.
+///
+/// This closes the residual gaps of the heuristic detectors for a **controlled
+/// single-author corpus**: bare hex (information-theoretically indistinguishable
+/// from a SHA/checksum) and arbitrary low-entropy tokens carry no prefix, context
+/// key, or entropy signal, so no signature can catch them without over-redacting
+/// non-secret data. But when the secret-holder is *known*, their secrets can be
+/// *enumerated* and matched literally with near-zero false positives.
+///
+/// Runs first so an author-known value wins priority over any signature rule.
+/// Literals shorter than [`DENYLIST_MIN_LEN`] are skipped (over-redaction guard).
+/// The denylist values themselves are supplied at runtime from a gitignored
+/// source and are never compiled into this crate.
+fn detect_denylist(text: &str, denylist: &[String], spans: &mut Vec<Span>) {
+    for literal in denylist {
+        if literal.chars().count() < DENYLIST_MIN_LEN {
+            continue;
+        }
+        let mut search_start = 0;
+        while let Some(rel) = text[search_start..].find(literal.as_str()) {
+            let start = search_start + rel;
+            let end = start + literal.len();
+            if !overlaps(spans, start, end) {
+                spans.push(Span {
+                    start,
+                    end,
+                    rule: "denylist",
+                });
+            }
+            // Advance past this match; guard against a zero-width step.
+            search_start = end.max(start + 1);
+        }
+    }
 }
 
 // ── Detector 1: provider-prefix ──────────────────────────────────────────────
@@ -468,8 +510,13 @@ fn detect_high_entropy(text: &str, spans: &mut Vec<Span>) {
 // ── Span collection + string reconstruction ───────────────────────────────────
 
 /// Run all detectors in priority order; collect non-overlapping spans.
-fn collect_spans(text: &str) -> Vec<Span> {
+///
+/// `denylist` holds author-supplied known-secret literals (empty for the
+/// signature-only path). Detector 0 (denylist) runs first so author-known
+/// values win priority over the heuristic rules.
+fn collect_spans(text: &str, denylist: &[String]) -> Vec<Span> {
     let mut spans: Vec<Span> = Vec::new();
+    detect_denylist(text, denylist, &mut spans);
     detect_provider_prefix(text, &mut spans);
     detect_url_credential(text, &mut spans);
     detect_email(text, &mut spans);
@@ -515,11 +562,25 @@ fn rebuild(text: &str, spans: &[Span]) -> (String, Vec<Finding>) {
 /// re-redacted.
 #[must_use]
 pub fn redact_text(text: &str) -> (String, Vec<Finding>) {
+    redact_text_with_denylist(text, &[])
+}
+
+/// Redact secrets/PII from `text`, additionally redacting every author-supplied
+/// known-secret literal in `denylist` (priority over the signature rules).
+///
+/// Use this on a controlled corpus where the secret-holder can enumerate their
+/// own secrets: it closes the bare-hex / arbitrary-low-entropy gaps the
+/// signature detectors cannot (see [`detect_denylist`]). The `denylist` values
+/// are supplied at runtime from a gitignored source — never committed.
+///
+/// `redact_text(text)` == `redact_text_with_denylist(text, &[])`.
+#[must_use]
+pub fn redact_text_with_denylist(text: &str, denylist: &[String]) -> (String, Vec<Finding>) {
     // Idempotency: text that only contains placeholders is a no-op.
     // The detectors naturally avoid re-redacting because:
     //  - `[REDACTED:...]` does not match any prefix, email, hex, or entropy rule.
     // No special guard needed; the invariant holds by construction.
-    let spans = collect_spans(text);
+    let spans = collect_spans(text, denylist);
     rebuild(text, &spans)
 }
 
@@ -527,10 +588,23 @@ pub fn redact_text(text: &str) -> (String, Vec<Finding>) {
 /// returning the redacted entries and an auditable coverage report.
 #[must_use]
 pub fn redact_entries(entries: &[String]) -> (Vec<String>, RedactionReport) {
+    redact_entries_with_denylist(entries, &[])
+}
+
+/// Redact session entries, also redacting each author-supplied denylist literal.
+///
+/// This is the wired backfill path: callers load `denylist` from a gitignored
+/// source and pass it here in front of any bulk import (see `bootstrap`).
+/// `redact_entries(entries)` == `redact_entries_with_denylist(entries, &[])`.
+#[must_use]
+pub fn redact_entries_with_denylist(
+    entries: &[String],
+    denylist: &[String],
+) -> (Vec<String>, RedactionReport) {
     let mut report = RedactionReport::default();
     let mut redacted = Vec::with_capacity(entries.len());
     for entry in entries {
-        let (clean, findings) = redact_text(entry);
+        let (clean, findings) = redact_text_with_denylist(entry, denylist);
         report.entries_scanned += 1;
         for finding in &findings {
             report.record(&finding.rule);
@@ -538,6 +612,43 @@ pub fn redact_entries(entries: &[String]) -> (Vec<String>, RedactionReport) {
         redacted.push(clean);
     }
     (redacted, report)
+}
+
+// ── Author-seeded denylist loading (#51) ──────────────────────────────────────
+
+/// Environment variable naming the **gitignored** file of author-known secret literals.
+///
+/// One secret per line. The recommended source: the *path* is in the environment, but
+/// the secret values live only in the gitignored file — never in the repo, never in the
+/// process table.
+pub const DENYLIST_ENV_VAR: &str = "ME_REDACT_DENYLIST_FILE";
+
+/// Parse denylist file contents into literals: one secret per line, trimmed,
+/// skipping blank lines and `#`-comments. Pure (no I/O) so it is unit-tested
+/// without a temp file.
+fn parse_denylist(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Load the author-seeded secret denylist from the gitignored file named by
+/// [`DENYLIST_ENV_VAR`].
+///
+/// Returns an empty list (→ signatures-only mode) when the variable is unset.
+/// The referenced file is the ONLY place real secrets live; it MUST be gitignored
+/// and never committed. Feed the result to [`redact_entries_with_denylist`].
+///
+/// # Errors
+/// Returns an error only when the variable is set but its file cannot be read.
+pub fn load_secret_denylist() -> std::io::Result<Vec<String>> {
+    let Some(path) = std::env::var_os(DENYLIST_ENV_VAR) else {
+        return Ok(Vec::new());
+    };
+    Ok(parse_denylist(&std::fs::read_to_string(path)?))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -1022,5 +1133,129 @@ mod tests {
                 "context-gated hex missed in {line:?}: {out}"
             );
         }
+    }
+
+    // ── Author-seeded denylist (#51) ──────────────────────────────────────────
+    //
+    // For a controlled single-author corpus the signature gaps (bare hex ≡ checksum,
+    // arbitrary low-entropy tokens) are closed by matching the author's *enumerated*
+    // secrets literally — even with no prefix/context/entropy signal.
+
+    #[test]
+    fn denylist_catches_bare_hex_that_signatures_miss() {
+        // Same shape as `bare_sha256_not_redacted`: a 64-char bare hex with no key
+        // context. Signatures provably leave it alone — but if the author KNOWS this
+        // value is a real secret (e.g. a bare API key that happens to be hex), the
+        // denylist catches it.
+        let secret = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let text = format!("checksum: {secret}");
+
+        // Precondition: the existing pipeline does NOT catch it.
+        let (baseline, _) = redact_text(&text);
+        assert_eq!(
+            baseline, text,
+            "precondition: bare hex must be a signature gap"
+        );
+
+        // With the author's denylist, it IS redacted.
+        let denylist = vec![secret.to_owned()];
+        let (out, findings) = redact_text_with_denylist(&text, &denylist);
+        assert!(
+            !out.contains(secret),
+            "denylist failed to redact bare hex: {out}"
+        );
+        assert!(
+            findings.iter().any(|f| f.rule == "denylist"),
+            "no denylist finding; findings: {findings:?}"
+        );
+        assert_eq!(out, "checksum: [REDACTED:denylist]");
+    }
+
+    #[test]
+    fn denylist_catches_arbitrary_low_entropy_token() {
+        // A short, low-entropy, no-prefix token: invisible to every signature detector.
+        let secret = "hunter2-dev-pw";
+        let text = format!("db password is {secret} ok");
+        let (baseline, _) = redact_text(&text);
+        assert_eq!(
+            baseline, text,
+            "precondition: low-entropy token must be a gap"
+        );
+
+        let (out, findings) = redact_text_with_denylist(&text, &[secret.to_owned()]);
+        assert!(
+            !out.contains(secret),
+            "denylist missed low-entropy token: {out}"
+        );
+        assert!(findings.iter().any(|f| f.rule == "denylist"));
+    }
+
+    #[test]
+    fn empty_denylist_is_backward_compatible() {
+        // redact_text_with_denylist(text, &[]) must equal redact_text(text).
+        let text = "api_key=a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6 and craig@example.com";
+        assert_eq!(redact_text_with_denylist(text, &[]), redact_text(text));
+    }
+
+    #[test]
+    fn denylist_skips_short_entries_to_avoid_over_redaction() {
+        // A stray short/blank line in the (gitignored) denylist source must NOT nuke
+        // the corpus. Entries below DENYLIST_MIN_LEN are ignored.
+        let text = "the cat sat on the mat".to_owned();
+        let denylist = vec![String::new(), "a".to_owned(), "at".to_owned()];
+        let (out, findings) = redact_text_with_denylist(&text, &denylist);
+        assert_eq!(out, text, "short denylist entries over-redacted: {out}");
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn denylist_redacts_all_occurrences() {
+        let secret = "s3cr3t-token-value";
+        let text = format!("{secret} appears twice: {secret}");
+        let (out, findings) = redact_text_with_denylist(&text, &[secret.to_owned()]);
+        assert!(!out.contains(secret), "not all occurrences redacted: {out}");
+        assert_eq!(findings.iter().filter(|f| f.rule == "denylist").count(), 2);
+    }
+
+    #[test]
+    fn denylist_wins_priority_over_signature_rules() {
+        // A denylisted value that also matches a signature rule is tagged `denylist`
+        // (priority-0), not the signature rule — author knowledge is the strongest signal.
+        let secret = "ghp_0123456789abcdefghij0123456789abcdef";
+        let (_out, findings) = redact_text_with_denylist(secret, &[secret.to_owned()]);
+        assert!(findings.iter().any(|f| f.rule == "denylist"));
+        assert!(
+            !findings.iter().any(|f| f.rule == "github-pat"),
+            "signature rule won over denylist: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn parse_denylist_skips_blanks_and_comments() {
+        let contents = "\
+# my known secrets — gitignored, never committed
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+  hunter2-dev-pw
+# trailing comment
+";
+        let parsed = parse_denylist(contents);
+        assert_eq!(
+            parsed,
+            vec![
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                "hunter2-dev-pw".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn redact_entries_with_denylist_tallies_denylist_rule() {
+        let secret = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let entries = vec![format!("bare: {secret}"), "clean line".to_owned()];
+        let (redacted, report) = redact_entries_with_denylist(&entries, &[secret.to_owned()]);
+        assert!(!redacted[0].contains(secret));
+        assert_eq!(report.entries_scanned, 2);
+        assert_eq!(report.by_rule.get("denylist"), Some(&1));
     }
 }

--- a/src/bootstrap/redact.rs
+++ b/src/bootstrap/redact.rs
@@ -718,7 +718,20 @@ pub fn load_secret_denylist() -> std::io::Result<Vec<String>> {
     let Some(path) = std::env::var_os(DENYLIST_ENV_VAR) else {
         return Ok(Vec::new());
     };
-    Ok(parse_denylist(&std::fs::read_to_string(path)?))
+    // Read directly and add path context on failure rather than pre-checking
+    // `is_file()`: the read already errors on a missing path or directory, and a
+    // check-then-read pre-flight is a TOCTOU race for no gain. The preserved
+    // `e.kind()` still distinguishes NotFound vs IsADirectory for callers.
+    let contents = std::fs::read_to_string(&path).map_err(|e| {
+        std::io::Error::new(
+            e.kind(),
+            format!(
+                "reading denylist file {:?} (from {DENYLIST_ENV_VAR}): {e}",
+                std::path::Path::new(&path)
+            ),
+        )
+    })?;
+    Ok(parse_denylist(&contents))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/bootstrap/redact.rs
+++ b/src/bootstrap/redact.rs
@@ -183,29 +183,94 @@ fn overlaps(spans: &[Span], a_start: usize, a_end: usize) -> bool {
 /// *enumerated* and matched literally with near-zero false positives.
 ///
 /// Runs first so an author-known value wins priority over any signature rule.
-/// Literals shorter than [`DENYLIST_MIN_LEN`] are skipped (over-redaction guard).
-/// The denylist values themselves are supplied at runtime from a gitignored
-/// source and are never compiled into this crate.
+/// Literals shorter than [`DENYLIST_MIN_LEN`] **bytes** are skipped (over-redaction
+/// guard; byte length so a short-char/multibyte secret the author listed is honored).
+/// The denylist values themselves are supplied at runtime from a gitignored source
+/// and are never compiled into this crate.
+///
+/// Matching is authoritative *within* this detector: every occurrence of every
+/// literal is collected and overlapping/extending ranges are **merged** into maximal
+/// spans before emission, so an author who enumerates overlapping secrets (a token and
+/// a longer line containing it; two secrets sharing an interior region) gets full
+/// coverage regardless of iteration order — no partial-overlap tail leak. Matches that
+/// fall inside an existing `[REDACTED:...]` placeholder are skipped so re-running on
+/// already-redacted text is idempotent even when a literal collides with placeholder text.
 fn detect_denylist(text: &str, denylist: &[String], spans: &mut Vec<Span>) {
+    let placeholders = placeholder_spans(text);
+
+    // 1. Collect every match range for every literal (≥ DENYLIST_MIN_LEN bytes),
+    //    skipping any match inside an existing placeholder.
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
     for literal in denylist {
-        if literal.chars().count() < DENYLIST_MIN_LEN {
+        if literal.len() < DENYLIST_MIN_LEN {
             continue;
         }
         let mut search_start = 0;
         while let Some(rel) = text[search_start..].find(literal.as_str()) {
             let start = search_start + rel;
             let end = start + literal.len();
-            if !overlaps(spans, start, end) {
-                spans.push(Span {
-                    start,
-                    end,
-                    rule: "denylist",
-                });
+            if !range_overlaps(&placeholders, start, end) {
+                ranges.push((start, end));
             }
             // Advance past this match; guard against a zero-width step.
             search_start = end.max(start + 1);
         }
     }
+    if ranges.is_empty() {
+        return;
+    }
+
+    // 2. Merge truly-overlapping ranges into maximal spans (sorted by start; merge
+    //    when the next range starts strictly before the current end — adjacent,
+    //    non-overlapping ranges stay distinct).
+    ranges.sort_unstable();
+    let mut cur = ranges[0];
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+    for &(s, e) in &ranges[1..] {
+        if s < cur.1 {
+            cur.1 = cur.1.max(e);
+        } else {
+            merged.push(cur);
+            cur = (s, e);
+        }
+    }
+    merged.push(cur);
+
+    // 3. Emit merged spans (denylist runs first, so `spans` is normally empty here;
+    //    the overlap guard keeps the non-overlap invariant if ordering ever changes).
+    for (start, end) in merged {
+        if !overlaps(spans, start, end) {
+            spans.push(Span {
+                start,
+                end,
+                rule: "denylist",
+            });
+        }
+    }
+}
+
+/// Byte ranges of existing `[REDACTED:<rule>]` placeholders, so the denylist detector
+/// never re-redacts inside a prior pass's output (idempotency). The other detectors are
+/// naturally placeholder-safe; only literal denylist matching can collide with one.
+fn placeholder_spans(text: &str) -> Vec<(usize, usize)> {
+    const OPEN: &str = "[REDACTED:";
+    let mut out = Vec::new();
+    let mut from = 0;
+    while let Some(rel) = text[from..].find(OPEN) {
+        let start = from + rel;
+        let Some(close_rel) = text[start..].find(']') else {
+            break;
+        };
+        let end = start + close_rel + 1;
+        out.push((start, end));
+        from = end;
+    }
+    out
+}
+
+/// Returns true if `[start, end)` overlaps any `(s, e)` range in `ranges`.
+fn range_overlaps(ranges: &[(usize, usize)], start: usize, end: usize) -> bool {
+    ranges.iter().any(|&(s, e)| start < e && end > s)
 }
 
 // ── Detector 1: provider-prefix ──────────────────────────────────────────────
@@ -616,11 +681,12 @@ pub fn redact_entries_with_denylist(
 
 // ── Author-seeded denylist loading (#51) ──────────────────────────────────────
 
-/// Environment variable naming the **gitignored** file of author-known secret literals.
+/// Environment variable naming a file of author-known secret literals, one per line.
 ///
-/// One secret per line. The recommended source: the *path* is in the environment, but
-/// the secret values live only in the gitignored file — never in the repo, never in the
-/// process table.
+/// Only the *path* enters the environment; the secret values never do — they live in
+/// the file alone. That file MUST be kept out of version control (caller's
+/// responsibility, as the path may point anywhere); `.secrets-denylist` at the repo root
+/// is pre-listed in `.gitignore` as a safe default.
 pub const DENYLIST_ENV_VAR: &str = "ME_REDACT_DENYLIST_FILE";
 
 /// Parse denylist file contents into literals: one secret per line, trimmed,
@@ -635,12 +701,16 @@ fn parse_denylist(contents: &str) -> Vec<String> {
         .collect()
 }
 
-/// Load the author-seeded secret denylist from the gitignored file named by
-/// [`DENYLIST_ENV_VAR`].
+/// Load the author-seeded secret denylist from the file named by [`DENYLIST_ENV_VAR`].
 ///
-/// Returns an empty list (→ signatures-only mode) when the variable is unset.
-/// The referenced file is the ONLY place real secrets live; it MUST be gitignored
-/// and never committed. Feed the result to [`redact_entries_with_denylist`].
+/// Returns an empty list (→ signatures-only mode) when the variable is unset. The
+/// referenced file is the only place real secrets live and must be kept out of version
+/// control (caller's responsibility; `.secrets-denylist` is a pre-`.gitignore`d default).
+/// Feed the result to [`redact_entries_with_denylist`].
+///
+/// Note: an unset variable degrading to signatures-only is silent by design here (the
+/// gate is not yet wired); the #53 backfill caller should log how many literals loaded
+/// so "denylist active" vs "silently empty" is never inferred from a missing var.
 ///
 /// # Errors
 /// Returns an error only when the variable is set but its file cannot be read.
@@ -1257,5 +1327,85 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         assert!(!redacted[0].contains(secret));
         assert_eq!(report.entries_scanned, 2);
         assert_eq!(report.by_rule.get("denylist"), Some(&1));
+    }
+
+    // ── Regression tests (adversarial review of #545) ─────────────────────────
+
+    #[test]
+    fn denylist_overlapping_literals_no_tail_leak() {
+        // Finding 1: two enumerated secrets where one extends the other. The longer
+        // secret's tail must NOT leak (was: first-writer-wins + binary overlap reject
+        // dropped the longer match whole, leaving its tail bytes in the output).
+        let dl = vec![
+            "AKIASECRETONE".to_owned(),
+            "AKIASECRETONEXTRATAILBYTES".to_owned(),
+        ];
+        let (out, _) = redact_text_with_denylist("key=AKIASECRETONEXTRATAILBYTES end", &dl);
+        assert!(
+            !out.contains("XTRATAILBYTES"),
+            "longer secret tail leaked: {out}"
+        );
+        assert_eq!(out, "key=[REDACTED:denylist] end");
+    }
+
+    #[test]
+    fn denylist_interior_overlap_no_leak() {
+        // Finding 1 (distinct-secret variant): two secrets sharing an interior region,
+        // neither a substring of the other. Merged coverage must redact the whole span.
+        let dl = vec!["ABCDEFGHSECRET".to_owned(), "SECRETWXYZ1234".to_owned()];
+        let (out, _) = redact_text_with_denylist("ABCDEFGHSECRETWXYZ1234", &dl);
+        assert!(
+            !out.contains("WXYZ1234"),
+            "interior-overlap tail leaked: {out}"
+        );
+        assert_eq!(out, "[REDACTED:denylist]");
+    }
+
+    #[test]
+    fn denylist_does_not_reredact_inside_placeholder() {
+        // Finding 3: a denylist literal that collides with placeholder vocabulary must
+        // not re-redact an existing [REDACTED:...] placeholder (idempotency contract).
+        let already = "x [REDACTED:denylist] y";
+        let (out, findings) = redact_text_with_denylist(already, &["denylist".to_owned()]);
+        assert_eq!(out, already, "re-redacted inside placeholder: {out}");
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn denylist_redaction_is_idempotent() {
+        // Re-running redaction on already-redacted output with the same denylist is stable.
+        let secret = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let dl = vec![secret.to_owned()];
+        let (once, _) = redact_text_with_denylist(&format!("bare {secret} here"), &dl);
+        let (twice, findings2) = redact_text_with_denylist(&once, &dl);
+        assert_eq!(once, twice, "second pass changed output");
+        assert!(
+            findings2.is_empty(),
+            "second pass produced findings: {findings2:?}"
+        );
+    }
+
+    #[test]
+    fn denylist_honors_short_char_multibyte_secret() {
+        // Finding 2: 3 chars but 9 bytes — the byte-length guard must honor it
+        // (the old chars().count() guard wrongly skipped short-char/long-byte secrets).
+        let secret = "€€€";
+        assert_eq!(secret.chars().count(), 3);
+        assert!(secret.len() >= DENYLIST_MIN_LEN);
+        let (out, findings) =
+            redact_text_with_denylist(&format!("pw={secret}"), &[secret.to_owned()]);
+        assert!(!out.contains(secret), "multibyte secret survived: {out}");
+        assert!(findings.iter().any(|f| f.rule == "denylist"));
+    }
+
+    #[test]
+    fn denylist_min_len_boundary() {
+        // Byte-length guard boundary: 3 bytes skipped, 4 bytes honored.
+        let (out3, f3) = redact_text_with_denylist("abc xyz", &["abc".to_owned()]);
+        assert_eq!(out3, "abc xyz");
+        assert!(f3.is_empty());
+        let (out4, f4) = redact_text_with_denylist("abcd xyz", &["abcd".to_owned()]);
+        assert!(!out4.contains("abcd"));
+        assert!(f4.iter().any(|f| f.rule == "denylist"));
     }
 }


### PR DESCRIPTION
## What

Closes the documented redaction-coverage gaps from #45 (S0.5) with an
**author-seeded known-secret denylist**, and records the ratified #51 review-gate
decision. This is the #51 gate that **unblocks #53** (9-month backfill).

## The decision (ratified)

**Accept the residual signature gaps for the controlled 9-month single-author
corpus, with a documented risk statement, AND close them with a denylist** —
chosen over a gitleaks/regex upgrade.

### Why not gitleaks/regex

The two headline gaps are **information-theoretically unclosable by signatures**:

- A bare hex run is indistinguishable from a SHA/checksum/git-object-id. Any rule
  aggressive enough to redact a bare-hex *secret* also redacts every git SHA in the
  corpus → mass over-redaction → corrupts the corpus the benchmark measures.
- An arbitrary low-entropy token with no prefix/context carries no signal at all.

gitleaks would add value only as *more provider prefixes* (cheaply addable to
`SECRET_PREFIXES`, no runtime dep) — it does **not** close the headline gaps.

### What closes them for a *controlled* corpus

The secret-holder is known and can **enumerate** their own secrets. Detector 0
(`detect_denylist`, priority over all signature rules) matches author-supplied
literals exactly — catching bare-hex/low-entropy secrets with near-zero false
positives.

## Changes

- `detect_denylist` (priority-0) + `redact_text_with_denylist` /
  `redact_entries_with_denylist`. API is **additive**: `redact_text`/`redact_entries`
  delegate with an empty list → existing behaviour unchanged.
- `load_secret_denylist()` reads a **gitignored** file named by
  `ME_REDACT_DENYLIST_FILE` (pure `parse_denylist` core, unit-tested). Real secrets
  live only in that file — never in the repo, never in the process table.
- `DENYLIST_MIN_LEN = 4` guard against a stray short line over-redacting.
- Ratified decision + residual-risk statement in `docs/audits/S0.5-redaction-gate.md`.

## Scope / deferred

Pipeline wiring is **deferred to #53**'s backfill harness (per the #51-vs-#53
split): it loads the denylist and consumes the coverage report. The seam is
exported and ready. No change to `bootstrap_session_inner` / `BootstrapConfig` /
`BootstrapReport` in this PR.

## Verification

- 8 new unit tests (bare-hex caught, low-entropy caught, empty-denylist backward-compat,
  short-entry guard, all-occurrences, priority-over-signatures, report tally, loader parse)
- `cargo test --lib`: **616 passed**; `redact`: **46 passed**
- `cargo +nightly fmt --check`: clean; `cargo clippy --all-targets` (`clippy::all` = deny): **0 errors**

## Follow-up (owner action)

Create the gitignored denylist file with your real secret literals (one per line)
and point `ME_REDACT_DENYLIST_FILE` at it before the #53 backfill. Keep that file
outside the repo (or add its path to `.gitignore`).


---

**Tracking:** dutiona/autonomous-agent-project#51 (cross-repo; this is the #51 review gate that unblocks #53). No same-repo issue to auto-close.
