### PR TITLE
perf(retrieval): batch fact fetch in hybrid_search

### DIFF
--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -211,12 +211,23 @@ pub fn hybrid_search(
     let effective_limit = effective_target;
     let ranked_count = ranked.len();
     let store = FactStore::new(conn, embed_dim);
+
+    // Batch-materialize all ranked ids in a single round-trip, then re-order
+    // to the ranked order below. Fetching every ranked id (not just the first
+    // `effective_limit`) preserves the previous semantics: the temporal
+    // post-filter can drop candidates, so later ranked ids may be needed to
+    // fill the limit. The map keys back to ranked order; ids the store failed
+    // to load (e.g. raced deletion) are simply absent and skipped, matching
+    // the prior per-id `store.get` warn-and-continue behavior.
+    let ranked_ids: Vec<i64> = ranked.iter().map(|&(id, _)| id).collect();
+    let mut facts_by_id = store.get_many(&ranked_ids)?;
+
     let mut results = Vec::new();
     for (id, score) in ranked {
         if results.len() >= effective_limit {
             break;
         }
-        let Ok(fact) = store.get(id) else {
+        let Some(fact) = facts_by_id.remove(&id) else {
             tracing::warn!("failed to load fact id={id} during result collection, skipping");
             continue;
         };

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -237,6 +237,39 @@ impl<'a> FactStore<'a> {
         }
     }
 
+    /// Get multiple facts by id in a single round-trip.
+    ///
+    /// Materializes all requested ids with one `WHERE id IN (...)` query
+    /// (via `json_each`, so `SQLite`'s bound-variable limit is never hit
+    /// regardless of `ids` length) and returns them keyed by id. Missing
+    /// ids are simply absent from the map — callers reconcile against the
+    /// requested set (e.g. to preserve a ranked order and skip dropped rows).
+    ///
+    /// Returns an empty map for an empty `ids` slice (no query issued).
+    /// Order of the returned map is unspecified; callers that need a
+    /// particular order must re-index by id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn get_many(&self, ids: &[i64]) -> Result<std::collections::HashMap<i64, Fact>> {
+        if ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let ids_json = serde_json::to_string(ids)?;
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {FACT_COLUMNS} FROM facts WHERE id IN (SELECT value FROM json_each(?1))"
+        ))?;
+        let dim = self.embed_dim;
+        let rows = stmt.query_map(params![ids_json], |row| row_to_fact(row, dim))?;
+        let mut out = std::collections::HashMap::with_capacity(ids.len());
+        for row in rows {
+            let fact = row?;
+            out.insert(fact.id, fact);
+        }
+        Ok(out)
+    }
+
     /// List active facts (`t_expired IS NULL`), optionally limited.
     ///
     /// When `limit` is `Some(n)`, a SQL `LIMIT n` clause is pushed into the
@@ -1222,6 +1255,28 @@ mod tests {
             frac.timestamp_micros(),
             "last_accessed = fractional (latest) in the zero-vs-fractional case"
         );
+    }
+
+    #[test]
+    fn get_many_round_trips_and_skips_missing() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let id1 = store.insert(&make_fact("alpha", vec![0.1; DIM])).unwrap();
+        let id2 = store.insert(&make_fact("beta", vec![0.2; DIM])).unwrap();
+
+        // Empty slice issues no query and returns an empty map.
+        assert!(store.get_many(&[]).unwrap().is_empty());
+
+        // A nonexistent id is simply absent — no error, no placeholder.
+        let missing = id2 + 9999;
+        let fetched = store.get_many(&[id1, missing, id2]).unwrap();
+        assert_eq!(fetched.len(), 2);
+        assert_eq!(fetched[&id1].content, "alpha");
+        assert_eq!(fetched[&id2].content, "beta");
+        assert!(!fetched.contains_key(&missing));
+
+        // Each returned fact round-trips its full payload (embedding included).
+        assert_eq!(fetched[&id1].embedding, vec![0.1_f32; DIM]);
     }
 
     #[test]


### PR DESCRIPTION
## What

`hybrid_search` materialized the post-RRF ranked facts **one id at a time** — N separate `SELECT ... WHERE id = ?` round-trips after fusion. This replaces the per-id loop with a single batched fetch.

## How

- New `FactStore::get_many(&[i64]) -> HashMap<i64, Fact>` resolves all ranked ids in one query: `WHERE id IN (SELECT value FROM json_each(?1))`.
  - `json_each` binds the id set as a single JSON parameter, so SQLite's bound-variable limit is never hit regardless of result size — no chunking needed (ranked sets are bounded by `effective_target` anyway).
  - Missing ids are simply absent from the map (no error), preserving the prior warn-and-skip-on-missing behavior.
- `hybrid_search` collects the ranked ids, calls `get_many` once, then walks `ranked` in order, `remove`-ing each fact from the map.

## Behavior preservation

This is behavior-preserving:
- **Same facts, same ranked order** — the iteration still walks `ranked` and re-indexes the map by id.
- **Temporal post-filter** (`t_valid`/`t_invalid` vs `cutoff`) is unchanged and still applied in the ranked-order loop.
- **`effective_limit` cap** and **`fact_type`/`scope`/`t_expired`** SQL-level filters are untouched.
- **Missing-id skip** matches the old `store.get` warn-and-continue path.
- Ranked ids are unique (FTS/vector lists carry distinct ids; RRF dedupes via `HashMap`), so `remove` is equivalent to the old per-id `get`.

The existing `hybrid_search` / `execute_query` tests pass unchanged (the oracle), plus a new `get_many_round_trips_and_skips_missing` unit test locks in the batch getter (round-trip, empty-slice no-op, absent missing id).

## Gates

- `cargo build --workspace` ✅
- `cargo test -p memory-engine -p memory-engine-mcp -p memory-engine-embed` ✅ (exit 0)
- `cargo clippy -p memory-engine -p memory-engine-mcp --all-targets` ✅ (exit 0, delta-clean — zero new warnings vs the pre-existing #539 set)
- `cargo fmt --check` ✅

Refs #573 (L21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)