### PR TITLE
feat(cli): bootstrap subcommand — jsonl + native .md import, redaction-gated (#551)

### DIFF
--- a/memory-engine-cli/src/commands/bootstrap.rs
+++ b/memory-engine-cli/src/commands/bootstrap.rs
@@ -1,0 +1,339 @@
+//! `bootstrap` subcommand — load historical memory into the store from the
+//! read-only history backbone, idempotently and with backdated timestamps.
+//!
+//! Two source kinds, either or both per invocation:
+//!   - `--jsonl-dir` — Claude/Codex/Gemini session `.jsonl` transcripts (AAP #53).
+//!   - `--memory-dir` — native `.md` memory files (`MEMORY.md` + fact files).
+//!
+//! Both paths are **redaction-gated** (#45/#51 — runs before any write, no
+//! bypass flag), **dedup-with-reinforced** (#520), and **backdated** (#521).
+//! Sources are opened read-only and never modified.
+
+use std::path::{Path, PathBuf};
+
+use memory_engine::MemoryEngine;
+use memory_engine::bootstrap::{
+    BootstrapConfig, BootstrapReport, KeywordExtractor, load_secret_denylist,
+};
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine_embed::HttpEmbeddingProvider;
+
+use crate::db::open_engine_writable;
+use crate::output::{OutputFormat, print_json};
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+#[derive(clap::Args)]
+pub struct BootstrapArgs {
+    /// Directory of session `.jsonl` transcripts to import (recursive; skips `subagents/`).
+    #[arg(long)]
+    jsonl_dir: Option<PathBuf>,
+
+    /// Directory of native `.md` memory files to import (recursive).
+    #[arg(long)]
+    memory_dir: Option<PathBuf>,
+
+    /// OpenAI-compatible embedding endpoint URL (e.g. `http://localhost:11434/v1/embeddings`)
+    #[arg(long, env = "MEMORY_ENGINE_EMBED_URL")]
+    embed_url: String,
+
+    /// Embedding model name
+    #[arg(long, env = "MEMORY_ENGINE_EMBED_MODEL")]
+    embed_model: String,
+
+    /// Bearer API key for the embedding endpoint
+    #[arg(long, env = "MEMORY_ENGINE_EMBED_API_KEY")]
+    embed_api_key: Option<String>,
+
+    /// HTTP timeout in seconds for embedding calls
+    #[arg(long, default_value = "30")]
+    embed_timeout: u64,
+
+    /// Default scope path for all imported facts
+    #[arg(long)]
+    scope: Option<String>,
+
+    /// Maximum turns per session (`.jsonl` path only). `0` = no limit.
+    #[arg(long, default_value = "0")]
+    max_turns: usize,
+
+    /// Re-process already-bootstrapped sessions instead of skipping them
+    /// (`.jsonl` path). Off by default; idempotency normally skips on the
+    /// session marker. With this set, re-runs reinforce instead of skipping.
+    #[arg(long)]
+    reprocess: bool,
+
+    /// Create a new database (requires `--embed-dim`)
+    #[arg(long)]
+    create: bool,
+
+    /// Embedding dimension (required with `--create`)
+    #[arg(long)]
+    embed_dim: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Report output
+// ---------------------------------------------------------------------------
+
+fn print_report(report: &BootstrapReport, format: OutputFormat) -> anyhow::Result<()> {
+    match format {
+        OutputFormat::Json => print_json(report)?,
+        OutputFormat::Table => {
+            println!("Bootstrap complete:");
+            println!("  sessions processed: {}", report.sessions_processed);
+            println!("  sessions skipped:   {}", report.sessions_skipped);
+            println!("  memory files:       {}", report.memory_files_parsed);
+            println!("  memory skipped:     {}", report.memory_files_skipped);
+            println!("  facts created:      {}", report.facts_created);
+            println!("  facts reinforced:   {}", report.facts_reinforced);
+            println!("  secrets redacted:   {}", report.secrets_redacted);
+        }
+        OutputFormat::Plain => {
+            println!(
+                "sessions_processed={} sessions_skipped={} memory_files_parsed={} \
+                 memory_files_skipped={} facts_created={} facts_reinforced={} secrets_redacted={}",
+                report.sessions_processed,
+                report.sessions_skipped,
+                report.memory_files_parsed,
+                report.memory_files_skipped,
+                report.facts_created,
+                report.facts_reinforced,
+                report.secrets_redacted,
+            );
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Core logic (testable — accepts engine + embedder + config)
+// ---------------------------------------------------------------------------
+
+/// Run the bootstrap import over whichever source dirs are provided, merging
+/// both reports. The `.jsonl` path uses the no-LLM [`KeywordExtractor`]; both
+/// paths share the redaction/dedup/backdating semantics in `config`.
+///
+/// # Errors
+///
+/// Propagates engine errors (embedding, DB, traversal) and bails if neither
+/// `--jsonl-dir` nor `--memory-dir` was given.
+pub(crate) fn run_bootstrap(
+    engine: &MemoryEngine,
+    jsonl_dir: Option<&Path>,
+    memory_dir: Option<&Path>,
+    embedder: &dyn EmbeddingProvider,
+    config: &BootstrapConfig,
+) -> anyhow::Result<BootstrapReport> {
+    anyhow::ensure!(
+        jsonl_dir.is_some() || memory_dir.is_some(),
+        "nothing to do: pass --jsonl-dir and/or --memory-dir"
+    );
+
+    let mut report = BootstrapReport::default();
+
+    if let Some(dir) = jsonl_dir {
+        anyhow::ensure!(
+            dir.is_dir(),
+            "--jsonl-dir is not a directory: {}",
+            dir.display()
+        );
+        let extractor = KeywordExtractor;
+        let sub = engine.bootstrap_directory(dir, embedder, &extractor, config, None)?;
+        report.merge(&sub);
+    }
+
+    if let Some(dir) = memory_dir {
+        anyhow::ensure!(
+            dir.is_dir(),
+            "--memory-dir is not a directory: {}",
+            dir.display()
+        );
+        let sub = engine.bootstrap_memory_directory(dir, embedder, config, None)?;
+        report.merge(&sub);
+    }
+
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub fn run(db: &Path, args: &BootstrapArgs, format: OutputFormat) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        args.jsonl_dir.is_some() || args.memory_dir.is_some(),
+        "pass --jsonl-dir and/or --memory-dir"
+    );
+
+    // Open or create the engine.
+    let engine = if args.create {
+        let embed_dim = args
+            .embed_dim
+            .ok_or_else(|| anyhow::anyhow!("--embed-dim is required when using --create"))?;
+        anyhow::ensure!(
+            !db.exists(),
+            "database {} already exists — remove it first or omit --create",
+            db.display()
+        );
+        MemoryEngine::builder(embed_dim)
+            .path(db.to_path_buf())
+            .build()?
+    } else {
+        open_engine_writable(db)?
+    };
+
+    // Embedding provider (Ollama / any OpenAI-compatible endpoint).
+    let embedder = HttpEmbeddingProvider::new(
+        args.embed_url.clone(),
+        args.embed_model.clone(),
+        args.embed_api_key.clone(),
+        engine.embed_dim(),
+        args.embed_timeout,
+    )
+    .map_err(|e| anyhow::anyhow!("failed to create embedding provider: {e}"))?;
+
+    // Author-seeded denylist (#51). Loud about how many literals loaded so an
+    // unset env var (→ signatures-only) is never silently mistaken for "active".
+    let denylist = load_secret_denylist()
+        .map_err(|e| anyhow::anyhow!("failed to load secret denylist: {e}"))?;
+    eprintln!(
+        "redaction: signatures + {} author-seeded denylist literal(s)",
+        denylist.len()
+    );
+
+    let config = BootstrapConfig {
+        scope: args.scope.clone(),
+        max_turns: args.max_turns,
+        skip_existing: !args.reprocess,
+        redact: true, // no bypass in normal CLI operation (#51)
+        denylist,
+    };
+
+    let report = run_bootstrap(
+        &engine,
+        args.jsonl_dir.as_deref(),
+        args.memory_dir.as_deref(),
+        &embedder,
+        &config,
+    )?;
+
+    print_report(&report, format)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Zero-vector embedder (dim 4) — no network.
+    struct FakeEmbed;
+    impl EmbeddingProvider for FakeEmbed {
+        fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
+            Ok(vec![0.0; 4])
+        }
+    }
+
+    const PLANTED: &str = "AKIAIOSFODNN7EXAMPLE";
+
+    fn write_session(dir: &Path) {
+        // A minimal Claude-Code JSONL session whose assistant turn trips the
+        // keyword pre-filter ("root cause", "fix", "tests pass") and plants a
+        // secret to prove redaction on the .jsonl path too.
+        let jsonl = format!(
+            "{}\n{}\n",
+            serde_json::json!({
+                "type": "user", "sessionId": "s1", "timestamp": "2024-02-01T10:00:00Z",
+                "uuid": "s1-0", "parentUuid": serde_json::Value::Null,
+                "message": {"role": "user", "content": [{"type": "text", "text": "Fix the off-by-one in parser.rs"}]}
+            }),
+            serde_json::json!({
+                "type": "assistant", "sessionId": "s1", "timestamp": "2024-02-01T10:00:30Z",
+                "uuid": "s1-1", "parentUuid": "s1-0",
+                "message": {"role": "assistant", "content": [{"type": "text",
+                    "text": format!("Found the root cause and applied the fix; tests pass. Leaked {PLANTED} here.")}]}
+            }),
+        );
+        fs::write(dir.join("s1.jsonl"), jsonl).unwrap();
+    }
+
+    fn write_memory(dir: &Path) {
+        fs::write(
+            dir.join("pref.md"),
+            "---\nmetadata:\n  type: user\n---\nThe user prefers Conventional Commits.\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn run_bootstrap_both_dirs_redacts_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let jsonl_dir = tmp.path().join("jsonl");
+        let memory_dir = tmp.path().join("md");
+        fs::create_dir_all(&jsonl_dir).unwrap();
+        fs::create_dir_all(&memory_dir).unwrap();
+        write_session(&jsonl_dir);
+        write_memory(&memory_dir);
+
+        let engine = MemoryEngine::builder(4).build().unwrap();
+        let config = BootstrapConfig::default();
+
+        let report = run_bootstrap(
+            &engine,
+            Some(&jsonl_dir),
+            Some(&memory_dir),
+            &FakeEmbed,
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(report.sessions_processed, 1, "one jsonl session imported");
+        assert_eq!(report.memory_files_parsed, 1, "one md memory imported");
+        assert!(
+            report.facts_created >= 2,
+            "at least the session fact + the memory fact"
+        );
+        assert!(
+            report.secrets_redacted >= 1,
+            "the planted secret was redacted"
+        );
+
+        // The secret is nowhere in the store.
+        for f in engine.list_active_facts(None).unwrap() {
+            assert!(
+                !f.content.contains(PLANTED),
+                "secret leaked: {:?}",
+                f.content
+            );
+        }
+
+        // Idempotency: re-run creates nothing new.
+        let report2 = run_bootstrap(
+            &engine,
+            Some(&jsonl_dir),
+            Some(&memory_dir),
+            &FakeEmbed,
+            &config,
+        )
+        .unwrap();
+        assert_eq!(report2.facts_created, 0, "re-run creates 0 facts");
+        // jsonl session is skipped on the marker; the md memory reinforces.
+        assert_eq!(report2.sessions_skipped, 1);
+        assert_eq!(report2.facts_reinforced, 1, "the md memory reinforces");
+    }
+
+    #[test]
+    fn run_bootstrap_requires_a_source() {
+        let engine = MemoryEngine::builder(4).build().unwrap();
+        let config = BootstrapConfig::default();
+        let err = run_bootstrap(&engine, None, None, &FakeEmbed, &config).unwrap_err();
+        assert!(err.to_string().contains("nothing to do"));
+    }
+}

--- a/memory-engine-cli/src/commands/mod.rs
+++ b/memory-engine-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod add_fact;
 pub mod batch_ingest;
+pub mod bootstrap;
 pub mod dump;
 pub mod explain;
 pub mod export;

--- a/memory-engine-cli/src/main.rs
+++ b/memory-engine-cli/src/main.rs
@@ -60,6 +60,8 @@ enum Commands {
     AddFact(commands::add_fact::AddFactArgs),
     /// Ingest facts from a JSONL file via an embedding API
     BatchIngest(commands::batch_ingest::BatchIngestArgs),
+    /// Import historical memory from session `.jsonl` and/or native `.md` dirs
+    Bootstrap(commands::bootstrap::BootstrapArgs),
     /// Record an outcome signal (positive/negative/neutral) for a fact
     RecordOutcome(commands::record_outcome::RecordOutcomeArgs),
     /// Show aggregated outcome counts for a fact
@@ -100,6 +102,9 @@ fn main() -> ExitCode {
         }
         Commands::BatchIngest(ref args) => {
             commands::batch_ingest::run(&cli.db, args, cli.format).map(|()| ExitCode::SUCCESS)
+        }
+        Commands::Bootstrap(ref args) => {
+            commands::bootstrap::run(&cli.db, args, cli.format).map(|()| ExitCode::SUCCESS)
         }
         Commands::RecordOutcome(ref args) => {
             commands::record_outcome::run(&cli.db, args, cli.format).map(|()| ExitCode::SUCCESS)

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1269,10 +1269,30 @@ fn handle_bootstrap_session(
         None,
     ))?;
 
+    // Redaction is always on for the live MCP path (#45/#51 — no bypass). The
+    // author-seeded denylist is a backfill-time concern (its env var is normally
+    // unset here → signatures-only). An UNSET var yields Ok(empty) and is fine to
+    // stay silent about; a SET-but-unreadable file is a misconfiguration we
+    // surface (warn) while still proceeding signatures-only rather than failing a
+    // live bootstrap. Mirrors the CLI, which logs the literal count loudly.
+    let denylist = match memory_engine::bootstrap::load_secret_denylist() {
+        Ok(d) => {
+            if !d.is_empty() {
+                tracing::info!(literals = d.len(), "redaction denylist loaded");
+            }
+            d
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "denylist file set but unreadable; bootstrap proceeding signatures-only");
+            Vec::new()
+        }
+    };
     let config = BootstrapConfig {
         scope: get_str(&args, "scope"),
         max_turns: get_usize(&args, "max_turns").unwrap_or(0),
         skip_existing: get_bool(&args, "skip_existing").unwrap_or(true),
+        redact: true,
+        denylist,
     };
 
     let reader = Cursor::new(jsonl_data.into_bytes());

--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -455,7 +455,11 @@ mod tests {
     }
 
     fn opt(s: &str) -> Option<String> {
-        if s.is_empty() { None } else { Some(s.into()) }
+        if s.is_empty() {
+            None
+        } else {
+            Some(s.into())
+        }
     }
 
     fn user_entry(uuid: &str, parent: &str, text: &str, secs: i64) -> SessionEntry {
@@ -701,11 +705,9 @@ mod tests {
         let episodes = keyword_prefilter(&[turn], "s1");
         assert_eq!(episodes.len(), 1);
         assert_eq!(episodes[0].category, EpisodeCategory::Bug);
-        assert!(
-            episodes[0]
-                .matched_keywords
-                .contains(&"root cause".to_owned())
-        );
+        assert!(episodes[0]
+            .matched_keywords
+            .contains(&"root cause".to_owned()));
     }
 
     #[test]
@@ -732,11 +734,9 @@ mod tests {
         let episodes = keyword_prefilter(&[turn], "s1");
         assert_eq!(episodes.len(), 1);
         assert_eq!(episodes[0].category, EpisodeCategory::Convention);
-        assert!(
-            episodes[0]
-                .matched_keywords
-                .contains(&"always use".to_owned())
-        );
+        assert!(episodes[0]
+            .matched_keywords
+            .contains(&"always use".to_owned()));
     }
 
     #[test]
@@ -745,11 +745,9 @@ mod tests {
         let episodes = keyword_prefilter(&[turn], "s1");
         assert_eq!(episodes.len(), 1);
         assert_eq!(episodes[0].category, EpisodeCategory::Learning);
-        assert!(
-            episodes[0]
-                .matched_keywords
-                .contains(&"turns out".to_owned())
-        );
+        assert!(episodes[0]
+            .matched_keywords
+            .contains(&"turns out".to_owned()));
     }
 
     #[test]

--- a/src/bootstrap/memory_dir.rs
+++ b/src/bootstrap/memory_dir.rs
@@ -1,0 +1,644 @@
+//! Native `.md` memory-file import (#551, Stream B Deliverable E).
+//!
+//! The Claude Code harness keeps durable memory as flat `.md` files: a
+//! `MEMORY.md` index plus one file per fact, each with shallow YAML frontmatter
+//! (`name`, `description`, `metadata.type`) and a Markdown body. This module
+//! parses those files into ME facts with **backdated** `t_created` (a frontmatter
+//! date when present, else a filename-encoded date, else the file mtime),
+//! redaction-gated and dedup-with-reinforced exactly like the JSONL session
+//! path. Sources are opened read-only and never modified.
+//!
+//! The frontmatter scanner here is deliberately minimal — it understands only
+//! the handful of fields the native-memory schema uses, not arbitrary YAML — so
+//! the engine takes on no YAML dependency. Anything it cannot parse degrades to
+//! "no frontmatter, the whole file is the body."
+//!
+//! Crash semantics: facts are written one at a time in autocommit (no
+//! per-directory savepoint), trading a single all-or-nothing transaction for
+//! per-file resilience — one bad file does not abort the batch. A run
+//! interrupted partway leaves the facts written so far; a re-run is idempotent
+//! (dedup-with-reinforcement collapses them), so partial imports self-heal
+//! rather than duplicate. The one accepted side effect is that the
+//! already-committed prefix gets its `access_count` reinforced once on the
+//! recovery re-run — a benign frequency-signal drift; row count and `t_created`
+//! (via `min`) are unaffected.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::store::facts::FactStore;
+use crate::traits::{EmbeddingProvider, PersistenceClassifier};
+use crate::types::{FactType, NewFact};
+
+use super::metrics::BootstrapReport;
+use super::redact;
+use super::BootstrapConfig;
+
+/// Baseline importance for curated native-memory facts. Higher than the
+/// keyword-extracted session candidates: these files are hand-authored durable
+/// memory, not auto-mined episodes.
+const MEMORY_IMPORTANCE: f64 = 0.6;
+
+/// Fields lifted from a native memory `.md` file.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ParsedMemory {
+    /// `name:` slug from frontmatter, if present.
+    pub name: Option<String>,
+    /// `description:` one-liner from frontmatter, if present.
+    pub description: Option<String>,
+    /// Memory `type` (`metadata.type`, or a top-level `type:`), lowercased.
+    pub mem_type: Option<String>,
+    /// A date parsed from a frontmatter `valid_from`/`date`/`created` field.
+    pub frontmatter_date: Option<DateTime<Utc>>,
+    /// Everything after the frontmatter block, trimmed. The whole input when
+    /// there is no frontmatter.
+    pub body: String,
+}
+
+/// Parse a native memory `.md` file into its frontmatter fields + body.
+///
+/// Recognizes a leading `---`-delimited block. Only the fields the
+/// native-memory schema uses are extracted; unknown keys are ignored. With no
+/// frontmatter (or an unterminated block) the whole input becomes `body` and
+/// every field is `None`.
+#[must_use]
+pub fn parse_memory_file(raw: &str) -> ParsedMemory {
+    // Some editors (notably on Windows) prepend a UTF-8 BOM, which would sit
+    // before the leading `---` and defeat frontmatter detection. Strip it first.
+    let raw = raw.strip_prefix('\u{FEFF}').unwrap_or(raw);
+    let (front, body) = split_frontmatter(raw);
+
+    let mut parsed = ParsedMemory {
+        body: body.trim().to_owned(),
+        ..ParsedMemory::default()
+    };
+
+    let Some(front) = front else {
+        return parsed;
+    };
+
+    for line in front.lines() {
+        let line = line.trim_end_matches('\r');
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = unquote(value.trim());
+        match key {
+            "name" if parsed.name.is_none() => parsed.name = nonempty(value),
+            "description" if parsed.description.is_none() => parsed.description = nonempty(value),
+            // `type:` appears top-level (wiki) or nested under `metadata:`
+            // (native). We accept either — first non-empty wins.
+            "type" if parsed.mem_type.is_none() => {
+                parsed.mem_type = nonempty(value).map(|s| s.to_ascii_lowercase());
+            }
+            "valid_from" | "date" | "created" if parsed.frontmatter_date.is_none() => {
+                parsed.frontmatter_date = parse_date(value);
+                if parsed.frontmatter_date.is_none() && !value.is_empty() && value != "null" {
+                    // A present-but-unparseable date is a likely authoring
+                    // mistake; warn so the silent fall-through to filename/mtime
+                    // is observable rather than mysterious.
+                    tracing::warn!(
+                        key,
+                        value,
+                        "unparseable frontmatter date; falling back to filename/mtime"
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    parsed
+}
+
+/// Split a leading `---` frontmatter block from the body.
+///
+/// Returns `(Some(frontmatter), body)` when the file opens with a `---` line and
+/// has a matching closing `---`; otherwise `(None, whole_input)`.
+fn split_frontmatter(raw: &str) -> (Option<&str>, &str) {
+    let after_open = if let Some(r) = raw.strip_prefix("---\n") {
+        r
+    } else if let Some(r) = raw.strip_prefix("---\r\n") {
+        r
+    } else {
+        return (None, raw);
+    };
+
+    let mut search_from = 0usize;
+    loop {
+        let line_end = after_open[search_from..]
+            .find('\n')
+            .map_or(after_open.len(), |i| search_from + i);
+        let line = after_open[search_from..line_end].trim_end_matches('\r');
+        if line == "---" {
+            let front = &after_open[..search_from];
+            let body_start = if line_end < after_open.len() {
+                line_end + 1
+            } else {
+                after_open.len()
+            };
+            return (Some(front), &after_open[body_start..]);
+        }
+        // Guard against a leading `---` that opened a horizontal rule / prose
+        // document rather than frontmatter: if we hit a line that is not
+        // frontmatter-shaped (blank, comment, indented/nested, list item, or a
+        // `key: value`) before any closing fence, abort and treat the whole
+        // input as body. Otherwise a stray `---` divider later in the prose
+        // would be mistaken for the closing fence and the body above it
+        // silently swallowed as frontmatter.
+        let yaml_shaped = line.is_empty()
+            || line.starts_with(' ')
+            || line.starts_with('\t')
+            || line.starts_with('#')
+            || line.starts_with('-')
+            || line.contains(':');
+        if !yaml_shaped {
+            return (None, raw);
+        }
+        if line_end >= after_open.len() {
+            // No closing delimiter — not a frontmatter block.
+            return (None, raw);
+        }
+        search_from = line_end + 1;
+    }
+}
+
+/// Strip a single pair of surrounding ASCII quotes, if present.
+fn unquote(s: &str) -> &str {
+    let b = s.as_bytes();
+    if b.len() >= 2
+        && ((b[0] == b'"' && b[b.len() - 1] == b'"') || (b[0] == b'\'' && b[b.len() - 1] == b'\''))
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+fn nonempty(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_owned())
+    }
+}
+
+/// Parse a frontmatter date: RFC-3339, then naive `YYYY-MM-DDThh:mm:ss` (as UTC),
+/// then bare `YYYY-MM-DD` (→ midnight UTC). `null`/empty yields `None`.
+///
+/// The naive-datetime fallback mirrors the JSONL path's `parse::parse_timestamp`
+/// so both importers accept the same timestamp grammar.
+fn parse_date(s: &str) -> Option<DateTime<Utc>> {
+    if s.is_empty() || s == "null" {
+        return None;
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return Some(DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
+    }
+    NaiveDate::parse_from_str(s, "%Y-%m-%d")
+        .ok()
+        .and_then(|d| d.and_hms_opt(0, 0, 0))
+        .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc))
+}
+
+/// Map a native memory `type` to an ME [`FactType`] and a route-to-KB hint.
+///
+/// Routing follows the ratified ownership map (Option A): preferences →
+/// Memory, durable directives → Wisdom, reference material → Knowledge. There is
+/// no KB sink reachable from here yet, so `reference` facts are stored in ME
+/// tagged `route: knowledge-base` for a later migration pass to relocate.
+fn classify_memory_type(mem_type: Option<&str>) -> (FactType, bool) {
+    match mem_type {
+        Some("feedback") => (FactType::Procedural, false),
+        Some("project") => (FactType::Episodic, false),
+        Some("reference") => (FactType::Semantic, true),
+        // `user`, unknown, or absent: a durable semantic fact, ME-resident.
+        _ => (FactType::Semantic, false),
+    }
+}
+
+/// Extract a `YYYY[-_]MM[-_]DD` date embedded in the file stem (e.g.
+/// `project_s0_review_2026_06_14.md`) as UTC midnight.
+///
+/// Native memory files encode their authored date in the filename but carry no
+/// frontmatter date, so this is preferred over mtime — mtime tracks in-place
+/// rewrites (≈ import time), not authorship. Scans `-`/`_`-separated tokens for
+/// the first valid `4-digit / 2-digit / 2-digit` run.
+fn filename_date(path: &Path) -> Option<DateTime<Utc>> {
+    let stem = path.file_stem()?.to_str()?;
+    let tokens: Vec<&str> = stem.split(['-', '_']).collect();
+    for w in tokens.windows(3) {
+        let [y, m, d] = [w[0], w[1], w[2]];
+        let shaped = y.len() == 4
+            && m.len() == 2
+            && d.len() == 2
+            && [y, m, d]
+                .iter()
+                .all(|t| t.bytes().all(|b| b.is_ascii_digit()));
+        if !shaped {
+            continue;
+        }
+        if let (Ok(yy), Ok(mm), Ok(dd)) = (y.parse::<i32>(), m.parse::<u32>(), d.parse::<u32>()) {
+            // from_ymd_opt rejects impossible dates (e.g. month 13), so a numeric
+            // run that is not a real calendar date is skipped, not mis-dated.
+            if let Some(date) = NaiveDate::from_ymd_opt(yy, mm, dd) {
+                return date
+                    .and_hms_opt(0, 0, 0)
+                    .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
+            }
+        }
+    }
+    None
+}
+
+/// File modification time as a UTC instant, if the metadata is readable.
+fn file_mtime(path: &Path) -> Option<DateTime<Utc>> {
+    std::fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()
+        .map(DateTime::<Utc>::from)
+}
+
+/// Recursively collect `*.md` files under `dir` into `out`.
+fn collect_md_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        // `file_type()` reads the dirent's own type (no extra `stat`) and does
+        // NOT follow symlinks, so a circular symlink cannot drive infinite
+        // recursion — a symlink is neither dir nor file here and is skipped.
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            collect_md_files(&path, out)?;
+        } else if file_type.is_file() && path.extension().and_then(|e| e.to_str()) == Some("md") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Build the provenance metadata object for a memory-dir fact.
+fn build_metadata(path: &Path, parsed: &ParsedMemory, route_kb: bool) -> serde_json::Value {
+    let mut metadata = serde_json::json!({
+        "source": "memory-dir",
+        "file": path.file_name().and_then(|f| f.to_str()).unwrap_or_default(),
+    });
+    if let Some(name) = &parsed.name {
+        metadata["name"] = serde_json::Value::String(name.clone());
+    }
+    if let Some(desc) = &parsed.description {
+        metadata["description"] = serde_json::Value::String(desc.clone());
+    }
+    if let Some(mt) = &parsed.mem_type {
+        metadata["memory_type"] = serde_json::Value::String(mt.clone());
+    }
+    if route_kb {
+        metadata["route"] = serde_json::Value::String("knowledge-base".to_owned());
+    }
+    metadata
+}
+
+/// Build and store one fact from a parsed `.md` memory file.
+///
+/// Returns the importance to fold into the prewarm average — `0.0` when the
+/// fact was *reinforced* rather than created (reinforcement updates no prewarm
+/// counters). Updates `report`'s `facts_created`/`facts_reinforced`/
+/// `secrets_redacted` and the prewarm tallies in place.
+#[allow(clippy::too_many_arguments)]
+fn import_one_memory(
+    fact_store: &FactStore,
+    embedder: &dyn EmbeddingProvider,
+    config: &BootstrapConfig,
+    classifier: Option<&dyn PersistenceClassifier>,
+    scope_id: i64,
+    path: &Path,
+    parsed: &ParsedMemory,
+    report: &mut BootstrapReport,
+) -> Result<f64> {
+    // Backdate priority: frontmatter date > filename-encoded date > file mtime
+    // > now(). Native memory files carry no frontmatter date but encode the
+    // authored date in the filename; mtime tracks in-place rewrites (≈ import
+    // time), so it is the last historical signal before falling back to now()
+    // (reached only when none of the above is available — effectively never).
+    let timestamp = parsed
+        .frontmatter_date
+        .or_else(|| filename_date(path))
+        .or_else(|| file_mtime(path))
+        .unwrap_or_else(Utc::now);
+
+    // Redaction gate (#45/#51): scrub BEFORE embed/store. ME copy only — the
+    // source .md is never modified. The finding count is held in `redactions`
+    // and only added to the report on the *created* branch below, so the audit
+    // counter is idempotent (a reinforced re-run re-scrubs but does not re-count).
+    let mut redactions = 0usize;
+    let content = if config.redact {
+        let (clean, findings) = redact::redact_text_with_denylist(&parsed.body, &config.denylist);
+        redactions += findings.len();
+        clean
+    } else {
+        parsed.body.clone()
+    };
+
+    let (fact_type, route_kb) = classify_memory_type(parsed.mem_type.as_deref());
+    let embedding = embedder.embed(&content)?;
+
+    // Redact the metadata too: the frontmatter `name`/`description` are author
+    // free-text and can carry a secret (e.g. a memory quoting a leaked token).
+    // Scrub the whole metadata object so the stored row holds no unredacted
+    // secret anywhere, not just in the body content.
+    let mut metadata = build_metadata(path, parsed, route_kb);
+    if config.redact {
+        redactions += redact::redact_json_strings(&mut metadata, &config.denylist);
+    }
+
+    let is_pinned = classifier.is_some_and(|c| {
+        let temp = crate::types::Fact {
+            id: 0,
+            content: content.clone(),
+            content_hash: String::new(),
+            embedding: embedding.clone(),
+            fact_type,
+            t_created: timestamp,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: MEMORY_IMPORTANCE,
+            access_count: 0,
+            last_accessed: timestamp,
+            metadata: metadata.clone(),
+            scope_id,
+            is_pinned: false,
+            importance_score: MEMORY_IMPORTANCE,
+            surfaced_at: None,
+        };
+        c.should_pin(&temp)
+    });
+
+    // Bi-temporal note (#521): t_created backdated to the file's date/mtime;
+    // t_valid deliberately None (a retro-observed memory carries no asserted
+    // valid-time interval — transaction-time is the temporal signal).
+    let new_fact = NewFact {
+        content,
+        content_hash: String::new(),
+        embedding,
+        fact_type,
+        t_created: timestamp,
+        t_expired: None,
+        t_valid: None,
+        t_invalid: None,
+        source_event_id: None,
+        importance: MEMORY_IMPORTANCE,
+        access_count: 0,
+        last_accessed: timestamp,
+        metadata,
+        scope_id,
+        is_pinned,
+    };
+
+    let (_, reinforced) = fact_store.insert_or_reinforce(&new_fact)?;
+    if reinforced {
+        report.facts_reinforced += 1;
+        return Ok(0.0);
+    }
+    report.facts_created += 1;
+    report.secrets_redacted += redactions;
+    match fact_type {
+        FactType::Episodic => report.prewarm_metrics.episodic_count += 1,
+        FactType::Semantic => report.prewarm_metrics.semantic_count += 1,
+        FactType::Procedural => report.prewarm_metrics.procedural_count += 1,
+    }
+    Ok(MEMORY_IMPORTANCE)
+}
+
+/// Import every `*.md` memory file under `dir` (recursive) into the store.
+///
+/// Each file becomes one fact: body as content, `t_created` backdated from the
+/// frontmatter date, else a filename-encoded date, else the file mtime,
+/// type-routed per [`classify_memory_type`],
+/// redaction-gated, and dedup-with-reinforced. Files with an empty body (e.g. a
+/// frontmatter-only stub) are skipped. Unreadable files are logged and skipped,
+/// not fatal.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Io` if `dir` cannot be traversed, or an embedding/DB
+/// error from processing a file (which aborts the run; a re-run resumes
+/// idempotently).
+pub fn bootstrap_memory_directory_inner(
+    conn: &Connection,
+    embed_dim: usize,
+    dir: &Path,
+    embedder: &dyn EmbeddingProvider,
+    config: &BootstrapConfig,
+    classifier: Option<&dyn PersistenceClassifier>,
+    scope_id: i64,
+) -> Result<BootstrapReport> {
+    let mut report = BootstrapReport::default();
+    let fact_store = FactStore::new(conn, embed_dim);
+
+    let mut files = Vec::new();
+    collect_md_files(dir, &mut files)?;
+    files.sort();
+
+    let mut importance_sum = 0.0;
+
+    for path in &files {
+        let raw = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping unreadable memory file");
+                report.memory_files_skipped += 1;
+                continue;
+            }
+        };
+
+        let parsed = parse_memory_file(&raw);
+        if parsed.body.is_empty() {
+            report.memory_files_skipped += 1;
+            continue;
+        }
+        report.memory_files_parsed += 1;
+
+        importance_sum += import_one_memory(
+            &fact_store,
+            embedder,
+            config,
+            classifier,
+            scope_id,
+            path,
+            &parsed,
+            &mut report,
+        )?;
+    }
+
+    let total = report.prewarm_metrics.total_count();
+    if total > 0 {
+        // Tiny tally (<< 2^52): the usize -> f64 cast cannot lose precision.
+        #[allow(clippy::cast_precision_loss)]
+        {
+            report.prewarm_metrics.avg_importance = importance_sum / total as f64;
+        }
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_native_memory_frontmatter() {
+        let raw = "---\n\
+            name: stream-b-handoff\n\
+            description: \"resume pointer for Stream B\"\n\
+            metadata:\n  \
+              node_type: memory\n  \
+              type: project\n\
+            ---\n\
+            The body of the memory.\nSecond line.\n";
+        let p = parse_memory_file(raw);
+        assert_eq!(p.name.as_deref(), Some("stream-b-handoff"));
+        assert_eq!(
+            p.description.as_deref(),
+            Some("resume pointer for Stream B")
+        );
+        assert_eq!(p.mem_type.as_deref(), Some("project"));
+        assert_eq!(p.body, "The body of the memory.\nSecond line.");
+    }
+
+    #[test]
+    fn parses_top_level_type_and_date() {
+        let raw = "---\n\
+            type: Reference\n\
+            valid_from: 2026-03-01\n\
+            ---\nbody\n";
+        let p = parse_memory_file(raw);
+        assert_eq!(p.mem_type.as_deref(), Some("reference")); // lowercased
+        let d = p.frontmatter_date.expect("date parsed");
+        assert_eq!(d.to_rfc3339(), "2026-03-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn rfc3339_frontmatter_date() {
+        let raw = "---\ncreated: 2026-06-16T09:30:00+00:00\n---\nx\n";
+        let p = parse_memory_file(raw);
+        assert_eq!(
+            p.frontmatter_date.unwrap().to_rfc3339(),
+            "2026-06-16T09:30:00+00:00"
+        );
+    }
+
+    #[test]
+    fn naive_datetime_parses_as_utc() {
+        // Grammar parity with the JSONL path's parse_timestamp.
+        let d = parse_date("2024-05-01T10:30:00").expect("naive datetime parses");
+        assert_eq!(d.to_rfc3339(), "2024-05-01T10:30:00+00:00");
+    }
+
+    #[test]
+    fn filename_date_extracts_embedded_date() {
+        use std::path::Path;
+        assert_eq!(
+            filename_date(Path::new("/m/project_s0_review_2026_06_14.md"))
+                .unwrap()
+                .to_rfc3339(),
+            "2026-06-14T00:00:00+00:00"
+        );
+        // Hyphen separators also work.
+        assert_eq!(
+            filename_date(Path::new("note-2024-05-01-final.md"))
+                .unwrap()
+                .to_rfc3339(),
+            "2024-05-01T00:00:00+00:00"
+        );
+        // No embedded date → None; an impossible date is rejected, not mis-dated.
+        assert!(filename_date(Path::new("MEMORY.md")).is_none());
+        assert!(filename_date(Path::new("x_2024_13_40.md")).is_none());
+    }
+
+    #[test]
+    fn bom_prefixed_frontmatter_parses() {
+        // A UTF-8 BOM before the leading `---` must not defeat detection.
+        let raw = "\u{FEFF}---\nname: x\nmetadata:\n  type: user\n---\nbody text\n";
+        let p = parse_memory_file(raw);
+        assert_eq!(p.name.as_deref(), Some("x"));
+        assert_eq!(p.mem_type.as_deref(), Some("user"));
+        assert_eq!(p.body, "body text");
+    }
+
+    #[test]
+    fn no_frontmatter_whole_file_is_body() {
+        let raw = "# MEMORY index\n- [a](a.md) — hook\n";
+        let p = parse_memory_file(raw);
+        assert!(p.name.is_none());
+        assert!(p.mem_type.is_none());
+        assert!(p.frontmatter_date.is_none());
+        assert_eq!(p.body, "# MEMORY index\n- [a](a.md) — hook");
+    }
+
+    #[test]
+    fn unterminated_frontmatter_is_not_parsed() {
+        // Opens with `---` but never closes — treat the whole thing as body.
+        let raw = "---\nname: x\nbody with no closing fence\n";
+        let p = parse_memory_file(raw);
+        assert!(p.name.is_none());
+        assert!(p.body.starts_with("---"));
+    }
+
+    #[test]
+    fn leading_rule_with_later_divider_keeps_body() {
+        // A prose doc that merely OPENS with a `---` rule and has another `---`
+        // divider further down must NOT be parsed as frontmatter — otherwise the
+        // prose above the second `---` is silently swallowed. The non-YAML first
+        // body line aborts frontmatter detection (regression: metadata leak/data
+        // loss found in review).
+        let raw = "---\nThis is prose, not frontmatter.\n\n---\n\nMore prose.\n";
+        let p = parse_memory_file(raw);
+        assert!(p.name.is_none());
+        assert!(p.mem_type.is_none());
+        assert!(
+            p.body.contains("This is prose, not frontmatter."),
+            "body above the divider must be preserved, got: {:?}",
+            p.body
+        );
+        assert!(p.body.contains("More prose."));
+    }
+
+    #[test]
+    fn null_date_yields_none() {
+        let raw = "---\nvalid_to: null\ndate: null\n---\nbody\n";
+        let p = parse_memory_file(raw);
+        assert!(p.frontmatter_date.is_none());
+    }
+
+    #[test]
+    fn classify_routes_reference_to_kb() {
+        assert_eq!(
+            classify_memory_type(Some("user")),
+            (FactType::Semantic, false)
+        );
+        assert_eq!(
+            classify_memory_type(Some("feedback")),
+            (FactType::Procedural, false)
+        );
+        assert_eq!(
+            classify_memory_type(Some("project")),
+            (FactType::Episodic, false)
+        );
+        assert_eq!(
+            classify_memory_type(Some("reference")),
+            (FactType::Semantic, true)
+        );
+        assert_eq!(classify_memory_type(None), (FactType::Semantic, false));
+    }
+}

--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -12,6 +12,17 @@ pub struct BootstrapConfig {
     pub max_turns: usize,
     /// Skip sessions already bootstrapped (idempotency via `session_id` check).
     pub skip_existing: bool,
+    /// Redact secrets/PII from every candidate's content **before** it is
+    /// embedded or stored (#45/#51 gate). Default `true`; the CLI offers no
+    /// flag to disable it in normal operation. The switch exists for library
+    /// callers and for tests that assert on raw content. Redaction touches the
+    /// ME copy only — the source `.jsonl`/`.md` backbone is never modified.
+    pub redact: bool,
+    /// Author-seeded known-secret literals (loaded from the gitignored denylist
+    /// file, see [`crate::bootstrap::load_secret_denylist`]). Augments the
+    /// signature detectors; empty = signatures-only. Ignored when `redact` is
+    /// `false`.
+    pub denylist: Vec<String>,
 }
 
 impl Default for BootstrapConfig {
@@ -20,6 +31,8 @@ impl Default for BootstrapConfig {
             scope: None,
             max_turns: 0,
             skip_existing: true,
+            redact: true,
+            denylist: Vec::new(),
         }
     }
 }
@@ -36,6 +49,17 @@ pub struct BootstrapReport {
     pub facts_created: usize,
     /// Existing facts reinforced (dedup-with-reinforcement) instead of duplicated.
     pub facts_reinforced: usize,
+    /// Secret/PII findings scrubbed before any content reaches an extractor, the
+    /// embedder, or storage (#51). Counts individual findings, not facts. The
+    /// jsonl path scrubs whole turns upfront; the md path scrubs body + metadata.
+    /// A redundant re-run reports `0`: the jsonl path skips already-bootstrapped
+    /// sessions before redacting, and the md path counts only on fact creation.
+    pub secrets_redacted: usize,
+    /// Native `.md` memory files parsed (the `--memory-dir` path only).
+    pub memory_files_parsed: usize,
+    /// Native `.md` memory files skipped — unreadable or no parseable body
+    /// (the `--memory-dir` path only).
+    pub memory_files_skipped: usize,
     pub events_ingested: usize,
     pub outcome_counts: OutcomeCounts,
     pub category_counts: CategoryCounts,
@@ -53,6 +77,9 @@ impl BootstrapReport {
         self.candidates_found += other.candidates_found;
         self.facts_created += other.facts_created;
         self.facts_reinforced += other.facts_reinforced;
+        self.secrets_redacted += other.secrets_redacted;
+        self.memory_files_parsed += other.memory_files_parsed;
+        self.memory_files_skipped += other.memory_files_skipped;
         self.events_ingested += other.events_ingested;
         self.outcome_counts.success += other.outcome_counts.success;
         self.outcome_counts.failure += other.outcome_counts.failure;
@@ -178,6 +205,9 @@ mod tests {
             candidates_found: 12,
             facts_created: 8,
             facts_reinforced: 2,
+            secrets_redacted: 3,
+            memory_files_parsed: 0,
+            memory_files_skipped: 0,
             events_ingested: 15,
             outcome_counts: OutcomeCounts {
                 success: 5,

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod extract;
 pub(crate) mod filter;
+pub(crate) mod memory_dir;
 pub(crate) mod metrics;
 pub(crate) mod outcome;
 pub(crate) mod parse;
@@ -13,7 +14,7 @@ pub(crate) mod redact;
 use std::io::BufRead;
 use std::path::Path;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
 use crate::error::Result;
@@ -25,11 +26,13 @@ use crate::types::{EventType, FactType, NewEvent, NewFact};
 
 pub use extract::{ExtractedFact, KeywordExtractor, SessionExtractor};
 pub use filter::{CandidateEpisode, ConversationTurn, EpisodeCategory, ToolCallRecord};
+pub use memory_dir::{parse_memory_file, ParsedMemory};
 pub use metrics::{BootstrapConfig, BootstrapReport, PrewarmMetrics};
 pub use outcome::{OutcomeSignals, SessionOutcome};
 pub use redact::{
-    DENYLIST_ENV_VAR, Finding, RedactionReport, load_secret_denylist, redact_entries,
-    redact_entries_with_denylist, redact_text, redact_text_with_denylist, shannon_entropy,
+    load_secret_denylist, redact_entries, redact_entries_with_denylist, redact_json_strings,
+    redact_text, redact_text_with_denylist, shannon_entropy, Finding, RedactionReport,
+    DENYLIST_ENV_VAR,
 };
 
 /// Bootstrap one session from a JSONL reader into the memory engine.
@@ -148,6 +151,165 @@ fn ingest_bootstrap_marker(
     EventStore::new(conn, upcaster_registry).insert(&marker_event)
 }
 
+/// Redact secrets/PII from every turn in place (user + assistant text and each
+/// tool call's input/stdout/stderr), returning the total finding count.
+///
+/// Run BEFORE extraction so the extractor — which may be a caller-supplied
+/// LLM-powered [`SessionExtractor`] reaching an external service — never sees an
+/// unredacted secret. A `[REDACTED:*]` placeholder is never re-matched, so this
+/// is idempotent.
+fn redact_turns(turns: &mut [ConversationTurn], denylist: &[String]) -> usize {
+    let redact_field = |s: &mut String, n: &mut usize| {
+        let (clean, findings) = redact::redact_text_with_denylist(s, denylist);
+        if !findings.is_empty() {
+            *s = clean;
+            *n += findings.len();
+        }
+    };
+    let mut total = 0;
+    for turn in turns {
+        redact_field(&mut turn.user_text, &mut total);
+        redact_field(&mut turn.assistant_text, &mut total);
+        for tc in &mut turn.tool_calls {
+            total += redact::redact_json_strings(&mut tc.input, denylist);
+            if let Some(s) = tc.stdout.as_mut() {
+                redact_field(s, &mut total);
+            }
+            if let Some(s) = tc.stderr.as_mut() {
+                redact_field(s, &mut total);
+            }
+        }
+    }
+    total
+}
+
+/// Redact, embed, and store one extracted fact (dedup-with-reinforcement).
+///
+/// Returns the importance to fold into the prewarm average — `0.0` when the
+/// fact was *reinforced* rather than created. Updates `report`'s
+/// `facts_created`/`facts_reinforced`/`secrets_redacted` and the prewarm tallies
+/// in place. The session-path analogue of `memory_dir::import_one_memory`.
+#[allow(clippy::too_many_arguments)]
+fn store_extracted_fact(
+    fact_store: &FactStore,
+    embedder: &dyn EmbeddingProvider,
+    config: &BootstrapConfig,
+    classifier: Option<&dyn PersistenceClassifier>,
+    fact: &ExtractedFact,
+    effective_created: DateTime<Utc>,
+    marker_event_id: i64,
+    scope_id: i64,
+    report: &mut BootstrapReport,
+) -> Result<f64> {
+    // Defense-in-depth redaction (#45/#51): the turns were already scrubbed
+    // upfront (see `redact_turns`), so `fact.content` derived from them is
+    // normally clean and this pass finds nothing — but it guards against an
+    // extractor that introduces text not present verbatim in the turns. Findings
+    // here are held in `redactions` and only added to the report on the *created*
+    // branch, so the audit counter stays idempotent (a reinforced re-run
+    // re-scrubs but does not re-count). Disabled only when `config.redact` is
+    // false (library/test callers); the CLI has no bypass.
+    let mut redactions = 0usize;
+    let content = if config.redact {
+        let (clean, findings) = redact::redact_text_with_denylist(&fact.content, &config.denylist);
+        redactions += findings.len();
+        clean
+    } else {
+        fact.content.clone()
+    };
+
+    // Redact the extractor-supplied metadata too: a pluggable SessionExtractor
+    // may place turn-derived text in metadata, and the stored row must carry no
+    // unredacted secret anywhere (not just in content). Keys are left intact.
+    let mut metadata = fact.metadata.clone();
+    if config.redact {
+        redactions += redact::redact_json_strings(&mut metadata, &config.denylist);
+    }
+
+    // Session files are third-party input: a fact whose (redacted) content or
+    // metadata exceeds the ingest bound is skipped best-effort — mirroring the
+    // malformed-line policy — rather than aborting the whole import. Checked on
+    // the redacted, about-to-be-stored values, before the costly embed
+    // (issue #572 / L10). A skipped fact is neither created nor reinforced.
+    if let Err(e) = crate::limits::check_str_size(&content, "fact content")
+        .and_then(|()| crate::limits::check_json_size(&metadata, "fact metadata"))
+    {
+        tracing::warn!(error = %e, "skipping oversized bootstrap fact");
+        return Ok(0.0);
+    }
+
+    let embedding = embedder.embed(&content)?;
+
+    let is_pinned = classifier.is_some_and(|c| {
+        let temp = crate::types::Fact {
+            id: 0,
+            content: content.clone(),
+            content_hash: String::new(),
+            embedding: embedding.clone(),
+            fact_type: fact.fact_type,
+            t_created: effective_created,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: Some(marker_event_id),
+            importance: fact.importance,
+            access_count: 0,
+            last_accessed: effective_created,
+            metadata: metadata.clone(),
+            scope_id,
+            is_pinned: false,
+            importance_score: fact.importance,
+            surfaced_at: None,
+        };
+        c.should_pin(&temp)
+    });
+
+    // Bi-temporal note (#521): t_created is backdated to the historical turn
+    // timestamp, but t_valid is deliberately left None. Valid-time is the
+    // externally-asserted "true in the world" interval, which a retro-observed
+    // session fact does not carry — transaction-time (t_created) is the temporal
+    // signal here. Consequences: these facts are visible to active-at queries
+    // (None = unbounded-valid) but are NOT scheduled by list_due (which requires
+    // t_valid IS NOT NULL); memarch #42 sweeps on t_created for the same reason.
+    let new_fact = NewFact {
+        content,
+        content_hash: String::new(),
+        embedding,
+        fact_type: fact.fact_type,
+        t_created: effective_created,
+        t_expired: None,
+        t_valid: None,
+        t_invalid: None,
+        source_event_id: Some(marker_event_id),
+        scope_id,
+        importance: fact.importance,
+        access_count: 0,
+        last_accessed: effective_created,
+        metadata,
+        is_pinned,
+    };
+
+    // Dedup-with-reinforcement (#520): a fact whose content already exists
+    // (active, same scope) is reinforced — recency/frequency bumped — rather than
+    // duplicated. A 9-month backfill re-encounters recurring conventions and
+    // decisions across sessions; this collapses them to one reinforced row.
+    let (_, reinforced) = fact_store.insert_or_reinforce(&new_fact)?;
+    if reinforced {
+        // A reinforcement adds no new row, so it does not count toward prewarm
+        // metrics or the created-fact importance average.
+        report.facts_reinforced += 1;
+        return Ok(0.0);
+    }
+    report.facts_created += 1;
+    report.secrets_redacted += redactions;
+    match fact.fact_type {
+        FactType::Episodic => report.prewarm_metrics.episodic_count += 1,
+        FactType::Semantic => report.prewarm_metrics.semantic_count += 1,
+        FactType::Procedural => report.prewarm_metrics.procedural_count += 1,
+    }
+    Ok(fact.importance)
+}
+
 /// Inner pipeline logic running within a savepoint.
 #[allow(clippy::too_many_arguments)]
 fn bootstrap_within_savepoint(
@@ -168,8 +330,20 @@ fn bootstrap_within_savepoint(
     report.events_ingested = 1;
 
     // --- Reconstruct turns ---
-    let turns = filter::reconstruct_turns(entries);
+    let mut turns = filter::reconstruct_turns(entries);
     report.turns_reconstructed = turns.len();
+
+    // --- Redaction gate (#45/#51), applied UPFRONT ---
+    // Scrub secrets/PII from every turn BEFORE extraction so a pluggable
+    // (possibly LLM-powered) SessionExtractor never receives unredacted content —
+    // the gate covers extraction, embedding, AND storage, not just the stored
+    // row. Secrets are never outcome markers or keywords, so this does not
+    // perturb classification or the keyword pre-filter. Counted here (per
+    // session); a redundant re-run is skipped on the bootstrap marker before
+    // reaching this point, so the count stays idempotent.
+    if config.redact {
+        report.secrets_redacted += redact_turns(&mut turns, &config.denylist);
+    }
 
     // --- Classify outcome on FULL turns (before truncation) ---
     // Outcome evidence (commits, test results) lives at the end of sessions,
@@ -215,92 +389,18 @@ fn bootstrap_within_savepoint(
 
     for candidate in &candidates {
         let facts = extractor.extract(candidate, &outcome)?;
-
         for fact in &facts {
-            // Session files are third-party input: an extracted fact whose
-            // content/metadata exceeds the ingest bound is skipped (best-effort,
-            // mirroring the malformed-line policy) rather than aborting the whole
-            // import. Checked before the costly embed (issue #572 / L10).
-            if let Err(e) = crate::limits::check_str_size(&fact.content, "fact content")
-                .and_then(|()| crate::limits::check_json_size(&fact.metadata, "fact metadata"))
-            {
-                tracing::warn!(error = %e, "skipping oversized bootstrap fact");
-                continue;
-            }
-
-            let embedding = embedder.embed(&fact.content)?;
-            let effective_created = candidate.timestamp;
-
-            // Determine pinning
-            let is_pinned = classifier.is_some_and(|c| {
-                let temp = crate::types::Fact {
-                    id: 0,
-                    content: fact.content.clone(),
-                    content_hash: String::new(),
-                    embedding: embedding.clone(),
-                    fact_type: fact.fact_type,
-                    t_created: effective_created,
-                    t_expired: None,
-                    t_valid: None,
-                    t_invalid: None,
-                    source_event_id: Some(marker_event_id),
-                    importance: fact.importance,
-                    access_count: 0,
-                    last_accessed: effective_created,
-                    metadata: fact.metadata.clone(),
-                    scope_id,
-                    is_pinned: false,
-                    importance_score: fact.importance,
-                    surfaced_at: None,
-                };
-                c.should_pin(&temp)
-            });
-
-            // Bi-temporal note (#521): t_created is backdated to the historical turn
-            // timestamp, but t_valid is deliberately left None. Valid-time is the
-            // externally-asserted "true in the world" interval, which a retro-observed
-            // session fact does not carry — transaction-time (t_created) is the temporal
-            // signal here. Consequences: these facts are visible to active-at queries
-            // (None = unbounded-valid) but are NOT scheduled by list_due (which requires
-            // t_valid IS NOT NULL); memarch #42 sweeps on t_created for the same reason.
-            let new_fact = NewFact {
-                content: fact.content.clone(),
-                content_hash: String::new(),
-                embedding,
-                fact_type: fact.fact_type,
-                t_created: effective_created,
-                t_expired: None,
-                t_valid: None,
-                t_invalid: None,
-                source_event_id: Some(marker_event_id),
+            importance_sum += store_extracted_fact(
+                &fact_store,
+                embedder,
+                config,
+                classifier,
+                fact,
+                candidate.timestamp,
+                marker_event_id,
                 scope_id,
-                importance: fact.importance,
-                access_count: 0,
-                last_accessed: effective_created,
-                metadata: fact.metadata.clone(),
-                is_pinned,
-            };
-
-            // Dedup-with-reinforcement (#520): a fact whose content already exists
-            // (active, same scope) is reinforced — recency/frequency bumped — rather
-            // than duplicated. A 9-month backfill re-encounters recurring conventions
-            // and decisions across sessions; this collapses them to one reinforced row.
-            let (_, reinforced) = fact_store.insert_or_reinforce(&new_fact)?;
-            if reinforced {
-                // A reinforcement adds no new row, so it does not count toward
-                // prewarm metrics or the created-fact importance average.
-                report.facts_reinforced += 1;
-                continue;
-            }
-            report.facts_created += 1;
-
-            // Update prewarm metrics (newly-created rows only)
-            match fact.fact_type {
-                FactType::Episodic => report.prewarm_metrics.episodic_count += 1,
-                FactType::Semantic => report.prewarm_metrics.semantic_count += 1,
-                FactType::Procedural => report.prewarm_metrics.procedural_count += 1,
-            }
-            importance_sum += fact.importance;
+                report,
+            )?;
         }
     }
 
@@ -317,9 +417,37 @@ fn bootstrap_within_savepoint(
     Ok(())
 }
 
-/// Bootstrap all JSONL session logs in a directory.
+/// Recursively collect `*.jsonl` session files under `dir`, skipping any
+/// `subagents/` subdirectory (those hold lower-value subagent tool-call logs).
 ///
-/// Discovers top-level `*.jsonl` files (not in `subagents/` subdirectories).
+/// Real Claude/Codex/Gemini transcripts live one level down
+/// (`<project-slug>/<uuid>.jsonl`), so a flat top-level scan would silently find
+/// nothing when pointed at `~/.claude/projects`. This mirrors the `--memory-dir`
+/// path's recursion (`memory_dir::collect_md_files`).
+fn collect_jsonl_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        // `file_type()` reads the dirent's own type (no extra `stat`) and does
+        // NOT follow symlinks, so a circular symlink cannot drive infinite
+        // recursion — a symlink is neither dir nor file here and is skipped.
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            if path.file_name().and_then(|n| n.to_str()) == Some("subagents") {
+                continue;
+            }
+            collect_jsonl_files(&path, out)?;
+        } else if file_type.is_file() && path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+        {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Bootstrap all JSONL session logs under a directory (recursive).
+///
+/// Discovers `*.jsonl` files at any depth, skipping `subagents/` subdirectories.
 /// Processes each session independently, aggregating reports.
 ///
 /// # Errors
@@ -340,17 +468,12 @@ pub(crate) fn bootstrap_directory_inner(
 ) -> Result<BootstrapReport> {
     let mut aggregate = BootstrapReport::default();
 
-    let entries = std::fs::read_dir(dir)?;
-    for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
+    let mut files = Vec::new();
+    collect_jsonl_files(dir, &mut files)?;
+    files.sort();
 
-        // Only top-level .jsonl files (skip directories like subagents/)
-        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-
-        let file = match std::fs::File::open(&path) {
+    for path in &files {
+        let file = match std::fs::File::open(path) {
             Ok(f) => f,
             Err(e) => {
                 tracing::warn!(path = %path.display(), error = %e, "skipping unreadable session file");

--- a/src/bootstrap/redact.rs
+++ b/src/bootstrap/redact.rs
@@ -679,6 +679,38 @@ pub fn redact_entries_with_denylist(
     (redacted, report)
 }
 
+/// Redact every string leaf of a JSON value in place, returning the total
+/// finding count.
+///
+/// Walks objects (values), arrays (elements), and a bare string root; object
+/// **keys are left intact** (they are structural identifiers, not content).
+/// Used to scrub fact `metadata` before it is persisted — frontmatter
+/// `name`/`description` on the `.md` path and any pluggable extractor's
+/// `metadata` on the `.jsonl` path — so the redaction gate covers the whole
+/// stored row, not just the fact content. Idempotent (a `[REDACTED:*]`
+/// placeholder is never re-matched).
+pub fn redact_json_strings(value: &mut serde_json::Value, denylist: &[String]) -> usize {
+    match value {
+        serde_json::Value::String(s) => {
+            let (clean, findings) = redact_text_with_denylist(s, denylist);
+            if !findings.is_empty() {
+                *s = clean;
+            }
+            findings.len()
+        }
+        serde_json::Value::Array(items) => items
+            .iter_mut()
+            .map(|v| redact_json_strings(v, denylist))
+            .sum(),
+        serde_json::Value::Object(map) => map
+            .values_mut()
+            .map(|v| redact_json_strings(v, denylist))
+            .sum(),
+        // Numbers, booleans, and null carry no redactable text.
+        _ => 0,
+    }
+}
+
 // ── Author-seeded denylist loading (#51) ──────────────────────────────────────
 
 /// Environment variable naming a file of author-known secret literals, one per line.
@@ -739,6 +771,38 @@ pub fn load_secret_denylist() -> std::io::Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── JSON metadata redaction ───────────────────────────────────────────────
+
+    #[test]
+    fn redact_json_strings_scrubs_nested_values_keeps_keys() {
+        let mut v = serde_json::json!({
+            "description": "leaked AKIAIOSFODNN7EXAMPLE here",
+            "nested": { "note": "token ghp_0123456789abcdefghij0123456789abcdef" },
+            "list": ["sk-abcdefghijklmnopqrstuvwxyz0123", "harmless"],
+            "count": 7,
+            "flag": true,
+        });
+        let n = redact_json_strings(&mut v, &[]);
+        assert_eq!(n, 3, "three secrets across the tree");
+        let s = v.to_string();
+        assert!(!s.contains("AKIAIOSFODNN7EXAMPLE"));
+        assert!(!s.contains("ghp_0123456789abcdefghij0123456789abcdef"));
+        assert!(!s.contains("sk-abcdefghijklmnopqrstuvwxyz0123"));
+        // Structural keys + non-secret leaves survive intact.
+        assert!(v.get("description").is_some());
+        assert_eq!(v["list"][1], "harmless");
+        assert_eq!(v["count"], 7);
+        assert_eq!(v["flag"], true);
+    }
+
+    #[test]
+    fn redact_json_strings_clean_input_is_noop() {
+        let mut v = serde_json::json!({ "a": "nothing secret", "b": [1, 2, 3] });
+        let before = v.clone();
+        assert_eq!(redact_json_strings(&mut v, &[]), 0);
+        assert_eq!(v, before);
+    }
 
     // ── Provider prefixes ─────────────────────────────────────────────────────
 
@@ -1190,8 +1254,8 @@ mod tests {
     #[test]
     fn bare_hex_with_unrelated_key_substring_not_redacted() {
         let sha = "a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0"; // 40-char SHA-1
-        // `monkey` contains "key", `key.rs` mentions a key — but neither is the WORD
-        // adjacent to the hex, so the bare SHA must survive (no data loss).
+                                                              // `monkey` contains "key", `key.rs` mentions a key — but neither is the WORD
+                                                              // adjacent to the hex, so the bare SHA must survive (no data loss).
         for line in [
             format!("monkey {sha} bars"),
             format!("modified key.rs: now points to {sha}"),

--- a/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_default_report.snap
+++ b/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_default_report.snap
@@ -10,6 +10,9 @@ turns_reconstructed: 0
 candidates_found: 0
 facts_created: 0
 facts_reinforced: 0
+secrets_redacted: 0
+memory_files_parsed: 0
+memory_files_skipped: 0
 events_ingested: 0
 outcome_counts:
   success: 0

--- a/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_populated_report.snap
+++ b/src/bootstrap/snapshots/memory_engine__bootstrap__metrics__tests__snapshot_populated_report.snap
@@ -10,6 +10,9 @@ turns_reconstructed: 18
 candidates_found: 12
 facts_created: 8
 facts_reinforced: 2
+secrets_redacted: 3
+memory_files_parsed: 0
+memory_files_skipped: 0
 events_ingested: 15
 outcome_counts:
   success: 5

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -104,4 +104,46 @@ impl MemoryEngine {
             scope_id,
         )
     }
+
+    /// Import native `.md` memory files (recursive) from a directory.
+    ///
+    /// Each file becomes one fact with a **backdated** `t_created` (frontmatter
+    /// date, else a filename-encoded date, else file mtime), type-routed from
+    /// its frontmatter `type:`,
+    /// redaction-gated, and dedup-with-reinforced. Unlike [`Self::bootstrap_directory`]
+    /// this path has no session/turn structure and no LLM extractor — the file
+    /// body is the fact. Sources are read-only.
+    ///
+    /// Dedup matches on body content (per #520), so a re-import after editing
+    /// ONLY a file's frontmatter (e.g. correcting `type:` or `description`) while
+    /// the body is unchanged reinforces the existing row and **keeps its original
+    /// `fact_type`/metadata** — frontmatter-only corrections are not re-synced.
+    /// This is an import/backfill tool, not an edit-sync tool; change the body or
+    /// expire the fact to re-derive metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
+    /// Returns `MemoryError::Io` for directory traversal failures, or an
+    /// embedding/DB error (which aborts; a re-run resumes idempotently).
+    #[allow(clippy::significant_drop_tightening)]
+    pub fn bootstrap_memory_directory(
+        &self,
+        dir: &std::path::Path,
+        embedder: &dyn EmbeddingProvider,
+        config: &crate::bootstrap::BootstrapConfig,
+        classifier: Option<&dyn PersistenceClassifier>,
+    ) -> Result<crate::bootstrap::BootstrapReport> {
+        let conn = self.write_conn()?;
+        let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
+        crate::bootstrap::memory_dir::bootstrap_memory_directory_inner(
+            &conn,
+            self.embed_dim,
+            dir,
+            embedder,
+            config,
+            classifier,
+            scope_id,
+        )
+    }
 }

--- a/tests/bootstrap_memory_dir.rs
+++ b/tests/bootstrap_memory_dir.rs
@@ -1,0 +1,278 @@
+//! #551 — native `.md` memory-directory import.
+//!
+//! Exercises `MemoryEngine::bootstrap_memory_directory` end-to-end against a
+//! temp tree of native memory files, asserting the four properties the
+//! acceptance criteria call out:
+//!   1. parse + type-routing — frontmatter `type:` maps to the right `FactType`;
+//!   2. backdating — `t_created` comes from the frontmatter date (or mtime),
+//!      never `Utc::now()`;
+//!   3. redaction-before-write — a planted secret never reaches the store;
+//!   4. idempotency — a re-run creates 0 facts and reinforces instead;
+//!   5. sources read-only — every `.md` byte is unchanged after a run.
+//!
+//! Hermetic: in-memory engine + zero-vector embedder. No network, no Ollama.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Datelike;
+use memory_engine::types::FactType;
+use memory_engine::{BootstrapConfig, EmbeddingProvider, MemoryEngine, MemoryError};
+
+/// Zero-vector embedder (dim 4) — retrieval is irrelevant here.
+struct TestEmbedder;
+impl EmbeddingProvider for TestEmbedder {
+    fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
+        Ok(vec![0.0; 4])
+    }
+}
+
+/// A planted AWS-access-key literal (matches the `aws-access-key` detector).
+const PLANTED_SECRET: &str = "AKIAIOSFODNN7EXAMPLE";
+
+/// Write `name` under `dir` with `contents`; create parent dirs as needed.
+fn write_file(dir: &Path, name: &str, contents: &str) -> PathBuf {
+    let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, contents).unwrap();
+    path
+}
+
+/// Recursively read every file's bytes under `dir` into `out`.
+fn walk_bytes(dir: &Path, out: &mut BTreeMap<PathBuf, Vec<u8>>) {
+    for entry in fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            walk_bytes(&path, out);
+        } else {
+            out.insert(path.clone(), fs::read(&path).unwrap());
+        }
+    }
+}
+
+/// Snapshot every file's raw bytes under `dir` (recursive) for a read-only proof.
+fn snapshot_bytes(dir: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    let mut out = BTreeMap::new();
+    walk_bytes(dir, &mut out);
+    out
+}
+
+fn build_corpus(root: &Path) {
+    write_file(
+        root,
+        "user_pref.md",
+        "---\nname: user-pref\ndescription: editor preference\nmetadata:\n  type: user\n---\nThe user prefers tabs over spaces.\n",
+    );
+    write_file(
+        root,
+        "feedback_tdd.md",
+        "---\nname: tdd\nmetadata:\n  type: feedback\n---\nAlways write a failing test first.\n",
+    );
+    // project type + explicit backdate + a planted secret in the body.
+    write_file(
+        root,
+        "project_handoff.md",
+        &format!(
+            "---\nname: handoff\nvalid_from: 2024-05-01\nmetadata:\n  type: project\n---\nStream B resumes at issue 551. Leaked token {PLANTED_SECRET} must be scrubbed.\n"
+        ),
+    );
+    write_file(
+        root,
+        "reference_spec.md",
+        "---\nname: spec\nmetadata:\n  type: reference\n---\nThe four-layer architecture spec lives in the wiki.\n",
+    );
+    // No frontmatter — whole body is the fact (the MEMORY index file).
+    write_file(root, "MEMORY.md", "# Memory Index\n- pointer to a fact\n");
+    // Recursion: a memory in a nested project subdir.
+    write_file(
+        root,
+        "sub/nested.md",
+        "---\nmetadata:\n  type: user\n---\nA nested memory fact.\n",
+    );
+    // Frontmatter-only stub → empty body → skipped.
+    write_file(root, "empty.md", "---\nname: stub\n---\n");
+}
+
+#[test]
+fn memory_dir_import_routes_backdates_redacts_and_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    build_corpus(root);
+
+    let before = snapshot_bytes(root);
+
+    let engine = MemoryEngine::builder(4).build().unwrap();
+    let config = BootstrapConfig::default(); // redact = true
+
+    // --- First pass ---
+    let report = engine
+        .bootstrap_memory_directory(root, &TestEmbedder, &config, None)
+        .unwrap();
+
+    assert_eq!(
+        report.memory_files_parsed, 6,
+        "6 files have a body (one stub skipped), got {}",
+        report.memory_files_parsed
+    );
+    assert_eq!(
+        report.memory_files_skipped, 1,
+        "the frontmatter-only stub is skipped"
+    );
+    assert_eq!(report.facts_created, 6, "one fact per parsed file");
+    assert_eq!(
+        report.facts_reinforced, 0,
+        "first pass creates, never reinforces"
+    );
+    assert!(
+        report.secrets_redacted >= 1,
+        "the planted AWS key must be counted as redacted, got {}",
+        report.secrets_redacted
+    );
+
+    // --- Redaction: the secret is nowhere in the store ---
+    let stored = engine.list_active_facts(None).unwrap();
+    assert_eq!(stored.len(), 6);
+    for f in &stored {
+        assert!(
+            !f.content.contains(PLANTED_SECRET),
+            "planted secret leaked into stored fact: {:?}",
+            f.content
+        );
+    }
+
+    // --- Type routing ---
+    let count_type = |t: FactType| stored.iter().filter(|f| f.fact_type == t).count();
+    assert_eq!(count_type(FactType::Procedural), 1, "feedback → Procedural");
+    assert_eq!(count_type(FactType::Episodic), 1, "project → Episodic");
+    // user(2) + reference(1) + MEMORY-no-type(1) = 4 Semantic.
+    assert_eq!(count_type(FactType::Semantic), 4);
+
+    // reference fact carries the KB routing tag.
+    let reference = stored
+        .iter()
+        .find(|f| f.metadata.get("memory_type").and_then(|v| v.as_str()) == Some("reference"))
+        .expect("reference fact present");
+    assert_eq!(
+        reference.metadata.get("route").and_then(|v| v.as_str()),
+        Some("knowledge-base"),
+        "reference-typed memory tagged for KB relocation"
+    );
+
+    // --- Backdating: the project fact uses its frontmatter date (2024) ---
+    let project = stored
+        .iter()
+        .find(|f| f.metadata.get("memory_type").and_then(|v| v.as_str()) == Some("project"))
+        .expect("project fact present");
+    assert_eq!(
+        project.t_created.year(),
+        2024,
+        "project t_created backdated to valid_from 2024, got {}",
+        project.t_created.year()
+    );
+    // No fact is stamped with a wall-clock (current-year) t_created via mtime:
+    // the temp files' mtime IS the current year, so MEMORY.md (no frontmatter,
+    // mtime-dated) legitimately carries the current year — assert only that the
+    // explicitly-dated project fact is historical.
+    assert!(project.t_created < chrono::Utc::now());
+
+    // --- Idempotency: re-run creates nothing, reinforces everything ---
+    let report2 = engine
+        .bootstrap_memory_directory(root, &TestEmbedder, &config, None)
+        .unwrap();
+    assert_eq!(report2.facts_created, 0, "re-run must create 0 facts");
+    assert_eq!(report2.facts_reinforced, 6, "re-run reinforces all 6");
+    assert_eq!(report2.memory_files_parsed, 6);
+    assert_eq!(
+        report2.secrets_redacted, 0,
+        "secrets_redacted is create-gated: a reinforced re-run re-scrubs but re-counts nothing"
+    );
+    assert_eq!(
+        engine.list_active_facts(None).unwrap().len(),
+        6,
+        "store still holds exactly 6 facts after re-run"
+    );
+
+    // --- Sources read-only: every byte unchanged ---
+    let after = snapshot_bytes(root);
+    assert_eq!(
+        before, after,
+        "source .md files must be byte-identical after import"
+    );
+}
+
+#[test]
+fn filename_encoded_date_backdates_when_no_frontmatter_date() {
+    // The real native corpus encodes the authored date in the filename and
+    // carries no frontmatter date. Without filename parsing this would fall to
+    // mtime (≈ current import time); assert it backdates to the filename's year.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_file(
+        root,
+        "project_decision_2024_05_01.md",
+        "---\nname: decision\nmetadata:\n  type: project\n---\nWe chose option A.\n",
+    );
+
+    let engine = MemoryEngine::builder(4).build().unwrap();
+    let config = BootstrapConfig::default();
+    engine
+        .bootstrap_memory_directory(root, &TestEmbedder, &config, None)
+        .unwrap();
+
+    let stored = engine.list_active_facts(None).unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(
+        stored[0].t_created.year(),
+        2024,
+        "t_created must come from the filename date (2024), not mtime, got {}",
+        stored[0].t_created.year()
+    );
+}
+
+#[test]
+fn frontmatter_secret_in_description_is_redacted() {
+    // Regression (review BLOCKER): a secret in a frontmatter `description:` must
+    // not reach the stored `metadata` column — redaction covers the whole row,
+    // not just the body content.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_file(
+        root,
+        "incident.md",
+        &format!(
+            "---\nname: incident-note\ndescription: \"leaked key {PLANTED_SECRET}\"\nmetadata:\n  type: project\n---\nThe incident is resolved.\n"
+        ),
+    );
+
+    let engine = MemoryEngine::builder(4).build().unwrap();
+    let config = BootstrapConfig::default();
+    let report = engine
+        .bootstrap_memory_directory(root, &TestEmbedder, &config, None)
+        .unwrap();
+
+    assert_eq!(report.facts_created, 1);
+    assert!(
+        report.secrets_redacted >= 1,
+        "the description secret must be counted as redacted, got {}",
+        report.secrets_redacted
+    );
+
+    let stored = engine.list_active_facts(None).unwrap();
+    assert_eq!(stored.len(), 1);
+    let meta = &stored[0].metadata;
+    assert!(
+        !meta.to_string().contains(PLANTED_SECRET),
+        "secret leaked into stored metadata: {meta}"
+    );
+    let desc = meta
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        desc.contains("[REDACTED:"),
+        "description value should be scrubbed, got {desc:?}"
+    );
+}

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -212,6 +212,108 @@ fn bootstrap_directory_multiple() {
 }
 
 #[test]
+fn bootstrap_directory_recurses_and_skips_subagents() {
+    // Real transcripts live one level down (`<project-slug>/<uuid>.jsonl`), and
+    // `subagents/` holds lower-value subagent logs we exclude. Regression: a flat
+    // top-level scan silently found nothing when pointed at `~/.claude/projects`.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("proj/subagents")).unwrap();
+    // Nested main transcript — must be discovered by recursion.
+    std::fs::write(dir.path().join("proj/main.jsonl"), success_fixture()).unwrap();
+    // Subagent transcript with a DISTINCT session id — must be skipped, so it
+    // does not add to sessions_processed even though it would yield a fact.
+    let subagent = "{\"type\":\"user\",\"sessionId\":\"subagent-xyz\",\"timestamp\":\"2024-03-01T10:00:00Z\",\"uuid\":\"sa-0\",\"parentUuid\":null,\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Fix the bug in parser.rs\"}]}}\n{\"type\":\"assistant\",\"sessionId\":\"subagent-xyz\",\"timestamp\":\"2024-03-01T10:00:30Z\",\"uuid\":\"sa-1\",\"parentUuid\":\"sa-0\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Found the root cause and applied the fix; tests pass.\"}]}}\n";
+    std::fs::write(dir.path().join("proj/subagents/sub.jsonl"), subagent).unwrap();
+
+    let engine = engine();
+    let extractor = KeywordExtractor;
+    let config = BootstrapConfig::default();
+
+    let report = engine
+        .bootstrap_directory(dir.path(), &TestEmbedder, &extractor, &config, None)
+        .unwrap();
+
+    assert_eq!(
+        report.sessions_processed, 1,
+        "nested main.jsonl imported (recursion); subagents/ excluded"
+    );
+    assert!(report.entries_parsed > 0);
+}
+
+#[test]
+fn redaction_runs_before_extraction() {
+    // #45/#51 (review P1): a pluggable SessionExtractor (the public API supports
+    // LLM-powered extractors reaching external services) must receive ALREADY
+    // REDACTED turns. Plant a secret in a turn, record what the extractor sees,
+    // and assert the secret never reaches it.
+    use std::sync::Mutex;
+
+    use memory_engine::bootstrap::{
+        CandidateEpisode, ExtractedFact, SessionExtractor, SessionOutcome,
+    };
+
+    const PLANTED: &str = "AKIAIOSFODNN7EXAMPLE";
+
+    #[derive(Default)]
+    struct RecordingExtractor {
+        seen: Mutex<Vec<String>>,
+    }
+    impl SessionExtractor for RecordingExtractor {
+        fn extract(
+            &self,
+            episode: &CandidateEpisode,
+            _outcome: &SessionOutcome,
+        ) -> memory_engine::Result<Vec<ExtractedFact>> {
+            for turn in &episode.turns {
+                self.seen.lock().unwrap().push(turn.user_text.clone());
+                self.seen.lock().unwrap().push(turn.assistant_text.clone());
+            }
+            Ok(vec![]) // we only care about the extractor's INPUT
+        }
+    }
+
+    let jsonl = format!(
+        "{}\n{}\n",
+        serde_json::json!({
+            "type": "user", "sessionId": "redact-extract", "timestamp": "2024-02-01T10:00:00Z",
+            "uuid": "r-0", "parentUuid": serde_json::Value::Null,
+            "message": {"role": "user", "content": [{"type": "text", "text": "Fix the bug in parser.rs"}]}
+        }),
+        serde_json::json!({
+            "type": "assistant", "sessionId": "redact-extract", "timestamp": "2024-02-01T10:00:30Z",
+            "uuid": "r-1", "parentUuid": "r-0",
+            "message": {"role": "assistant", "content": [{"type": "text",
+                "text": format!("Found the root cause and applied the fix; tests pass. Token {PLANTED} leaked.")}]}
+        }),
+    );
+
+    let engine = engine();
+    let recorder = RecordingExtractor::default();
+    let config = BootstrapConfig::default(); // redact = true
+
+    engine
+        .bootstrap_session(Cursor::new(jsonl), &TestEmbedder, &recorder, &config, None)
+        .unwrap();
+
+    let seen = recorder.seen.lock().unwrap().clone();
+    assert!(
+        !seen.is_empty(),
+        "extractor should have been offered a candidate"
+    );
+    for text in &seen {
+        assert!(
+            !text.contains(PLANTED),
+            "extractor received UNREDACTED turn text: {text:?}"
+        );
+    }
+    // And the redaction was actually applied (placeholder present somewhere).
+    assert!(
+        seen.iter().any(|t| t.contains("[REDACTED:")),
+        "expected a redaction placeholder in the extractor's input"
+    );
+}
+
+#[test]
 fn bootstrap_with_scope() {
     let engine = engine();
     let extractor = KeywordExtractor;


### PR DESCRIPTION
## What

Adds `memory-engine-cli bootstrap` (#551) — the single entry point the harness and the release-gate use to load historical memory from the **read-only history backbone** into ME, from two sources:

- `--jsonl-dir` — Claude/Codex/Gemini session `.jsonl` transcripts (recursive, skips `subagents/`); feeds the AAP #53 nine-month backfill.
- `--memory-dir` — the native `.md` memory files (`MEMORY.md` + per-fact files with frontmatter).

## Invariants upheld

- **Backdated `t_created`** — session timestamp / frontmatter date / **filename-encoded date** / mtime, never wall-clock. `t_valid` left `None` (retro-observed facts carry no asserted valid-time, #521).
- **Dedup-with-reinforcement** (#520) — re-run yields **0 new rows**, bumps reinforcement counts; idempotent.
- **Redaction-before-write** (#45/#51) — content **and metadata** are scrubbed before embedding or storage, on the ME copy only. Sources are never modified (checksum-proven). On by default, no CLI bypass; author-seeded denylist augments the signature detectors and is loaded loudly. The MCP live path redacts too.
- **Sources read-only** — `.jsonl`/`.md` are parsed only; never opened for write/append/delete.

## Design

- New engine method `bootstrap_memory_directory` + a minimal frontmatter scanner (**no YAML dependency**): one file → one fact, type-routed from `metadata.type` (`user`→Semantic, `feedback`→Procedural, `project`→Episodic, `reference`→Semantic + `route: knowledge-base` for a later KB-relocation pass).
- `BootstrapConfig` gains `redact`/`denylist`; `BootstrapReport` gains `secrets_redacted` (create-gated → idempotent) and memory-file counters.
- A recursive JSON-string redactor (`redact_json_strings`) scrubs the whole metadata object on both paths.

## Review

Adversarial multi-model review — **agy + gemini one-shot + a 20-agent ultracode workflow** (no codex; rate-limited). All three independently flagged one real leak (unredacted frontmatter `name`/`description` → DB metadata); fixed + regression-tested. The workflow's 6 further confirmed findings were all addressed: recursive `--jsonl-dir` (was silently 0-result on the real layout), filename-date backdating, create-gated audit counter, `split_frontmatter` divider-collision guard, MCP denylist diagnostics, and `parse_date`↔`parse_timestamp` grammar alignment. The one informational item (autocommit `access_count` drift on crash-recovery) is documented as an accepted tradeoff for per-file resilience.

## Tests

`cargo test --workspace` → **1024 passed**; `+nightly fmt --check` clean; `clippy --workspace --all-targets` no new warnings. 19 new tests cover redaction-before-write (incl. metadata), backdating (frontmatter/filename/naive-ISO), idempotency, recursion + `subagents/` exclusion, the divider-collision guard, and read-only checksums.

Closes #551.
