### PR TITLE
fix(security): pak version guards + scope traversal cycle guards (super-qa #505)

### DIFF
--- a/src/archive/pak.rs
+++ b/src/archive/pak.rs
@@ -3,8 +3,9 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
-use crate::archive::types::ArchivePak;
+use crate::archive::types::{ArchivePak, CURRENT_PAK_VERSION};
 use crate::error::{MemoryError, Result};
+use crate::store::schema::CURRENT_SCHEMA_VERSION;
 
 /// Maximum decompressed `.pak` size (4 GiB) — prevents decompression bombs.
 const MAX_PAK_DECOMPRESSED_SIZE: u64 = 4 * 1024 * 1024 * 1024;
@@ -60,6 +61,25 @@ pub fn read_pak(path: &Path) -> Result<ArchivePak> {
         .map_err(|e| MemoryError::Archive(format!("failed to create zstd decoder: {e}")))?;
     let limited = std::io::Read::take(decoder, MAX_PAK_DECOMPRESSED_SIZE);
     let pak: ArchivePak = serde_json::from_reader(limited)?;
+
+    // Validate versions after deserialize, mirroring `validate_schema_version`
+    // (store/schema.rs): reject archives written by a *newer* library, but
+    // accept older ones (forward-only incompatibility, backward-compatible read).
+    if pak.pak_version > CURRENT_PAK_VERSION {
+        return Err(MemoryError::Archive(format!(
+            "pak_version {} is newer than supported {CURRENT_PAK_VERSION}; \
+             consider upgrading the memory-engine crate",
+            pak.pak_version
+        )));
+    }
+    if pak.engine_schema_version > CURRENT_SCHEMA_VERSION {
+        return Err(MemoryError::Archive(format!(
+            "engine_schema_version {} is newer than supported {CURRENT_SCHEMA_VERSION}; \
+             consider upgrading the memory-engine crate",
+            pak.engine_schema_version
+        )));
+    }
+
     Ok(pak)
 }
 
@@ -162,5 +182,86 @@ mod tests {
         write_pak(&empty_pak(), &pak_path).unwrap();
         assert!(!tmp_path.exists());
         assert!(pak_path.exists());
+    }
+
+    #[test]
+    fn read_pak_rejects_future_pak_version() {
+        use crate::store::schema::CURRENT_SCHEMA_VERSION;
+        let dir = tempfile::tempdir().unwrap();
+        let pak_path = dir.path().join("future_pak.pak");
+        let mut pak = empty_pak();
+        pak.pak_version = CURRENT_PAK_VERSION + 1;
+        pak.engine_schema_version = CURRENT_SCHEMA_VERSION;
+        write_pak(&pak, &pak_path).unwrap();
+
+        let err = read_pak(&pak_path).unwrap_err();
+        match err {
+            MemoryError::Archive(msg) => {
+                assert!(
+                    msg.contains("newer than supported"),
+                    "expected 'newer than supported' in {msg:?}"
+                );
+                assert!(
+                    msg.contains("pak_version"),
+                    "expected 'pak_version' in {msg:?}"
+                );
+            }
+            other => panic!("expected MemoryError::Archive, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_pak_rejects_future_schema_version() {
+        use crate::store::schema::CURRENT_SCHEMA_VERSION;
+        let dir = tempfile::tempdir().unwrap();
+        let pak_path = dir.path().join("future_schema.pak");
+        let mut pak = empty_pak();
+        pak.engine_schema_version = CURRENT_SCHEMA_VERSION + 1;
+        write_pak(&pak, &pak_path).unwrap();
+
+        let err = read_pak(&pak_path).unwrap_err();
+        match err {
+            MemoryError::Archive(msg) => {
+                assert!(
+                    msg.contains("newer than supported"),
+                    "expected 'newer than supported' in {msg:?}"
+                );
+                assert!(
+                    msg.contains("engine_schema_version"),
+                    "expected 'engine_schema_version' in {msg:?}"
+                );
+            }
+            other => panic!("expected MemoryError::Archive, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_pak_accepts_current_and_older_versions() {
+        use crate::store::schema::CURRENT_SCHEMA_VERSION;
+        let dir = tempfile::tempdir().unwrap();
+
+        // Current versions read OK.
+        let current_path = dir.path().join("current.pak");
+        let mut current = empty_pak();
+        current.engine_schema_version = CURRENT_SCHEMA_VERSION;
+        write_pak(&current, &current_path).unwrap();
+        assert!(
+            read_pak(&current_path).is_ok(),
+            "current versions must read"
+        );
+
+        // Older schema version reads OK (backward-compat). empty_pak() already
+        // stamps engine_schema_version = 7 (< CURRENT_SCHEMA_VERSION = 9).
+        let older_path = dir.path().join("older.pak");
+        let older = empty_pak();
+        assert!(
+            older.engine_schema_version < CURRENT_SCHEMA_VERSION,
+            "fixture must use an older schema version to exercise backward-compat"
+        );
+        write_pak(&older, &older_path).unwrap();
+        assert!(
+            read_pak(&older_path).is_ok(),
+            "older versions must still read (backward-compat)"
+        );
     }
 }

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -84,10 +84,12 @@ impl ScopeTree {
     /// parent-walk — no id ever repeats, so the guard never fires.
     pub fn ancestors(&self, scope_id: i64) -> Vec<i64> {
         let mut result = Vec::new();
-        let mut seen = HashSet::new();
         let mut current = Some(scope_id);
         while let Some(id) = current {
-            if !seen.insert(id) {
+            // Cycle guard: the ancestor chain is shallow (bounded by tree depth),
+            // so a linear scan of `result` is cheaper than a `HashSet` and needs
+            // no allocation.
+            if result.contains(&id) {
                 break; // cycle detected — id already visited
             }
             result.push(id);

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use rusqlite::Connection;
 
@@ -77,10 +77,19 @@ impl ScopeTree {
     }
 
     /// Get ancestor `scope_ids` from leaf to root (inclusive).
+    ///
+    /// Cycle-safe: a malformed `parent_id` graph (e.g. a snapshot with a parent
+    /// cycle) would otherwise loop forever. We stop the walk the first time an
+    /// id repeats. For a valid (acyclic) tree this is byte-identical to a plain
+    /// parent-walk — no id ever repeats, so the guard never fires.
     pub fn ancestors(&self, scope_id: i64) -> Vec<i64> {
         let mut result = Vec::new();
+        let mut seen = HashSet::new();
         let mut current = Some(scope_id);
         while let Some(id) = current {
+            if !seen.insert(id) {
+                break; // cycle detected — id already visited
+            }
             result.push(id);
             current = self.nodes.get(&id).and_then(|n| n.parent_id);
         }
@@ -88,11 +97,20 @@ impl ScopeTree {
     }
 
     /// Get all descendant `scope_ids` (BFS, inclusive of start node).
+    ///
+    /// Cycle-safe: a malformed `children` graph with a cycle would otherwise
+    /// enqueue ids forever. We skip any id already visited. For a valid
+    /// (acyclic) tree this is byte-identical to a plain BFS — each node is
+    /// reachable on exactly one path, so the guard never skips a real node.
     pub fn subtree(&self, scope_id: i64) -> Vec<i64> {
         let mut result = Vec::new();
+        let mut visited = HashSet::new();
         let mut queue = VecDeque::new();
         queue.push_back(scope_id);
         while let Some(id) = queue.pop_front() {
+            if !visited.insert(id) {
+                continue; // already visited — cycle protection
+            }
             result.push(id);
             if let Some(child_ids) = self.children.get(&id) {
                 for &cid in child_ids {
@@ -171,12 +189,18 @@ impl ScopeTree {
             return Some("/".to_string());
         }
 
-        // Walk ancestors (excluding root) and collect labels in reverse
+        // Walk ancestors (excluding root) and collect labels in reverse.
+        // Cycle-safe: stop if an id repeats so a malformed parent cycle cannot
+        // loop forever. For a valid tree no id repeats, so behavior is identical.
         let mut segments = Vec::new();
+        let mut seen = HashSet::new();
         let mut current = Some(scope_id);
         while let Some(id) = current {
             if id == Self::root_id() {
                 break;
+            }
+            if !seen.insert(id) {
+                break; // cycle detected — id already visited
             }
             let node = self.nodes.get(&id)?;
             segments.push(node.label.clone());
@@ -413,6 +437,71 @@ mod tests {
             children: HashMap::new(),
         };
         assert_eq!(tree.max_depth(), 0);
+    }
+
+    /// Hand-build a tiny tree with a `parent_id` cycle: 10 -> 11 -> 10.
+    /// A malformed/hostile snapshot or DB could yield such a graph; the
+    /// traversals must terminate rather than spin forever.
+    fn cyclic_tree() -> ScopeTree {
+        let mut nodes = HashMap::new();
+        let mut children: HashMap<i64, Vec<i64>> = HashMap::new();
+        // 10's parent is 11, 11's parent is 10 — a 2-cycle.
+        nodes.insert(
+            10,
+            ScopeNode {
+                id: 10,
+                parent_id: Some(11),
+                label: "a:a".into(),
+                depth: 0,
+            },
+        );
+        nodes.insert(
+            11,
+            ScopeNode {
+                id: 11,
+                parent_id: Some(10),
+                label: "b:b".into(),
+                depth: 1,
+            },
+        );
+        children.entry(11).or_default().push(10);
+        children.entry(10).or_default().push(11);
+        ScopeTree { nodes, children }
+    }
+
+    #[test]
+    fn ancestors_terminates_on_cycle() {
+        let tree = cyclic_tree();
+        let anc = tree.ancestors(10);
+        // Must terminate and be bounded by the number of distinct nodes.
+        assert!(anc.len() <= tree.nodes.len(), "ancestors must be bounded");
+        // No id repeats — the cycle is broken on revisit.
+        let mut sorted = anc.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), anc.len(), "ancestors must not repeat ids");
+        assert!(anc.contains(&10));
+    }
+
+    #[test]
+    fn subtree_terminates_on_cycle() {
+        let tree = cyclic_tree();
+        let sub = tree.subtree(10);
+        assert!(sub.len() <= tree.nodes.len(), "subtree must be bounded");
+        let mut sorted = sub.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), sub.len(), "subtree must not repeat ids");
+        assert!(sub.contains(&10) && sub.contains(&11));
+    }
+
+    #[test]
+    fn path_for_id_terminates_on_cycle() {
+        let tree = cyclic_tree();
+        // The id is present, none of the cycle nodes is root, so the label
+        // walk would loop forever without cycle protection. It must return
+        // *something* finite (Some or None) and not hang.
+        let _ = tree.path_for_id(10);
     }
 
     mod proptest_scope {

--- a/src/types.rs
+++ b/src/types.rs
@@ -117,6 +117,12 @@ fn default_origin_node_id() -> String {
     "local".to_string()
 }
 
+/// Default `scope_id` for a `Fact` deserialized from an archive that predates
+/// the scope column — the root scope (id 1). Keeps old `.pak` archives readable.
+fn default_root_scope_id() -> i64 {
+    1
+}
+
 /// A bi-temporal fact derived from events.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Fact {
@@ -134,8 +140,11 @@ pub struct Fact {
     pub access_count: i64,
     pub last_accessed: DateTime<Utc>,
     pub metadata: serde_json::Value,
+    #[serde(default = "default_root_scope_id")]
     pub scope_id: i64,
+    #[serde(default)]
     pub is_pinned: bool,
+    #[serde(default)]
     pub importance_score: f64,
     #[serde(default)]
     pub surfaced_at: Option<DateTime<Utc>>,
@@ -937,6 +946,36 @@ mod tests {
             .surfaced_at
             .expect("surfaced_at should deserialize when present");
         assert_eq!(ts.to_rfc3339(), "2026-03-15T12:00:00+00:00");
+    }
+
+    #[test]
+    fn serde_fact_legacy_archive_applies_field_defaults() {
+        // A Fact from a .pak archive predating scope_id/is_pinned/importance_score
+        // omits those fields; they must deserialize to defaults so old archives
+        // remain readable (super-qa #505 / read_pak backward-compat).
+        let json = r#"{
+            "id": 7,
+            "content": "legacy",
+            "content_hash": "h",
+            "embedding": [0.1],
+            "fact_type": "Semantic",
+            "t_created": "2024-01-01T00:00:00Z",
+            "t_expired": null,
+            "t_valid": null,
+            "t_invalid": null,
+            "source_event_id": null,
+            "importance": 0.9,
+            "access_count": 0,
+            "last_accessed": "2024-01-01T00:00:00Z",
+            "metadata": {}
+        }"#;
+        let fact: Fact = serde_json::from_str(json).unwrap();
+        assert_eq!(fact.scope_id, 1, "missing scope_id defaults to root (1)");
+        assert!(!fact.is_pinned, "missing is_pinned defaults to false");
+        assert_eq!(
+            fact.importance_score, 0.0,
+            "missing importance_score defaults to 0.0"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two **security/robustness** fixes from the super-qa #505 medium sweep, TDD-first.

### Findings
- **archive** (`pak.rs`, `read_pak`): the `.pak` was deserialized with **no version validation**. Now rejects archives whose `pak_version` > `CURRENT_PAK_VERSION` or `engine_schema_version` > `CURRENT_SCHEMA_VERSION` with `MemoryError::Archive("… newer than supported …")`, mirroring `validate_schema_version`. Older/current versions still read OK (backward-compat). Prevents an old binary from silently mis-reading a future-format archive. *Tests:* `read_pak_rejects_future_pak_version`, `read_pak_rejects_future_schema_version`, `read_pak_accepts_current_and_older_versions`.
- **scope** (`tree.rs`): `ancestors`, `subtree`, and `path_for_id` walked the `parent_id`/`children` graph **unbounded** — a malformed/cyclic graph (corrupt snapshot/DB) would infinite-loop (DoS). Added `visited`/`seen` `HashSet` guards so each traversal terminates. **Acyclic output is byte-identical** (the guard never fires on a valid tree). *Tests:* `ancestors_terminates_on_cycle`, `subtree_terminates_on_cycle`, `path_for_id_terminates_on_cycle` (one was proven to hang without the guard).

### Verification
Gate: `cargo build --workspace` ✅, `cargo test -p memory-engine [--features archive]` ✅, `cargo clippy --workspace --all-targets` ✅, `cargo fmt --check` ✅. Adversarial review (3 lenses): security-completeness, behavior-preservation, dos-robustness — all approve (cosmetic doc nit fixed). All 25 scope tests (incl. 2 proptests) stay green; cycle tests complete in <0.3s.

Part of #505.
