### PR TITLE
chore(core): remove unused MemoryError::Bootstrap variant

### DIFF
--- a/memory-engine-mcp/src/error.rs
+++ b/memory-engine-mcp/src/error.rs
@@ -39,10 +39,6 @@ pub fn to_mcp_error(err: MemoryError) -> ErrorData {
 
         MemoryError::Io(e) => ErrorData::internal_error(format!("I/O error: {e}"), None),
 
-        MemoryError::Bootstrap(msg) => {
-            ErrorData::internal_error(format!("bootstrap error: {msg}"), None)
-        }
-
         MemoryError::Reranker(msg) => {
             ErrorData::internal_error(format!("reranker error: {msg}"), None)
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -340,11 +340,6 @@ pub enum MemoryError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// A bootstrap/backdate import step failed (e.g. parsing or validating the
-    /// seed dataset).
-    #[error("bootstrap error: {0}")]
-    Bootstrap(String),
-
     /// A failure in the reranking stage; see [`RerankerError`] for the specific
     /// cause (a consumer-reported `rerank` failure, or one of the four
     /// engine-detected output-contract violations).


### PR DESCRIPTION
## What

Remove the unused `MemoryError::Bootstrap(String)` variant.

**Step 4 of #560** (the typed-error-hierarchy cleanup). #560 stays open — the terminal-variant doc-pass step still follows. (Linked as "part of", not a closing reference.)

## Why

`Bootstrap(String)` is a **ghost variant**: a workspace-wide grep (`src/` + all member crates) finds **zero construction sites**. Its only references were the definition itself and an unreachable match arm in the MCP error dispatch (`memory-engine-mcp/src/error.rs`). The bootstrap *feature* (`crate::bootstrap::*` — `BootstrapConfig`, `BootstrapReport`, `KeywordExtractor`) never surfaced failures through this variant; bootstrap errors flow through `Internal`/`Conflict`/`Serialization` etc.

Per the #560 design note, terminal/unused variants are removed rather than split.

## Changes

- Delete the variant from `MemoryError`.
- Delete the now-dead `MemoryError::Bootstrap(msg)` arm in the MCP dispatch — it falls through to the existing `#[non_exhaustive]` catch-all (`other => internal_error`), which is unreachable for this case anyway.

## Safety

No behavior change: a value that is never constructed cannot have been observed. `MemoryError` is `#[non_exhaustive]`, so downstream `match` expressions already require a wildcard arm — removing a never-constructed variant cannot break an exhaustive match.

## Verification

- `cargo build --workspace` ✓ · `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets` exit 0
- `cargo test --workspace` — 1032 passed / 0 failed ✓
- `cargo test --all-features` — 862 passed / 0 failed ✓
- Post-removal grep: zero remaining `MemoryError::Bootstrap` references.

Part of #560 · epic #241.
