### PR TITLE
refactor(core): split MemoryError::Migration into typed MigrationError

### DIFF
--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -77,7 +77,7 @@ pub fn consolidate(
         .map(|s| DateTime::parse_from_rfc3339(&s))
         .transpose()
         .map_err(|e| {
-            crate::error::MemoryError::Migration(format!("invalid last_consolidated_at: {e}"))
+            crate::error::MigrationError::Incompatible(format!("invalid last_consolidated_at: {e}"))
         })?
         .map(|dt| dt.with_timezone(&Utc));
     let now = Utc::now();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use parking_lot::{MutexGuard, RwLock};
 use rusqlite::Connection;
 
-use crate::error::{MemoryError, RerankerError, Result};
+use crate::error::{MemoryError, MigrationError, RerankerError, Result};
 use crate::graph::MemoryGraph;
 use crate::pool::ConnectionPool;
 use crate::scope::ScopeTree;
@@ -388,12 +388,14 @@ impl MemoryEngine {
     fn validate_or_set_embed_dim(conn: &Connection, embed_dim: usize) -> Result<()> {
         if let Some(stored) = get_config(conn, "embed_dim")? {
             let stored_dim: usize = stored.parse().map_err(|_| {
-                MemoryError::Migration(format!("invalid stored embed_dim: {stored}"))
+                MigrationError::Incompatible(format!("invalid stored embed_dim: {stored}"))
             })?;
             if stored_dim != embed_dim {
-                return Err(MemoryError::Migration(format!(
-                    "embed_dim mismatch: stored {stored_dim} vs requested {embed_dim}"
-                )));
+                return Err(MigrationError::EmbedDimMismatch {
+                    stored: stored_dim,
+                    requested: embed_dim,
+                }
+                .into());
             }
         } else {
             set_config(conn, "embed_dim", &embed_dim.to_string())?;
@@ -405,18 +407,21 @@ impl MemoryEngine {
     fn validate_embed_dim(conn: &Connection, embed_dim: usize) -> Result<()> {
         if let Some(stored) = get_config(conn, "embed_dim")? {
             let stored_dim: usize = stored.parse().map_err(|_| {
-                MemoryError::Migration(format!("invalid stored embed_dim: {stored}"))
+                MigrationError::Incompatible(format!("invalid stored embed_dim: {stored}"))
             })?;
             if stored_dim != embed_dim {
-                return Err(MemoryError::Migration(format!(
-                    "embed_dim mismatch: stored {stored_dim} vs requested {embed_dim}"
-                )));
+                return Err(MigrationError::EmbedDimMismatch {
+                    stored: stored_dim,
+                    requested: embed_dim,
+                }
+                .into());
             }
             Ok(())
         } else {
-            Err(MemoryError::Migration(
+            Err(MigrationError::Incompatible(
                 "embed_dim not set in database; open in read-write mode first".to_string(),
-            ))
+            )
+            .into())
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -210,6 +210,76 @@ pub enum ArchiveError {
     Transaction(String),
 }
 
+/// A failure from the schema-migration / database-compatibility subsystem.
+///
+/// This is the typed payload of [`MemoryError::Migration`]. The version and
+/// embed-dim variants carry their operands as fields, so a caller can branch on
+/// "the database is from a newer build", "needs migration", or "embedding
+/// dimension mismatch" without string-matching. The remaining variants group
+/// the operational failure modes — pre-migration backup, a missing event
+/// upcaster, and the terminal incompatibilities (corrupt config values, an
+/// uninitialized database, post-rebuild FK violations, …) whose detail is
+/// carried verbatim in the message.
+///
+/// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
+/// downstream `match` expressions must include a wildcard (`_`) arm.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MigrationError {
+    /// The stored `schema_version` is newer than this build supports — a newer
+    /// library wrote the database. Forward-incompatible.
+    #[error(
+        "schema_version {found} is newer than supported {supported}; consider upgrading the memory-engine crate"
+    )]
+    SchemaVersionUnsupported {
+        /// The `schema_version` found in the database.
+        found: u32,
+        /// The highest `schema_version` this build supports.
+        supported: u32,
+    },
+
+    /// The stored `schema_version` is older than current and the database was
+    /// opened read-only, so migrations cannot run. Re-open read-write.
+    #[error(
+        "schema_version {found} needs migration to {target}; open in read-write mode first to run migrations"
+    )]
+    SchemaVersionNeedsMigration {
+        /// The `schema_version` found in the database.
+        found: u32,
+        /// The `schema_version` this build expects.
+        target: u32,
+    },
+
+    /// The database's stored embedding dimension does not match the dimension
+    /// the engine was opened with. All vectors in a store share one dimension.
+    #[error("embed_dim mismatch: stored {stored} vs requested {requested}")]
+    EmbedDimMismatch {
+        /// The `embed_dim` recorded in the database.
+        stored: usize,
+        /// The `embed_dim` the engine was opened with.
+        requested: usize,
+    },
+
+    /// The pre-migration WAL-safe backup step failed (in-memory database,
+    /// null-byte path, removal of a stale backup, or the `VACUUM INTO` itself).
+    /// The string names the precise backup failure.
+    #[error("{0}")]
+    Backup(String),
+
+    /// No registered event upcaster bridges a stored payload revision to the
+    /// current one, so the event cannot be upgraded. The string names the event
+    /// type and revision gap.
+    #[error("{0}")]
+    MissingUpcaster(String),
+
+    /// The database or snapshot is in a state this build cannot open or migrate
+    /// — a corrupt/unparseable config value, an uninitialized database, a
+    /// snapshot from a newer schema, post-rebuild foreign-key violations, or a
+    /// non-file path opened read-only. The string carries the specific cause.
+    #[error("{0}")]
+    Incompatible(String),
+}
+
 /// Errors returned by the memory engine.
 ///
 /// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
@@ -240,9 +310,11 @@ pub enum MemoryError {
     #[error("conflict: {0}")]
     Conflict(#[from] ConflictError),
 
-    /// A schema migration (forward or epoch upgrade) failed to apply.
+    /// A schema migration or database-compatibility check failed; see
+    /// [`MigrationError`] for the specific cause (version mismatch, embed-dim
+    /// mismatch, backup failure, missing upcaster, or terminal incompatibility).
     #[error("schema migration failed: {0}")]
-    Migration(String),
+    Migration(#[from] MigrationError),
 
     /// The requested operation is recognized but not yet implemented.
     #[error("not implemented: {0}")]
@@ -437,6 +509,76 @@ mod tests {
             MemoryError::Archive(ArchiveError::PakVersionUnsupported {
                 found: 9,
                 supported: 1
+            })
+        ));
+    }
+
+    #[test]
+    fn migration_variants_display_byte_for_byte() {
+        // Byte-preservation: each variant renders exactly the string the
+        // pre-split `format!` call sites produced, under the outer
+        // `schema migration failed: ` prefix.
+        assert_eq!(
+            MemoryError::Migration(MigrationError::SchemaVersionUnsupported {
+                found: 12,
+                supported: 11,
+            })
+            .to_string(),
+            "schema migration failed: schema_version 12 is newer than supported 11; consider upgrading the memory-engine crate"
+        );
+        assert_eq!(
+            MemoryError::Migration(MigrationError::SchemaVersionNeedsMigration {
+                found: 9,
+                target: 11,
+            })
+            .to_string(),
+            "schema migration failed: schema_version 9 needs migration to 11; open in read-write mode first to run migrations"
+        );
+        assert_eq!(
+            MemoryError::Migration(MigrationError::EmbedDimMismatch {
+                stored: 768,
+                requested: 512,
+            })
+            .to_string(),
+            "schema migration failed: embed_dim mismatch: stored 768 vs requested 512"
+        );
+        // String-carrying variants surface their message verbatim under the prefix.
+        assert_eq!(
+            MemoryError::Migration(MigrationError::Backup(
+                "cannot backup in-memory database".into()
+            ))
+            .to_string(),
+            "schema migration failed: cannot backup in-memory database"
+        );
+        assert_eq!(
+            MemoryError::Migration(MigrationError::MissingUpcaster(
+                "missing upcaster for event type 'ToolCall' from revision 1 to 2".into()
+            ))
+            .to_string(),
+            "schema migration failed: missing upcaster for event type 'ToolCall' from revision 1 to 2"
+        );
+        assert_eq!(
+            MemoryError::Migration(MigrationError::Incompatible(
+                "invalid schema_version: abc".into()
+            ))
+            .to_string(),
+            "schema migration failed: invalid schema_version: abc"
+        );
+    }
+
+    #[test]
+    fn migration_error_from_into_memory_error() {
+        // `#[from]` lets a bare `MigrationError` convert via `?`/`.into()`.
+        let err: MemoryError = MigrationError::SchemaVersionNeedsMigration {
+            found: 9,
+            target: 11,
+        }
+        .into();
+        assert!(matches!(
+            err,
+            MemoryError::Migration(MigrationError::SchemaVersionNeedsMigration {
+                found: 9,
+                target: 11
             })
         ));
     }

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use rusqlite::Connection;
 
-use crate::error::{ConflictError, MemoryError, Result};
+use crate::error::{ConflictError, MemoryError, MigrationError, Result};
 use crate::store::events::event_type_to_str;
 use crate::store::lineage::LineageStore;
 use crate::store::schema::{CURRENT_SCHEMA_VERSION, STORAGE_EPOCH, set_config};
@@ -133,10 +133,11 @@ fn read_zstd(_reader: impl Read) -> Result<EngineSnapshot> {
 /// - [`MemoryError::Internal`] if `embed_dim` is zero or root scope is missing.
 pub fn validate_snapshot(snapshot: &EngineSnapshot) -> Result<()> {
     if snapshot.schema_version > CURRENT_SCHEMA_VERSION {
-        return Err(MemoryError::Migration(format!(
+        return Err(MigrationError::Incompatible(format!(
             "snapshot schema_version {} is newer than supported {}",
             snapshot.schema_version, CURRENT_SCHEMA_VERSION
-        )));
+        ))
+        .into());
     }
     if snapshot.storage_epoch > STORAGE_EPOCH {
         return Err(MemoryError::UnsupportedEpoch {

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use parking_lot::{Condvar, Mutex, MutexGuard};
 use rusqlite::Connection;
 
-use crate::error::{MemoryError, Result};
+use crate::error::{MemoryError, MigrationError, Result};
 use crate::store::schema::{
     init_schema, migrate, open_connection, open_connection_read_only,
     open_memory as open_memory_conn,
@@ -159,10 +159,11 @@ impl ConnectionPool {
 
         // Reject nonexistent or non-file paths before SQLite can act
         if !path.is_file() {
-            return Err(MemoryError::Migration(format!(
+            return Err(MigrationError::Incompatible(format!(
                 "database path is not a regular file: {}; cannot open read-only",
                 path.display()
-            )));
+            ))
+            .into());
         }
 
         // Open with SQLITE_OPEN_READ_ONLY — no file creation, no WAL mutation

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
 
-use crate::error::{MemoryError, Result};
+use crate::error::{MemoryError, MigrationError, Result};
 
 /// Current schema version. Bump when adding migrations.
 pub const CURRENT_SCHEMA_VERSION: u32 = 11;
@@ -199,16 +199,16 @@ const MIGRATIONS: &[(MigrationFn, bool)] = &[
 /// supported, or if any migration step fails.
 pub fn migrate(conn: &Connection, backup_dir: Option<&Path>) -> Result<()> {
     let version_str = get_config(conn, "schema_version")?.unwrap_or_else(|| "1".to_string());
-    let version: u32 = version_str
-        .parse()
-        .map_err(|_| MemoryError::Migration(format!("invalid schema_version: {version_str}")))?;
+    let version: u32 = version_str.parse().map_err(|_| {
+        MigrationError::Incompatible(format!("invalid schema_version: {version_str}"))
+    })?;
 
     // --- Epoch gate ---
     let epoch_str = get_config(conn, "storage_epoch")?;
     let epoch_raw = epoch_str.as_deref().unwrap_or("1"); // pre-epoch DBs are implicitly epoch 1
     let db_epoch: u16 = epoch_raw
         .parse()
-        .map_err(|_| MemoryError::Migration(format!("invalid storage_epoch: {epoch_raw}")))?;
+        .map_err(|_| MigrationError::Incompatible(format!("invalid storage_epoch: {epoch_raw}")))?;
     if db_epoch > STORAGE_EPOCH {
         return Err(MemoryError::UnsupportedEpoch {
             db_epoch,
@@ -217,10 +217,11 @@ pub fn migrate(conn: &Connection, backup_dir: Option<&Path>) -> Result<()> {
     }
 
     if version > CURRENT_SCHEMA_VERSION {
-        return Err(MemoryError::Migration(format!(
-            "schema_version {version} is newer than supported {CURRENT_SCHEMA_VERSION}; \
-             consider upgrading the memory-engine crate"
-        )));
+        return Err(MigrationError::SchemaVersionUnsupported {
+            found: version,
+            supported: CURRENT_SCHEMA_VERSION,
+        }
+        .into());
     }
 
     // Nothing to migrate
@@ -297,10 +298,11 @@ pub fn validate_schema_version(conn: &Connection) -> Result<()> {
         .map_err(MemoryError::Database)?;
 
     if !has_config {
-        return Err(MemoryError::Migration(
+        return Err(MigrationError::Incompatible(
             "database has no config table; cannot open read-only on an uninitialized database"
                 .to_string(),
-        ));
+        )
+        .into());
     }
 
     // Check epoch
@@ -308,7 +310,7 @@ pub fn validate_schema_version(conn: &Connection) -> Result<()> {
     let epoch_raw = epoch_str.as_deref().unwrap_or("1");
     let db_epoch: u16 = epoch_raw
         .parse()
-        .map_err(|_| MemoryError::Migration(format!("invalid storage_epoch: {epoch_raw}")))?;
+        .map_err(|_| MigrationError::Incompatible(format!("invalid storage_epoch: {epoch_raw}")))?;
     if db_epoch > STORAGE_EPOCH {
         return Err(MemoryError::UnsupportedEpoch {
             db_epoch,
@@ -318,22 +320,24 @@ pub fn validate_schema_version(conn: &Connection) -> Result<()> {
 
     // Check schema version
     let version_str = get_config(conn, "schema_version")?.unwrap_or_else(|| "1".to_string());
-    let version: u32 = version_str
-        .parse()
-        .map_err(|_| MemoryError::Migration(format!("invalid schema_version: {version_str}")))?;
+    let version: u32 = version_str.parse().map_err(|_| {
+        MigrationError::Incompatible(format!("invalid schema_version: {version_str}"))
+    })?;
 
     if version > CURRENT_SCHEMA_VERSION {
-        return Err(MemoryError::Migration(format!(
-            "schema_version {version} is newer than supported {CURRENT_SCHEMA_VERSION}; \
-             consider upgrading the memory-engine crate"
-        )));
+        return Err(MigrationError::SchemaVersionUnsupported {
+            found: version,
+            supported: CURRENT_SCHEMA_VERSION,
+        }
+        .into());
     }
 
     if version < CURRENT_SCHEMA_VERSION {
-        return Err(MemoryError::Migration(format!(
-            "schema_version {version} needs migration to {CURRENT_SCHEMA_VERSION}; \
-             open in read-write mode first to run migrations"
-        )));
+        return Err(MigrationError::SchemaVersionNeedsMigration {
+            found: version,
+            target: CURRENT_SCHEMA_VERSION,
+        }
+        .into());
     }
 
     Ok(())
@@ -365,12 +369,10 @@ pub fn backup_before_migration(
     // Extract the source database file path via PRAGMA database_list
     let db_path: String = conn
         .query_row("PRAGMA database_list", [], |row| row.get::<_, String>(2))
-        .map_err(|e| MemoryError::Migration(format!("cannot read database path: {e}")))?;
+        .map_err(|e| MigrationError::Backup(format!("cannot read database path: {e}")))?;
 
     if db_path.is_empty() || db_path == ":memory:" {
-        return Err(MemoryError::Migration(
-            "cannot backup in-memory database".to_string(),
-        ));
+        return Err(MigrationError::Backup("cannot backup in-memory database".to_string()).into());
     }
 
     let db_name = Path::new(&db_path)
@@ -385,15 +387,13 @@ pub fn backup_before_migration(
     // the target path. Validate-before-use / fail-fast. Mirrors the guard in
     // `inspect::dump::dump_sqlite`.
     if backup_path.to_string_lossy().contains('\0') {
-        return Err(MemoryError::Migration(
-            "backup path contains null byte".to_string(),
-        ));
+        return Err(MigrationError::Backup("backup path contains null byte".to_string()).into());
     }
 
     // Remove existing backup to avoid VACUUM INTO failure on re-run
     if backup_path.exists() {
         std::fs::remove_file(&backup_path).map_err(|e| {
-            MemoryError::Migration(format!(
+            MigrationError::Backup(format!(
                 "cannot remove existing backup {}: {e}",
                 backup_path.display()
             ))
@@ -407,7 +407,7 @@ pub fn backup_before_migration(
     let escaped = backup_path.to_string_lossy().replace('\'', "''");
     let sql = format!("VACUUM INTO '{escaped}'");
     conn.execute_batch(&sql)
-        .map_err(|e| MemoryError::Migration(format!("backup failed: {e}")))?;
+        .map_err(|e| MigrationError::Backup(format!("backup failed: {e}")))?;
 
     Ok(backup_path)
 }
@@ -426,9 +426,10 @@ fn check_foreign_keys(conn: &Connection) -> Result<()> {
     let mut stmt = conn.prepare("PRAGMA foreign_key_check")?;
     let mut rows = stmt.query([])?;
     if rows.next()?.is_some() {
-        return Err(MemoryError::Migration(
+        return Err(MigrationError::Incompatible(
             "foreign key violations detected after table rebuild".to_string(),
-        ));
+        )
+        .into());
     }
     Ok(())
 }
@@ -1872,7 +1873,7 @@ CREATE TABLE IF NOT EXISTS config (
         let dir = tempfile::tempdir().unwrap();
         let err = backup_before_migration(&conn, dir.path(), 4).unwrap_err();
         assert!(
-            matches!(err, MemoryError::Migration(ref msg) if msg.contains("in-memory")),
+            matches!(err, MemoryError::Migration(MigrationError::Backup(ref msg)) if msg.contains("in-memory")),
             "expected in-memory error, got: {err:?}"
         );
     }
@@ -1931,7 +1932,7 @@ CREATE TABLE IF NOT EXISTS config (
 
         let err = backup_before_migration(&conn, &evil_dir, 4).unwrap_err();
         assert!(
-            matches!(err, MemoryError::Migration(ref msg) if msg.contains("null byte")),
+            matches!(err, MemoryError::Migration(MigrationError::Backup(ref msg)) if msg.contains("null byte")),
             "expected null-byte rejection, got: {err:?}"
         );
     }
@@ -1946,7 +1947,7 @@ CREATE TABLE IF NOT EXISTS config (
         let bad_dir = dir.path().join("nonexistent");
         let err = backup_before_migration(&conn, &bad_dir, 4).unwrap_err();
         assert!(
-            matches!(err, MemoryError::Migration(ref msg) if msg.contains("backup failed")),
+            matches!(err, MemoryError::Migration(MigrationError::Backup(ref msg)) if msg.contains("backup failed")),
             "expected backup failed error, got: {err:?}"
         );
     }

--- a/src/store/upcaster.rs
+++ b/src/store/upcaster.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::error::{MemoryError, Result};
+use crate::error::{MigrationError, Result};
 
 /// Function that transforms an event payload from revision N to N+1.
 pub type UpcasterFn = fn(serde_json::Value) -> Result<serde_json::Value>;
@@ -107,7 +107,7 @@ impl UpcasterRegistry {
         while rev < latest {
             let key = (type_key.clone(), rev);
             let func = self.upcasters.get(&key).ok_or_else(|| {
-                MemoryError::Migration(format!(
+                MigrationError::MissingUpcaster(format!(
                     "missing upcaster for event type '{event_type}' from revision {rev} to {}",
                     rev + 1
                 ))
@@ -123,6 +123,7 @@ impl UpcasterRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::MemoryError;
 
     #[test]
     fn empty_returns_unchanged() {
@@ -190,7 +191,7 @@ mod tests {
         let payload = serde_json::json!({});
         let err = registry.upcast("ToolCall", 1, payload).unwrap_err();
         assert!(
-            matches!(err, MemoryError::Migration(ref msg) if msg.contains("missing upcaster")),
+            matches!(err, MemoryError::Migration(MigrationError::MissingUpcaster(ref msg)) if msg.contains("missing upcaster")),
             "expected missing upcaster error, got: {err:?}"
         );
     }


### PR DESCRIPTION
## What

Split the stringly-typed `MemoryError::Migration(String)` into a typed `thiserror` sub-enum `MigrationError`, completing the *split* phase of the typed-error hierarchy from #559 (`ConflictError`), #577 (`RerankerError`), and #586 (`ArchiveError`).

**Step 3 of #560.** #560 remains open after this merges — the Bootstrap-removal and terminal-variant doc-pass steps still follow. (Linked as "part of", not a closing reference.)

## The variants — grouped by consumer actionability (23 call sites, 6 modules)

| Variant | Kind | Origin |
| --- | --- | --- |
| `SchemaVersionUnsupported { found, supported }` | structured (u32) | schema too new (`migrate`, `validate_schema_version`) |
| `SchemaVersionNeedsMigration { found, target }` | structured (u32) | schema too old, read-only |
| `EmbedDimMismatch { stored, requested }` | structured (usize) | stored vs requested embedding dim |
| `Backup(String)` | string | WAL-safe pre-migration backup (in-memory / null-byte / stale removal / VACUUM INTO) |
| `MissingUpcaster(String)` | string | no upcaster bridges a payload revision |
| `Incompatible(String)` | string | terminal long-tail: corrupt config value, uninitialized DB, FK violations, snapshot-too-new, non-file path |

The 3 structured variants are the cases anything branches on (a caller can detect "database from a newer build" / "needs migration" without string-matching). The 3 string variants wrap arbitrary detail that can't be enumerated further; `Backup` and `MissingUpcaster` are kept distinct because the test suite probes them specifically.

## Behavior preservation

- Outer keeps `#[error("schema migration failed: {0}")]` + `#[from]`; each inner `#[error(...)]` reproduces the **exact** prior `format!` text → Display byte-for-byte unchanged. The structured version strings reproduce the original `\`-continuation collapse (single space after the semicolon). Pinned by `migration_variants_display_byte_for_byte`.
- MCP dispatch untouched (`format!("schema migration failed: {msg}")`, `msg` now `MigrationError: Display`).

## Tests

The 4 substring-matching tests (backup in-memory / null-byte / backup-failed; missing-upcaster) are tightened from `Migration(msg)` + `msg.contains(...)` to `Migration(MigrationError::Backup/MissingUpcaster(ref msg))`, keeping the substring as a within-family Display guard. The ~8 generic `matches!(_, Migration(_))` assertions compile unchanged.

## Verification

- `cargo build --workspace` ✓ · `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets` exit 0 (no new warnings)
- `cargo test --workspace` — 1010 passed / 0 failed ✓
- `cargo test --all-features` — 840 passed / 0 failed ✓

Part of #560 · follow-up to #586 · epic #241.
