### PR TITLE
docs(core): mark terminal MemoryError variants as not-for-matching

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -363,10 +363,19 @@ pub enum MemoryError {
     Migration(#[from] MigrationError),
 
     /// The requested operation is recognized but not yet implemented.
+    ///
+    /// **Terminal — propagate, don't `match`.** Informational only; the message
+    /// identifies the unbuilt path (e.g. a disabled compression feature gate).
+    /// Deliberately kept as a plain string rather than a typed sub-enum (see
+    /// #560): callers cannot recover differently per cause.
     #[error("not implemented: {0}")]
     NotImplemented(String),
 
     /// The connection pool could not hand out or manage a connection.
+    ///
+    /// **Terminal — propagate, don't `match`.** Only surfaced under the `async`
+    /// feature (a task-join failure); a single failure mode, so no typed
+    /// sub-enum is warranted (see #560).
     #[error("connection pool error: {0}")]
     Pool(String),
 
@@ -379,6 +388,11 @@ pub enum MemoryError {
 
     /// An invariant was violated inside the engine — a bug or corrupted state
     /// that the caller cannot meaningfully recover from.
+    ///
+    /// **Terminal by definition — propagate (or log), never `match` on the
+    /// message.** It spans many unrelated internal failure domains and exists to
+    /// signal "this shouldn't happen", so it is intentionally *not* split into a
+    /// typed sub-enum (see #560).
     #[error("internal error: {0}")]
     Internal(String),
 
@@ -403,6 +417,11 @@ pub enum MemoryError {
     ReadOnly,
 
     /// A wisdom-fact lineage/provenance record is missing or inconsistent.
+    ///
+    /// **Terminal / low-traffic — propagate, don't `match`.** Too few sites and
+    /// too thin to warrant a typed sub-enum (see #560); a future change may fold
+    /// it into [`Conflict`](MemoryError::Conflict)/[`NotFound`](MemoryError::NotFound)
+    /// instead.
     #[error("lineage error: {0}")]
     Lineage(String),
 


### PR DESCRIPTION
## What

Document the four terminal `MemoryError` variants — `Internal`, `NotImplemented`, `Pool`, `Lineage` — as **"propagate, don't `match`"**, with the rationale for why each is intentionally *not* split into a typed sub-enum.

**Final step of #560.** With this, #560's scope is fully addressed — the umbrella issue can be closed. (Linked as "part of", not a closing reference, so the merge doesn't auto-close it; close it manually once satisfied.)

## Why

The four splits (#559 `ConflictError`, #577 `RerankerError`, #586 `ArchiveError`, #593 `MigrationError`) turned the *branch-worthy* stringly-typed variants into typed sub-enums. The #560 design note's deliberate counterpoint is that **not every `String` variant should be split** — the terminal ones earn their keep as opaque strings. This PR records that decision *in the doc comments* so a future reader doesn't "finish the job" by splitting them for no consumer value.

| Variant | Why terminal (not split) |
| --- | --- |
| `Internal` | Spans many unrelated internal failure domains; signals "this shouldn't happen" — no per-cause recovery. |
| `NotImplemented` | Informational feature-gate (e.g. disabled compression); callers can't recover differently per cause. |
| `Pool` | `async`-feature-only, a single failure mode (task join). |
| `Lineage` | Too few/thin to warrant a sub-enum; may later fold into `Conflict`/`NotFound`. |

## Changes

Doc comments only on `src/error.rs` — no code, no behavior change. Each variant gains a bold "Terminal — propagate, don't `match`" line + rationale + `(see #560)`.

## Verification

- `cargo build --workspace` ✓ · `cargo clippy --workspace --all-targets` exit 0
- `cargo test --workspace` — 1085 passed / 0 failed ✓
- `cargo doc --no-deps -p memory-engine` — the two new intra-doc links (`[Conflict]`, `[NotFound]`) resolve; no warnings on the edited region.
- My diff is `cargo fmt`-clean (a pre-existing rustfmt drift on an unrelated `CycleError` test line is tracked separately by #539).

Part of #560 · epic #241.
