### PR TITLE
docs(bootstrap): document t_valid=None as intended for backfilled facts

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -245,6 +245,13 @@ fn bootstrap_within_savepoint(
                 c.should_pin(&temp)
             });
 
+            // Bi-temporal note (#521): t_created is backdated to the historical turn
+            // timestamp, but t_valid is deliberately left None. Valid-time is the
+            // externally-asserted "true in the world" interval, which a retro-observed
+            // session fact does not carry — transaction-time (t_created) is the temporal
+            // signal here. Consequences: these facts are visible to active-at queries
+            // (None = unbounded-valid) but are NOT scheduled by list_due (which requires
+            // t_valid IS NOT NULL); memarch #42 sweeps on t_created for the same reason.
             let new_fact = NewFact {
                 content: fact.content.clone(),
                 content_hash: String::new(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -124,6 +124,11 @@ fn default_root_scope_id() -> i64 {
 }
 
 /// A bi-temporal fact derived from events.
+///
+/// Two independent time axes: **transaction-time** (`t_created`/`t_expired`) records when
+/// the row existed in the store; **valid-time** (`t_valid`/`t_invalid`) records when the
+/// fact was true in the world. A `None` valid-time bound means "unbounded/unknown" — see
+/// the per-field docs.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Fact {
     pub id: i64,
@@ -131,9 +136,18 @@ pub struct Fact {
     pub content_hash: String,
     pub embedding: Vec<f32>,
     pub fact_type: FactType,
+    /// Transaction-time start: when the row was first written. Bootstrap backdates this
+    /// to the historical turn timestamp so recency reflects the original session.
     pub t_created: DateTime<Utc>,
+    /// Transaction-time end: when the row was soft-deleted; `None` = still present.
     pub t_expired: Option<DateTime<Utc>>,
+    /// Valid-time start: when the fact became true in the world. `None` = "valid since
+    /// creation" (unbounded/unknown). Active-at queries treat `None` as valid from the
+    /// beginning, but the due/scheduling query requires a concrete `t_valid`. Bootstrap
+    /// intentionally leaves this `None`: valid-time is not externally asserted for
+    /// retro-observed session facts (see issue #521).
     pub t_valid: Option<DateTime<Utc>>,
+    /// Valid-time end: when the fact stopped being true; `None` = still valid.
     pub t_invalid: Option<DateTime<Utc>>,
     pub source_event_id: Option<i64>,
     pub importance: f64,

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -2,6 +2,7 @@
 
 use std::io::Cursor;
 
+use chrono::Utc;
 use memory_engine::{
     BootstrapConfig, EmbeddingProvider, KeywordExtractor, MemoryEngine, MemoryError,
 };
@@ -49,6 +50,43 @@ fn bootstrap_success_session() {
         "should classify as success or indeterminate"
     );
     assert_eq!(report.events_ingested, 1, "one marker event per session");
+}
+
+#[test]
+fn bootstrap_leaves_t_valid_none_visible_but_unscheduled() {
+    // #521: bootstrap intentionally leaves t_valid = None (valid-time is not externally
+    // asserted for retro-observed facts; t_created carries the recency signal). Pin the
+    // observable consequences: such facts are visible to active-at queries (None =
+    // unbounded-valid) but are NOT scheduled by list_due (which requires t_valid IS NOT NULL).
+    let engine = engine();
+    let extractor = KeywordExtractor;
+    let config = BootstrapConfig::default();
+
+    let reader = Cursor::new(success_fixture());
+    let report = engine
+        .bootstrap_session(reader, &TestEmbedder, &extractor, &config, None)
+        .unwrap();
+    assert!(report.facts_created > 0, "fixture should create facts");
+
+    // Visible, and every bootstrapped fact carries t_valid = None.
+    let active = engine.list_active_facts(None).unwrap();
+    assert_eq!(
+        active.len(),
+        report.facts_created,
+        "all bootstrapped facts should be active/visible"
+    );
+    assert!(
+        active.iter().all(|f| f.t_valid.is_none()),
+        "bootstrap must leave t_valid = None on every created fact"
+    );
+
+    // Unscheduled: list_due requires t_valid IS NOT NULL, so none are due.
+    let due = engine.list_due(Utc::now(), None).unwrap();
+    assert!(
+        due.is_empty(),
+        "facts with t_valid = None must not be scheduled by list_due; got {} due",
+        due.len()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #521.

## Decision (ratification point)
Per the Stream-B plan, this **documents `t_valid=None` as intended** for retro-observed bootstrap facts rather than populating it. Rationale: valid-time is the externally-asserted "true in the world" interval, which a backfilled session fact doesn't carry; `t_created` (backdated) is the temporal signal. This also preserves memarch#42's `t_created` horizon sweep and keeps backfilled facts out of `list_due` scheduling.

**Alternative (one-line, if you prefer):** set `t_valid = candidate.timestamp` in `bootstrap/mod.rs` — this would enrol backfilled facts into `list_due` and change memarch#42's assumption. Flagging for your final ratification at merge.

## Changes
- `types.rs`: document the bi-temporal `Fact` fields — `t_created`/`t_expired` (transaction-time) vs `t_valid`/`t_invalid` (valid-time), and that `None` valid-time = unbounded/unknown.
- `bootstrap/mod.rs`: comment at the construction site explaining the deliberate `t_valid=None`.
- `bootstrap_test.rs`: regression test — bootstrapped facts are visible via `list_active_facts`, all carry `t_valid=None`, and none appear in `list_due`.

## Verification
- `cargo test --lib --test bootstrap_test`: **653 passed, 0 failed**; `cargo +nightly fmt --check`: clean; no new clippy warnings (workspace debt = #539).
- Behavior-preserving (documents + pins existing behavior).