### PR TITLE
refactor(core): typed ConflictError + document MemoryError variants (#115)

### DIFF
--- a/src/conflict/temporal.rs
+++ b/src/conflict/temporal.rs
@@ -224,6 +224,7 @@ mod tests {
     use super::*;
     use chrono::Utc;
 
+    use crate::error::ConflictError;
     use crate::store::schema::{init_schema, open_memory};
     use crate::types::{Fact, FactType, NewFact};
 
@@ -243,7 +244,9 @@ mod tests {
 
     impl ConflictArbiter for FailingArbiter {
         fn arbitrate(&self, _old: &Fact, _new: &Fact) -> Result<CrudDecision> {
-            Err(MemoryError::Conflict("arbiter failed".into()))
+            Err(MemoryError::Conflict(ConflictError::Arbitration(
+                "arbiter failed".into(),
+            )))
         }
     }
 

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-use crate::error::{MemoryError, Result};
+use crate::error::{ConflictError, MemoryError, Result};
 use crate::search::hybrid::{
     QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult, hybrid_search,
 };
@@ -171,35 +171,35 @@ impl MemoryEngine {
     fn validate_memory_query(query: &MemoryQuery) -> Result<()> {
         // Period: both start and end must be set, or neither
         if query.period_start.is_some() != query.period_end.is_some() {
-            return Err(MemoryError::Conflict(
+            return Err(MemoryError::Conflict(ConflictError::QueryValidation(
                 "period_start and period_end must both be set or both unset".into(),
-            ));
+            )));
         }
 
         // valid_at and period are mutually exclusive
         if query.valid_at.is_some() && query.has_period() {
-            return Err(MemoryError::Conflict(
+            return Err(MemoryError::Conflict(ConflictError::QueryValidation(
                 "valid_at and period are mutually exclusive".into(),
-            ));
+            )));
         }
 
         // Search mode compatibility (D7)
         if let Some(ref mode) = query.search_mode {
             match mode {
                 SearchMode::Fts if query.text.is_none() => {
-                    return Err(MemoryError::Conflict(
+                    return Err(MemoryError::Conflict(ConflictError::QueryValidation(
                         "SearchMode::Fts requires text to be set".into(),
-                    ));
+                    )));
                 }
                 SearchMode::Vector if query.embedding.is_none() => {
-                    return Err(MemoryError::Conflict(
+                    return Err(MemoryError::Conflict(ConflictError::QueryValidation(
                         "SearchMode::Vector requires embedding to be set".into(),
-                    ));
+                    )));
                 }
                 SearchMode::Hybrid if query.text.is_none() || query.embedding.is_none() => {
-                    return Err(MemoryError::Conflict(
+                    return Err(MemoryError::Conflict(ConflictError::QueryValidation(
                         "SearchMode::Hybrid requires both text and embedding".into(),
-                    ));
+                    )));
                 }
                 _ => {}
             }

--- a/src/engine/restore.rs
+++ b/src/engine/restore.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::error::{MemoryError, Result};
+use crate::error::{ConflictError, MemoryError, Result};
 use crate::pool::ConnectionPool;
 use crate::store::schema::get_config;
 use crate::store::upcaster::UpcasterRegistry;
@@ -21,9 +21,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::Io` / `MemoryError::Serialization` on read failure.
     pub fn restore_json(snapshot_path: &Path, config: &EngineConfig) -> Result<Self> {
         if config.path.exists() {
-            return Err(MemoryError::Conflict(
-                "target database path already exists".into(),
-            ));
+            return Err(MemoryError::Conflict(ConflictError::TargetExists));
         }
 
         let snapshot = crate::inspect::restore::read_snapshot(snapshot_path)?;
@@ -111,9 +109,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::EmbeddingDimension` on dimension mismatch.
     pub fn restore_sqlite(backup_path: &Path, config: &EngineConfig) -> Result<Self> {
         if config.path.exists() {
-            return Err(MemoryError::Conflict(
-                "target database path already exists".into(),
-            ));
+            return Err(MemoryError::Conflict(ConflictError::TargetExists));
         }
         // Use `is_file()` (not `exists()`): a directory passed as the backup
         // source would pass an `exists()` guard and then fail deep inside

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,62 @@
+/// A precondition or input-validation conflict surfaced by the engine.
+///
+/// This is the typed payload of [`MemoryError::Conflict`]. Each variant maps to
+/// a distinct family of "the request cannot proceed as stated" failures —
+/// incompatible query options, out-of-range policy parameters, malformed scope
+/// labels, filesystem/restore preconditions, or a consumer-supplied trait that
+/// reported a failure. Splitting these out lets callers `match` on the precise
+/// cause instead of string-matching the message.
+///
+/// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
+/// downstream `match` expressions must include a wildcard (`_`) arm.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConflictError {
+    /// A [`MemoryQuery`](crate::types::MemoryQuery) combined options that are
+    /// mutually exclusive or incomplete (e.g. a half-open period, `valid_at`
+    /// together with a period, or a [`SearchMode`](crate::types::SearchMode)
+    /// missing its required input). The string names the specific rule violated.
+    #[error("{0}")]
+    QueryValidation(String),
+
+    /// A configuration or policy parameter is out of its accepted range — e.g. a
+    /// non-positive half-life, a weight below zero, or a ratio/percentile outside
+    /// `[0.0, 1.0]`. Raised by [`ForgetPolicy::validate`](crate::traits::ForgetPolicy::validate)
+    /// and [`DreamCycleConfig::validate`](crate::types::DreamCycleConfig::validate).
+    /// The string describes the offending parameter and its value.
+    #[error("{0}")]
+    PolicyParameter(String),
+
+    /// A scope label or path segment is malformed — empty, containing the `/`
+    /// separator, exceeding the length limit, or carrying surrounding whitespace.
+    /// The string names the specific constraint violated.
+    #[error("{0}")]
+    ScopeLabel(String),
+
+    /// A restore/open operation was asked to create a database at a path that
+    /// already exists. The target must not exist so an existing store is never
+    /// silently overwritten.
+    #[error("target database path already exists")]
+    TargetExists,
+
+    /// A restore was attempted into a database that already contains data.
+    /// Restore only runs against a fresh, empty engine.
+    #[error("target database is not empty; restore only works on a fresh engine")]
+    TargetNotEmpty,
+
+    /// A dump was directed at a path that resolves (possibly via a symlink) to the
+    /// live database file backing the engine, which would corrupt the live store.
+    #[error("dump target resolves to the live database file")]
+    DumpTargetIsLiveDatabase,
+
+    /// A consumer-supplied trait implementation (e.g. a
+    /// [`ConflictArbiter`](crate::traits::ConflictArbiter) or other injected
+    /// provider) reported a failure that the engine surfaces as a conflict. The
+    /// string carries the consumer's message.
+    #[error("{0}")]
+    Arbitration(String),
+}
+
 /// Errors returned by the memory engine.
 ///
 /// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
@@ -5,47 +64,68 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum MemoryError {
+    /// A requested entity (fact, event, scope, snapshot, …) does not exist.
     #[error("not found: {0}")]
     NotFound(String),
 
+    /// An underlying `SQLite` operation failed (query, statement, or connection).
     #[error("database error: {0}")]
     Database(#[from] rusqlite::Error),
 
+    /// JSON (de)serialization of a payload, snapshot, or config failed.
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    /// An embedding's length does not match the engine's configured dimension.
     #[error("invalid embedding dimension: expected {expected}, got {actual}")]
     EmbeddingDimension { expected: usize, actual: usize },
 
+    /// A precondition or input-validation conflict; see [`ConflictError`] for the
+    /// specific cause (incompatible query options, out-of-range parameters,
+    /// malformed scope labels, restore/dump preconditions, or a consumer-trait
+    /// failure).
     #[error("conflict: {0}")]
-    Conflict(String),
+    Conflict(#[from] ConflictError),
 
+    /// A schema migration (forward or epoch upgrade) failed to apply.
     #[error("schema migration failed: {0}")]
     Migration(String),
 
+    /// The requested operation is recognized but not yet implemented.
     #[error("not implemented: {0}")]
     NotImplemented(String),
 
+    /// The connection pool could not hand out or manage a connection.
     #[error("connection pool error: {0}")]
     Pool(String),
 
+    /// The database's on-disk storage epoch is incompatible with the epoch this
+    /// build supports (too old or too new to open safely).
     #[error(
         "unsupported storage epoch: database is epoch {db_epoch}, this library supports epoch {supported_epoch}"
     )]
     UnsupportedEpoch { db_epoch: u16, supported_epoch: u16 },
 
+    /// An invariant was violated inside the engine — a bug or corrupted state
+    /// that the caller cannot meaningfully recover from.
     #[error("internal error: {0}")]
     Internal(String),
 
+    /// A filesystem I/O operation (read, write, copy, canonicalize, …) failed.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// A bootstrap/backdate import step failed (e.g. parsing or validating the
+    /// seed dataset).
     #[error("bootstrap error: {0}")]
     Bootstrap(String),
 
+    /// The consumer-supplied [`Reranker`](crate::traits::Reranker) failed while
+    /// scoring candidates.
     #[error("reranker error: {0}")]
     Reranker(String),
 
+    /// A cold-storage archive operation (pack/unpack of a `.pak` file) failed.
     #[error("archive error: {0}")]
     Archive(String),
 
@@ -53,6 +133,7 @@ pub enum MemoryError {
     #[error("operation requires write access, but engine was opened read-only")]
     ReadOnly,
 
+    /// A wisdom-fact lineage/provenance record is missing or inconsistent.
     #[error("lineage error: {0}")]
     Lineage(String),
 }
@@ -118,5 +199,38 @@ mod tests {
             err.to_string(),
             "invalid embedding dimension: expected 768, got 512"
         );
+    }
+
+    #[test]
+    fn conflict_delegates_to_inner_display() {
+        // String-carrying variant: inner message is surfaced verbatim under the
+        // outer `conflict: ` prefix.
+        let err = MemoryError::Conflict(ConflictError::QueryValidation(
+            "valid_at and period are mutually exclusive".into(),
+        ));
+        assert_eq!(
+            err.to_string(),
+            "conflict: valid_at and period are mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn conflict_unit_variant_display() {
+        // Unit variant: fixed message, still wrapped by the outer prefix.
+        let err = MemoryError::Conflict(ConflictError::TargetExists);
+        assert_eq!(
+            err.to_string(),
+            "conflict: target database path already exists"
+        );
+    }
+
+    #[test]
+    fn conflict_error_from_into_memory_error() {
+        // `#[from]` lets a bare `ConflictError` convert via `?`/`.into()`.
+        let err: MemoryError = ConflictError::TargetNotEmpty.into();
+        assert!(matches!(
+            err,
+            MemoryError::Conflict(ConflictError::TargetNotEmpty)
+        ));
     }
 }

--- a/src/inspect/dump.rs
+++ b/src/inspect/dump.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use rusqlite::Connection;
 use serde::Serialize;
 
-use crate::error::{MemoryError, Result};
+use crate::error::{ConflictError, MemoryError, Result};
 use crate::store::UpcasterRegistry;
 use crate::store::edges::EdgeStore;
 use crate::store::events::EventStore;
@@ -201,7 +201,7 @@ pub fn dump_sqlite(conn: &Connection, path: &Path) -> Result<()> {
         if let Ok(target) = std::fs::canonicalize(path) {
             if target == source {
                 return Err(MemoryError::Conflict(
-                    "dump target resolves to the live database file".to_string(),
+                    ConflictError::DumpTargetIsLiveDatabase,
                 ));
             }
         }

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use rusqlite::Connection;
 
-use crate::error::{MemoryError, Result};
+use crate::error::{ConflictError, MemoryError, Result};
 use crate::store::events::event_type_to_str;
 use crate::store::lineage::LineageStore;
 use crate::store::schema::{CURRENT_SCHEMA_VERSION, STORAGE_EPOCH, set_config};
@@ -182,9 +182,7 @@ fn assert_empty_db(conn: &Connection) -> Result<()> {
 
     let total = event_count + fact_count + edge_count + summary_count + scope_count + lineage_count;
     if total > 0 {
-        return Err(MemoryError::Conflict(
-            "target database is not empty; restore only works on a fresh engine".into(),
-        ));
+        return Err(MemoryError::Conflict(ConflictError::TargetNotEmpty));
     }
     Ok(())
 }

--- a/src/store/scopes.rs
+++ b/src/store/scopes.rs
@@ -105,12 +105,13 @@ impl<'a> ScopeStore<'a> {
     /// All top-level segments are children of root (id=1). Uses
     /// `INSERT OR IGNORE` + `SELECT` for race-safe creation.
     pub fn ensure_path(&self, path: &str) -> Result<i64> {
-        let segments: Vec<&str> = path.split('/').collect();
-        if segments.is_empty() {
+        if path.is_empty() {
             return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
                 "scope path must not be empty".into(),
             )));
         }
+
+        let segments: Vec<&str> = path.split('/').collect();
 
         let mut parent_id: i64 = 1; // root
 

--- a/src/store/scopes.rs
+++ b/src/store/scopes.rs
@@ -1,6 +1,6 @@
 use rusqlite::Connection;
 
-use crate::error::{MemoryError, Result};
+use crate::error::{ConflictError, MemoryError, Result};
 use crate::types::ScopeNode;
 
 /// CRUD operations for the `scopes` table.
@@ -76,24 +76,24 @@ impl<'a> ScopeStore<'a> {
     fn validate_label(label: &str) -> Result<()> {
         let trimmed = label.trim();
         if trimmed.is_empty() {
-            return Err(MemoryError::Conflict(
+            return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
                 "scope label must not be empty".into(),
-            ));
+            )));
         }
         if trimmed.contains('/') {
-            return Err(MemoryError::Conflict(
+            return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
                 "scope label must not contain '/'".into(),
-            ));
+            )));
         }
         if trimmed.len() > 256 {
-            return Err(MemoryError::Conflict(
+            return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
                 "scope label must be at most 256 bytes".into(),
-            ));
+            )));
         }
         if trimmed != label {
-            return Err(MemoryError::Conflict(
+            return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
                 "scope label must not have leading/trailing whitespace".into(),
-            ));
+            )));
         }
         Ok(())
     }
