### PR TITLE
refactor(core): split MemoryError::Reranker into typed RerankerError

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use parking_lot::{MutexGuard, RwLock};
 use rusqlite::Connection;
 
-use crate::error::{MemoryError, Result};
+use crate::error::{MemoryError, RerankerError, Result};
 use crate::graph::MemoryGraph;
 use crate::pool::ConnectionPool;
 use crate::scope::ScopeTree;
@@ -650,29 +650,28 @@ impl MemoryEngine {
         use std::collections::HashSet;
 
         if output.len() > num_candidates {
-            return Err(MemoryError::Reranker(format!(
-                "reranker violated subset contract: output length ({}) exceeds input length ({num_candidates})",
-                output.len(),
-            )));
+            return Err(RerankerError::OutputTooLong {
+                output_len: output.len(),
+                input_len: num_candidates,
+            }
+            .into());
         }
 
         let mut seen = HashSet::with_capacity(output.len());
 
         for &(idx, score) in output {
             if idx >= num_candidates {
-                return Err(MemoryError::Reranker(format!(
-                    "reranker returned out-of-bounds index {idx} (candidates length: {num_candidates})",
-                )));
+                return Err(RerankerError::OutOfBoundsIndex {
+                    index: idx,
+                    num_candidates,
+                }
+                .into());
             }
             if !seen.insert(idx) {
-                return Err(MemoryError::Reranker(format!(
-                    "reranker violated subset contract: duplicate index {idx} in output",
-                )));
+                return Err(RerankerError::DuplicateIndex { index: idx }.into());
             }
             if !score.is_finite() {
-                return Err(MemoryError::Reranker(format!(
-                    "reranker returned non-finite score {score} for index {idx}",
-                )));
+                return Err(RerankerError::NonFiniteScore { score, index: idx }.into());
             }
         }
 

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -1682,7 +1682,9 @@ impl Reranker for ReverseReranker {
 struct FailingReranker;
 impl Reranker for FailingReranker {
     fn rerank(&self, _query: &str, _candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
-        Err(MemoryError::Reranker("cross-encoder timeout".into()))
+        Err(MemoryError::Reranker(
+            crate::error::RerankerError::Provider("cross-encoder timeout".into()),
+        ))
     }
     fn name(&self) -> &'static str {
         "failing"
@@ -2114,7 +2116,10 @@ fn reranker_error_propagates() {
     });
 
     assert!(result.is_err());
-    assert!(matches!(result.unwrap_err(), MemoryError::Reranker(_)));
+    assert!(matches!(
+        result.unwrap_err(),
+        MemoryError::Reranker(crate::error::RerankerError::Provider(_))
+    ));
 }
 
 #[test]
@@ -2502,8 +2507,11 @@ fn reranker_rejects_out_of_bounds_index() {
     assert!(result.is_err(), "should reject out-of-bounds index");
     let err = result.unwrap_err();
     assert!(
-        matches!(err, MemoryError::Reranker(_)),
-        "should be a Reranker error, got: {err}"
+        matches!(
+            err,
+            MemoryError::Reranker(crate::error::RerankerError::OutOfBoundsIndex { .. })
+        ),
+        "should be a Reranker(OutOfBoundsIndex) error, got: {err}"
     );
     assert!(
         err.to_string().contains("out-of-bounds"),
@@ -2559,8 +2567,11 @@ fn reranker_rejects_duplicates() {
     assert!(result.is_err(), "should reject duplicates");
     let err = result.unwrap_err();
     assert!(
-        matches!(err, MemoryError::Reranker(_)),
-        "should be a Reranker error, got: {err}"
+        matches!(
+            err,
+            MemoryError::Reranker(crate::error::RerankerError::DuplicateIndex { .. })
+        ),
+        "should be a Reranker(DuplicateIndex) error, got: {err}"
     );
     assert!(
         err.to_string().contains("duplicate"),
@@ -2739,8 +2750,11 @@ fn reranker_rejects_non_finite_score() {
     assert!(result.is_err(), "should reject NaN score");
     let err = result.unwrap_err();
     assert!(
-        matches!(err, MemoryError::Reranker(_)),
-        "should be a Reranker error, got: {err}"
+        matches!(
+            err,
+            MemoryError::Reranker(crate::error::RerankerError::NonFiniteScore { .. })
+        ),
+        "should be a Reranker(NonFiniteScore) error, got: {err}"
     );
     assert!(
         err.to_string().contains("non-finite"),

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -2762,6 +2762,77 @@ fn reranker_rejects_non_finite_score() {
     );
 }
 
+#[test]
+fn reranker_rejects_output_too_long() {
+    // Returns more (index, score) pairs than it was given candidates, tripping
+    // the subset-contract length check — which `validate_reranker_output` runs
+    // *before* the bounds/duplicate/finite checks. Pins the `OutputTooLong`
+    // variant end-to-end (its three sibling variants already have integration
+    // coverage; this closes the remaining gap).
+    struct TooManyResultsReranker;
+    impl Reranker for TooManyResultsReranker {
+        fn rerank(&self, _query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>> {
+            // One more pair than there are candidates. Index 0 is reused with an
+            // in-bounds value so the *only* invariant violated is output length
+            // (keeps the earlier bounds check from firing first).
+            let mut out: Vec<(usize, f64)> = candidates
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i, c.score))
+                .collect();
+            out.push((0, 0.0));
+            Ok(out)
+        }
+        fn name(&self) -> &'static str {
+            "too_many"
+        }
+    }
+
+    let engine = MemoryEngine::builder(DIM)
+        .reranker(Box::new(TooManyResultsReranker))
+        .build()
+        .unwrap();
+    let embedder = MockEmbedder { dim: DIM };
+    engine
+        .add_fact(
+            &AddFactRequest {
+                content: "length contract fact".into(),
+                fact_type: FactType::Episodic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+            &embedder,
+            None,
+        )
+        .unwrap();
+
+    let result = engine.query(&SearchQuery {
+        text: Some("length".into()),
+        embedding: None,
+        mode: SearchMode::Fts,
+        limit: 10,
+        rerank_depth: None,
+        valid_at: None,
+        fact_type: None,
+        scope: None,
+    });
+
+    assert!(result.is_err(), "should reject output longer than input");
+    let err = result.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            MemoryError::Reranker(crate::error::RerankerError::OutputTooLong { .. })
+        ),
+        "should be a Reranker(OutputTooLong) error, got: {err}"
+    );
+    assert!(
+        err.to_string().contains("exceeds input length"),
+        "error message should mention exceeding input length, got: {err}"
+    );
+}
+
 // --- Batch embedding + batch add_fact tests ---
 
 #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,69 @@ pub enum ConflictError {
     Arbitration(String),
 }
 
+/// A failure originating from the reranking stage of a query.
+///
+/// This is the typed payload of [`MemoryError::Reranker`]. It distinguishes two
+/// origins: a failure reported by the consumer-supplied
+/// [`Reranker`](crate::traits::Reranker) itself ([`Provider`](RerankerError::Provider)),
+/// and the four output-contract violations the engine detects *after* the
+/// reranker returns (`validate_reranker_output`). The engine-detected variants
+/// carry the offending values as fields, so a caller can `match` on the precise
+/// cause — and act on the data — instead of string-matching the message.
+///
+/// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
+/// downstream `match` expressions must include a wildcard (`_`) arm.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RerankerError {
+    /// The consumer-supplied [`Reranker`](crate::traits::Reranker) returned an
+    /// error from its `rerank` call (e.g. an API call, timeout, or inference
+    /// failure). The string carries the consumer's message verbatim.
+    #[error("{0}")]
+    Provider(String),
+
+    /// The reranker returned more `(index, score)` pairs than it was given
+    /// candidates, violating the subset contract (output must be a permutation
+    /// of a subset of the input).
+    #[error(
+        "reranker violated subset contract: output length ({output_len}) exceeds input length ({input_len})"
+    )]
+    OutputTooLong {
+        /// Number of pairs the reranker returned.
+        output_len: usize,
+        /// Number of candidates the reranker was given.
+        input_len: usize,
+    },
+
+    /// The reranker returned an index that is not a valid position in the
+    /// candidate slice (`index >= num_candidates`).
+    #[error("reranker returned out-of-bounds index {index} (candidates length: {num_candidates})")]
+    OutOfBoundsIndex {
+        /// The offending out-of-range index.
+        index: usize,
+        /// Number of candidates the reranker was given.
+        num_candidates: usize,
+    },
+
+    /// The reranker returned the same index more than once, violating the subset
+    /// contract (each candidate may appear at most once in the output).
+    #[error("reranker violated subset contract: duplicate index {index} in output")]
+    DuplicateIndex {
+        /// The index that appeared more than once.
+        index: usize,
+    },
+
+    /// The reranker assigned a non-finite score (`NaN` or `±∞`) to a candidate,
+    /// which cannot participate in a deterministic ordering.
+    #[error("reranker returned non-finite score {score} for index {index}")]
+    NonFiniteScore {
+        /// The non-finite score value.
+        score: f64,
+        /// The index the score was assigned to.
+        index: usize,
+    },
+}
+
 /// Errors returned by the memory engine.
 ///
 /// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
