### PR TITLE
fix: correctness fixes from super-qa #505 (medium)

### DIFF
--- a/docs/design/adr/0009-session-bootstrap.md
+++ b/docs/design/adr/0009-session-bootstrap.md
@@ -54,6 +54,8 @@ Session outcome and session ID are stored in fact `metadata` JSON fields (`sessi
 
 **Trade-off:** Querying "all facts from failed sessions" requires JSON extraction in SQL (`json_extract(metadata, '$.session_outcome')`), which is slower than a column index. Acceptable for the current scale; a materialized column can be added later if needed.
 
+**Forward-compatibility note (super-qa #505):** Until this fix, `session_outcome` was written only for `Success`/`Failure` sessions and **omitted** for `Indeterminate` ones, so `json_extract(metadata, '$.session_outcome')` returned SQL `NULL` for indeterminate facts. It is now written as `"indeterminate"`. Pre-fix rows retain the absent key — SQL consumers must treat a _missing_ `$.session_outcome` as "unknown/legacy", not as a specific outcome.
+
 ## Consequences
 
 **Positive:**

--- a/memory-engine-cli/src/commands/stats.rs
+++ b/memory-engine-cli/src/commands/stats.rs
@@ -101,8 +101,10 @@ pub fn run(db: &Path, format: OutputFormat) -> anyhow::Result<()> {
             println!("edges.active={}", stats.edges.active);
             println!("events.total={}", stats.events.total);
             println!("scopes.total={}", stats.scopes.total);
+            println!("scopes.max_depth={}", stats.scopes.max_depth);
             println!("summaries.total={}", stats.summaries.total);
             println!("storage.size_bytes={}", stats.storage.main_db_bytes);
+            println!("storage.page_count={}", stats.storage.page_count);
         }
     }
 

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -112,6 +112,61 @@ fn stats_plain_output() {
         .stdout(predicate::str::contains("facts.active=3"));
 }
 
+#[test]
+fn stats_plain_includes_max_depth_and_page_count() {
+    // Seed a fact under a nested scope so max_depth > 0 is observable.
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    let config = memory_engine::EngineConfig::new(db_path.clone(), 4);
+    let engine = memory_engine::MemoryEngine::open(&config).unwrap();
+
+    struct FakeEmbed;
+    impl memory_engine::EmbeddingProvider for FakeEmbed {
+        fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
+            Ok(vec![0.1, 0.2, 0.3, 0.4])
+        }
+    }
+
+    engine
+        .add_fact(
+            &memory_engine::AddFactRequest {
+                content: "scoped fact".into(),
+                fact_type: memory_engine::FactType::Semantic,
+                source_event_id: None,
+                scope: Some("project/sub".into()),
+                opts: None,
+            },
+            &FakeEmbed,
+            None,
+        )
+        .unwrap();
+
+    // Ground the expected max_depth via the JSON projection.
+    let expected_max_depth = engine.statistics().unwrap().scopes.max_depth;
+    assert!(
+        expected_max_depth > 0,
+        "nested scope should produce max_depth > 0"
+    );
+    drop(engine);
+
+    // Plain output must include both scopes.max_depth and storage.page_count.
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "plain",
+            "stats",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "scopes.max_depth={expected_max_depth}"
+        )))
+        .stdout(predicate::str::contains("storage.page_count="));
+}
+
 // --- inspect ---
 
 #[test]

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -689,10 +689,16 @@ fn handle_query(
     if let Some(scope) = get_str(&args, "scope") {
         let scope_mode = get_str(&args, "scope_mode").unwrap_or_else(|| "subtree".to_owned());
         query = match scope_mode.as_str() {
+            "subtree" => query.scope_subtree(scope),
             "exact" => query.scope_exact(scope),
             "ancestors" => query.scope_ancestors(scope),
             "inherited" => query.scope_inherited(scope),
-            _ => query.scope_subtree(scope),
+            other => {
+                return Err(ErrorData::invalid_params(
+                    format!("unknown scope_mode: {other}"),
+                    None,
+                ));
+            }
         };
     }
 

--- a/memory-engine-mcp/tests/query_mode_inference.rs
+++ b/memory-engine-mcp/tests/query_mode_inference.rs
@@ -320,6 +320,49 @@ fn query_with_scope_parameters_accepted() {
     }
 }
 
+#[test]
+fn query_with_invalid_scope_mode_returns_error() {
+    let engine = make_engine();
+    let embedder = TestEmbedder { dim: DIM };
+
+    engine
+        .add_fact(
+            &AddFactRequest {
+                content: "Rust borrow checker ensures safety".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: Some("lang/rust".into()),
+                opts: None,
+            },
+            &embedder,
+            None,
+        )
+        .unwrap();
+
+    // An explicit but unknown scope_mode must error rather than silently
+    // falling back to subtree.
+    let result = tools::dispatch(
+        "memory_query",
+        args(json!({
+            "text": "Rust",
+            "mode": "fts",
+            "scope": "lang/rust",
+            "scope_mode": "bogus",
+        })),
+        &engine,
+        None,
+        None,
+        DIM,
+        &memory_engine::ActivityFilterConfig::default(),
+    );
+    let err = result.expect_err("invalid scope_mode should error");
+    assert!(
+        err.message.contains("scope_mode"),
+        "error message should mention scope_mode, got: {}",
+        err.message
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Fact type filter with mode
 // ---------------------------------------------------------------------------

--- a/src/bootstrap/extract.rs
+++ b/src/bootstrap/extract.rs
@@ -79,11 +79,12 @@ impl SessionExtractor for KeywordExtractor {
             "matched_keywords": episode.matched_keywords,
         });
 
-        match outcome {
-            SessionOutcome::Failure => metadata["session_outcome"] = "failure".into(),
-            SessionOutcome::Success => metadata["session_outcome"] = "success".into(),
-            SessionOutcome::Indeterminate => {}
-        }
+        let outcome_str = match outcome {
+            SessionOutcome::Failure => "failure",
+            SessionOutcome::Success => "success",
+            SessionOutcome::Indeterminate => "indeterminate",
+        };
+        metadata["session_outcome"] = outcome_str.into();
 
         Ok(vec![ExtractedFact {
             content,
@@ -178,6 +179,16 @@ mod tests {
         assert_eq!(facts[0].fact_type, FactType::Episodic);
         assert!((facts[0].importance - 0.4).abs() < f64::EPSILON);
         assert_eq!(facts[0].metadata["session_outcome"], "failure");
+    }
+
+    #[test]
+    fn keyword_extractor_indeterminate_sets_outcome_key() {
+        let ep = make_episode(EpisodeCategory::Bug, "investigate", "unclear");
+        let ext = KeywordExtractor;
+        let facts = ext.extract(&ep, &SessionOutcome::Indeterminate).unwrap();
+
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].metadata["session_outcome"], "indeterminate");
     }
 
     #[test]

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -430,7 +430,7 @@ impl<'a> FactStore<'a> {
         let result: Option<String> =
             stmt.query_row(rusqlite::params_from_iter(params), |r| r.get(0))?;
         match result {
-            Some(s) => Ok(Some(crate::store::parse_timestamp(&s)?)),
+            Some(s) => Ok(Some(parse_timestamp(&s)?)),
             None => Ok(None),
         }
     }
@@ -1018,7 +1018,8 @@ mod tests {
         fs.insert(&past).unwrap();
 
         let mut future = make_fact("future reminder", vec![0.2; DIM]);
-        future.t_valid = Some(now + chrono::Duration::hours(1));
+        const VALID_DURATION_HOURS: i64 = 1;
+        future.t_valid = Some(now + TimeDelta::hours(VALID_DURATION_HOURS));
         fs.insert(&future).unwrap();
 
         fs.insert(&make_fact("regular fact", vec![0.3; DIM]))

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -430,12 +430,7 @@ impl<'a> FactStore<'a> {
         let result: Option<String> =
             stmt.query_row(rusqlite::params_from_iter(params), |r| r.get(0))?;
         match result {
-            Some(s) => {
-                let dt = DateTime::parse_from_rfc3339(&s)
-                    .map_err(|e| crate::error::MemoryError::Migration(format!("bad t_valid: {e}")))?
-                    .with_timezone(&Utc);
-                Ok(Some(dt))
-            }
+            Some(s) => Ok(Some(crate::store::parse_timestamp(&s)?)),
             None => Ok(None),
         }
     }
@@ -1052,6 +1047,36 @@ mod tests {
 
         let next = fs.next_due_time(now, &[]).unwrap().unwrap();
         assert!(next < now + chrono::Duration::hours(2));
+    }
+
+    #[test]
+    fn next_due_time_corrupt_t_valid_is_database_error_not_migration() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+        let now = Utc::now();
+
+        let mut future = make_fact("reminder", vec![0.1; DIM]);
+        future.t_valid = Some(now + chrono::Duration::hours(1));
+        let id = fs.insert(&future).unwrap();
+
+        // Corrupt the stored t_valid to a non-RFC3339 string.
+        conn.execute(
+            "UPDATE facts SET t_valid = 'not-a-timestamp' WHERE id = ?1",
+            params![id],
+        )
+        .unwrap();
+
+        let err = fs.next_due_time(now, &[]).unwrap_err();
+        // A row TEXT->timestamp conversion failure is a Database error, NOT a
+        // schema migration failure.
+        assert!(
+            !matches!(err, MemoryError::Migration(_)),
+            "expected non-Migration error, got: {err:?}"
+        );
+        assert!(
+            matches!(err, MemoryError::Database(_)),
+            "expected Database error, got: {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Four **behavior-correctness** fixes from the super-qa #505 medium sweep, each implemented TDD-first (failing test → fix → green).

### Findings
- **bootstrap** (`extract.rs`): `KeywordExtractor` left `metadata.session_outcome` **absent** for `Indeterminate` sessions (Success/Failure wrote `"success"`/`"failure"`). Collapsed the match so it now writes `"indeterminate"`. *Test:* `keyword_extractor_indeterminate_sets_outcome_key`.
- **cli** (`stats.rs`): `stats --format plain` omitted `scopes.max_depth` and `storage.page_count` that the Table format includes. Added both lines (parity). *Test:* `stats_plain_includes_max_depth_and_page_count`.
- **mcp** (`tools/mod.rs`, `memory_query`): an unknown `scope_mode` silently fell back to `subtree`. Now returns `invalid_params` ("unknown scope_mode: …") per the `parse_search_mode` convention; an **omitted** `scope_mode` still defaults to `subtree`. *Test:* `query_with_invalid_scope_mode_returns_error`.
- **store** (`facts.rs`, `next_due_time`): a corrupt stored `t_valid` was mapped to `MemoryError::Migration` ("schema migration failed") — wrong variant. Now uses the canonical `parse_timestamp` helper → `MemoryError::Database` (TEXT→timestamp conversion), matching `stamp_surfaced`/`row_to_fact`. *Test:* `next_due_time_corrupt_t_valid_is_database_error_not_migration`.

### Notes
- **Data forward-compat** (documented in ADR-0009): pre-fix DBs have `session_outcome` absent for Indeterminate facts; SQL consumers must treat a missing `$.session_outcome` as "unknown/legacy", not a specific outcome.
- **CLI edge case** (intended): an explicit empty-string `scope_mode` now errors instead of defaulting — strict validation against the schema enum.

### Verification
Gate: `cargo build --workspace` ✅, `cargo test --workspace` ✅, `cargo clippy --workspace --all-targets` ✅, `cargo fmt --check` ✅. Adversarial review (3 lenses): correctness ✅, no-regression ✅, api-and-persist ✅ (nit folded in).

Part of #505.
