### PR TITLE
test(consolidation,inspect): orchestrator + serde roundtrip tests; fix DumpFormat doc

### DIFF
--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -116,7 +116,7 @@ pub fn consolidate(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Duration;
+    use chrono::TimeDelta;
 
     use crate::store::facts::FactStore;
     use crate::store::schema::{init_schema, open_memory};
@@ -170,7 +170,7 @@ mod tests {
         store
             .insert(&NewFact {
                 content: content.into(),
-                content_hash: blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string(),
+                content_hash: String::new(),
                 embedding,
                 fact_type: FactType::Semantic,
                 t_created: Utc::now(),
@@ -288,7 +288,7 @@ mod tests {
         init_schema(&conn).unwrap();
 
         // Seed a watermark in the future so EVERY existing fact predates it.
-        let future = Utc::now() + Duration::days(1);
+        let future = Utc::now() + TimeDelta::days(1);
         set_config(&conn, "last_consolidated_at", &future.to_rfc3339()).unwrap();
 
         // Two near-duplicate facts, both created "now" (before the watermark).

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -112,3 +112,290 @@ pub fn consolidate(
         expired_ids,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    use crate::store::facts::FactStore;
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::store::summaries::SummaryStore;
+    use crate::types::{ConsolidationLevel, FactType, NewFact};
+
+    const DIM: usize = 4;
+
+    /// Mock generator that concatenates fact contents. Always succeeds.
+    struct MockGenerator;
+
+    impl SummaryGenerator for MockGenerator {
+        fn summarize(&self, facts: &[Fact]) -> Result<String> {
+            Ok(facts
+                .iter()
+                .map(|f| f.content.as_str())
+                .collect::<Vec<_>>()
+                .join(" + "))
+        }
+    }
+
+    /// Mock generator that always fails — used to force the cluster pass to error
+    /// so the whole transaction must roll back.
+    struct FailingGenerator;
+
+    impl SummaryGenerator for FailingGenerator {
+        fn summarize(&self, _facts: &[Fact]) -> Result<String> {
+            Err(crate::error::MemoryError::Internal("summarize boom".into()))
+        }
+    }
+
+    /// Mock embedder returning a fixed-dimension constant vector.
+    struct MockEmbedder;
+
+    impl EmbeddingProvider for MockEmbedder {
+        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.5; DIM])
+        }
+    }
+
+    fn default_config() -> ConsolidationConfig {
+        ConsolidationConfig {
+            dedup_threshold: 0.90,
+            min_cluster_size: 2,
+        }
+    }
+
+    /// Insert an active fact, returning its id.
+    fn insert_fact(conn: &Connection, content: &str, embedding: Vec<f32>, importance: f64) -> i64 {
+        let store = FactStore::new(conn, DIM);
+        store
+            .insert(&NewFact {
+                content: content.into(),
+                content_hash: blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string(),
+                embedding,
+                fact_type: FactType::Semantic,
+                t_created: Utc::now(),
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                scope_id: 1,
+                importance,
+                access_count: 0,
+                last_accessed: Utc::now(),
+                metadata: serde_json::json!({}),
+                is_pinned: false,
+            })
+            .unwrap()
+    }
+
+    /// Three near-identical facts → one dedup, one cluster, one global summary.
+    fn seed_cluster(conn: &Connection) {
+        insert_fact(conn, "alpha", vec![1.0, 0.0, 0.0, 0.0], 0.9);
+        insert_fact(conn, "beta", vec![0.99, 0.01, 0.0, 0.0], 0.5);
+        insert_fact(conn, "gamma", vec![0.98, 0.02, 0.0, 0.0], 0.7);
+    }
+
+    #[test]
+    fn three_pass_pipeline_runs_atomically() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        seed_cluster(&conn);
+
+        let (stats, expired) =
+            consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &default_config()).unwrap();
+
+        // Dedup pass: near-duplicates above 0.90 collapse. With 3 facts all > 0.90
+        // similar, two get expired down to a single survivor.
+        assert_eq!(stats.duplicates_removed, 2);
+        assert_eq!(expired.len(), 2);
+
+        // After dedup only one active fact remains, so it cannot form a cluster of
+        // size >= 2; cluster + global therefore produce nothing.
+        assert_eq!(stats.clusters_created, 0);
+        assert_eq!(stats.global_summaries, 0);
+
+        let active = FactStore::new(&conn, DIM).list_active(None).unwrap();
+        assert_eq!(active.len(), 1);
+    }
+
+    #[test]
+    fn cluster_and_global_summaries_created() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        // Three facts forming a single-linkage chain whose adjacent cosine
+        // similarities (~0.883) sit BETWEEN the 0.85 cluster threshold and the
+        // 0.90 dedup threshold, so none is a near-duplicate (no expiry) yet all
+        // three link into one cluster. Unit vectors → cosine == dot product.
+        // a-b = b-c = cos(28°) ≈ 0.883; a-c = cos(56°) ≈ 0.559.
+        insert_fact(&conn, "a", vec![1.0, 0.0, 0.0, 0.0], 0.5);
+        insert_fact(&conn, "b", vec![0.8829, 0.4695, 0.0, 0.0], 0.5);
+        insert_fact(&conn, "c", vec![0.5592, 0.829, 0.0, 0.0], 0.5);
+
+        let (stats, expired) =
+            consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &default_config()).unwrap();
+
+        assert_eq!(stats.duplicates_removed, 0, "no near-duplicates expected");
+        assert!(expired.is_empty());
+        assert_eq!(stats.clusters_created, 1);
+        assert_eq!(stats.global_summaries, 1);
+
+        let store = SummaryStore::new(&conn, DIM);
+        assert_eq!(
+            store
+                .list_by_level(&ConsolidationLevel::Cluster)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .list_by_level(&ConsolidationLevel::Global)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn watermark_written_after_success() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        seed_cluster(&conn);
+
+        // No watermark before the first run.
+        assert!(get_config(&conn, "last_consolidated_at").unwrap().is_none());
+
+        let before = Utc::now();
+        consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &default_config()).unwrap();
+        let after = Utc::now();
+
+        let raw = get_config(&conn, "last_consolidated_at")
+            .unwrap()
+            .expect("watermark must be written after a successful run");
+        let watermark = DateTime::parse_from_rfc3339(&raw)
+            .unwrap()
+            .with_timezone(&Utc);
+        assert!(
+            watermark >= before && watermark <= after,
+            "watermark {watermark} not within [{before}, {after}]"
+        );
+    }
+
+    #[test]
+    fn watermark_read_scopes_dedup_to_new_facts() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        // Seed a watermark in the future so EVERY existing fact predates it.
+        let future = Utc::now() + Duration::days(1);
+        set_config(&conn, "last_consolidated_at", &future.to_rfc3339()).unwrap();
+
+        // Two near-duplicate facts, both created "now" (before the watermark).
+        insert_fact(&conn, "old A", vec![1.0, 0.0, 0.0, 0.0], 0.5);
+        insert_fact(&conn, "old B", vec![0.99, 0.01, 0.0, 0.0], 0.3);
+
+        let (stats, expired) =
+            consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &default_config()).unwrap();
+
+        // Because both facts predate the watermark, dedup's "new facts" set is
+        // empty and nothing is removed — proving the watermark is read and applied.
+        assert_eq!(stats.duplicates_removed, 0);
+        assert!(expired.is_empty());
+        assert_eq!(
+            FactStore::new(&conn, DIM).list_active(None).unwrap().len(),
+            2
+        );
+    }
+
+    #[test]
+    fn invalid_watermark_in_config_errors() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        set_config(&conn, "last_consolidated_at", "not-a-timestamp").unwrap();
+
+        let err = consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &default_config())
+            .expect_err("a malformed watermark must surface as an error");
+        assert!(
+            matches!(err, crate::error::MemoryError::Migration(_)),
+            "expected Migration error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn failing_pass_rolls_back_entire_transaction() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        // Three facts: a near-duplicate pair (dedup expires "dup B") plus a third
+        // that still clusters with the survivor so the cluster pass actually
+        // invokes the (failing) generator.
+        //   dup A vs dup B: cos ≈ 1.0  → above 0.90 dedup threshold → B expires.
+        //   dup A vs near C: cos ≈ 0.883 → below dedup, above 0.85 cluster → links.
+        insert_fact(&conn, "dup A", vec![1.0, 0.0, 0.0, 0.0], 0.9);
+        insert_fact(&conn, "dup B", vec![0.999, 0.001, 0.0, 0.0], 0.5);
+        insert_fact(&conn, "near C", vec![0.8829, 0.4695, 0.0, 0.0], 0.5);
+
+        let active_before = FactStore::new(&conn, DIM).list_active(None).unwrap().len();
+        assert_eq!(active_before, 3);
+
+        // The cluster pass calls FailingGenerator → error → whole tx rolls back.
+        let err = consolidate(
+            &conn,
+            &FailingGenerator,
+            &MockEmbedder,
+            DIM,
+            &default_config(),
+        )
+        .expect_err("a failing pass must abort consolidation");
+        assert!(
+            matches!(err, crate::error::MemoryError::Internal(_)),
+            "expected Internal error from the generator, got {err:?}"
+        );
+
+        // ROLLBACK invariants: dedup expirations are undone, no summaries persist,
+        // and the watermark is NOT advanced.
+        let active_after = FactStore::new(&conn, DIM).list_active(None).unwrap();
+        assert_eq!(
+            active_after.len(),
+            3,
+            "dedup expirations must be rolled back on a later-pass failure"
+        );
+
+        let store = SummaryStore::new(&conn, DIM);
+        assert!(
+            store
+                .list_by_level(&ConsolidationLevel::Cluster)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            store
+                .list_by_level(&ConsolidationLevel::Global)
+                .unwrap()
+                .is_empty()
+        );
+
+        assert!(
+            get_config(&conn, "last_consolidated_at").unwrap().is_none(),
+            "watermark must not advance when consolidation rolls back"
+        );
+    }
+
+    #[test]
+    fn empty_engine_consolidates_to_noop() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let (stats, expired) =
+            consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &default_config()).unwrap();
+
+        assert_eq!(stats.duplicates_removed, 0);
+        assert_eq!(stats.clusters_created, 0);
+        assert_eq!(stats.global_summaries, 0);
+        assert!(expired.is_empty());
+
+        // An empty run is still a successful run: the watermark advances.
+        assert!(get_config(&conn, "last_consolidated_at").unwrap().is_some());
+    }
+}

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -143,7 +143,7 @@ pub enum DumpFormat {
     JsonGzip(PathBuf),
     /// Zstandard-compressed JSON. Requires the `compress-zstd` feature.
     JsonZstd(PathBuf),
-    /// Atomic `SQLite` backup via `VACUUM INTO` (file-backed engines only).
+    /// Atomic `SQLite` backup via `VACUUM INTO` (file-backed and in-memory engines).
     Sqlite(PathBuf),
 }
 
