### PR TITLE
refactor(core): split MemoryError::Archive into typed ArchiveError

### DIFF
--- a/src/archive/pak.rs
+++ b/src/archive/pak.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::archive::types::{ArchivePak, CURRENT_PAK_VERSION};
-use crate::error::{MemoryError, Result};
+use crate::error::{ArchiveError, Result};
 use crate::store::schema::CURRENT_SCHEMA_VERSION;
 
 /// Maximum decompressed `.pak` size (4 GiB) — prevents decompression bombs.
@@ -22,7 +22,7 @@ pub fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
         .create_new(true)
         .open(&tmp_path)
         .map_err(|e| {
-            MemoryError::Archive(format!(
+            ArchiveError::Io(format!(
                 "failed to create temp pak file {}: {e}",
                 tmp_path.display()
             ))
@@ -34,16 +34,16 @@ pub fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
         hasher: &mut hasher,
     };
     let mut encoder = zstd::Encoder::new(hashing_writer, 3)
-        .map_err(|e| MemoryError::Archive(format!("failed to create zstd encoder: {e}")))?;
+        .map_err(|e| ArchiveError::Codec(format!("failed to create zstd encoder: {e}")))?;
     serde_json::to_writer(&mut encoder, pak)?;
     encoder
         .finish()
-        .map_err(|e| MemoryError::Archive(format!("failed to finalize zstd stream: {e}")))?;
+        .map_err(|e| ArchiveError::Codec(format!("failed to finalize zstd stream: {e}")))?;
 
     let hash = hasher.finalize().to_hex().to_string();
 
     fs::rename(&tmp_path, path).map_err(|e| {
-        MemoryError::Archive(format!(
+        ArchiveError::Io(format!(
             "failed to rename {} -> {}: {e}",
             tmp_path.display(),
             path.display()
@@ -55,10 +55,10 @@ pub fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
 /// Read and decompress a `.pak` file. Caps at 4 GiB decompressed.
 pub fn read_pak(path: &Path) -> Result<ArchivePak> {
     let file = fs::File::open(path).map_err(|e| {
-        MemoryError::Archive(format!("failed to open pak file {}: {e}", path.display()))
+        ArchiveError::Io(format!("failed to open pak file {}: {e}", path.display()))
     })?;
     let decoder = zstd::Decoder::new(file)
-        .map_err(|e| MemoryError::Archive(format!("failed to create zstd decoder: {e}")))?;
+        .map_err(|e| ArchiveError::Codec(format!("failed to create zstd decoder: {e}")))?;
     let limited = std::io::Read::take(decoder, MAX_PAK_DECOMPRESSED_SIZE);
     let pak: ArchivePak = serde_json::from_reader(limited)?;
 
@@ -66,18 +66,18 @@ pub fn read_pak(path: &Path) -> Result<ArchivePak> {
     // (store/schema.rs): reject archives written by a *newer* library, but
     // accept older ones (forward-only incompatibility, backward-compatible read).
     if pak.pak_version > CURRENT_PAK_VERSION {
-        return Err(MemoryError::Archive(format!(
-            "pak_version {} is newer than supported {CURRENT_PAK_VERSION}; \
-             consider upgrading the memory-engine crate",
-            pak.pak_version
-        )));
+        return Err(ArchiveError::PakVersionUnsupported {
+            found: pak.pak_version,
+            supported: CURRENT_PAK_VERSION,
+        }
+        .into());
     }
     if pak.engine_schema_version > CURRENT_SCHEMA_VERSION {
-        return Err(MemoryError::Archive(format!(
-            "engine_schema_version {} is newer than supported {CURRENT_SCHEMA_VERSION}; \
-             consider upgrading the memory-engine crate",
-            pak.engine_schema_version
-        )));
+        return Err(ArchiveError::SchemaVersionUnsupported {
+            found: pak.engine_schema_version,
+            supported: CURRENT_SCHEMA_VERSION,
+        }
+        .into());
     }
 
     Ok(pak)
@@ -86,10 +86,10 @@ pub fn read_pak(path: &Path) -> Result<ArchivePak> {
 /// Compute blake3 hash of a file (streaming, not `fs::read`).
 pub fn hash_file(path: &Path) -> Result<String> {
     let mut file = fs::File::open(path)
-        .map_err(|e| MemoryError::Archive(format!("failed to read pak file for hashing: {e}")))?;
+        .map_err(|e| ArchiveError::Io(format!("failed to read pak file for hashing: {e}")))?;
     let mut hasher = blake3::Hasher::new();
     std::io::copy(&mut file, &mut hasher)
-        .map_err(|e| MemoryError::Archive(format!("failed to hash pak file: {e}")))?;
+        .map_err(|e| ArchiveError::Io(format!("failed to hash pak file: {e}")))?;
     Ok(hasher.finalize().to_hex().to_string())
 }
 
@@ -121,6 +121,7 @@ impl<W: Write> Write for HashingWriter<'_, W> {
 mod tests {
     use super::*;
     use crate::archive::types::CURRENT_PAK_VERSION;
+    use crate::error::MemoryError;
     use chrono::Utc;
 
     /// Write an `ArchivePak` as zstd-compressed JSON (test convenience wrapper).
@@ -195,19 +196,23 @@ mod tests {
         write_pak(&pak, &pak_path).unwrap();
 
         let err = read_pak(&pak_path).unwrap_err();
+        let display = err.to_string();
         match err {
-            MemoryError::Archive(msg) => {
-                assert!(
-                    msg.contains("newer than supported"),
-                    "expected 'newer than supported' in {msg:?}"
-                );
-                assert!(
-                    msg.contains("pak_version"),
-                    "expected 'pak_version' in {msg:?}"
-                );
+            MemoryError::Archive(ArchiveError::PakVersionUnsupported { found, supported }) => {
+                assert_eq!(found, CURRENT_PAK_VERSION + 1);
+                assert_eq!(supported, CURRENT_PAK_VERSION);
             }
-            other => panic!("expected MemoryError::Archive, got {other:?}"),
+            other => panic!("expected Archive(PakVersionUnsupported), got {other:?}"),
         }
+        // Display byte-preservation: message still names the field and the cause.
+        assert!(
+            display.contains("newer than supported"),
+            "expected 'newer than supported' in {display:?}"
+        );
+        assert!(
+            display.contains("pak_version"),
+            "expected 'pak_version' in {display:?}"
+        );
     }
 
     #[test]
@@ -220,19 +225,23 @@ mod tests {
         write_pak(&pak, &pak_path).unwrap();
 
         let err = read_pak(&pak_path).unwrap_err();
+        let display = err.to_string();
         match err {
-            MemoryError::Archive(msg) => {
-                assert!(
-                    msg.contains("newer than supported"),
-                    "expected 'newer than supported' in {msg:?}"
-                );
-                assert!(
-                    msg.contains("engine_schema_version"),
-                    "expected 'engine_schema_version' in {msg:?}"
-                );
+            MemoryError::Archive(ArchiveError::SchemaVersionUnsupported { found, supported }) => {
+                assert_eq!(found, CURRENT_SCHEMA_VERSION + 1);
+                assert_eq!(supported, CURRENT_SCHEMA_VERSION);
             }
-            other => panic!("expected MemoryError::Archive, got {other:?}"),
+            other => panic!("expected Archive(SchemaVersionUnsupported), got {other:?}"),
         }
+        // Display byte-preservation: message still names the field and the cause.
+        assert!(
+            display.contains("newer than supported"),
+            "expected 'newer than supported' in {display:?}"
+        );
+        assert!(
+            display.contains("engine_schema_version"),
+            "expected 'engine_schema_version' in {display:?}"
+        );
     }
 
     #[test]

--- a/src/engine/archive.rs
+++ b/src/engine/archive.rs
@@ -14,7 +14,7 @@ use crate::archive::types::{
     ArchiveManifestEntry, ArchivePak, ArchivePolicy, ArchiveStats, ArchiveVerifyResult,
     CURRENT_PAK_VERSION,
 };
-use crate::error::{MemoryError, Result};
+use crate::error::{ArchiveError, Result};
 use crate::store::archive_manifest::ArchiveManifestStore;
 use crate::store::edges::EdgeStore;
 use crate::store::facts::FactStore;
@@ -49,9 +49,10 @@ impl MemoryEngine {
         drop(self.pool.try_write()?);
 
         if !self.is_file_backed() {
-            return Err(MemoryError::Archive(
+            return Err(ArchiveError::NotFileBacked(
                 "archival requires a file-backed engine".to_string(),
-            ));
+            )
+            .into());
         }
 
         let archive_dir = self.archive_dir()?;
@@ -192,7 +193,7 @@ impl MemoryEngine {
         pak: &ArchivePak,
     ) -> Result<(PathBuf, u64, String)> {
         std::fs::create_dir_all(archive_dir).map_err(|e| {
-            MemoryError::Archive(format!(
+            ArchiveError::Io(format!(
                 "failed to create archive dir {}: {e}",
                 archive_dir.display()
             ))
@@ -206,7 +207,7 @@ impl MemoryEngine {
         let blake3_hash = write_pak_and_hash(pak, &pak_path)?;
         let pak_size_bytes = std::fs::metadata(&pak_path)
             .map_err(|e| {
-                MemoryError::Archive(format!(
+                ArchiveError::Io(format!(
                     "failed to stat pak file {}: {e}",
                     pak_path.display()
                 ))
@@ -245,7 +246,7 @@ impl MemoryEngine {
         let conn = self.write_conn()?;
         let tx = conn
             .unchecked_transaction()
-            .map_err(|e| MemoryError::Archive(format!("failed to begin transaction: {e}")))?;
+            .map_err(|e| ArchiveError::Transaction(format!("failed to begin transaction: {e}")))?;
 
         ArchiveManifestStore::new(&tx).insert(
             pak_filename,
@@ -265,7 +266,7 @@ impl MemoryEngine {
         FactStore::new(&tx, self.embed_dim).hard_delete_ids(fact_ids)?;
 
         tx.commit().map_err(|e| {
-            MemoryError::Archive(format!("failed to commit archive transaction: {e}"))
+            ArchiveError::Transaction(format!("failed to commit archive transaction: {e}"))
         })?;
 
         Ok(())
@@ -332,10 +333,12 @@ impl MemoryEngine {
     /// Resolve the archive directory (sibling of DB file + `/archives/`).
     fn archive_dir(&self) -> Result<PathBuf> {
         let db_path = self.pool.path().ok_or_else(|| {
-            MemoryError::Archive("cannot resolve archive dir for in-memory database".to_string())
+            ArchiveError::NotFileBacked(
+                "cannot resolve archive dir for in-memory database".to_string(),
+            )
         })?;
         let parent = db_path.parent().ok_or_else(|| {
-            MemoryError::Archive(format!(
+            ArchiveError::Io(format!(
                 "database path has no parent: {}",
                 db_path.display()
             ))

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,6 +120,74 @@ pub enum RerankerError {
     },
 }
 
+/// A failure from the cold-storage archive subsystem (`.pak` pack/unpack).
+///
+/// This is the typed payload of [`MemoryError::Archive`]. The two
+/// version-mismatch variants carry the offending and supported versions as
+/// fields, so a caller can detect "archive written by a newer build" and react
+/// (e.g. prompt to upgrade) without string-matching. The remaining variants
+/// group the operational failure modes — preconditions, compression codec,
+/// filesystem I/O, and the archive write transaction — each carrying the
+/// underlying error message verbatim (these wrap arbitrary `std::io`/codec
+/// errors that cannot be enumerated further).
+///
+/// Only constructed when the `archive` feature is enabled; the type itself is
+/// always present so [`MemoryError`] has a stable shape across feature sets.
+///
+/// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
+/// downstream `match` expressions must include a wildcard (`_`) arm.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ArchiveError {
+    /// The `.pak` file's `pak_version` is newer than this build supports —
+    /// forward-incompatible (a newer library wrote it). Reading older versions
+    /// is allowed; only newer ones are rejected.
+    #[error(
+        "pak_version {found} is newer than supported {supported}; consider upgrading the memory-engine crate"
+    )]
+    PakVersionUnsupported {
+        /// The `pak_version` read from the archive.
+        found: u32,
+        /// The highest `pak_version` this build supports.
+        supported: u32,
+    },
+
+    /// The `.pak` file's `engine_schema_version` is newer than this build
+    /// supports — same forward-only incompatibility as
+    /// [`PakVersionUnsupported`](ArchiveError::PakVersionUnsupported).
+    #[error(
+        "engine_schema_version {found} is newer than supported {supported}; consider upgrading the memory-engine crate"
+    )]
+    SchemaVersionUnsupported {
+        /// The `engine_schema_version` read from the archive.
+        found: u32,
+        /// The highest `engine_schema_version` this build supports.
+        supported: u32,
+    },
+
+    /// Archival requires a file-backed engine, but the engine is in-memory (or
+    /// its database path cannot be resolved). The string names the precise
+    /// precondition violated.
+    #[error("{0}")]
+    NotFileBacked(String),
+
+    /// A zstd compression or decompression step failed (encoder/decoder
+    /// creation or stream finalization). The string carries the codec message.
+    #[error("{0}")]
+    Codec(String),
+
+    /// A filesystem operation on a `.pak` file or the archive directory failed
+    /// (create, open, read, rename, stat, mkdir, path resolution). The string
+    /// carries the underlying I/O message.
+    #[error("{0}")]
+    Io(String),
+
+    /// The archive write transaction failed to begin or commit. The string
+    /// carries the underlying database message.
+    #[error("{0}")]
+    Transaction(String),
+}
+
 /// Errors returned by the memory engine.
 ///
 /// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
@@ -189,9 +257,11 @@ pub enum MemoryError {
     #[error("reranker error: {0}")]
     Reranker(#[from] RerankerError),
 
-    /// A cold-storage archive operation (pack/unpack of a `.pak` file) failed.
+    /// A cold-storage archive operation (pack/unpack of a `.pak` file) failed;
+    /// see [`ArchiveError`] for the specific cause (version mismatch, precondition,
+    /// compression codec, filesystem I/O, or the archive transaction).
     #[error("archive error: {0}")]
-    Archive(String),
+    Archive(#[from] ArchiveError),
 
     /// Attempted a write operation on a read-only engine.
     #[error("operation requires write access, but engine was opened read-only")]
@@ -279,6 +349,73 @@ mod tests {
         assert!(matches!(
             err,
             MemoryError::Reranker(RerankerError::DuplicateIndex { index: 0 })
+        ));
+    }
+
+    #[test]
+    fn archive_variants_display_byte_for_byte() {
+        // Byte-preservation: each variant must render exactly the string the
+        // pre-split `format!` call sites produced (under the outer `archive
+        // error: ` prefix), so existing message consumers keep working.
+        assert_eq!(
+            MemoryError::Archive(ArchiveError::PakVersionUnsupported {
+                found: 2,
+                supported: 1,
+            })
+            .to_string(),
+            "archive error: pak_version 2 is newer than supported 1; consider upgrading the memory-engine crate"
+        );
+        assert_eq!(
+            MemoryError::Archive(ArchiveError::SchemaVersionUnsupported {
+                found: 12,
+                supported: 11,
+            })
+            .to_string(),
+            "archive error: engine_schema_version 12 is newer than supported 11; consider upgrading the memory-engine crate"
+        );
+        // String-carrying variants surface their message verbatim under the prefix.
+        assert_eq!(
+            MemoryError::Archive(ArchiveError::NotFileBacked(
+                "archival requires a file-backed engine".into()
+            ))
+            .to_string(),
+            "archive error: archival requires a file-backed engine"
+        );
+        assert_eq!(
+            MemoryError::Archive(ArchiveError::Codec(
+                "failed to create zstd encoder: boom".into()
+            ))
+            .to_string(),
+            "archive error: failed to create zstd encoder: boom"
+        );
+        assert_eq!(
+            MemoryError::Archive(ArchiveError::Io("failed to open pak file /x: boom".into()))
+                .to_string(),
+            "archive error: failed to open pak file /x: boom"
+        );
+        assert_eq!(
+            MemoryError::Archive(ArchiveError::Transaction(
+                "failed to begin transaction: boom".into()
+            ))
+            .to_string(),
+            "archive error: failed to begin transaction: boom"
+        );
+    }
+
+    #[test]
+    fn archive_error_from_into_memory_error() {
+        // `#[from]` lets a bare `ArchiveError` convert via `?`/`.into()`.
+        let err: MemoryError = ArchiveError::PakVersionUnsupported {
+            found: 9,
+            supported: 1,
+        }
+        .into();
+        assert!(matches!(
+            err,
+            MemoryError::Archive(ArchiveError::PakVersionUnsupported {
+                found: 9,
+                supported: 1
+            })
         ));
     }
 


### PR DESCRIPTION
## What

Split the stringly-typed `MemoryError::Archive(String)` into a typed `thiserror` sub-enum `ArchiveError`, continuing the typed-error hierarchy from #559 (`ConflictError`) and #577 (`RerankerError`).

**Step 2 of #560.** #560 remains open after this merges — Migration and the Bootstrap-removal step still follow. (Linked as "part of", not a closing reference.)

## The variants — grouped by consumer actionability (17 call sites)

| Variant | Kind | Sites |
| --- | --- | --- |
| `PakVersionUnsupported { found, supported }` | structured (u32) | pak.rs version check |
| `SchemaVersionUnsupported { found, supported }` | structured (u32) | pak.rs schema check |
| `NotFileBacked(String)` | string | archive() precondition, in-memory archive_dir |
| `Codec(String)` | string | zstd encoder/decoder/finalize |
| `Io(String)` | string | create/open/read/rename/stat/mkdir/path |
| `Transaction(String)` | string | begin/commit archive txn |

The two **version-mismatch** variants are structured because they're the only cases anything branches on (the pak.rs version-rejection tests) — a caller can now detect "archive written by a newer build" without string-matching. The four string variants wrap arbitrary `std::io`/codec errors that can't be enumerated further, so they honestly stay as grouped strings.

## Behavior preservation

- Outer keeps `#[error("archive error: {0}")]` + `#[from]`; each inner `#[error(...)]` reproduces the **exact** prior `format!` text → Display byte-for-byte unchanged. Pinned by `archive_variants_display_byte_for_byte` (runs even without the `archive` feature, since `ArchiveError` is always present).
- MCP dispatch untouched (`format!("archive error: {msg}")`, `msg` now `ArchiveError: Display`).
- `ArchiveError` is always-present but only constructed under the `archive` feature → `MemoryError`'s shape stays stable across feature sets.

## Tests

The two pak.rs version-rejection tests are tightened from `Archive(msg)` + `msg.contains(...)` to **structured-variant matches** asserting the `found`/`supported` fields, keeping the Display `.contains` as a byte-preservation guard.

## Verification

- `cargo build --features archive` ✓ · `cargo build --workspace` ✓
- `cargo fmt --check` ✓ · `cargo clippy --features archive --all-targets` exit 0 · `cargo clippy --workspace` exit 0 (no new warnings)
- `cargo test --features archive` — 817 passed / 0 failed ✓
- `cargo test --workspace` — 1008 passed / 0 failed ✓
- `cargo test --all-features` — 838 passed / 0 failed ✓

Part of #560 · follow-up to #577 · epic #241.
