### PR TITLE
feat(storage): dedup-with-reinforcement for bootstrap (#520)

### DIFF
--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -34,6 +34,8 @@ pub struct BootstrapReport {
     pub turns_reconstructed: usize,
     pub candidates_found: usize,
     pub facts_created: usize,
+    /// Existing facts reinforced (dedup-with-reinforcement) instead of duplicated.
+    pub facts_reinforced: usize,
     pub events_ingested: usize,
     pub outcome_counts: OutcomeCounts,
     pub category_counts: CategoryCounts,
@@ -50,6 +52,7 @@ impl BootstrapReport {
         self.turns_reconstructed += other.turns_reconstructed;
         self.candidates_found += other.candidates_found;
         self.facts_created += other.facts_created;
+        self.facts_reinforced += other.facts_reinforced;
         self.events_ingested += other.events_ingested;
         self.outcome_counts.success += other.outcome_counts.success;
         self.outcome_counts.failure += other.outcome_counts.failure;
@@ -174,6 +177,7 @@ mod tests {
             turns_reconstructed: 18,
             candidates_found: 12,
             facts_created: 8,
+            facts_reinforced: 2,
             events_ingested: 15,
             outcome_counts: OutcomeCounts {
                 success: 5,

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -270,10 +270,20 @@ fn bootstrap_within_savepoint(
                 is_pinned,
             };
 
-            fact_store.insert(&new_fact)?;
+            // Dedup-with-reinforcement (#520): a fact whose content already exists
+            // (active, same scope) is reinforced — recency/frequency bumped — rather
+            // than duplicated. A 9-month backfill re-encounters recurring conventions
+            // and decisions across sessions; this collapses them to one reinforced row.
+            let (_, reinforced) = fact_store.insert_or_reinforce(&new_fact)?;
+            if reinforced {
+                // A reinforcement adds no new row, so it does not count toward
+                // prewarm metrics or the created-fact importance average.
+                report.facts_reinforced += 1;
+                continue;
+            }
             report.facts_created += 1;
 
-            // Update prewarm metrics
+            // Update prewarm metrics (newly-created rows only)
             match fact.fact_type {
                 FactType::Episodic => report.prewarm_metrics.episodic_count += 1,
                 FactType::Semantic => report.prewarm_metrics.semantic_count += 1,

--- a/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_default_report.snap
+++ b/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_default_report.snap
@@ -1,6 +1,5 @@
 ---
 source: src/bootstrap/metrics.rs
-assertion_line: 157
 expression: report
 ---
 sessions_processed: 0
@@ -10,6 +9,7 @@ entries_malformed: 0
 turns_reconstructed: 0
 candidates_found: 0
 facts_created: 0
+facts_reinforced: 0
 events_ingested: 0
 outcome_counts:
   success: 0

--- a/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_populated_report.snap
+++ b/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_populated_report.snap
@@ -1,6 +1,5 @@
 ---
 source: src/bootstrap/metrics.rs
-assertion_line: 189
 expression: report
 ---
 sessions_processed: 3
@@ -10,6 +9,7 @@ entries_malformed: 2
 turns_reconstructed: 18
 candidates_found: 12
 facts_created: 8
+facts_reinforced: 2
 events_ingested: 15
 outcome_counts:
   success: 5

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1122,6 +1122,38 @@ mod tests {
             late.timestamp_micros(),
             "last_accessed = latest even at sub-second precision"
         );
+
+        // The zero-fraction-vs-fractional case (the one the review flagged): to_rfc3339()
+        // uses a numeric `+00:00` offset, NOT `Z`. The whole-second string ends in `+...`
+        // where the fractional one has `.123`; `+` (0x2B) < `.` (0x2E), so the whole second
+        // (earlier) still sorts first. (With a `Z` suffix this WOULD invert — hence the
+        // explicit format assertion below guarding the invariant.)
+        let whole: DateTime<Utc> = "2024-07-20T15:00:00+00:00".parse().unwrap();
+        let frac: DateTime<Utc> = "2024-07-20T15:00:00.123+00:00".parse().unwrap();
+        assert!(
+            whole.to_rfc3339().ends_with("+00:00") && !whole.to_rfc3339().contains('Z'),
+            "to_rfc3339() must use a numeric offset, not Z: {}",
+            whole.to_rfc3339()
+        );
+        let mut w = make_fact("conv2", vec![0.1; DIM]);
+        w.t_created = frac;
+        w.last_accessed = whole;
+        let (id2, _) = store.insert_or_reinforce(&w).unwrap();
+        let mut x = make_fact("conv2", vec![0.1; DIM]);
+        x.t_created = whole;
+        x.last_accessed = frac;
+        store.insert_or_reinforce(&x).unwrap();
+        let got2 = store.get(id2).unwrap();
+        assert_eq!(
+            got2.t_created.timestamp_micros(),
+            whole.timestamp_micros(),
+            "t_created = whole-second (earliest) in the zero-vs-fractional case"
+        );
+        assert_eq!(
+            got2.last_accessed.timestamp_micros(),
+            frac.timestamp_micros(),
+            "last_accessed = fractional (latest) in the zero-vs-fractional case"
+        );
     }
 
     #[test]

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::error::{MemoryError, Result};
 use crate::store::{
@@ -107,6 +107,72 @@ impl<'a> FactStore<'a> {
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Insert a fact, or reinforce an existing active fact with identical content
+    /// in the same scope.
+    ///
+    /// A bulk backfill (autonomous-agent-project#53) re-encounters recurring facts
+    /// (conventions, decisions) across many sessions; inserting each occurrence
+    /// duplicates rows. Instead, if an active (`t_expired IS NULL`) fact with the
+    /// same `content_hash` **and** identical content exists in the same `scope_id`,
+    /// this reinforces it — increments `access_count`, advances `last_accessed` to
+    /// the later timestamp, and rolls `t_created` back to the earlier one (so
+    /// first-seen and last-seen are independent of import order) — and returns its
+    /// id. Otherwise it inserts a new row.
+    ///
+    /// This instantiates "memory decays unless reinforced": a re-mention strengthens
+    /// the recency/frequency signal rather than spawning a duplicate. It is
+    /// deliberately **not** a global `UNIQUE` constraint — identical content in
+    /// different scopes is legitimate, and the reinforce-vs-insert decision is
+    /// per-scope and active-only.
+    ///
+    /// Returns `(id, reinforced)`: `reinforced` is `true` when an existing fact was
+    /// reinforced instead of a new row inserted.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::EmbeddingDimension` if embedding length != `embed_dim`.
+    /// Returns `MemoryError::Database` on query or insert failure.
+    pub fn insert_or_reinforce(&self, fact: &NewFact) -> Result<(i64, bool)> {
+        if fact.embedding.len() != self.embed_dim {
+            return Err(MemoryError::EmbeddingDimension {
+                expected: self.embed_dim,
+                actual: fact.embedding.len(),
+            });
+        }
+        let hash = content_hash(&fact.content);
+        // content_hash is index-backed (idx_facts_hash); the content equality guard
+        // rejects the astronomically-unlikely 128-bit hash collision.
+        let existing: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT id FROM facts
+                 WHERE content_hash = ?1 AND content = ?2 AND scope_id = ?3 AND t_expired IS NULL
+                 ORDER BY id LIMIT 1",
+                params![hash, fact.content, fact.scope_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        match existing {
+            Some(id) => {
+                // RFC-3339 produced by to_rfc3339() sorts lexicographically ==
+                // chronologically, so SQL min/max give earliest/latest.
+                let t_created = fact.t_created.to_rfc3339();
+                let last_accessed = fact.last_accessed.to_rfc3339();
+                self.conn.execute(
+                    "UPDATE facts
+                     SET access_count = access_count + 1,
+                         t_created = min(t_created, ?1),
+                         last_accessed = max(last_accessed, ?2)
+                     WHERE id = ?3",
+                    params![t_created, last_accessed, id],
+                )?;
+                Ok((id, true))
+            }
+            None => Ok((self.insert(fact)?, false)),
+        }
     }
 
     /// Get a fact by id, including full embedding deserialization.
@@ -864,6 +930,109 @@ mod tests {
         assert_eq!(retrieved.content, "Rust is a systems language");
         assert_eq!(retrieved.fact_type, FactType::Episodic);
         assert!(!retrieved.content_hash.is_empty());
+    }
+
+    #[test]
+    fn insert_or_reinforce_dedups_and_reinforces_in_scope() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let mut first = make_fact("always use rustfmt", vec![0.1; DIM]);
+        first.t_created = "2024-07-20T14:00:00Z".parse().unwrap();
+        first.last_accessed = first.t_created;
+        let (id, reinforced) = store.insert_or_reinforce(&first).unwrap();
+        assert!(!reinforced, "first occurrence inserts");
+
+        let mut again = make_fact("always use rustfmt", vec![0.9; DIM]);
+        again.t_created = "2025-01-12T10:00:00Z".parse().unwrap();
+        again.last_accessed = again.t_created;
+        let (id2, reinforced2) = store.insert_or_reinforce(&again).unwrap();
+        assert_eq!(id2, id, "reinforce returns the existing id");
+        assert!(reinforced2, "second occurrence reinforces");
+
+        assert_eq!(
+            store.list_active(None).unwrap().len(),
+            1,
+            "deduped to one row"
+        );
+        let got = store.get(id).unwrap();
+        assert_eq!(got.access_count, 1, "reinforced once");
+        assert_eq!(
+            got.t_created.timestamp(),
+            first.t_created.timestamp(),
+            "t_created rolls back to the earliest occurrence"
+        );
+        assert_eq!(
+            got.last_accessed.timestamp(),
+            again.last_accessed.timestamp(),
+            "last_accessed advances to the latest occurrence"
+        );
+    }
+
+    #[test]
+    fn insert_or_reinforce_timestamps_are_order_independent() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        // Insert the LATER occurrence first, then the EARLIER one.
+        let mut late = make_fact("conv", vec![0.1; DIM]);
+        late.t_created = "2025-01-12T10:00:00Z".parse().unwrap();
+        late.last_accessed = late.t_created;
+        let (id, _) = store.insert_or_reinforce(&late).unwrap();
+        let mut early = make_fact("conv", vec![0.1; DIM]);
+        early.t_created = "2024-07-20T14:00:00Z".parse().unwrap();
+        early.last_accessed = early.t_created;
+        store.insert_or_reinforce(&early).unwrap();
+        let got = store.get(id).unwrap();
+        assert_eq!(
+            got.t_created.timestamp(),
+            early.t_created.timestamp(),
+            "earliest t_created wins regardless of import order"
+        );
+        assert_eq!(
+            got.last_accessed.timestamp(),
+            late.last_accessed.timestamp(),
+            "latest last_accessed wins"
+        );
+    }
+
+    #[test]
+    fn insert_or_reinforce_distinguishes_scope_and_content() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        conn.execute(
+            "INSERT INTO scopes (id, parent_id, label, depth) VALUES (2, 1, 'other', 1)",
+            [],
+        )
+        .unwrap();
+        let mut a = make_fact("same text", vec![0.1; DIM]);
+        a.scope_id = 1;
+        let mut b = make_fact("same text", vec![0.1; DIM]);
+        b.scope_id = 2;
+        let (_, ra) = store.insert_or_reinforce(&a).unwrap();
+        let (_, rb) = store.insert_or_reinforce(&b).unwrap();
+        assert!(
+            !ra && !rb,
+            "identical content in different scopes is not deduped"
+        );
+        let (_, rc) = store
+            .insert_or_reinforce(&make_fact("different text", vec![0.1; DIM]))
+            .unwrap();
+        assert!(!rc, "different content is not deduped");
+        assert_eq!(store.list_active(None).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn insert_or_reinforce_ignores_expired_facts() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let (id, _) = store
+            .insert_or_reinforce(&make_fact("convention", vec![0.1; DIM]))
+            .unwrap();
+        store.expire(id, Utc::now()).unwrap();
+        let (id2, reinforced) = store
+            .insert_or_reinforce(&make_fact("convention", vec![0.1; DIM]))
+            .unwrap();
+        assert!(!reinforced, "an expired fact must not be reinforced");
+        assert_ne!(id2, id, "a fresh row is inserted instead");
     }
 
     #[test]

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -121,11 +121,20 @@ impl<'a> FactStore<'a> {
     /// first-seen and last-seen are independent of import order) — and returns its
     /// id. Otherwise it inserts a new row.
     ///
+    /// Reinforcement also keeps the **strongest** per-occurrence signal: `is_pinned`
+    /// and `importance` move to the max across occurrences (a fact later judged pinned
+    /// or more important stays so). Frequency does not inflate `importance` — only the
+    /// independent per-occurrence score does.
+    ///
     /// This instantiates "memory decays unless reinforced": a re-mention strengthens
     /// the recency/frequency signal rather than spawning a duplicate. It is
     /// deliberately **not** a global `UNIQUE` constraint — identical content in
     /// different scopes is legitimate, and the reinforce-vs-insert decision is
     /// per-scope and active-only.
+    ///
+    /// The lookup-then-write is non-atomic but safe under the engine's single-writer
+    /// pool (one mutex-guarded write connection); a caller outside that serialization
+    /// must provide its own.
     ///
     /// Returns `(id, reinforced)`: `reinforced` is `true` when an existing fact was
     /// reinforced instead of a new row inserted.
@@ -157,17 +166,28 @@ impl<'a> FactStore<'a> {
 
         match existing {
             Some(id) => {
-                // RFC-3339 produced by to_rfc3339() sorts lexicographically ==
-                // chronologically, so SQL min/max give earliest/latest.
+                // to_rfc3339() emits a `+00:00` offset with AutoSi-padded (0/3/6/9-digit)
+                // fractions; `+` (0x2B) sorts before any digit, so a shorter fraction
+                // (chronologically <=) always sorts first — lexicographic == chronological,
+                // and SQL min/max give earliest/latest. (Same invariant the rest of the
+                // store relies on for t_created/t_valid string comparison.)
                 let t_created = fact.t_created.to_rfc3339();
                 let last_accessed = fact.last_accessed.to_rfc3339();
                 self.conn.execute(
                     "UPDATE facts
                      SET access_count = access_count + 1,
                          t_created = min(t_created, ?1),
-                         last_accessed = max(last_accessed, ?2)
-                     WHERE id = ?3",
-                    params![t_created, last_accessed, id],
+                         last_accessed = max(last_accessed, ?2),
+                         is_pinned = max(is_pinned, ?3),
+                         importance = max(importance, ?4)
+                     WHERE id = ?5",
+                    params![
+                        t_created,
+                        last_accessed,
+                        i64::from(fact.is_pinned),
+                        fact.importance,
+                        id
+                    ],
                 )?;
                 Ok((id, true))
             }
@@ -1033,6 +1053,75 @@ mod tests {
             .unwrap();
         assert!(!reinforced, "an expired fact must not be reinforced");
         assert_ne!(id2, id, "a fresh row is inserted instead");
+    }
+
+    #[test]
+    fn insert_or_reinforce_keeps_strongest_pin_and_importance() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let mut weak = make_fact("shared note", vec![0.1; DIM]);
+        weak.is_pinned = false;
+        weak.importance = 0.3;
+        let (id, _) = store.insert_or_reinforce(&weak).unwrap();
+
+        // A later occurrence judged pinned + more important — the strongest signal wins.
+        let mut strong = make_fact("shared note", vec![0.1; DIM]);
+        strong.is_pinned = true;
+        strong.importance = 0.9;
+        store.insert_or_reinforce(&strong).unwrap();
+        let got = store.get(id).unwrap();
+        assert!(got.is_pinned, "is_pinned rises to pinned on reinforcement");
+        assert!(
+            (got.importance - 0.9).abs() < f64::EPSILON,
+            "importance rises to the max"
+        );
+
+        // A weaker later occurrence lowers neither signal.
+        let mut weaker = make_fact("shared note", vec![0.1; DIM]);
+        weaker.is_pinned = false;
+        weaker.importance = 0.2;
+        store.insert_or_reinforce(&weaker).unwrap();
+        let got = store.get(id).unwrap();
+        assert!(got.is_pinned, "pin is not lost by a weaker reinforcement");
+        assert!(
+            (got.importance - 0.9).abs() < f64::EPSILON,
+            "importance does not drop"
+        );
+    }
+
+    #[test]
+    fn insert_or_reinforce_subsecond_timestamps_sort_chronologically() {
+        // Regression guard for the RFC-3339 min/max invariant: variable sub-second
+        // precision (3-digit vs 6-digit fraction sharing a prefix) is the lexicographic-
+        // vs-chronological trap. The `+00:00` offset + AutoSi padding must keep min/max
+        // chronologically correct.
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let early: DateTime<Utc> = "2024-07-20T14:00:00.500+00:00".parse().unwrap();
+        let late: DateTime<Utc> = "2024-07-20T14:00:00.500123+00:00".parse().unwrap();
+        assert!(early < late, "fixture sanity: early precedes late");
+
+        // Insert the LATER occurrence first, then reinforce with the EARLIER.
+        let mut first = make_fact("conv", vec![0.1; DIM]);
+        first.t_created = late;
+        first.last_accessed = late;
+        let (id, _) = store.insert_or_reinforce(&first).unwrap();
+        let mut second = make_fact("conv", vec![0.1; DIM]);
+        second.t_created = early;
+        second.last_accessed = early;
+        store.insert_or_reinforce(&second).unwrap();
+
+        let got = store.get(id).unwrap();
+        assert_eq!(
+            got.t_created.timestamp_micros(),
+            early.timestamp_micros(),
+            "t_created = earliest even at sub-second precision"
+        );
+        assert_eq!(
+            got.last_accessed.timestamp_micros(),
+            late.timestamp_micros(),
+            "last_accessed = latest even at sub-second precision"
+        );
     }
 
     #[test]

--- a/tests/bootstrap_dryrun.rs
+++ b/tests/bootstrap_dryrun.rs
@@ -7,8 +7,9 @@
 //!   2. idempotency — re-running a bootstrapped session is a no-op (`skip_existing`);
 //!   3. `t_created` backdating — facts carry the historical session timestamp,
 //!      never `Utc::now()`;
-//!   4. NO cross-session fact dedup — the same fact in two sessions is stored
-//!      twice (relevant to a 9-month backfill).
+//!   4. cross-session dedup-with-reinforcement (#520) — the same fact in two
+//!      sessions is stored ONCE and reinforced (access_count bumped, t_created =
+//!      earliest, last_accessed = latest), relevant to a 9-month backfill.
 //!
 //! Hermetic: in-memory engine + zero-vector embedder. No network, no Ollama,
 //! no GPU contention (S0 is build-only). See `docs/audits/S0.3-bootstrap-audit.md`.
@@ -138,9 +139,9 @@ fn specs() -> Vec<SessionSpec> {
             vec![
                 // Convention turn — byte-identical (user + assistant) to session 3, so the
                 // extracted fact content matches VERBATIM across two distinct sessions: the
-                // real cross-session dedup probe. A content-hash dedup-on-insert would collapse
-                // the two identical facts, dropping the stored count below 2 and FAILING the
-                // no-dedup assertions below (which a mere substring match would not catch).
+                // cross-session dedup-with-reinforcement probe. insert_or_reinforce collapses
+                // the two identical facts into one stored row and reinforces it (access_count
+                // bumped, t_created = earliest, last_accessed = latest) — asserted below.
                 ("user", "Any formatting rule for commits?"),
                 (
                     "assistant",
@@ -164,7 +165,7 @@ const SHARED: &str = "always use rustfmt before every commit";
 // no-dedup) sharing one engine + recorder; kept as a single test on purpose.
 #[allow(clippy::too_many_lines)]
 #[test]
-fn dryrun_yield_backdate_idempotency_no_dedup() {
+fn dryrun_yield_backdate_idempotency_dedup_reinforce() {
     let engine = MemoryEngine::builder(4).build().unwrap();
     let extractor = KeywordExtractor;
     let recorder = RecordingClassifier::default();
@@ -178,6 +179,7 @@ fn dryrun_yield_backdate_idempotency_no_dedup() {
 
     // --- First pass: yield ---
     let mut total_facts = 0;
+    let mut total_reinforced = 0;
     for (i, jsonl) in sessions.iter().enumerate() {
         let report = engine
             .bootstrap_session(
@@ -207,18 +209,29 @@ fn dryrun_yield_backdate_idempotency_no_dedup() {
         assert_eq!(report.sessions_processed, 1, "session {i} should process");
         assert_eq!(report.events_ingested, 1, "one marker event per session");
         total_facts += report.facts_created;
+        total_reinforced += report.facts_reinforced;
     }
     println!("TOTAL facts (first pass) = {total_facts}");
     for (content, t) in recorder.seen.lock().unwrap().iter() {
         let snippet: String = content.chars().take(90).collect();
         println!("  fact t_created={t} content={snippet:?}");
     }
-    // Deterministic yield: sessions 1–4 → 1 fact each (4); session 5 → 2 facts (a
-    // convention turn identical to session 3's + a separate bug turn) => 6. Pins expected
-    // yield against extractor drift.
+    // Deterministic yield with dedup-with-reinforcement: sessions 1–4 → 1 created fact
+    // each (4); session 5 → its bug turn is created (1) while its convention turn (identical
+    // to session 3's) is REINFORCED, not created ⇒ 5 created + 1 reinforced. The classifier
+    // still sees all 6 candidate facts (it runs before the dedup decision).
     assert_eq!(
-        total_facts, 6,
-        "expected 6 facts (sessions 1–4 single + session-5 convention + bug), got {total_facts}"
+        total_facts, 5,
+        "expected 5 created facts (sessions 1–4 + session-5 bug; convention reinforced), got {total_facts}"
+    );
+    assert_eq!(
+        total_reinforced, 1,
+        "expected 1 reinforced fact (session-5 convention dedups onto session-3's), got {total_reinforced}"
+    );
+    assert_eq!(
+        recorder.seen.lock().unwrap().len(),
+        6,
+        "classifier should be offered all 6 candidate facts (it runs pre-dedup)"
     );
 
     // --- Idempotency: re-run all five, expect skips + zero new facts ---
@@ -236,6 +249,10 @@ fn dryrun_yield_backdate_idempotency_no_dedup() {
         assert_eq!(report.sessions_processed, 0, "re-run must skip");
         assert_eq!(report.sessions_skipped, 1);
         assert_eq!(report.facts_created, 0);
+        assert_eq!(
+            report.facts_reinforced, 0,
+            "skipped session reinforces nothing"
+        );
         assert_eq!(
             report.events_ingested, 0,
             "skipped session ingests no marker"
@@ -260,48 +277,72 @@ fn dryrun_yield_backdate_idempotency_no_dedup() {
         assert!(t < &now, "t_created must be historical, got {t}");
     }
 
-    // --- No cross-session dedup: the IDENTICAL convention sentence appears verbatim
-    //     in sessions 3 and 5. Assert (a) it is stored more than once (no dedup) AND
-    //     (b) the copies originate in distinct backdated sessions (cross-session, not
-    //     merely session 5's intra-session dual-category fan-out). ---
-    let shared_copies = seen.iter().filter(|(c, _)| c.contains(SHARED)).count();
-    let shared_sessions: std::collections::BTreeSet<i64> = seen
+    // --- Cross-session dedup-with-reinforcement (#520): the IDENTICAL convention sentence
+    //     appears verbatim in sessions 3 and 5. The classifier runs BEFORE the dedup
+    //     decision, so it is offered both occurrences across two distinct backdated
+    //     sessions — that is the pre-dedup view, not the stored view. ---
+    let classifier_copies = seen.iter().filter(|(c, _)| c.contains(SHARED)).count();
+    let classifier_sessions: std::collections::BTreeSet<i64> = seen
         .iter()
         .filter(|(c, _)| c.contains(SHARED))
         .map(|(_, t)| t.timestamp())
         .collect();
     println!(
-        "shared convention: {shared_copies} stored copies across {} distinct sessions",
-        shared_sessions.len()
+        "shared convention: classifier saw {classifier_copies} copies across {} distinct sessions",
+        classifier_sessions.len()
     );
-    assert!(
-        shared_copies >= 2,
-        "identical fact must be stored more than once (no dedup), got {shared_copies}"
+    assert_eq!(
+        classifier_copies, 2,
+        "classifier (pre-dedup) must be offered both occurrences, got {classifier_copies}"
     );
-    assert!(
-        shared_sessions.len() >= 2,
-        "duplicate copies must originate in distinct backdated sessions (cross-session), got {}",
-        shared_sessions.len()
+    assert_eq!(
+        classifier_sessions.len(),
+        2,
+        "the two occurrences originate in distinct backdated sessions, got {}",
+        classifier_sessions.len()
     );
 
     // Drop the borrow so we can call engine methods below.
     drop(seen);
 
-    // --- Store-level no-dedup: query the persisted rows directly.
-    //     This is the authoritative check: both identical-content facts must
-    //     actually be present in the store, not merely have reached the
-    //     classifier.  The assertion stays true even if bootstrap is later
-    //     changed to skip classifier calls for duplicates (as long as it
-    //     still stores them), and it would catch a dedup-on-insert regression
-    //     that the recorder-only check cannot. ---
+    // --- Store-level dedup-with-reinforcement: query the persisted rows directly.
+    //     Authoritative check — the two identical-content occurrences collapse to ONE
+    //     stored row, reinforced: access_count bumped (one reinforcement), t_created
+    //     rolled back to the earliest session (2024), last_accessed advanced to the
+    //     latest (2025). Total active facts drop from 6 candidates to 5 stored. ---
     let stored_facts = engine.list_active_facts(None).unwrap();
-    let stored_shared_count = stored_facts
+    assert_eq!(
+        stored_facts.len(),
+        5,
+        "store must contain 5 active facts after dedup, got {}",
+        stored_facts.len()
+    );
+    let shared_rows: Vec<&Fact> = stored_facts
         .iter()
         .filter(|f| f.content.contains(SHARED))
-        .count();
-    assert!(
-        stored_shared_count >= 2,
-        "store must contain ≥2 rows with the shared convention text (no dedup-on-insert), \
-         got {stored_shared_count}"
+        .collect();
+    assert_eq!(
+        shared_rows.len(),
+        1,
+        "store must contain exactly ONE row for the shared convention (dedup-on-insert), got {}",
+        shared_rows.len()
+    );
+    let shared = shared_rows[0];
+    assert_eq!(
+        shared.access_count, 1,
+        "the shared convention must be reinforced once (access_count), got {}",
+        shared.access_count
+    );
+    assert_eq!(
+        shared.t_created.year(),
+        2024,
+        "t_created must roll back to the earliest occurrence (session 3, 2024), got {}",
+        shared.t_created.year()
+    );
+    assert_eq!(
+        shared.last_accessed.year(),
+        2025,
+        "last_accessed must advance to the latest occurrence (session 5, 2025), got {}",
+        shared.last_accessed.year()
     );
 }

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -172,7 +172,16 @@ fn bootstrap_skip_existing_false_allows_reimport() {
         .unwrap();
     assert_eq!(report2.sessions_processed, 1);
     assert_eq!(report2.sessions_skipped, 0);
-    assert_eq!(report2.facts_created, first_facts);
+    // Re-processed (not skipped), but dedup-with-reinforcement (#520) reinforces the
+    // already-stored facts instead of duplicating them.
+    assert_eq!(
+        report2.facts_created, 0,
+        "re-import creates no new rows — the facts already exist"
+    );
+    assert_eq!(
+        report2.facts_reinforced, first_facts,
+        "re-import reinforces the existing facts"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #520.

## What
`FactStore::insert_or_reinforce`: when an **active** fact with identical content already exists in the **same scope** (index-backed `content_hash` lookup + content-equality guard), reinforce it instead of inserting a duplicate; otherwise insert. Returns `(id, reinforced)`.

Reinforce = bump `access_count`, advance `last_accessed` to the latest occurrence, roll `t_created` back to the earliest — **order-independent** (`min`/`max` on the uniform RFC-3339 form), so out-of-order backfill is correct.

## Why
The 9-month session backfill (autonomous-agent-project#53) re-encounters recurring facts (conventions, decisions) across sessions; plain `insert` duplicated each occurrence (#520). This instantiates the four-layer thesis's **"memory decays unless reinforced"** — a re-mention strengthens recency/frequency rather than spawning a row.

**Deliberately not a global `UNIQUE` constraint:** identical content across *different* scopes is legitimate, and the reinforce-vs-insert decision is per-scope and active-only (expired facts are not reinforced).

## Wiring + accounting
- Bootstrap loop calls `insert_or_reinforce`; new `report.facts_reinforced`. A reinforcement adds no row, so it does **not** count toward prewarm metrics or the created-fact importance average.
- Behavior change: a re-import with `skip_existing=false` now **reinforces** the existing facts rather than duplicating them (still processes the session).

## Tests
- 4 unit tests: dedup+reinforce in-scope, order-independent timestamps, scope/content distinctness, expired-skip.
- Rewrote the S0.3 dry-run audit from "no cross-session dedup" → **dedup-with-reinforcement** (the shared convention across sessions 3+5 now collapses to one reinforced row: `access_count=1`, `t_created`=2024, `last_accessed`=2025).
- Updated `bootstrap_skip_existing_false_allows_reimport` + 2 metrics snapshots (`facts_reinforced`).
- Full suite: **674 passed, 0 failed**; `cargo +nightly fmt --check` clean; no new clippy (debt = #539).

## Note
Backfill quality prereq for #53 (the other two being #521 ✅ merged, #522 ✅ merged).