@@ -107,7 +107,9 @@ impl<'a> ScopeStore<'a> {
     pub fn ensure_path(&self, path: &str) -> Result<i64> {
         let segments: Vec<&str> = path.split('/').collect();
         if segments.is_empty() {
-            return Err(MemoryError::Conflict("scope path must not be empty".into()));
+            return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
+                "scope path must not be empty".into(),
+            )));
         }
 
         let mut parent_id: i64 = 1; // root

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -308,22 +308,24 @@ impl ForgetPolicy {
     ///
     /// Returns `MemoryError::Conflict` if any parameter is out of range.
     pub fn validate(&self) -> Result<()> {
-        use crate::error::MemoryError;
+        use crate::error::{ConflictError, MemoryError};
 
         if !self.half_life_days.is_finite() || self.half_life_days <= 0.0 {
-            return Err(MemoryError::Conflict("half_life_days must be > 0".into()));
+            return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                "half_life_days must be > 0".into(),
+            )));
         }
         for (ft, &hl) in &self.half_life_overrides {
             if !hl.is_finite() || hl <= 0.0 {
-                return Err(MemoryError::Conflict(format!(
-                    "half_life for {ft:?} must be > 0"
+                return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                    format!("half_life for {ft:?} must be > 0"),
                 )));
             }
         }
         if !(0.0..=1.0).contains(&self.min_importance) {
-            return Err(MemoryError::Conflict(
+            return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
                 "min_importance must be in [0, 1]".into(),
-            ));
+            )));
         }
         if !self.recency_weight.is_finite()
             || !self.frequency_weight.is_finite()