@@ -227,4 +227,448 @@ pub struct StorageStats {
     pub page_size: i64,
     pub main_db_bytes: i64,
     pub file_path: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    use crate::types::{FactType, PromotionProvenance};
+
+    /// `serialize → deserialize` must round-trip to a value equal to the original.
+    /// These types are the engine's import/export wire format (`EngineSnapshot`
+    /// and friends), so a serde drift here silently corrupts dump/restore.
+    fn roundtrip<T>(value: &T) -> T
+    where
+        T: Serialize + serde::de::DeserializeOwned,
+    {
+        let json = serde_json::to_string(value).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    /// Assert `serialize → deserialize == original` for a `PartialEq` type.
+    fn assert_roundtrip_eq<T>(value: &T)
+    where
+        T: Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+    {
+        assert_eq!(&roundtrip(value), value);
+    }
+
+    /// Assert the JSON is stable across a `serialize → deserialize → serialize`
+    /// cycle. Used for the few snapshot types that are not `PartialEq`
+    /// (`EngineSnapshot`, `EngineStatistics`) but still must survive the wire.
+    fn assert_roundtrip_json_stable<T>(value: &T)
+    where
+        T: Serialize + serde::de::DeserializeOwned,
+    {
+        let json1 = serde_json::to_value(value).expect("serialize #1");
+        let back: T = serde_json::from_value(json1.clone()).expect("deserialize");
+        let json2 = serde_json::to_value(&back).expect("serialize #2");
+        assert_eq!(json1, json2);
+    }
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0)
+            .single()
+            .expect("valid timestamp")
+    }
+
+    fn sample_fact() -> Fact {
+        Fact {
+            id: 7,
+            content: "a representative fact".into(),
+            content_hash: "deadbeefcafebabe0011223344556677".into(),
+            embedding: vec![0.1, -0.2, 0.3, 0.4],
+            fact_type: FactType::Semantic,
+            t_created: ts(1_000),
+            t_expired: Some(ts(2_000)),
+            t_valid: Some(ts(1_500)),
+            t_invalid: None,
+            source_event_id: Some(3),
+            importance: 0.75,
+            access_count: 12,
+            last_accessed: ts(1_800),
+            metadata: serde_json::json!({"k": "v", "n": 42}),
+            scope_id: 4,
+            is_pinned: true,
+            importance_score: 0.66,
+            surfaced_at: Some(ts(1_900)),
+        }
+    }
+
+    fn sample_edge() -> Edge {
+        Edge {
+            id: 9,
+            source_fact_id: 7,
+            target_fact_id: 8,
+            relation_type: "supports".into(),
+            weight: 0.42,
+            t_created: ts(1_000),
+            t_expired: None,
+            scope_id: 4,
+        }
+    }
+
+    fn sample_event() -> Event {
+        Event {
+            id: 11,
+            timestamp: ts(1_234),
+            event_type: EventType::OutcomeSignal,
+            payload: serde_json::json!({"fact_id": 7, "outcome": "Positive"}),
+            source: "agent".into(),
+            session_id: Some("sess-1".into()),
+            scope_id: 4,
+            origin_node_id: "node-a".into(),
+            sequence_id: 5,
+            created_at: Some(ts(1_240)),
+            event_revision: 2,
+        }
+    }
+
+    fn sample_summary() -> Summary {
+        Summary {
+            id: 13,
+            content: "cluster summary".into(),
+            embedding: vec![0.5, 0.5, 0.5, 0.5],
+            level: ConsolidationLevel::Cluster,
+            source_fact_ids: vec![7, 8, 9],
+            created_at: ts(2_000),
+            scope_id: 4,
+        }
+    }
+
+    fn sample_scope() -> ScopeNode {
+        ScopeNode {
+            id: 4,
+            parent_id: Some(1),
+            label: "project:demo".into(),
+            depth: 2,
+        }
+    }
+
+    fn sample_lineage() -> LineageSnapshotEntry {
+        LineageSnapshotEntry {
+            lineage_id: 21,
+            wisdom_fact_id: 7,
+            source_fact_ids: vec![1, 2, 3],
+            provenance: PromotionProvenance {
+                source_count: 3,
+                session_count: 2,
+                date_range_start: ts(1_000),
+                date_range_end: ts(2_000),
+                confidence: 0.9,
+                method_version: "v1".into(),
+                representative_ids: vec![1, 2],
+                lineage_id: 21,
+            },
+        }
+    }
+
+    // --- Fact explanation -------------------------------------------------
+
+    #[test]
+    fn fact_state_variants_roundtrip() {
+        // Each variant carries distinct payload shapes — exercise them all so a
+        // serde rename/reshape can't slip a variant through untested.
+        for state in [
+            FactState::Active,
+            FactState::Pinned,
+            FactState::Expired {
+                reason: ExpiredReason::Unknown,
+            },
+            FactState::Expired {
+                reason: ExpiredReason::Forgotten,
+            },
+            FactState::Expired {
+                reason: ExpiredReason::ConflictResolved {
+                    superseded_by: Some(99),
+                },
+            },
+            FactState::Expired {
+                reason: ExpiredReason::Deduplicated { canonical_id: None },
+            },
+            FactState::Invalidated {
+                t_invalid: ts(3_000),
+            },
+            FactState::Due {
+                t_valid: ts(1_500),
+                surfaced_at: Some(ts(1_600)),
+            },
+            FactState::Due {
+                t_valid: ts(1_500),
+                surfaced_at: None,
+            },
+        ] {
+            assert_roundtrip_eq(&state);
+        }
+    }
+
+    #[test]
+    fn expired_reason_variants_roundtrip() {
+        for reason in [
+            ExpiredReason::Forgotten,
+            ExpiredReason::ConflictResolved {
+                superseded_by: Some(5),
+            },
+            ExpiredReason::Deduplicated {
+                canonical_id: Some(6),
+            },
+            ExpiredReason::Unknown,
+        ] {
+            assert_roundtrip_eq(&reason);
+        }
+    }
+
+    #[test]
+    fn fact_provenance_roundtrip() {
+        // Both the Some(event) and None branches of source_event.
+        assert_roundtrip_eq(&FactProvenance {
+            source_event_id: Some(3),
+            source_event: Some(sample_event()),
+            importance: 0.5,
+            importance_score: 0.4,
+            is_pinned: false,
+            access_count: 7,
+        });
+        assert_roundtrip_eq(&FactProvenance {
+            source_event_id: None,
+            source_event: None,
+            importance: 0.1,
+            importance_score: 0.2,
+            is_pinned: true,
+            access_count: 0,
+        });
+    }
+
+    #[test]
+    fn graph_context_roundtrip() {
+        assert_roundtrip_eq(&GraphContext {
+            degree: 3,
+            neighbor_ids: vec![1, 2, 3],
+            component_size: 10,
+        });
+    }
+
+    #[test]
+    fn fact_explanation_roundtrip() {
+        assert_roundtrip_eq(&FactExplanation {
+            fact_id: 7,
+            state: FactState::Due {
+                t_valid: ts(1_500),
+                surfaced_at: None,
+            },
+            provenance: FactProvenance {
+                source_event_id: Some(3),
+                source_event: Some(sample_event()),
+                importance: 0.5,
+                importance_score: 0.4,
+                is_pinned: false,
+                access_count: 7,
+            },
+            graph_context: GraphContext {
+                degree: 2,
+                neighbor_ids: vec![8, 9],
+                component_size: 4,
+            },
+            scope_path: "user:michael/project:demo".into(),
+        });
+    }
+
+    // --- Temporal history -------------------------------------------------
+
+    #[test]
+    fn history_event_kind_variants_roundtrip() {
+        for kind in [
+            HistoryEventKind::Created,
+            HistoryEventKind::BecameValid,
+            HistoryEventKind::BecameInvalid,
+            HistoryEventKind::Expired,
+        ] {
+            assert_roundtrip_eq(&kind);
+        }
+    }
+
+    #[test]
+    fn fact_history_roundtrip() {
+        assert_roundtrip_eq(&FactHistory {
+            fact_id: 7,
+            timeline: vec![
+                FactHistoryEntry {
+                    timestamp: ts(1_000),
+                    kind: HistoryEventKind::Created,
+                },
+                FactHistoryEntry {
+                    timestamp: ts(1_500),
+                    kind: HistoryEventKind::BecameValid,
+                },
+                FactHistoryEntry {
+                    timestamp: ts(2_000),
+                    kind: HistoryEventKind::Expired,
+                },
+            ],
+        });
+    }
+
+    // --- Replay -----------------------------------------------------------
+
+    #[test]
+    fn replay_order_variants_roundtrip() {
+        for order in [ReplayOrder::InsertionOrder, ReplayOrder::TimestampOrder] {
+            assert_roundtrip_eq(&order);
+        }
+    }
+
+    #[test]
+    fn replay_filter_roundtrip() {
+        // Fully-populated filter.
+        assert_roundtrip_eq(&ReplayFilter {
+            since: Some(ts(1_000)),
+            until: Some(ts(2_000)),
+            id_range: Some((10, 20)),
+            session_id: Some("sess-7".into()),
+            event_type: Some(EventType::ToolCall),
+            limit: Some(100),
+            upcast: true,
+            order: ReplayOrder::TimestampOrder,
+        });
+        // Default (all-None) filter.
+        assert_roundtrip_eq(&ReplayFilter::default());
+    }
+
+    // --- Statistics -------------------------------------------------------
+
+    #[test]
+    fn fact_stats_roundtrip() {
+        assert_roundtrip_eq(&FactStats {
+            total: 100,
+            active: 80,
+            expired: 15,
+            pinned: 5,
+            due: 3,
+        });
+    }
+
+    #[test]
+    fn edge_stats_roundtrip() {
+        assert_roundtrip_eq(&EdgeStats {
+            total: 50,
+            active: 40,
+            expired: 10,
+        });
+    }
+
+    #[test]
+    fn summary_stats_roundtrip() {
+        let mut by_level = BTreeMap::new();
+        by_level.insert(ConsolidationLevel::Local, 3);
+        by_level.insert(ConsolidationLevel::Cluster, 2);
+        by_level.insert(ConsolidationLevel::Global, 1);
+        assert_roundtrip_eq(&SummaryStats { total: 6, by_level });
+    }
+
+    #[test]
+    fn scope_stats_roundtrip() {
+        assert_roundtrip_eq(&ScopeStats {
+            total: 12,
+            max_depth: 4,
+        });
+    }
+
+    #[test]
+    fn event_stats_roundtrip() {
+        assert_roundtrip_eq(&EventStats { total: 999 });
+    }
+
+    #[test]
+    fn storage_stats_roundtrip() {
+        assert_roundtrip_eq(&StorageStats {
+            page_count: 100,
+            page_size: 4_096,
+            main_db_bytes: 409_600,
+            file_path: Some("/tmp/mem.db".into()),
+        });
+        assert_roundtrip_eq(&StorageStats {
+            page_count: 0,
+            page_size: 4_096,
+            main_db_bytes: 0,
+            file_path: None,
+        });
+    }
+
+    #[test]
+    fn engine_statistics_roundtrip() {
+        let mut by_level = BTreeMap::new();
+        by_level.insert(ConsolidationLevel::Cluster, 2);
+        assert_roundtrip_eq(&EngineStatistics {
+            facts: FactStats {
+                total: 10,
+                active: 8,
+                expired: 1,
+                pinned: 1,
+                due: 0,
+            },
+            edges: EdgeStats {
+                total: 5,
+                active: 4,
+                expired: 1,
+            },
+            summaries: SummaryStats { total: 2, by_level },
+            scopes: ScopeStats {
+                total: 3,
+                max_depth: 2,
+            },
+            events: EventStats { total: 20 },
+            storage: StorageStats {
+                page_count: 7,
+                page_size: 4_096,
+                main_db_bytes: 28_672,
+                file_path: None,
+            },
+        });
+    }
+
+    // --- Snapshot (import/export format) ----------------------------------
+
+    #[test]
+    fn engine_snapshot_roundtrip() {
+        let mut config = BTreeMap::new();
+        config.insert("schema_version".to_string(), "11".to_string());
+        config.insert("last_consolidated_at".to_string(), ts(2_000).to_rfc3339());
+
+        let snapshot = EngineSnapshot {
+            schema_version: 11,
+            storage_epoch: 1,
+            embed_dim: 4,
+            facts: vec![sample_fact()],
+            edges: vec![sample_edge()],
+            summaries: vec![sample_summary()],
+            scopes: vec![sample_scope()],
+            events: vec![sample_event()],
+            lineage: vec![sample_lineage()],
+            config,
+        };
+        // EngineSnapshot is not PartialEq; assert JSON stability instead.
+        assert_roundtrip_json_stable(&snapshot);
+    }
+
+    #[test]
+    fn engine_snapshot_lineage_defaults_when_absent() {
+        // Pre-v8 snapshots omit `lineage`; #[serde(default)] must fill an empty
+        // vec rather than fail deserialization (back-compat for old archives).
+        let json = serde_json::json!({
+            "schema_version": 7,
+            "storage_epoch": 1,
+            "embed_dim": 4,
+            "facts": [],
+            "edges": [],
+            "summaries": [],
+            "scopes": [],
+            "events": [],
+            "config": {}
+        });
+        let snapshot: EngineSnapshot =
+            serde_json::from_value(json).expect("pre-v8 snapshot must deserialize");
+        assert!(snapshot.lineage.is_empty());
+    }
 }

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -648,7 +648,10 @@ mod tests {
             lineage: vec![sample_lineage()],
             config,
         };
