### PR TITLE
chore(retrieval): expect-message on hnsw_strategy + fix stale dispatch doc (#124)

### DIFF
--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -17,7 +17,11 @@ impl MemoryEngine {
     fn active_vector_strategy(&self) -> &dyn VectorSearchStrategy {
         #[cfg(feature = "ann")]
         if self.should_use_hnsw() {
-            return self.hnsw_strategy.as_ref().unwrap() as &dyn VectorSearchStrategy;
+            return self
+                .hnsw_strategy
+                .as_ref()
+                .expect("should_use_hnsw() returns true only when hnsw_strategy is Some")
+                as &dyn VectorSearchStrategy;
         }
         &*self.vector_strategy
     }

--- a/src/search/strategy.rs
+++ b/src/search/strategy.rs
@@ -79,9 +79,10 @@ impl VectorSearchStrategy for BruteForce {
 
 /// Configuration for vector search dispatch.
 ///
-/// Documents the intended threshold semantics for switching between brute-force
-/// and ANN strategies.  **Not wired into the engine yet** — dispatch requires a
-/// second strategy (ANN) to exist.
+/// Documents the threshold semantics for switching between brute-force and ANN
+/// strategies. Dispatch is wired via `MemoryEngine::active_vector_strategy`
+/// (behind the `ann` feature): the engine uses the HNSW index once
+/// `should_use_hnsw()` holds, and brute-force cosine otherwise.
 ///
 /// # Threshold semantics
 ///


### PR DESCRIPTION
Two cheap "low" findings from super-qa sweep #124 (epic #241):

- **L3/L24** — `active_vector_strategy()` `unwrap()` on `hnsw_strategy` (guarded by `should_use_hnsw()`) now uses `.expect()` documenting the invariant.
- **L27** — `SearchConfig` doc claimed "Not wired into the engine yet"; dispatch **is** wired via `active_vector_strategy` (behind the `ann` feature). Updated.

No behavior change. Gates: workspace build + core 792 tests + `--features ann` build/clippy + fmt all green.

**Refs #124** (does not close it — remaining items tracked: 7 fixed, 12 design spun out to #572/#573, rest won't-fix).