@@ -334,7 +336,9 @@ impl ForgetPolicy {
             || self.graph_degree_weight < 0.0
             || self.base_importance_weight < 0.0
         {
-            return Err(MemoryError::Conflict("weights must be >= 0".into()));
+            return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                "weights must be >= 0".into(),
+            )));
         }
         // Note: weights intentionally do NOT need to sum to 1.0 (ADR-0006).
         // Each signal is independently normalized to [0,1] via ln_1p + ceilings,
@@ -707,7 +711,9 @@ mod tests {
         struct Failing;
         impl EmbeddingProvider for Failing {
             fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
-                Err(crate::error::MemoryError::Conflict("boom".into()))
+                Err(crate::error::MemoryError::Conflict(
+                    crate::error::ConflictError::Arbitration("boom".into()),
+                ))
             }
         }
         assert!(Failing.embed_batch(&["a"]).is_err());

--- a/src/types.rs
+++ b/src/types.rs
@@ -465,21 +465,23 @@ impl DreamCycleConfig {
     ///
     /// Returns `MemoryError::Conflict` if any ratio or percentile is out of [0, 1].
     pub fn validate(&self) -> crate::error::Result<()> {
-        use crate::error::MemoryError;
+        use crate::error::{ConflictError, MemoryError};
 
         for (ft, &ratio) in &self.compression_ratios {
             if !ratio.is_finite() || !(0.0..=1.0).contains(&ratio) {
-                return Err(MemoryError::Conflict(format!(
-                    "compression ratio for {ft:?} must be in [0.0, 1.0], got {ratio}"
+                return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                    format!("compression ratio for {ft:?} must be in [0.0, 1.0], got {ratio}"),
                 )));
             }
         }
         if !self.promotion_percentile.is_finite()
             || !(0.0..=1.0).contains(&self.promotion_percentile)
         {
-            return Err(MemoryError::Conflict(format!(
-                "promotion_percentile must be in [0.0, 1.0], got {}",
-                self.promotion_percentile
+            return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                format!(
+                    "promotion_percentile must be in [0.0, 1.0], got {}",
+                    self.promotion_percentile
+                ),
             )));
         }
         Ok(())


### PR DESCRIPTION
## Summary

Re-scoped slice of #115: split the stringly-typed `MemoryError::Conflict(String)` into a typed `ConflictError` sub-enum, and document **every** `MemoryError` variant.

## `ConflictError` variants (derived from the 26 real construction sites — not invented; no catch-all `Other`)

| Variant | Meaning | Sites |
| --- | --- | --- |
| `QueryValidation(String)` | Incompatible/incomplete `MemoryQuery` options (half-open period, `valid_at` + period, `SearchMode` missing its input) | 5 — `engine/query.rs` |
| `PolicyParameter(String)` | Config/policy parameter out of range (half-life, weights, ratios, percentiles) | 6 — `ForgetPolicy::validate` (4) + `DreamCycleConfig::validate` (2) |
| `ScopeLabel(String)` | Malformed scope label/path segment (empty, contains `/`, too long, whitespace) | 5 — `store/scopes.rs` |
| `TargetExists` *(unit)* | Restore target DB path already exists | 2 — `engine/restore.rs` |
| `TargetNotEmpty` *(unit)* | Restore into a non-empty DB | 1 — `inspect/restore.rs` |
| `DumpTargetIsLiveDatabase` *(unit)* | Dump path resolves to the live DB file | 1 — `inspect/dump.rs` |
| `Arbitration(String)` | A consumer-supplied trait reported a failure | 2 — `ConflictArbiter`/`EmbeddingProvider` test mocks |

**26 sites accounted for**: 22 constructions migrated to typed variants + 3 `matches!(_, MemoryError::Conflict(_))` assertions (unchanged, wildcard binds the inner enum) + 1 MCP `to_mcp_error` match arm (unchanged; `ConflictError: Display` keeps `"conflict: <msg>"` output). No `Conflict(format!/String)` remains.

## Design

- `Conflict(String)` → `Conflict(#[from] ConflictError)`; outer `#[error("conflict: {0}")]` delegates to `ConflictError`'s Display, so all user-facing messages are **preserved** (string variants verbatim; unit variants carry their text in `#[error(...)]`).
- `ConflictError` derives `Debug` + `thiserror::Error`, is `#[non_exhaustive]`, and is re-exported at the crate root via `pub use error::*` (`memory_engine::ConflictError`).
- Every `MemoryError` variant now has a `///` doc stating when it is returned (the enum was already `#[non_exhaustive]`; most variants were undocumented).

## Verification (workspace gate — 4 crates: core, cli, mcp, embed)

- `cargo build --workspace` ✅ (and `--all-features` ✅)
- `cargo test --workspace` ✅ — 925 passed, 6 ignored
- `cargo clippy --workspace --all-targets` ✅ — exit 0, **zero new** warnings (pre-existing ~#539 pedantic/nursery only)
- `cargo fmt --check` ✅

Fixes #115
Resolves #496 (core-root/documentation-error-variants-undocumented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)