@@ -120,10 +183,11 @@ pub enum MemoryError {
     #[error("bootstrap error: {0}")]
     Bootstrap(String),
 
-    /// The consumer-supplied [`Reranker`](crate::traits::Reranker) failed while
-    /// scoring candidates.
+    /// A failure in the reranking stage; see [`RerankerError`] for the specific
+    /// cause (a consumer-reported `rerank` failure, or one of the four
+    /// engine-detected output-contract violations).
     #[error("reranker error: {0}")]
-    Reranker(String),
+    Reranker(#[from] RerankerError),
 
     /// A cold-storage archive operation (pack/unpack of a `.pak` file) failed.
     #[error("archive error: {0}")]
@@ -166,9 +230,56 @@ mod tests {
     }
 
     #[test]
-    fn reranker_error_display() {
-        let err = MemoryError::Reranker("cross-encoder timeout".into());
+    fn reranker_provider_display() {
+        // Consumer-reported failure: the provider's message is surfaced verbatim
+        // under the outer `reranker error: ` prefix.
+        let err = MemoryError::Reranker(RerankerError::Provider("cross-encoder timeout".into()));
         assert_eq!(err.to_string(), "reranker error: cross-encoder timeout");
+    }
+
+    #[test]
+    fn reranker_contract_variants_display_byte_for_byte() {
+        // Byte-preservation: each engine-detected variant must render exactly the
+        // string the pre-split `format!` call sites produced (under the outer
+        // `reranker error: ` prefix), so existing message-matching keeps working.
+        assert_eq!(
+            MemoryError::Reranker(RerankerError::OutputTooLong {
+                output_len: 5,
+                input_len: 3,
+            })
+            .to_string(),
+            "reranker error: reranker violated subset contract: output length (5) exceeds input length (3)"
+        );
+        assert_eq!(
+            MemoryError::Reranker(RerankerError::OutOfBoundsIndex {
+                index: 7,
+                num_candidates: 4,
+            })
+            .to_string(),
+            "reranker error: reranker returned out-of-bounds index 7 (candidates length: 4)"
+        );
+        assert_eq!(
+            MemoryError::Reranker(RerankerError::DuplicateIndex { index: 2 }).to_string(),
+            "reranker error: reranker violated subset contract: duplicate index 2 in output"
+        );
+        assert_eq!(
+            MemoryError::Reranker(RerankerError::NonFiniteScore {
+                score: f64::NAN,
+                index: 1,
+            })
+            .to_string(),
+            "reranker error: reranker returned non-finite score NaN for index 1"
+        );
+    }
+
+    #[test]
+    fn reranker_error_from_into_memory_error() {
+        // `#[from]` lets a bare `RerankerError` convert via `?`/`.into()`.
+        let err: MemoryError = RerankerError::DuplicateIndex { index: 0 }.into();
+        assert!(matches!(
+            err,
+            MemoryError::Reranker(RerankerError::DuplicateIndex { index: 0 })
+        ));
     }
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -142,7 +142,9 @@ pub trait PersistenceClassifier: Send + Sync {
 /// the reranker from mutating fact content, embeddings, or match types (issue #144).
 ///
 /// These invariants are enforced at runtime by `MemoryEngine::query()`.
-/// Violations produce `MemoryError::Reranker`.
+/// Violations produce `MemoryError::Reranker` with the matching
+/// [`RerankerError`](crate::error::RerankerError) variant
+/// (`OutputTooLong`, `OutOfBoundsIndex`, `DuplicateIndex`, `NonFiniteScore`).
 pub trait Reranker: Send + Sync {
     /// Rerank candidates for the given query text.
     ///
@@ -152,7 +154,9 @@ pub trait Reranker: Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Reranker` if reranking fails (e.g., API call, inference error).
+    /// Returns `MemoryError::Reranker` (wrapping
+    /// [`RerankerError::Provider`](crate::error::RerankerError::Provider)) if
+    /// reranking fails (e.g., API call, inference error).
     fn rerank(&self, query: &str, candidates: &[SearchResult]) -> Result<Vec<(usize, f64)>>;
 
     /// Human-readable name for logging and debug output.


### PR DESCRIPTION
## What

Split the stringly-typed `MemoryError::Reranker(String)` into a typed `thiserror` sub-enum `RerankerError`, following the `ConflictError` pattern established in #559.

**Step 1 of #560** (the typed-error-hierarchy tracker). #560 stays open after this merges — Archive, Migration, and the Bootstrap-removal steps remain. (Linked to #560 as "part of", not as a closing reference.)

## Why

Per the design note on #560, the call-site sweep showed `Reranker` is the cleanest split: its messages fall into a small set of **fixed, distinguishable families** a caller can branch on, rather than freeform strings. Splitting lets consumers `match` on the precise cause instead of substring-matching the Display text.

## The variants — derived from the two real error origins

| Variant | Origin | Carries |
| --- | --- | --- |
| `Provider(String)` | consumer `Reranker::rerank` reported a failure (API/timeout/inference) | message verbatim (≙ `ConflictError::Arbitration`) |
| `OutputTooLong` | engine-detected: output longer than input | `{ output_len, input_len }` |
| `OutOfBoundsIndex` | engine-detected: index ≥ candidate count | `{ index, num_candidates }` |
| `DuplicateIndex` | engine-detected: repeated index | `{ index }` |
| `NonFiniteScore` | engine-detected: NaN/±∞ score | `{ score, index }` |

The four engine-detected variants carry **structured fields**, not just strings — a strict improvement over the all-`String` `ConflictError`: a caller gets the offending index/score/lengths directly.

## Behavior preservation

- Outer variant keeps `#[error("reranker error: {0}")]` + `#[from]`; each inner `#[error(...)]` reproduces the **exact** prior `format!` text → Display is byte-for-byte unchanged.
- MCP dispatch (`format!("reranker error: {msg}")`) is untouched and renders identically (`msg` is now `RerankerError`, which is `Display`).
- `reranker_contract_variants_display_byte_for_byte` test pins every variant's rendered string.

## Tests

The four engine-level contract tests are tightened from `matches!(_, Reranker(_))` to the **specific variant** (`OutputTooLong`/`OutOfBoundsIndex`/`DuplicateIndex`/`NonFiniteScore`/`Provider`), de-fragilizing assertions that previously leaned on `.to_string().contains(...)`. A new `reranker_rejects_output_too_long` integration test closes the only missing end-to-end branch (review follow-up).

## Verification

- `cargo build --workspace` ✓
- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets` exit 0, no new warnings ✓
- `cargo test --workspace` — 997 passed, 4 ignored ✓
- `cargo test --all-features` — 835 passed, 4 ignored ✓

Part of #560 · follow-up to #559 · epic #241.
