### PR TITLE
fix(core): enforce AddFactOptions.importance in [0,1]

### DIFF
--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -80,10 +80,11 @@ impl MemoryEngine {
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<i64> {
         let now = Utc::now();
+        // Reject an out-of-range importance BEFORE any work — the opts clone,
+        // embedding, or persisting: no event, no fact, no slow embedding call,
+        // and no (potentially expensive) metadata clone for an invalid request.
+        Self::validate_importance(req.opts.as_ref().and_then(|o| o.importance))?;
         let opts = req.opts.clone().unwrap_or_default();
-        // Reject an out-of-range importance BEFORE embedding or persisting:
-        // no event, no fact, no slow embedding call for an invalid request.
-        Self::validate_importance(opts.importance)?;
 
         // Embed OUTSIDE the write lock (potentially slow)
         let embedding = embedder.embed(&req.content)?;

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-use crate::error::{MemoryError, Result};
+use crate::error::{ConflictError, MemoryError, Result};
 use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
 use crate::store::scopes::ScopeStore;
@@ -38,6 +38,24 @@ impl MemoryEngine {
         EventStore::new(&conn, &self.upcaster_registry).insert(event)
     }
 
+    /// Validate a caller-supplied `importance` override.
+    ///
+    /// `AddFactOptions::importance` is documented as living in `[0, 1]`. We
+    /// reject out-of-range values (and non-finite ones such as `NaN`/`±inf`)
+    /// loudly rather than clamping silently, mirroring the typed
+    /// `Conflict(PolicyParameter)` errors raised elsewhere for out-of-range
+    /// policy parameters. `None` is always valid (the engine default is used).
+    fn validate_importance(importance: Option<f64>) -> Result<()> {
+        if let Some(v) = importance {
+            if !v.is_finite() || !(0.0..=1.0).contains(&v) {
+                return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                    format!("importance must be in [0, 1], got {v}"),
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Add a fact: compute embedding via `embedder`, compute blake3 content hash,
     /// and insert into the fact store. Returns the assigned fact id.
     ///
@@ -47,6 +65,9 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
+    /// Returns `MemoryError::Conflict(ConflictError::PolicyParameter)` if
+    /// `opts.importance` is set and outside `[0, 1]` (or non-finite); the
+    /// request is rejected before any embedding, event, or fact is written.
     /// Returns errors from embedding computation, dimension validation, or DB insert.
     // `conn` (write lock) is reused by `FactStore::new(&conn).insert(..)` at the
     // block's return expression; clippy's nursery suggestion to drop it after
@@ -58,10 +79,14 @@ impl MemoryEngine {
         embedder: &dyn EmbeddingProvider,
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<i64> {
-        // Embed OUTSIDE the write lock (potentially slow)
-        let embedding = embedder.embed(&req.content)?;
         let now = Utc::now();
         let opts = req.opts.clone().unwrap_or_default();
+        // Reject an out-of-range importance BEFORE embedding or persisting:
+        // no event, no fact, no slow embedding call for an invalid request.
+        Self::validate_importance(opts.importance)?;
+
+        // Embed OUTSIDE the write lock (potentially slow)
+        let embedding = embedder.embed(&req.content)?;
         let base_importance = opts.importance.unwrap_or(0.5);
         let effective_created = opts.t_created.unwrap_or(now);
         let effective_last_accessed = opts.last_accessed.unwrap_or(now);
@@ -240,6 +265,9 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
+    /// Returns `MemoryError::Conflict(ConflictError::PolicyParameter)` if any
+    /// entry's `opts.importance` is set and outside `[0, 1]` (or non-finite);
+    /// the whole batch is rejected up front, so no entry is embedded or written.
     /// Returns errors from batch embedding, dimension validation, or DB insert.
     /// Returns `MemoryError::Internal` if the embedder returns a different
     /// number of embeddings than input entries.
@@ -254,6 +282,12 @@ impl MemoryEngine {
     ) -> Result<Vec<i64>> {
         if entries.is_empty() {
             return Ok(Vec::new());
+        }
+
+        // Reject any out-of-range importance up front: the batch is
+        // all-or-nothing, so no entry is embedded or persisted if one is invalid.
+        for entry in entries {
+            Self::validate_importance(entry.opts.as_ref().and_then(|o| o.importance))?;
         }
 
         // --- Phase 1: Batch embed OUTSIDE the write lock ---

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -3420,47 +3420,71 @@ fn add_fact_invalid_scope_path_returns_scope_label_conflict() {
 }
 
 #[test]
-fn add_fact_importance_above_one_is_silently_accepted() {
-    // LATENT BUG (issue #130 follow-up): `AddFactOptions::importance` is
-    // documented as "Must be in [0, 1]", but no layer enforces it — not
-    // `add_fact`, not `FactStore::insert`, and the `facts.importance` column has
-    // no CHECK constraint. An out-of-range value is therefore accepted and
-    // stored verbatim. This test PINS that real behavior (it does not assert the
-    // ideal rejection); when the bug is fixed, this test should be updated to
-    // expect a `Conflict(PolicyParameter)` (or clamp) and will fail loudly here,
-    // flagging the contract change.
+fn add_fact_rejects_out_of_range_importance() {
+    // CONTRACT (issue #571, follow-up to #130): `AddFactOptions::importance` is
+    // documented as "Must be in [0, 1]". `add_fact` now ENFORCES this loudly —
+    // an out-of-range (or non-finite) value is rejected with
+    // `Conflict(PolicyParameter)` BEFORE anything is persisted (no event, no
+    // fact), rather than being silently stored verbatim. A valid [0, 1] value
+    // still succeeds.
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder = MockEmbedder { dim: DIM };
 
-    let opts = AddFactOptions {
-        importance: Some(5.0), // grossly out of the documented [0, 1] range
-        ..Default::default()
+    let request = |importance: f64| AddFactRequest {
+        content: format!("importance = {importance}"),
+        fact_type: FactType::Semantic,
+        source_event_id: None,
+        scope: None,
+        opts: Some(AddFactOptions {
+            importance: Some(importance),
+            ..Default::default()
+        }),
     };
-    let id = engine
-        .add_fact(
-            &AddFactRequest {
-                content: "importance way out of range".into(),
-                fact_type: FactType::Semantic,
-                source_event_id: None,
-                scope: None,
-                opts: Some(opts),
-            },
-            &embedder,
-            None,
-        )
-        .expect("add_fact currently accepts out-of-range importance (latent bug)");
 
-    // The value is stored verbatim — both the base `importance` and the
-    // materialized `importance_score` seeded from it.
+    // Above the range: rejected as Conflict(PolicyParameter), nothing persisted.
+    let err_high = engine
+        .add_fact(&request(5.0), &embedder, None)
+        .expect_err("importance > 1.0 must be rejected");
+    assert!(
+        matches!(
+            err_high,
+            MemoryError::Conflict(crate::error::ConflictError::PolicyParameter(_))
+        ),
+        "expected Conflict(PolicyParameter) for importance 5.0, got {err_high:?}"
+    );
+
+    // Below the range: also rejected.
+    let err_low = engine
+        .add_fact(&request(-0.1), &embedder, None)
+        .expect_err("importance < 0.0 must be rejected");
+    assert!(
+        matches!(
+            err_low,
+            MemoryError::Conflict(crate::error::ConflictError::PolicyParameter(_))
+        ),
+        "expected Conflict(PolicyParameter) for importance -0.1, got {err_low:?}"
+    );
+
+    // Neither rejected insert left a fact behind.
+    assert_eq!(
+        engine.list_active_facts(None).unwrap().len(),
+        0,
+        "rejected out-of-range inserts must not persist any fact"
+    );
+
+    // In-range still works and is stored verbatim (base + materialized score).
+    let id = engine
+        .add_fact(&request(0.8), &embedder, None)
+        .expect("in-range importance 0.8 must succeed");
     let fact = engine.get_fact(id).unwrap();
     assert!(
-        (fact.importance - 5.0).abs() < f64::EPSILON,
-        "out-of-range importance is stored verbatim (no clamp): got {}",
+        (fact.importance - 0.8).abs() < f64::EPSILON,
+        "in-range importance stored verbatim: got {}",
         fact.importance
     );
     assert!(
-        (fact.importance_score - 5.0).abs() < f64::EPSILON,
-        "importance_score is seeded from the verbatim base importance: got {}",
+        (fact.importance_score - 0.8).abs() < f64::EPSILON,
+        "importance_score seeded from the base importance: got {}",
         fact.importance_score
     );
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -289,7 +289,10 @@ pub struct LineageSnapshotEntry {
 /// (importance=0.5, metadata={}, no temporal bounds).
 #[derive(Debug, Clone, Default)]
 pub struct AddFactOptions {
-    /// Override default importance (0.5). Must be in [0, 1].
+    /// Override default importance (0.5). Must be in [0, 1]; an out-of-range
+    /// or non-finite value is rejected with `Conflict(PolicyParameter)` by
+    /// [`add_fact`](crate::engine::MemoryEngine::add_fact) and
+    /// [`add_facts_batch`](crate::engine::MemoryEngine::add_facts_batch).
     pub importance: Option<f64>,
     /// Override default metadata (empty object).
     pub metadata: Option<serde_json::Value>,


### PR DESCRIPTION
## Summary

`AddFactOptions::importance` was documented as "Must be in [0, 1]" but **no layer enforced it** — not `add_fact`, not `add_facts_batch`, not `FactStore::insert`, and the `facts.importance` column has no CHECK constraint. An out-of-range value (e.g. `5.0`) was silently accepted and stored verbatim into both `importance` and the materialized `importance_score`. Surfaced + pinned during #130 (PR #565).

## Fix

Reject out-of-range (and non-finite: `NaN`/`±inf`) values **loudly** with `MemoryError::Conflict(ConflictError::PolicyParameter(..))` rather than clamping silently — consistent with the typed conflict errors raised for other out-of-range policy parameters (#115).

- Validation runs at the `add_fact` / `add_facts_batch` boundary, **before** any embedding, event, or fact is written → a rejected request leaves no trace.
- `add_facts_batch` validates **all** entries up front, preserving its all-or-nothing contract.
- `None` (use engine default 0.5) and any in-range `[0, 1]` value still work.
- Doc comments on `AddFactOptions::importance`, `add_fact`, and `add_facts_batch` updated to state the enforced contract.

## Test

Flipped the pinning test from #565: `add_fact_importance_above_one_is_silently_accepted` → `add_fact_rejects_out_of_range_importance`. It now asserts:
- `importance = 5.0` → `Conflict(PolicyParameter)`
- `importance = -0.1` → `Conflict(PolicyParameter)`
- neither rejected insert persists a fact (`list_active_facts` empty)
- `importance = 0.8` succeeds and is stored verbatim (base + materialized `importance_score`)

## Other callers

No breakage. The CLI (`batch_ingest`) already rejects out-of-range importance via `validate_jsonl_fact` before reaching `add_fact`; the MCP server already validates in its tool layer. All other `importance: Some(..)` callers/tests use in-range values.

## Gates

- `cargo build --workspace` ✅
- `cargo test -p memory-engine -p memory-engine-mcp` ✅ (915 passed, 4 ignored)
- `cargo clippy -p memory-engine -p memory-engine-mcp --all-targets` ✅ (exit 0; zero new warnings on changed files)
- `cargo fmt --check` ✅

Fixes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)