-        // EngineSnapshot is not PartialEq; assert JSON stability instead.
+        // EngineSnapshot is intentionally not `PartialEq`: `PromotionProvenance`
+        // carries a denormalized `lineage_id` re-derived from its parent entry on
+        // load, so serialize→deserialize is not value-identity. Assert JSON
+        // stability (re-serialization is byte-stable) instead.
         assert_roundtrip_json_stable(&snapshot);
     }
 


### PR DESCRIPTION
## Summary

Adds test coverage to two previously-untested modules (#129, re-scoped to consolidation + inspect-types) and fixes a stale doc comment (#127).

### #129 — new tests

**`src/consolidation/mod.rs`** — 7 unit tests for the `consolidate()` orchestrator (was 0):
- **Config read/write** of `last_consolidated_at`: written after a successful run, read to scope dedup to new facts only, and a malformed value surfaces as `MemoryError::Migration`.
- **3-pass transaction**: dedup → cluster → global all run in one transaction; verified stats and the cluster/global summary outputs.
- **Partial-failure ROLLBACK**: a `FailingGenerator` in the cluster pass aborts the whole consolidation — dedup expirations are undone, no summaries persist, and the watermark is **not** advanced.
- Plus an empty-engine no-op case.

**`src/inspect/types.rs`** — 18 serde round-trip tests (was 0) covering every `Serialize`/`Deserialize` type in the import/export wire format. Each asserts `serialize → deserialize == original`; the two non-`PartialEq` snapshot types (`EngineSnapshot`, `EngineStatistics`-snapshot path) assert JSON stability instead. Also covers the `#[serde(default)]` back-compat path for pre-v8 snapshots missing `lineage`.

### #127 — doc fix

`DumpFormat::Sqlite` doc claimed `VACUUM INTO` was "file-backed engines only". It works for in-memory engines too (SQLite 3.27+, per #80, and `engine.rs` / `docs/usage/inspection.md` already say both). Reworded to "file-backed and in-memory engines".

## Gates

- `cargo build --workspace` ✅
- `cargo test -p memory-engine -p memory-engine-mcp -p memory-engine-embed` ✅ (core: 691 passed, incl. 25 new tests)
- `cargo clippy --workspace --all-targets` — DELTA-CLEAN: zero new warnings from the changed files (pre-existing pedantic/nursery warnings tracked in #539)
- `cargo fmt --check` ✅

## Pre-existing breakage (not introduced here)

`cargo test --workspace` fails to compile `memory-engine-cli`'s `cli_integration` test (`MemoryEngine::open` was removed by the typestate-builder refactor #556). Untouched by this PR — surfaced for visibility.

Fixes #129
Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)