### PR TITLE
security(qa): harden unbounded-input / resource-bound paths (super-qa #124: L6–L10)

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -217,6 +217,17 @@ fn bootstrap_within_savepoint(
         let facts = extractor.extract(candidate, &outcome)?;
 
         for fact in &facts {
+            // Session files are third-party input: an extracted fact whose
+            // content/metadata exceeds the ingest bound is skipped (best-effort,
+            // mirroring the malformed-line policy) rather than aborting the whole
+            // import. Checked before the costly embed (issue #572 / L10).
+            if let Err(e) = crate::limits::check_str_size(&fact.content, "fact content")
+                .and_then(|()| crate::limits::check_json_size(&fact.metadata, "fact metadata"))
+            {
+                tracing::warn!(error = %e, "skipping oversized bootstrap fact");
+                continue;
+            }
+
             let embedding = embedder.embed(&fact.content)?;
             let effective_created = candidate.timestamp;
 

--- a/src/bootstrap/parse.rs
+++ b/src/bootstrap/parse.rs
@@ -3,6 +3,8 @@
 //! Provides types and functions for deserializing raw JSONL lines into
 //! [`SessionEntry`] values and extracting structured content blocks.
 
+use std::io::{BufRead, Read};
+
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
@@ -95,34 +97,137 @@ pub enum ContentBlock {
 // Functions
 // ---------------------------------------------------------------------------
 
+/// Maximum bytes buffered for a single JSONL line.
+///
+/// `BufRead::lines()` grows one `String` per line with no ceiling, so a hostile
+/// (or corrupt) file containing a single newline-free run would force an
+/// allocation proportional to its size — an unbounded-memory `DoS` on otherwise
+/// best-effort parsing. Any logical line longer than this cap is drained and
+/// skipped as malformed rather than buffered (see [`parse_session_file`]).
+///
+/// 8 MiB is generously above any legitimate Claude Code session line (whole
+/// tool outputs and message payloads sit well under it) while bounding the
+/// worst-case working set to a constant.
+pub const MAX_JSONL_LINE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Outcome of reading one logical line under a byte cap.
+enum BoundedLine {
+    /// A complete line within the cap, trailing `\n` stripped.
+    Line(Vec<u8>),
+    /// The line exceeded the cap; its bytes were drained to the next newline
+    /// (or EOF) and discarded. Counts as malformed.
+    Oversized,
+    /// End of input.
+    Eof,
+}
+
+/// Read one logical line, buffering at most `cap` bytes.
+///
+/// On an oversized line the excess is drained via `fill_buf`/`consume` so memory
+/// stays flat and the *next* read resynchronizes at the following newline,
+/// rather than emitting a cascade of fragment "lines".
+fn read_bounded_line(
+    reader: &mut impl std::io::BufRead,
+    cap: usize,
+) -> std::io::Result<BoundedLine> {
+    let mut buf = Vec::new();
+    // Read at most cap+1 bytes or until a newline, whichever comes first.
+    // `saturating_add` guards the (unreachable for our 8 MiB cap) usize::MAX case.
+    let n = reader
+        .by_ref()
+        .take((cap as u64).saturating_add(1))
+        .read_until(b'\n', &mut buf)?;
+    if n == 0 {
+        return Ok(BoundedLine::Eof);
+    }
+    // Only `\n` is stripped here; a trailing `\r` (CRLF) is left in `buf` and
+    // removed downstream by `line.trim()` before JSON parsing.
+    if buf.last() == Some(&b'\n') {
+        buf.pop();
+        return Ok(BoundedLine::Line(buf));
+    }
+    // No newline seen. Either a final unterminated line within the cap, or a
+    // line longer than the cap (we stopped one byte past it).
+    if buf.len() <= cap {
+        return Ok(BoundedLine::Line(buf));
+    }
+    // Oversized: drain the remainder of this line, discarding in place.
+    loop {
+        let chunk = reader.fill_buf()?;
+        if chunk.is_empty() {
+            break; // EOF mid-line
+        }
+        if let Some(pos) = chunk.iter().position(|&b| b == b'\n') {
+            reader.consume(pos + 1); // consume through the newline
+            break;
+        }
+        let len = chunk.len();
+        reader.consume(len);
+    }
+    Ok(BoundedLine::Oversized)
+}
+
 /// Parse a JSONL file into a sequence of [`SessionEntry`] values.
 ///
 /// Malformed lines are skipped with a `tracing::warn`; this function never
-/// fails so callers always get a best-effort result.
+/// fails so callers always get a best-effort result. Lines longer than
+/// [`MAX_JSONL_LINE_BYTES`] are skipped (counted as malformed) to bound memory
+/// on hostile or corrupt input.
 ///
 /// Returns `(entries, malformed_count)` where `malformed_count` is the number
-/// of non-empty lines that failed to parse.
+/// of non-empty lines that failed to parse (including oversized ones).
 pub fn parse_session_file(reader: impl std::io::BufRead) -> (Vec<SessionEntry>, usize) {
+    parse_session_file_capped(reader, MAX_JSONL_LINE_BYTES)
+}
+
+/// [`parse_session_file`] with an explicit per-line byte cap (test seam).
+fn parse_session_file_capped(
+    mut reader: impl std::io::BufRead,
+    cap: usize,
+) -> (Vec<SessionEntry>, usize) {
     let mut entries = Vec::new();
     let mut malformed = 0;
-    for (idx, line) in reader.lines().enumerate() {
-        let line = match line {
-            Ok(l) => l,
-            Err(e) => {
-                tracing::warn!(line = idx + 1, error = %e, "failed to read line");
+    let mut line_no = 0usize;
+    loop {
+        match read_bounded_line(&mut reader, cap) {
+            Ok(BoundedLine::Eof) => break,
+            Ok(BoundedLine::Oversized) => {
+                line_no += 1;
+                tracing::warn!(
+                    line = line_no,
+                    cap,
+                    "skipping oversized JSONL line (exceeds per-line byte cap)"
+                );
                 malformed += 1;
-                continue;
             }
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<SessionEntry>(trimmed) {
-            Ok(entry) => entries.push(entry),
+            Ok(BoundedLine::Line(bytes)) => {
+                line_no += 1;
+                let line = match std::str::from_utf8(&bytes) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(line = line_no, error = %e, "skipping non-UTF8 JSONL line");
+                        malformed += 1;
+                        continue;
+                    }
+                };
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<SessionEntry>(trimmed) {
+                    Ok(entry) => entries.push(entry),
+                    Err(e) => {
+                        tracing::warn!(line = line_no, error = %e, "skipping malformed JSONL line");
+                        malformed += 1;
+                    }
+                }
+            }
             Err(e) => {
-                tracing::warn!(line = idx + 1, error = %e, "skipping malformed JSONL line");
+                // A read error is typically persistent (bad descriptor); stop to
+                // avoid a busy loop and return the best-effort result so far.
+                tracing::warn!(line = line_no + 1, error = %e, "failed to read line; stopping");
                 malformed += 1;
+                break;
             }
         }
     }
@@ -218,6 +323,44 @@ mod tests {
         let reader = BufReader::new(b"" as &[u8]);
         let (entries, _malformed) = parse_session_file(reader);
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_skips_oversized_line_and_resyncs() {
+        // A line longer than the cap is drained and skipped; the *next* line
+        // must still parse (proving the drain resynchronized at the newline
+        // rather than emitting a cascade of fragment lines).
+        let big = "x".repeat(200); // no embedded newline, far over the cap
+        let input = format!("{big}\n{{\"type\":\"user\"}}\n");
+        let (entries, malformed) = parse_session_file_capped(input.as_bytes(), 64);
+        assert_eq!(
+            entries.len(),
+            1,
+            "valid line after oversized must still parse"
+        );
+        assert_eq!(entries[0].entry_type, EntryType::User);
+        assert_eq!(malformed, 1, "the oversized line counts once as malformed");
+    }
+
+    #[test]
+    fn parse_line_at_cap_boundary_parses() {
+        // A valid line whose length is exactly the cap must parse normally —
+        // the cap is inclusive of legitimate lines, exclusive of overflow.
+        let line = r#"{"type":"user"}"#;
+        assert_eq!(line.len(), 15);
+        let (entries, malformed) = parse_session_file_capped(line.as_bytes(), 15);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(malformed, 0);
+    }
+
+    #[test]
+    fn parse_oversized_unterminated_at_eof() {
+        // An oversized final line with no trailing newline drains to EOF and is
+        // counted once; the parser terminates rather than looping.
+        let big = "y".repeat(100);
+        let (entries, malformed) = parse_session_file_capped(big.as_bytes(), 16);
+        assert!(entries.is_empty());
+        assert_eq!(malformed, 1);
     }
 
     #[test]

--- a/src/engine/conflict.rs
+++ b/src/engine/conflict.rs
@@ -26,6 +26,11 @@ impl MemoryEngine {
         old_id: i64,
         new_fact: &NewFact,
     ) -> Result<ConflictResolution> {
+        // The candidate fact is persisted verbatim on an Add/Update decision, so
+        // it is a consumer ingest path and must respect the same size bound as
+        // `add_fact` (issue #572 / L10).
+        crate::limits::check_new_fact(new_fact)?;
+
         #[cfg(feature = "ann")]
         let embedding = new_fact.embedding.clone();
         let resolution = {

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 
 use crate::error::{ConflictError, MemoryError, Result};
+use crate::limits::{check_json_size, check_str_size};
 use crate::store::events::EventStore;
 use crate::store::facts::FactStore;
 use crate::store::scopes::ScopeStore;
@@ -34,6 +35,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` on insert failure.
     pub fn ingest(&self, event: &NewEvent) -> Result<i64> {
+        check_json_size(&event.payload, "event payload")?;
         let conn = self.write_conn()?;
         EventStore::new(&conn, &self.upcaster_registry).insert(event)
     }
@@ -84,6 +86,12 @@ impl MemoryEngine {
         // embedding, or persisting: no event, no fact, no slow embedding call,
         // and no (potentially expensive) metadata clone for an invalid request.
         Self::validate_importance(req.opts.as_ref().and_then(|o| o.importance))?;
+        // Reject oversized content/metadata before any expensive work so a
+        // hostile request fails fast and cheap (issue #572 / L10).
+        check_str_size(&req.content, "fact content")?;
+        if let Some(metadata) = req.opts.as_ref().and_then(|o| o.metadata.as_ref()) {
+            check_json_size(metadata, "fact metadata")?;
+        }
         let opts = req.opts.clone().unwrap_or_default();
 
         // Embed OUTSIDE the write lock (potentially slow)
@@ -285,10 +293,15 @@ impl MemoryEngine {
             return Ok(Vec::new());
         }
 
-        // Reject any out-of-range importance up front: the batch is
-        // all-or-nothing, so no entry is embedded or persisted if one is invalid.
+        // Validate every entry up front: the batch is all-or-nothing, so a
+        // single invalid importance or oversized content/metadata rejects the
+        // whole call before any entry is embedded or persisted.
         for entry in entries {
             Self::validate_importance(entry.opts.as_ref().and_then(|o| o.importance))?;
+            check_str_size(&entry.content, "fact content")?;
+            if let Some(metadata) = entry.opts.as_ref().and_then(|o| o.metadata.as_ref()) {
+                check_json_size(metadata, "fact metadata")?;
+            }
         }
 
         // --- Phase 1: Batch embed OUTSIDE the write lock ---
@@ -398,5 +411,111 @@ impl MemoryEngine {
         }
 
         Ok(fact_ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ConflictError;
+    use crate::limits::MAX_PAYLOAD_BYTES;
+    use crate::traits::EmbeddingProvider;
+    use crate::types::{AddFactOptions, AddFactRequest, EventType, FactType};
+
+    const DIM: usize = 4;
+
+    struct FakeEmbed;
+    impl EmbeddingProvider for FakeEmbed {
+        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.1, 0.2, 0.3, 0.4])
+        }
+    }
+
+    /// An oversized event payload is rejected by `ingest` before it touches the
+    /// write path.
+    #[test]
+    fn ingest_rejects_oversized_payload() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let big = "x".repeat(MAX_PAYLOAD_BYTES + 10);
+        let event = NewEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::Value::String(big),
+            source: "test".into(),
+            session_id: None,
+            scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
+        };
+        let err = engine.ingest(&event).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::Conflict(ConflictError::PayloadTooLarge {
+                kind: "event payload",
+                ..
+            })
+        ));
+    }
+
+    /// An oversized fact `metadata` is rejected by `add_fact`, and a normal one
+    /// is accepted (guard does not regress the happy path).
+    #[test]
+    fn add_fact_rejects_oversized_metadata() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let big = "x".repeat(MAX_PAYLOAD_BYTES + 10);
+        let req = AddFactRequest {
+            content: "fact".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: Some(AddFactOptions {
+                metadata: Some(serde_json::json!({ "blob": big })),
+                ..Default::default()
+            }),
+        };
+        let err = engine.add_fact(&req, &FakeEmbed, None).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::Conflict(ConflictError::PayloadTooLarge {
+                kind: "fact metadata",
+                ..
+            })
+        ));
+
+        // Small metadata is accepted.
+        let ok_req = AddFactRequest {
+            content: "fact".into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: Some(AddFactOptions {
+                metadata: Some(serde_json::json!({ "k": "v" })),
+                ..Default::default()
+            }),
+        };
+        assert!(engine.add_fact(&ok_req, &FakeEmbed, None).is_ok());
+    }
+
+    /// An oversized fact `content` body is rejected by `add_fact` — the content
+    /// String is the larger unbounded vector, guarded alongside metadata.
+    #[test]
+    fn add_fact_rejects_oversized_content() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let req = AddFactRequest {
+            content: "x".repeat(MAX_PAYLOAD_BYTES + 1),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        };
+        let err = engine.add_fact(&req, &FakeEmbed, None).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::Conflict(ConflictError::PayloadTooLarge {
+                kind: "fact content",
+                ..
+            })
+        ));
     }
 }

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -71,6 +71,33 @@ fn insert_raw_fact(engine: &MemoryEngine, fact: &NewFact) -> i64 {
 
 // --- Phase 1 tests ---
 
+/// The L10 size bound also guards `resolve_conflict`, which persists the
+/// candidate `NewFact` verbatim on an Add/Update decision. The check runs
+/// before the arbiter and the old-fact lookup, so a non-existent `old_id`
+/// still surfaces `PayloadTooLarge` rather than `NotFound`.
+#[test]
+fn resolve_conflict_rejects_oversized_fact() {
+    use crate::error::{ConflictError, MemoryError};
+
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let arbiter = FixedArbiter {
+        decision: CrudDecision::Add,
+    };
+    let mut oversized = make_new_fact("seed", vec![0.5; DIM]);
+    oversized.content = "x".repeat(crate::limits::MAX_PAYLOAD_BYTES + 1);
+
+    let err = engine
+        .resolve_conflict(&arbiter, 9999, &oversized)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        MemoryError::Conflict(ConflictError::PayloadTooLarge {
+            kind: "fact content",
+            ..
+        })
+    ));
+}
+
 #[test]
 fn open_memory_succeeds() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,12 +49,34 @@ pub enum ConflictError {
     #[error("dump target resolves to the live database file")]
     DumpTargetIsLiveDatabase,
 
+    /// A dump was directed at a path that already exists and is a directory.
+    /// `VACUUM INTO` writes a file, and the engine refuses to unlink a directory
+    /// to make room — surfacing the mistake as a clear conflict instead of an
+    /// opaque "is a directory" I/O failure (see the trusted-path contract on
+    /// [`dump_sqlite`](crate::inspect::dump::dump_sqlite)).
+    #[error("dump target is an existing directory")]
+    DumpTargetIsDirectory,
+
     /// A consumer-supplied trait implementation (e.g. a
     /// [`ConflictArbiter`](crate::traits::ConflictArbiter) or other injected
     /// provider) reported a failure that the engine surfaces as a conflict. The
     /// string carries the consumer's message.
     #[error("{0}")]
     Arbitration(String),
+
+    /// An ingested document exceeded the engine's per-field ingest size bound:
+    /// an event `payload`, a fact's `metadata` (JSON), or a fact's `content`
+    /// (string). The bound caps per-row memory and serialization CPU on hostile
+    /// or runaway input. `kind` names the offending field and `limit` is the
+    /// ceiling; `size` is the offending byte length — exact for string fields,
+    /// but a lower bound for JSON fields, whose measurement aborts early once
+    /// it passes the limit.
+    #[error("{kind} is {size} bytes, exceeding the {limit}-byte ingest limit")]
+    PayloadTooLarge {
+        kind: &'static str,
+        size: usize,
+        limit: usize,
+    },
 }
 
 /// A failure originating from the reranking stage of a query.

--- a/src/forgetting/policy.rs
+++ b/src/forgetting/policy.rs
@@ -4,9 +4,9 @@ use rusqlite::Connection;
 use crate::error::Result;
 use crate::graph::MemoryGraph;
 use crate::store::edges::EdgeStore;
-use crate::store::facts::FactStore;
+use crate::store::facts::{FactScoringRow, FactStore};
 use crate::traits::{ForgetPolicy, PruneStats};
-use crate::types::Fact;
+use crate::types::{Fact, FactType};
 
 /// Argument to `ln()` for access-frequency normalization: 100 + 1.
 /// Gives `ln(101)` as the divisor so that 100 accesses produce a full score of 1.0.
@@ -23,6 +23,51 @@ pub(crate) fn ebbinghaus_decay(age_days: f64, half_life: f64) -> f64 {
     f64::exp2(-age_days / half_life)
 }
 
+/// The fact attributes [`compute_importance`] reads.
+///
+/// Implemented by both the full [`Fact`] and the lightweight [`FactScoringRow`]
+/// projection, so the prune pass can score the entire active set without
+/// materializing `content`/`embedding`/`metadata` (see [`prune`]).
+///
+/// `id` and `is_pinned` are intentionally absent — `prune` reads those directly
+/// off the concrete row; the trait captures only the scoring inputs.
+pub trait ImportanceInputs {
+    fn fact_type(&self) -> &FactType;
+    fn last_accessed(&self) -> DateTime<Utc>;
+    fn access_count(&self) -> i64;
+    fn importance(&self) -> f64;
+}
+
+impl ImportanceInputs for Fact {
+    fn fact_type(&self) -> &FactType {
+        &self.fact_type
+    }
+    fn last_accessed(&self) -> DateTime<Utc> {
+        self.last_accessed
+    }
+    fn access_count(&self) -> i64 {
+        self.access_count
+    }
+    fn importance(&self) -> f64 {
+        self.importance
+    }
+}
+
+impl ImportanceInputs for FactScoringRow {
+    fn fact_type(&self) -> &FactType {
+        &self.fact_type
+    }
+    fn last_accessed(&self) -> DateTime<Utc> {
+        self.last_accessed
+    }
+    fn access_count(&self) -> i64 {
+        self.access_count
+    }
+    fn importance(&self) -> f64 {
+        self.importance
+    }
+}
+
 /// Compute composite importance score for a fact.
 ///
 /// Weighted sum of 4 signals, each normalized to \[0, 1\]:
@@ -34,24 +79,24 @@ pub(crate) fn ebbinghaus_decay(age_days: f64, half_life: f64) -> f64 {
 /// 4. **Base importance**: `fact.importance` — already in \[0, 1\]
 #[must_use]
 pub(crate) fn compute_importance(
-    fact: &Fact,
+    fact: &impl ImportanceInputs,
     graph_degree: usize,
     now: DateTime<Utc>,
     policy: &ForgetPolicy,
 ) -> f64 {
     // Knowledge-shaped types don't lose validity with age: recency stays 1.0.
     // An explicit half-life override wins and re-enables decay.
-    let recency = if policy.is_decay_exempt(&fact.fact_type) {
+    let recency = if policy.is_decay_exempt(fact.fact_type()) {
         1.0
     } else {
         let half_life = policy
             .half_life_overrides
-            .get(&fact.fact_type)
+            .get(fact.fact_type())
             .copied()
             .unwrap_or(policy.half_life_days);
 
         #[allow(clippy::cast_precision_loss)]
-        let age_days = (now - fact.last_accessed).num_seconds() as f64 / 86400.0;
+        let age_days = (now - fact.last_accessed()).num_seconds() as f64 / 86400.0;
         ebbinghaus_decay(age_days.max(0.0), half_life)
     };
 
@@ -59,7 +104,7 @@ pub(crate) fn compute_importance(
     // Using ln_1p for numerical accuracy near zero.
     #[allow(clippy::cast_precision_loss)]
     let frequency =
-        (f64::ln_1p(fact.access_count as f64) / FREQUENCY_NORMALIZATION_ARG.ln()).min(1.0);
+        (f64::ln_1p(fact.access_count() as f64) / FREQUENCY_NORMALIZATION_ARG.ln()).min(1.0);
     #[allow(clippy::cast_precision_loss)]
     let connectivity =
         (f64::ln_1p(graph_degree as f64) / CONNECTIVITY_NORMALIZATION_ARG.ln()).min(1.0);
@@ -69,7 +114,7 @@ pub(crate) fn compute_importance(
         .mul_add(recency, policy.frequency_weight * frequency)
         + policy.graph_degree_weight.mul_add(
             connectivity,
-            policy.base_importance_weight * fact.importance,
+            policy.base_importance_weight * fact.importance(),
         )
 }
 
@@ -101,7 +146,11 @@ pub fn prune(
     policy.validate()?;
 
     let fact_store = FactStore::new(conn, embed_dim);
-    let active_facts = fact_store.list_active(None)?;
+    // Prune must evaluate the *entire* active set (importance is global), so we
+    // load the lightweight scoring projection rather than full facts — bounding
+    // the working set to a few scalars per fact instead of content + embedding
+    // + metadata. See `FactStore::list_active_scoring` (issue #572 / L8).
+    let active_facts = fact_store.list_active_scoring()?;
     let facts_evaluated = active_facts.len();
 
     // Score all facts once before mutating, so degree values are consistent

--- a/src/inspect/dump.rs
+++ b/src/inspect/dump.rs
@@ -181,12 +181,25 @@ pub fn dump_json_zstd(conn: &Connection, embed_dim: usize, path: &Path) -> Resul
 ///
 /// Works for both file-backed and in-memory databases (`SQLite` 3.27+).
 ///
+/// # Trusted-path contract
+///
+/// `path` is treated as a caller-controlled destination. The function probes
+/// the path and then writes to it, leaving an inherent check-then-act (TOCTOU)
+/// window; it does **not** defend against an adversary racing the filesystem to
+/// swap `path` between the probe and the write. Callers must not direct dumps at
+/// a location writable by an untrusted party. The guards below turn the common
+/// *mistakes* (live DB, a directory) into clear errors — they are not a defense
+/// against a concurrent attacker.
+///
 /// # Errors
 ///
-/// Returns [`MemoryError::Conflict`] if `path` resolves to the live database
-/// file (refusing to overwrite the source), [`MemoryError::Io`] on filesystem
-/// failures, or [`MemoryError::Internal`] if the database path cannot be read,
-/// `path` contains a null byte, or `VACUUM INTO` fails.
+/// Returns [`MemoryError::Conflict`] with
+/// [`ConflictError::DumpTargetIsLiveDatabase`] if `path` resolves to the live
+/// database file (refusing to overwrite the source) or
+/// [`ConflictError::DumpTargetIsDirectory`] if `path` is an existing directory;
+/// [`MemoryError::Io`] on filesystem failures; or [`MemoryError::Internal`] if
+/// the database path cannot be read, `path` contains a null byte, or
+/// `VACUUM INTO` fails.
 pub fn dump_sqlite(conn: &Connection, path: &Path) -> Result<()> {
     // Detect whether this is a file-backed database.
     let db_path: String = conn
@@ -207,9 +220,32 @@ pub fn dump_sqlite(conn: &Connection, path: &Path) -> Result<()> {
         }
     }
 
-    // Remove existing file to avoid VACUUM INTO failure on re-run.
-    if path.exists() {
-        std::fs::remove_file(path)?;
+    // Re-run support: `VACUUM INTO` refuses to write to a path that already
+    // exists, so a prior dump file must be unlinked first.
+    //
+    // Trusted-path contract: `path` is a caller-controlled dump destination. A
+    // residual check-then-act window remains between this probe and the
+    // `VACUUM INTO` below (a classic TOCTOU); the engine does *not* defend
+    // against an adversary racing the filesystem in that window, so callers
+    // MUST NOT direct dumps at a location writable by an untrusted party.
+    //
+    // What this guard *does* enforce: probe with `symlink_metadata` (which does
+    // not follow symlinks, unlike the previous `path.exists()`) and only ever
+    // unlink a non-directory. A directory target is rejected with a clear typed
+    // error instead of the opaque "Is a directory" I/O failure.
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => {
+            // `is_dir()` follows symlinks, so this refuses both a real directory
+            // and a symlink that resolves to one — neither is a valid VACUUM INTO
+            // target and we must never unlink a directory. A symlink to a regular
+            // file (or a broken symlink) is removed as the link itself.
+            if path.is_dir() {
+                return Err(MemoryError::Conflict(ConflictError::DumpTargetIsDirectory));
+            }
+            std::fs::remove_file(path)?;
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // absent: nothing to remove
+        Err(e) => return Err(MemoryError::Io(e)),
     }
 
     let escaped = path.to_string_lossy().replace('\'', "''");
@@ -521,5 +557,53 @@ mod tests {
             ".events" => "[]",
             ".config" => "{}",
         });
+    }
+
+    /// L6 hardening: a mistaken or hostile dump target that is a directory must
+    /// be refused with a clear typed error, not the opaque `remove_file`-on-a-
+    /// directory I/O failure the bare `path.exists()` check produced before.
+    #[test]
+    fn dump_sqlite_refuses_directory_target() {
+        use crate::store::schema::{init_schema, open_memory};
+
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let result = dump_sqlite(&conn, dir.path());
+
+        assert!(
+            matches!(
+                result,
+                Err(MemoryError::Conflict(ConflictError::DumpTargetIsDirectory))
+            ),
+            "dumping onto a directory must be refused with DumpTargetIsDirectory, got {result:?}"
+        );
+    }
+
+    /// A symlink resolving to a directory must also be refused — `is_dir()`
+    /// follows the link, so the guard is not bypassed by indirection.
+    #[cfg(unix)]
+    #[test]
+    fn dump_sqlite_refuses_symlink_to_directory() {
+        use crate::store::schema::{init_schema, open_memory};
+
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real_dir");
+        std::fs::create_dir(&real_dir).unwrap();
+        let link = dir.path().join("link_to_dir");
+        std::os::unix::fs::symlink(&real_dir, &link).unwrap();
+
+        let result = dump_sqlite(&conn, &link);
+        assert!(
+            matches!(
+                result,
+                Err(MemoryError::Conflict(ConflictError::DumpTargetIsDirectory))
+            ),
+            "a symlink to a directory must be refused, got {result:?}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub(crate) mod conflict;
 pub(crate) mod consolidation;
 pub(crate) mod forgetting;
 pub(crate) mod graph;
+pub(crate) mod limits;
 pub(crate) mod pool;
 pub(crate) mod resume;
 pub(crate) mod scope;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,0 +1,185 @@
+//! Ingest-time resource bounds (issue #572 / L10).
+//!
+//! Event `payload`, fact `metadata`, and fact `content` are free-form,
+//! consumer-supplied data persisted verbatim. Without a ceiling, a hostile or
+//! runaway caller could force the engine to store (and later re-materialize) an
+//! arbitrarily large blob per row. Every public *consumer* write path therefore
+//! caps these fields here.
+//!
+//! Operator-controlled paths are intentionally exempt: `restore_*` reconstructs
+//! an engine from a trusted snapshot/backup and must round-trip whatever it
+//! contains (consistent with the trusted-path contract on
+//! [`crate::inspect::dump::dump_sqlite`]).
+
+use crate::error::{ConflictError, MemoryError, Result};
+use crate::types::NewFact;
+
+/// Maximum serialized byte length of a single ingested JSON document (event
+/// `payload` or fact `metadata`) and of a fact's `content` body.
+///
+/// 1 MiB is far above any legitimate memory fact (KB-scale) while bounding the
+/// worst case to a constant. Currently a compile-time constant; making it
+/// per-engine configurable is a documented follow-up (see issue #572 / L10).
+pub const MAX_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+/// Measure the serialized byte length of `value`, aborting once it provably
+/// exceeds `limit`.
+///
+/// Bytes are counted through a zero-storage [`std::io::Write`] sink that returns
+/// an error the moment the running total passes `limit`, which halts
+/// `serde_json` mid-walk. This bounds **both** memory (O(1) — nothing is
+/// buffered, unlike `to_vec().len()` which would allocate a second full copy and
+/// be the very `DoS` we guard against) **and** CPU (O(limit) — serialization
+/// stops early), so a hostile multi-gigabyte `Value` can force neither an
+/// allocation nor an unbounded serialization pass.
+///
+/// Returns `Ok(exact_len)` when the value fits within `limit`, or `Err(len)`
+/// once it exceeds — where `len` is the count at the abort point (a lower bound
+/// on the true serialized size, sufficient to report "over the limit").
+fn serialized_len(value: &serde_json::Value, limit: usize) -> std::result::Result<usize, usize> {
+    use std::io::Write;
+
+    struct CountingSink {
+        count: usize,
+        limit: usize,
+    }
+    impl Write for CountingSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.count += buf.len();
+            if self.count > self.limit {
+                return Err(std::io::Error::other("payload exceeds limit"));
+            }
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut sink = CountingSink { count: 0, limit };
+    // A `Value` can only fail to serialize via our sink's limit-exceeded error
+    // (it holds no non-finite floats), so `Err` unambiguously means "over limit".
+    match serde_json::to_writer(&mut sink, value) {
+        Ok(()) => Ok(sink.count),
+        Err(_) => Err(sink.count),
+    }
+}
+
+/// Reject a JSON document that serializes past [`MAX_PAYLOAD_BYTES`].
+///
+/// `kind` names the offending field for the error message.
+///
+/// # Errors
+///
+/// Returns [`ConflictError::PayloadTooLarge`] when the serialized form exceeds
+/// the limit (measurement aborts early, so CPU is bounded to O(limit)).
+pub fn check_json_size(value: &serde_json::Value, kind: &'static str) -> Result<()> {
+    match serialized_len(value, MAX_PAYLOAD_BYTES) {
+        Ok(_) => Ok(()),
+        Err(size) => Err(MemoryError::Conflict(ConflictError::PayloadTooLarge {
+            kind,
+            size,
+            limit: MAX_PAYLOAD_BYTES,
+        })),
+    }
+}
+
+/// Reject a string body longer than [`MAX_PAYLOAD_BYTES`] bytes.
+///
+/// # Errors
+///
+/// Returns [`ConflictError::PayloadTooLarge`] when `s` exceeds the limit.
+pub const fn check_str_size(s: &str, kind: &'static str) -> Result<()> {
+    let size = s.len();
+    if size > MAX_PAYLOAD_BYTES {
+        return Err(MemoryError::Conflict(ConflictError::PayloadTooLarge {
+            kind,
+            size,
+            limit: MAX_PAYLOAD_BYTES,
+        }));
+    }
+    Ok(())
+}
+
+/// Reject a [`NewFact`] whose `content` or `metadata` exceeds the bound.
+///
+/// The single chokepoint for every path that persists a caller-supplied fact
+/// (`add_fact`, `add_facts_batch`, `resolve_conflict`, `bootstrap`).
+///
+/// # Errors
+///
+/// Returns [`ConflictError::PayloadTooLarge`] for the first offending field.
+pub fn check_new_fact(fact: &NewFact) -> Result<()> {
+    check_str_size(&fact.content, "fact content")?;
+    check_json_size(&fact.metadata, "fact metadata")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialized_len_counts_exact_bytes() {
+        const EXPECTED_STRING_LEN: usize = 5; // "abc" → content + two quotes
+        const EXPECTED_EMPTY_OBJECT_LEN: usize = 2; // {}
+
+        // Within a generous limit, the exact serialized length is returned.
+        assert_eq!(
+            serialized_len(&serde_json::Value::String("abc".into()), MAX_PAYLOAD_BYTES).unwrap(),
+            EXPECTED_STRING_LEN
+        );
+        assert_eq!(
+            serialized_len(&serde_json::json!({}), MAX_PAYLOAD_BYTES).unwrap(),
+            EXPECTED_EMPTY_OBJECT_LEN
+        );
+    }
+
+    #[test]
+    fn serialized_len_aborts_early_over_limit() {
+        // A value larger than a tiny limit returns Err with a count past the
+        // limit — proving serialization halted instead of walking the whole
+        // value (the CPU bound the gemini review asked for).
+        let big = serde_json::Value::String("x".repeat(1000));
+        let limit = 16;
+        match serialized_len(&big, limit) {
+            Err(n) => assert!(n > limit, "abort count {n} must exceed limit {limit}"),
+            Ok(n) => panic!("expected early abort over limit {limit}, got Ok({n})"),
+        }
+    }
+
+    #[test]
+    fn check_json_size_boundary() {
+        // Build a value serializing to exactly MAX_PAYLOAD_BYTES, then one over.
+        // A JSON string of N chars serializes to N + 2 bytes (the quotes).
+        let at_limit = serde_json::Value::String("x".repeat(MAX_PAYLOAD_BYTES - 2));
+        assert!(check_json_size(&at_limit, "fact metadata").is_ok());
+
+        let over = serde_json::Value::String("x".repeat(MAX_PAYLOAD_BYTES));
+        let err = check_json_size(&over, "fact metadata").unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::Conflict(ConflictError::PayloadTooLarge {
+                kind: "fact metadata",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn check_str_size_boundary() {
+        let at_limit = "x".repeat(MAX_PAYLOAD_BYTES);
+        assert!(check_str_size(&at_limit, "fact content").is_ok());
+
+        let over = "x".repeat(MAX_PAYLOAD_BYTES + 1);
+        let err = check_str_size(&over, "fact content").unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::Conflict(ConflictError::PayloadTooLarge {
+                kind: "fact content",
+                size,
+                limit
+            }) if size == MAX_PAYLOAD_BYTES + 1 && limit == MAX_PAYLOAD_BYTES
+        ));
+    }
+}

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -13,6 +13,33 @@ pub struct VectorResult {
     pub score: f32,
 }
 
+/// Candidate-set size above which a brute-force scan is flagged as a scaling
+/// signal.
+///
+/// Brute-force cosine search is inherently O(N) per query — every active
+/// embedding in the (post-SQL-filter) candidate set is deserialized and scored.
+/// There is therefore **no correctness-preserving way to cap the scan**: a SQL
+/// `LIMIT` would silently drop candidates and corrupt recall. The bound is
+/// instead observational — past this many candidates we emit a one-time `warn`
+/// directing operators at the `ann` feature (HNSW), which provides the actual
+/// sublinear path.
+///
+/// Kept equal to the default [`SearchConfig::ann_threshold`](crate::search::strategy::SearchConfig)
+/// (50,000) — the documented fact count at which ANN should take over.
+pub(crate) const BRUTE_FORCE_WARN_THRESHOLD: usize = 50_000;
+
+/// Whether a brute-force candidate set is large enough to warrant the scaling
+/// warning. Split out as a pure predicate so the boundary is unit-testable
+/// without materializing a 50k-fact corpus.
+#[must_use]
+pub(crate) const fn brute_force_scan_is_oversized(candidates: usize) -> bool {
+    candidates > BRUTE_FORCE_WARN_THRESHOLD
+}
+
+/// Process-lifetime guard so the scaling warning fires at most once, rather than
+/// spamming a line per query once a deployment has outgrown brute-force.
+static BRUTE_FORCE_WARN_ONCE: std::sync::Once = std::sync::Once::new();
+
 /// Compute the cosine similarity between two vectors.
 ///
 /// Returns 0.0 if either vector has zero magnitude (avoids NaN).
@@ -77,6 +104,21 @@ pub fn vector_search(
         scored.push(VectorResult { fact_id: id, score });
     }
 
+    // Scaling signal (issue #572 / L9): brute force is O(N) per query and cannot
+    // be capped without dropping recall, so flag — once — when the candidate set
+    // has outgrown it. The `ann` feature is the sublinear remedy.
+    if brute_force_scan_is_oversized(scored.len()) {
+        let candidates = scored.len();
+        BRUTE_FORCE_WARN_ONCE.call_once(|| {
+            tracing::warn!(
+                candidates,
+                threshold = BRUTE_FORCE_WARN_THRESHOLD,
+                "brute-force vector scan exceeded the scaling threshold; \
+                 enable the `ann` feature for sublinear search"
+            );
+        });
+    }
+
     // Partial sort: O(N) partition then sort only top `limit` elements
     if scored.len() > limit {
         scored.select_nth_unstable_by(limit, |a, b| {
@@ -128,6 +170,27 @@ mod tests {
             metadata: serde_json::json!({}),
             is_pinned: false,
         }
+    }
+
+    #[test]
+    fn brute_force_oversized_predicate_boundary() {
+        // Strictly greater than the threshold is "oversized"; equal is not.
+        assert!(!brute_force_scan_is_oversized(0));
+        assert!(!brute_force_scan_is_oversized(BRUTE_FORCE_WARN_THRESHOLD));
+        assert!(brute_force_scan_is_oversized(
+            BRUTE_FORCE_WARN_THRESHOLD + 1
+        ));
+    }
+
+    #[test]
+    fn brute_force_threshold_tracks_ann_threshold_default() {
+        // The scaling warning must fire at the same corpus size the engine
+        // documents for switching to ANN, so the two never drift apart.
+        use crate::search::strategy::SearchConfig;
+        assert_eq!(
+            BRUTE_FORCE_WARN_THRESHOLD,
+            SearchConfig::default().ann_threshold
+        );
     }
 
     #[test]

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -24,6 +24,30 @@ const FACT_COLUMNS: &str = "id, content, content_hash, embedding, fact_type, \
      source_event_id, importance, access_count, last_accessed, metadata, scope_id, \
      is_pinned, importance_score, surfaced_at";
 
+/// The minimal column set needed to score a fact's importance during a prune
+/// pass — identity, decay inputs, and the pin flag. Deliberately excludes the
+/// heavy `content`, `embedding`, and `metadata` columns. Kept in lockstep with
+/// [`row_to_scoring_row`].
+const SCORING_COLUMNS: &str = "id, fact_type, last_accessed, access_count, importance, is_pinned";
+
+/// A lightweight projection of a fact carrying only the fields the forgetting
+/// pass reads when scoring importance.
+///
+/// Prune evaluates **every** active fact (importance is a global, full-scan
+/// computation), so materializing full [`Fact`] rows made the prune working set
+/// scale with corpus size × embedding dimension × content length. This
+/// projection bounds it to a handful of scalar fields per fact while preserving
+/// exact full-scan semantics. See [`FactStore::list_active_scoring`].
+#[derive(Debug, Clone)]
+pub struct FactScoringRow {
+    pub id: i64,
+    pub fact_type: FactType,
+    pub last_accessed: DateTime<Utc>,
+    pub access_count: i64,
+    pub importance: f64,
+    pub is_pinned: bool,
+}
+
 pub const fn fact_type_to_str(ft: &FactType) -> &'static str {
     match ft {
         FactType::Episodic => "episodic",
@@ -233,6 +257,29 @@ impl<'a> FactStore<'a> {
             facts.push(row?);
         }
         Ok(facts)
+    }
+
+    /// List the importance-scoring projection of all active facts
+    /// (`t_expired IS NULL`).
+    ///
+    /// Like [`list_active`](Self::list_active) but selects only the columns the
+    /// forgetting pass needs (see [`FactScoringRow`]), so the working set never
+    /// materializes `content`, `embedding`, or `metadata`. Used by `prune`,
+    /// which must scan the entire active set to compute global importance.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn list_active_scoring(&self) -> Result<Vec<FactScoringRow>> {
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {SCORING_COLUMNS} FROM facts WHERE t_expired IS NULL"
+        ))?;
+        let rows = stmt.query_map([], row_to_scoring_row)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
     }
 
     /// List facts active at a given point in time (bi-temporal query).
@@ -902,6 +949,27 @@ fn row_to_fact(row: &rusqlite::Row<'_>, embed_dim: usize) -> rusqlite::Result<Fa
     })
 }
 
+/// Map a [`SCORING_COLUMNS`] row to a [`FactScoringRow`]. Kept in lockstep with
+/// the column list; reads by name so column order is irrelevant.
+fn row_to_scoring_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<FactScoringRow> {
+    let fact_type_str: String = row.get("fact_type")?;
+    let last_accessed_str: String = row.get("last_accessed")?;
+    let last_accessed = parse_timestamp(&last_accessed_str)?;
+    let fact_type = str_to_fact_type(&fact_type_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+    let is_pinned_i64: i64 = row.get("is_pinned")?;
+
+    Ok(FactScoringRow {
+        id: row.get("id")?,
+        fact_type,
+        last_accessed,
+        access_count: row.get("access_count")?,
+        importance: row.get("importance")?,
+        is_pinned: is_pinned_i64 != 0,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1194,6 +1262,37 @@ mod tests {
         let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].id, id2);
+    }
+
+    #[test]
+    fn list_active_scoring_returns_projection_and_excludes_expired() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+
+        let mut pinned = make_fact("pinned semantic", vec![0.1; DIM]);
+        pinned.fact_type = FactType::Semantic;
+        pinned.is_pinned = true;
+        pinned.importance = 0.9;
+        pinned.access_count = 7;
+        let pinned_id = store.insert(&pinned).unwrap();
+
+        let plain_id = store.insert(&make_fact("plain", vec![0.2; DIM])).unwrap();
+
+        let expired_id = store.insert(&make_fact("gone", vec![0.3; DIM])).unwrap();
+        store.expire(expired_id, Utc::now()).unwrap();
+
+        let rows = store.list_active_scoring().unwrap();
+        assert_eq!(rows.len(), 2, "expired facts must be excluded");
+
+        let pinned_row = rows.iter().find(|r| r.id == pinned_id).unwrap();
+        assert_eq!(pinned_row.fact_type, FactType::Semantic);
+        assert!(pinned_row.is_pinned);
+        assert!((pinned_row.importance - 0.9).abs() < f64::EPSILON);
+        assert_eq!(pinned_row.access_count, 7);
+
+        let plain_row = rows.iter().find(|r| r.id == plain_id).unwrap();
+        assert!(!plain_row.is_pinned);
+        assert_eq!(plain_row.fact_type, FactType::Episodic);
     }
 
     #[test]


### PR DESCRIPTION
Closes #572. Addresses all five low-severity hardening findings (L6–L10) from the super-qa sweep (#124, epic #241) in one cohesive PR. Each is a different costume of the same class: **missing resource bounds on attacker-influenced input.**

## Findings & fixes

| ID | Finding | Fix |
|----|---------|-----|
| **L6** | TOCTOU race in `dump_sqlite` self-protection | Probe with `symlink_metadata` (no symlink-follow) instead of `path.exists()`; refuse a directory target via typed `ConflictError::DumpTargetIsDirectory`; document the trusted-path contract. The TOCTOU window is inherent to `VACUUM INTO` (no OS atomic-exclusive-create) — named, not faked. |
| **L7** | Unbounded JSONL line parsing in bootstrap | Replace `BufRead::lines()` (unbounded `String` per line) with a bounded reader (`MAX_JSONL_LINE_BYTES` = 8 MiB). Overflow drains in place (flat memory) and resyncs at the next newline; counted once as malformed. Best-effort "never fails" contract preserved. |
| **L8** | Prune loads all active facts (full `Fact` rows) | New `FactScoringRow` projection + `FactStore::list_active_scoring()`. An `ImportanceInputs` trait lets one `compute_importance` serve both `Fact` and the projection (static dispatch). **Full-scan correctness unchanged** — prune still evaluates every active fact — but the per-fact working set drops from ~KB (content+embedding+metadata) to a few scalars. |
| **L9** | Brute-force streams all embeddings | Brute-force cosine is inherently O(N); a SQL `LIMIT` would corrupt recall. So the bound is **observational**: warn once when the candidate set exceeds the brute-force threshold (kept equal to `SearchConfig::ann_threshold` via a drift-guard test), pointing operators at the `ann` feature. |
| **L10** | Unbounded `serde_json::Value` payloads | Reject event `payload` / fact `metadata` serializing past **1 MiB** at `ingest` / `add_fact` / `add_facts_batch` with typed `ConflictError::PayloadTooLarge`. Size is measured via a zero-storage counting sink — O(1) extra memory, never a second full allocation (which would itself be the DoS). |

### Design notes
- **L8** is the most surgical: prune was materializing heavy columns purely to read four scalars. The trait keeps existing `Fact`-based callers (and tests) working with zero runtime cost.
- **L9/L10** deliberately avoid silent truncation — a naive cap on either would corrupt recall (L9) or leave the bound non-enforcing (L10). L9 observes; L10 rejects.
- **L10 follow-up:** the 1 MiB limit is a compile-time const. Making it per-`EngineConfig` configurable is deferred to avoid threading a public-API change through the builder/restore/CLI/MCP construction sites for a low-severity finding. Flag if you'd prefer it configurable now.

## Tests
New tests per finding (TDD, red→green where behavior changed): directory-target refusal (L6); bounded-line resync / cap-boundary / unterminated-EOF (L7); projection correctness + expired-exclusion (L8); threshold boundary + `ann_threshold` drift-guard (L9); `serialized_len` exactness + payload rejection on `ingest`/`add_fact` (L10).

## Verification
- `cargo fmt --all -- --check` ✓
- `cargo build --workspace` ✓
- `cargo test -p memory-engine` ✓ (764 passed) · `-p memory-engine-mcp` ✓ (116) · `-p memory-engine-embed` ✓ (18)
- `cargo clippy -p memory-engine --all-targets` ✓ (0 errors)

> ⚠️ **Pre-existing, unrelated:** `cargo test --workspace` does not compile `memory-engine-cli/tests/cli_integration.rs:124` (uses `MemoryEngine::open`, removed by the #556 typestate-builder refactor). Untouched by this PR (no CLI files in the diff); present on `main` and masked by the absence of build CI. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)