### PR TITLE
test(docs): runnable doctest for core engine flow (#121)

### DIFF
--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -120,8 +120,10 @@ fn stats_plain_includes_max_depth_and_page_count() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
 
-    let config = memory_engine::EngineConfig::new(db_path.clone(), 4);
-    let engine = memory_engine::MemoryEngine::open(&config).unwrap();
+    let engine = memory_engine::MemoryEngine::builder(4)
+        .path(db_path.clone())
+        .build()
+        .unwrap();
 
     struct FakeEmbed;
     impl memory_engine::EmbeddingProvider for FakeEmbed {

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -25,12 +25,44 @@ use crate::types::{AddFactRequest, ConsolidationLevel, Fact, NewEvent, NewFact, 
 /// All operations dispatch to `tokio::task::spawn_blocking`.
 /// Async methods take **owned** values (not references) for `'static` lifetime.
 ///
-/// ```rust,ignore
-/// let engine = MemoryEngine::builder(768).build()?;
-/// let async_engine = AsyncMemoryEngine::new(engine);
-/// let req = AddFactRequest { content: "hello".into(), fact_type: FactType::Semantic,
-///     source_event_id: None, scope: None, opts: None };
+/// ```
+/// use std::sync::Arc;
+///
+/// use memory_engine::async_engine::AsyncMemoryEngine;
+/// use memory_engine::{
+///     AddFactRequest, EmbeddingProvider, FactType, MemoryEngine, MemoryError,
+/// };
+///
+/// // Deterministic, dependency-free embedder (see the crate-level example).
+/// struct HashEmbedder {
+///     dim: usize,
+/// }
+/// impl EmbeddingProvider for HashEmbedder {
+///     fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+///         let mut v = vec![0.0_f32; self.dim];
+///         for &b in text.as_bytes() {
+///             v[b as usize % self.dim] += 1.0;
+///         }
+///         Ok(v)
+///     }
+/// }
+///
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// let dim = 64;
+/// let async_engine = AsyncMemoryEngine::new(MemoryEngine::builder(dim).build()?);
+/// // Owned values cross the spawn_blocking boundary; the embedder is shared as an Arc.
+/// let embedder: Arc<dyn EmbeddingProvider + Send + Sync> = Arc::new(HashEmbedder { dim });
+/// let req = AddFactRequest {
+///     content: "hello".into(),
+///     fact_type: FactType::Semantic,
+///     source_event_id: None,
+///     scope: None,
+///     opts: None,
+/// };
 /// let id = async_engine.add_fact(req, embedder, None).await?;
+/// assert!(id > 0);
+/// # Ok::<(), MemoryError>(())
+/// # }).unwrap();
 /// ```
 #[derive(Clone)]
 pub struct AsyncMemoryEngine {

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -61,6 +61,11 @@ use crate::types::{AddFactRequest, ConsolidationLevel, Fact, NewEvent, NewFact, 
 /// };
 /// let id = async_engine.add_fact(req, embedder, None).await?;
 /// assert!(id > 0);
+///
+/// // Read the fact back through a second spawn_blocking hop to prove the
+/// // async round-trip actually persisted it (not just returned an id).
+/// let fact = async_engine.get_fact(id).await?;
+/// assert_eq!(fact.content, "hello");
 /// # Ok::<(), MemoryError>(())
 /// # }).unwrap();
 /// ```

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -523,11 +523,34 @@ impl MemoryEngine {
     ///
     /// Shared helper for [`ensure_scope_path()`] and [`add_fact()`] to avoid
     /// duplicating scope resolution logic.
+    ///
+    /// `ensure_path` creates *every* segment of a multi-level path in the DB but
+    /// returns only the leaf id. The in-memory [`ScopeTree`] must mirror the DB,
+    /// so we insert the entire newly-resolved chain — leaf **and all ancestors up
+    /// to (but excluding) the root** — not just the leaf. Inserting only the leaf
+    /// would leave `resolve_path` (which walks `children` from root) unable to
+    /// traverse the missing intermediate links, making any depth > 1 scope query
+    /// (`scope_subtree`/`scope_exact`/…) return zero results in-session even
+    /// though the facts are correctly persisted. [`ScopeTree::insert`] is
+    /// idempotent by id, so re-inserting shared ancestors is a no-op.
     fn ensure_scope_with_conn(&self, conn: &Connection, path: &str) -> Result<i64> {
         let scope_store = ScopeStore::new(conn);
         let id = scope_store.ensure_path(path)?;
-        let node = scope_store.get(id)?;
-        self.scope_tree.write().insert(node);
+
+        // Walk leaf → root via parent_id, caching every node into the tree.
+        // Stop at the root (always present) and guard against a malformed
+        // parent cycle so a hostile DB can't spin this loop forever.
+        let mut tree = self.scope_tree.write();
+        let mut seen = std::collections::HashSet::new();
+        let mut current = Some(id);
+        while let Some(node_id) = current {
+            if node_id == ScopeTree::root_id() || !seen.insert(node_id) {
+                break;
+            }
+            let node = scope_store.get(node_id)?;
+            current = node.parent_id;
+            tree.insert(node);
+        }
         Ok(id)
     }
 

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -1215,6 +1215,61 @@ fn execute_query_scope_only() {
     assert_eq!(results[0].fact.content, "scoped fact");
 }
 
+/// Regression for the multi-segment scope-cache bug: `add_fact` on a path with
+/// depth > 1 (`user:michael/project:demo`) must make the fact retrievable via a
+/// `scope_subtree` query on that same path *in the same session*.
+///
+/// The defect was that `ensure_scope_with_conn` inserted only the leaf node into
+/// the in-memory `scope_tree`, leaving the intermediate `user:michael` link
+/// absent. `resolve_path` walks children from root, so it failed at the first
+/// missing segment and `scope_subtree("user:michael/project:demo")` resolved to
+/// `None` → 0 results, even though the DB held the full chain.
+#[test]
+fn execute_query_subtree_multi_segment_scope() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let embedder = MockEmbedder { dim: DIM };
+
+    engine
+        .add_fact(
+            &AddFactRequest {
+                content: "multi-segment scoped fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: Some("user:michael/project:demo".into()),
+                opts: None,
+            },
+            &embedder,
+            None,
+        )
+        .unwrap();
+
+    // Subtree of the deep leaf must find the fact.
+    let leaf = engine
+        .execute_query(&MemoryQuery::new().scope_subtree("user:michael/project:demo"))
+        .unwrap()
+        .results;
+    assert_eq!(leaf.len(), 1, "leaf subtree must retrieve the fact");
+    assert_eq!(leaf[0].fact.content, "multi-segment scoped fact");
+
+    // Subtree of an intermediate ancestor must also find the descendant fact.
+    let ancestor = engine
+        .execute_query(&MemoryQuery::new().scope_subtree("user:michael"))
+        .unwrap()
+        .results;
+    assert_eq!(
+        ancestor.len(),
+        1,
+        "ancestor subtree must retrieve the descendant fact"
+    );
+
+    // Exact match on the deep leaf must also resolve.
+    let exact = engine
+        .execute_query(&MemoryQuery::new().scope_exact("user:michael/project:demo"))
+        .unwrap()
+        .results;
+    assert_eq!(exact.len(), 1, "exact deep-path query must resolve");
+}
+
 #[test]
 fn execute_query_fact_type_filter() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,58 @@
 //! `MemoryEngine` is `Send + Sync`. Thread safety is provided by an internal
 //! connection pool (N readers + 1 writer) and `RwLock`-protected caches.
 //! Consumers can share via `Arc<MemoryEngine>`.
+//!
+//! ## Quick start
+//!
+//! Build an in-memory engine with the typestate [`MemoryEngine::builder`], add a
+//! fact, and retrieve it. The engine delegates embedding to a consumer-supplied
+//! [`EmbeddingProvider`]; the example wires a tiny deterministic one so it is
+//! fully self-contained and runs under `cargo test --doc`.
+//!
+//! ```
+//! use memory_engine::{
+//!     AddFactRequest, EmbeddingProvider, FactType, MemoryEngine, MemoryError, MemoryQuery,
+//! };
+//!
+//! // A deterministic, dependency-free embedder: hash each byte into a fixed-dim
+//! // bag-of-bytes vector. Real consumers plug in a model here instead.
+//! struct HashEmbedder {
+//!     dim: usize,
+//! }
+//! impl EmbeddingProvider for HashEmbedder {
+//!     fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+//!         let mut v = vec![0.0_f32; self.dim];
+//!         for &b in text.as_bytes() {
+//!             v[b as usize % self.dim] += 1.0;
+//!         }
+//!         Ok(v)
+//!     }
+//! }
+//!
+//! let dim = 64;
+//! let engine = MemoryEngine::builder(dim).build()?;
+//! let embedder = HashEmbedder { dim };
+//!
+//! // Ingest a fact (embedding computed via the provider, then persisted).
+//! let id = engine.add_fact(
+//!     &AddFactRequest {
+//!         content: "Rust has no garbage collector".into(),
+//!         fact_type: FactType::Semantic,
+//!         source_event_id: None,
+//!         scope: None,
+//!         opts: None,
+//!     },
+//!     &embedder,
+//!     None,
+//! )?;
+//! assert!(id > 0);
+//!
+//! // Retrieve it back via full-text search and assert on the result.
+//! let response = engine.execute_query(&MemoryQuery::new().text("garbage collector"))?;
+//! assert_eq!(response.results.len(), 1);
+//! assert_eq!(response.results[0].fact.content, "Rust has no garbage collector");
+//! # Ok::<(), MemoryError>(())
+//! ```
 
 // === Public modules (consumer-facing API) ===
 #[cfg(feature = "async")]

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -14,21 +14,55 @@ const DEFAULT_LIMIT: usize = 50;
 ///
 /// # Examples
 ///
-/// ```rust,ignore
-/// // Semantic search within a scope and time period
-/// let results = engine.execute_query(
-///     &MemoryQuery::new()
-///         .scope_subtree("user:michael/project:demo")
-///         .period(week_ago, now)
-///         .text("deployment issue")
-///         .min_importance_score(0.3)
-///         .limit(20)
+/// ```
+/// use memory_engine::{
+///     AddFactRequest, EmbeddingProvider, FactType, MemoryEngine, MemoryError, MemoryQuery,
+/// };
+///
+/// // Deterministic, dependency-free embedder (see the crate-level example).
+/// struct HashEmbedder {
+///     dim: usize,
+/// }
+/// impl EmbeddingProvider for HashEmbedder {
+///     fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+///         let mut v = vec![0.0_f32; self.dim];
+///         for &b in text.as_bytes() {
+///             v[b as usize % self.dim] += 1.0;
+///         }
+///         Ok(v)
+///     }
+/// }
+///
+/// let dim = 64;
+/// let engine = MemoryEngine::builder(dim).build()?;
+/// let embedder = HashEmbedder { dim };
+/// engine.add_fact(
+///     &AddFactRequest {
+///         content: "deployment issue in the demo project".into(),
+///         fact_type: FactType::Episodic,
+///         source_event_id: None,
+///         scope: Some("project:demo".into()),
+///         opts: None,
+///     },
+///     &embedder,
+///     None,
 /// )?;
 ///
-/// // All pinned facts
-/// let pinned = engine.execute_query(
-///     &MemoryQuery::new().pinned_only()
+/// // Scoped retrieval: all facts in the subtree rooted at `project:demo`, capped
+/// // at 20 results. An empty query (no `text`/`embedding`) returns every
+/// // temporally-valid fact in scope, sorted by importance.
+/// let response = engine.execute_query(
+///     &MemoryQuery::new()
+///         .scope_subtree("project:demo")
+///         .limit(20),
 /// )?;
+/// assert_eq!(response.results.len(), 1);
+/// assert_eq!(response.results[0].fact.content, "deployment issue in the demo project");
+///
+/// // All pinned facts (none were pinned, so this is empty).
+/// let pinned = engine.execute_query(&MemoryQuery::new().pinned_only())?;
+/// assert!(pinned.results.is_empty());
+/// # Ok::<(), MemoryError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct MemoryQuery {

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -36,24 +36,30 @@ const DEFAULT_LIMIT: usize = 50;
 /// let dim = 64;
 /// let engine = MemoryEngine::builder(dim).build()?;
 /// let embedder = HashEmbedder { dim };
+/// // A deep, hierarchical scope: the fact lives under `user:michael/project:demo`.
+/// // `add_fact` auto-creates every missing segment (`user:michael`, then
+/// // `project:demo`) in both the database and the in-memory scope tree.
 /// engine.add_fact(
 ///     &AddFactRequest {
 ///         content: "deployment issue in the demo project".into(),
 ///         fact_type: FactType::Episodic,
 ///         source_event_id: None,
-///         scope: Some("project:demo".into()),
+///         scope: Some("user:michael/project:demo".into()),
 ///         opts: None,
 ///     },
 ///     &embedder,
 ///     None,
 /// )?;
 ///
-/// // Scoped retrieval: all facts in the subtree rooted at `project:demo`, capped
-/// // at 20 results. An empty query (no `text`/`embedding`) returns every
-/// // temporally-valid fact in scope, sorted by importance.
+/// // Scoped retrieval over a *subtree*: every fact rooted at the `user:michael`
+/// // ancestor (which includes the deeper `project:demo` child), capped at 20
+/// // results. An empty query (no `text`/`embedding`) returns every
+/// // temporally-valid fact in scope, sorted by importance. This exercises the
+/// // multi-segment scope path: the intermediate `user:michael` node must be
+/// // resolvable for the subtree walk to reach its descendant.
 /// let response = engine.execute_query(
 ///     &MemoryQuery::new()
-///         .scope_subtree("project:demo")
+///         .scope_subtree("user:michael")
 ///         .limit(20),
 /// )?;
 /// assert_eq!(response.results.len(), 1);


### PR DESCRIPTION
## What

The crate had three `rust,ignore` doc examples and **no runnable doctest demonstrating the core `build -> add_fact -> query` flow** (issue #121, super-qa finding M24). Note: a couple of runnable doctests already existed (`engine/mod.rs` `EngineConfig`, `engine/builder.rs`), but none covered the end-to-end round-trip on a prominent public item.

This adds a self-contained, deterministic doctest on the crate-level `//!` and converts two of the three `ignore` examples into runnable ones, all driven by the typestate `MemoryEngine::builder` (#556):

- **`src/lib.rs` (`//!`)** — new quick-start: in-memory `MemoryEngine::builder(dim)` -> `add_fact` -> `execute_query(MemoryQuery::new().text(...))`, asserting the round-tripped fact content.
- **`src/async_engine.rs`** — the `AsyncMemoryEngine` example now runs on a real tokio runtime with an `Arc<dyn EmbeddingProvider + Send + Sync>` (executes under `--all-features`), and reads the fact back via `get_fact` to prove the `spawn_blocking` round-trip actually persists (not just that an id was returned).
- **`src/search/query.rs`** — the `MemoryQuery` example builds an engine, ingests a fact under the **multi-segment** scope `user:michael/project:demo`, and asserts on `scope_subtree("user:michael")` retrieval, genuinely exercising depth > 1 hierarchical resolution.

Each example wires a tiny dependency-free `HashEmbedder` (bag-of-bytes into a fixed dim) so it is deterministic and needs no model or network — true to the crate's "zero LLM/network deps" contract.

The third `ignore` (`src/resume/context.rs`) stays `ignore` with its existing inline reason: it documents a `pub(crate)` helper that a compiled doctest cannot reach from outside the crate.

## Bug fix (surfaced by the doctest work)

Writing the multi-segment scope example exposed a real latent bug: `ensure_scope_with_conn` cached only the **leaf** scope node into the in-memory `ScopeTree`, not its ancestors. Since `resolve_path` walks `children` from the root, the missing intermediate links made any depth > 1 scope query (`scope_subtree`/`scope_exact`/…) return **zero results in-session**, even though the facts were persisted correctly.

Rather than dodge it with a single-segment scope, this PR fixes the root cause: walk leaf -> root via `parent_id` and cache the entire chain (idempotent, cycle-guarded). Pinned with a regression test `execute_query_subtree_multi_segment_scope`.

## Collateral: CLI test compile breakage (#564 / #569)

`memory-engine-cli/tests/cli_integration.rs:124` still called the removed `MemoryEngine::open(&config)` constructor (dropped by the typestate-builder migration #556), so `cargo test --workspace` failed to compile — a pre-existing breakage on `main`, tracked by #564 and #569. Migrated the call site to the builder pattern already used elsewhere in the same file, restoring the workspace gate.

## Gates

- `cargo test --doc` — 5 pass + 1 justified ignore (6 pass + 1 ignore under `--all-features`, including the async example).
- `cargo build --workspace` — clean.
- `cargo test --workspace` — green (CLI test now compiles).
- `cargo clippy --workspace --all-targets` — zero errors.
- `cargo fmt --check` — clean.

Closes #121
Closes #564
Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
