### PR TITLE
refactor(cognitive): SQL-pushdown undreamt filter + batch outcome_counts (#595)

### DIFF
--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -139,6 +139,22 @@ impl<'a> DreamContext<'a> {
     pub fn outcome_counts(&self, fact_id: i64) -> Result<crate::types::OutcomeCounts> {
         self.engine.get_outcome_counts(fact_id)
     }
+
+    /// Aggregated outcome counts for many facts in a single query (batch rescoring).
+    ///
+    /// The batch form of [`Self::outcome_counts`] — one `GROUP BY` scan instead of
+    /// one query per fact. Facts with no outcomes (or unknown ids) are absent from
+    /// the map; callers treat a missing key as [`OutcomeCounts::default`](crate::types::OutcomeCounts).
+    ///
+    /// # Errors
+    ///
+    /// Returns a store error if the query fails.
+    pub fn outcome_counts_batch(
+        &self,
+        fact_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, crate::types::OutcomeCounts>> {
+        self.engine.get_outcome_counts_batch(fact_ids)
+    }
 }
 
 // --- MemoryEngine integration methods ---

--- a/src/engine/cycle/default_impl.rs
+++ b/src/engine/cycle/default_impl.rs
@@ -206,9 +206,14 @@ impl DreamCycle for DefaultDreamCycle {
         }
 
         // 3. Outcome-driven rescoring + quarantine (skip facts already promoted).
-        // Batch-fetch outcome counts for the whole window in one query (not N+1);
-        // a fact with no recorded outcomes is absent from the map → default (zeros).
-        let outcome_ids: Vec<FactId> = facts.iter().map(|f| f.id).collect();
+        // Batch-fetch outcome counts in one query (not N+1); a fact with no recorded
+        // outcomes is absent from the map → default (zeros). Already-promoted facts are
+        // skipped in the loop below, so omit them from the query too.
+        let outcome_ids: Vec<FactId> = facts
+            .iter()
+            .map(|f| f.id)
+            .filter(|id| !promoted.contains(id))
+            .collect();
         let outcome_counts = ctx.dream().outcome_counts_batch(&outcome_ids)?;
         for fact in &facts {
             if promoted.contains(&fact.id) {

--- a/src/engine/cycle/default_impl.rs
+++ b/src/engine/cycle/default_impl.rs
@@ -206,11 +206,15 @@ impl DreamCycle for DefaultDreamCycle {
         }
 
         // 3. Outcome-driven rescoring + quarantine (skip facts already promoted).
+        // Batch-fetch outcome counts for the whole window in one query (not N+1);
+        // a fact with no recorded outcomes is absent from the map → default (zeros).
+        let outcome_ids: Vec<FactId> = facts.iter().map(|f| f.id).collect();
+        let outcome_counts = ctx.dream().outcome_counts_batch(&outcome_ids)?;
         for fact in &facts {
             if promoted.contains(&fact.id) {
                 continue;
             }
-            let counts = ctx.dream().outcome_counts(fact.id)?;
+            let counts = outcome_counts.get(&fact.id).copied().unwrap_or_default();
             if counts.positive == 0 && counts.negative >= QUARANTINE_NEGATIVE_THRESHOLD {
                 deltas.push(CycleDelta::Quarantine {
                     fact_id: fact.id,

--- a/src/engine/outcome.rs
+++ b/src/engine/outcome.rs
@@ -98,4 +98,64 @@ impl MemoryEngine {
             Ok(counts)
         })
     }
+
+    /// Return aggregated outcome counts for many facts in a **single** query.
+    ///
+    /// The batch equivalent of [`Self::get_outcome_counts`], for callers like the
+    /// dream cycle that need counts for every fact in a window (avoids the N+1
+    /// pattern of one query per fact). Aggregates with one `GROUP BY fact_id, outcome`
+    /// scan filtered to the requested ids.
+    ///
+    /// Unlike the single-fact variant, this does **not** validate that each id
+    /// exists (that would reintroduce the per-fact round-trips it exists to avoid).
+    /// Facts with no recorded outcomes — including nonexistent ids — are simply
+    /// absent from the map; callers treat a missing key as [`OutcomeCounts::default`].
+    /// An empty `fact_ids` returns an empty map without querying.
+    ///
+    /// # Errors
+    ///
+    /// - [`MemoryError::Database`] on query failure.
+    pub fn get_outcome_counts_batch(
+        &self,
+        fact_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, OutcomeCounts>> {
+        if fact_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        self.with_read(|conn| {
+            let ids_json = serde_json::to_string(fact_ids)?;
+            let mut stmt = conn.prepare(
+                "SELECT json_extract(payload, '$.fact_id') AS fid,
+                        json_extract(payload, '$.outcome') AS outcome,
+                        COUNT(*) AS cnt
+                 FROM events
+                 WHERE event_type = 'OutcomeSignal'
+                   AND json_extract(payload, '$.fact_id') IN (SELECT value FROM json_each(?1))
+                 GROUP BY fid, outcome",
+            )?;
+
+            let mut by_fact: std::collections::HashMap<i64, OutcomeCounts> =
+                std::collections::HashMap::new();
+            let rows = stmt.query_map(params![ids_json], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, u32>(2)?,
+                ))
+            })?;
+
+            for row in rows {
+                let (fid, outcome_str, cnt) = row?;
+                let entry = by_fact.entry(fid).or_default();
+                match outcome_str.as_str() {
+                    "Positive" => entry.positive = cnt,
+                    "Negative" => entry.negative = cnt,
+                    "Neutral" => entry.neutral = cnt,
+                    _ => {} // skip unknown variants (forward-compat)
+                }
+            }
+
+            Ok(by_fact)
+        })
+    }
 }

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -3258,6 +3258,72 @@ fn get_outcome_counts_isolates_per_fact() {
 }
 
 #[test]
+fn get_outcome_counts_batch_matches_per_fact_loop() {
+    use crate::types::Outcome;
+
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let f1 = insert_raw_fact(&engine, &make_new_fact("batch one", vec![0.5; DIM]));
+    let f2 = insert_raw_fact(&engine, &make_new_fact("batch two", vec![0.3; DIM]));
+    let f3 = insert_raw_fact(
+        &engine,
+        &make_new_fact("batch three (no outcomes)", vec![0.1; DIM]),
+    );
+
+    engine.record_outcome(f1, Outcome::Positive).unwrap();
+    engine.record_outcome(f1, Outcome::Positive).unwrap();
+    engine.record_outcome(f1, Outcome::Negative).unwrap();
+    engine.record_outcome(f2, Outcome::Neutral).unwrap();
+    // f3 deliberately has no outcomes.
+
+    let nonexistent = 999_999;
+    let ids = [f1, f2, f3, nonexistent];
+    let batch = engine.get_outcome_counts_batch(&ids).unwrap();
+
+    // Batch must equal the per-fact loop for every existing fact.
+    for &id in &[f1, f2, f3] {
+        let loop_counts = engine.get_outcome_counts(id).unwrap();
+        let batch_counts = batch.get(&id).copied().unwrap_or_default();
+        assert_eq!(
+            batch_counts, loop_counts,
+            "batch and per-fact counts must match for fact {id}"
+        );
+    }
+    // Facts with no outcomes (f3) and nonexistent ids are absent from the map.
+    assert!(
+        !batch.contains_key(&f3),
+        "zero-outcome fact should be absent"
+    );
+    assert!(
+        !batch.contains_key(&nonexistent),
+        "nonexistent id should be absent"
+    );
+    // Spot-check the actual tallies.
+    assert_eq!(
+        batch[&f1],
+        crate::types::OutcomeCounts {
+            positive: 2,
+            negative: 1,
+            neutral: 0
+        }
+    );
+    assert_eq!(
+        batch[&f2],
+        crate::types::OutcomeCounts {
+            positive: 0,
+            negative: 0,
+            neutral: 1
+        }
+    );
+}
+
+#[test]
+fn get_outcome_counts_batch_empty_input_no_query() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let batch = engine.get_outcome_counts_batch(&[]).unwrap();
+    assert!(batch.is_empty());
+}
+
+#[test]
 fn outcome_serde_round_trip() {
     use crate::types::Outcome;
 

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -780,12 +780,18 @@ impl<'a> FactStore<'a> {
         scope_ids: &[i64],
         fact_type: Option<&FactType>,
     ) -> Result<Vec<Fact>> {
+        // `json_type` (not `json_extract`) keeps this bit-for-bit equivalent to the
+        // prior Rust filter `metadata.get("dream_cycle").is_none()`: `json_extract`
+        // collapses an absent key and a present-`null` value both to SQL NULL, whereas
+        // serde's `get().is_none()` is true only for an *absent* key. `json_type`
+        // returns the text `'null'` for a present-null value (so `IS NULL` is false)
+        // and SQL NULL only when the key is absent or the path doesn't resolve.
         self.list_active_in_period_inner(
             start,
             end,
             scope_ids,
             fact_type,
-            &["json_extract(metadata, '$.dream_cycle') IS NULL"],
+            &["json_type(metadata, '$.dream_cycle') IS NULL"],
         )
     }
 
@@ -1272,6 +1278,44 @@ mod tests {
             .list_undreamt_in_period(start, end, &[], Some(&FactType::Semantic))
             .unwrap();
         assert_eq!(after.iter().map(|f| f.id).collect::<Vec<_>>(), vec![s2]);
+    }
+
+    #[test]
+    fn list_undreamt_filter_matches_serde_is_none_on_null_value() {
+        // Equivalence guard: the SQL filter must match the prior Rust filter
+        // `metadata.get("dream_cycle").is_none()` even for a present-but-null value.
+        // serde's is_none() is true only for an ABSENT key, so a fact carrying
+        // `{"dream_cycle": null}` is treated as already-dreamt (excluded) — which
+        // `json_type(...) IS NULL` reproduces (json_extract would NOT).
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+
+        let mut absent = make_fact("absent key", vec![0.1; DIM]);
+        absent.metadata = serde_json::json!({"other": 1});
+        let mut present_null = make_fact("present null", vec![0.2; DIM]);
+        present_null.metadata = serde_json::json!({"dream_cycle": null});
+        let mut present_obj = make_fact("present object", vec![0.3; DIM]);
+        present_obj.metadata = serde_json::json!({"dream_cycle": {"cycle_id": 9}});
+
+        let a = store.insert(&absent).unwrap();
+        store.insert(&present_null).unwrap();
+        store.insert(&present_obj).unwrap();
+
+        let start = "2000-01-01T00:00:00Z".parse().unwrap();
+        let end = "2100-01-01T00:00:00Z".parse().unwrap();
+        let undreamt: Vec<i64> = store
+            .list_undreamt_in_period(start, end, &[], None)
+            .unwrap()
+            .iter()
+            .map(|f| f.id)
+            .collect();
+
+        // Only the absent-key fact is undreamt; present-null and present-object are excluded.
+        assert_eq!(
+            undreamt,
+            vec![a],
+            "present-null must be treated as dreamt (matching serde get().is_none())"
+        );
     }
 
     #[test]

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -766,6 +766,10 @@ impl<'a> FactStore<'a> {
     /// Like [`Self::list_active_in_period`] but excludes facts already stamped with
     /// the `dream_cycle` marker — the cycle's input-selection query.
     ///
+    /// The exclusion is pushed into SQL (`json_extract(metadata, '$.dream_cycle') IS
+    /// NULL`) so already-dream-cycled rows — and their embedding BLOBs — are never
+    /// materialized, rather than fetched and discarded Rust-side.
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on query failure.
@@ -776,11 +780,13 @@ impl<'a> FactStore<'a> {
         scope_ids: &[i64],
         fact_type: Option<&FactType>,
     ) -> Result<Vec<Fact>> {
-        let facts = self.list_active_in_period(start, end, scope_ids, fact_type)?;
-        Ok(facts
-            .into_iter()
-            .filter(|f| f.metadata.get("dream_cycle").is_none())
-            .collect())
+        self.list_active_in_period_inner(
+            start,
+            end,
+            scope_ids,
+            fact_type,
+            &["json_extract(metadata, '$.dream_cycle') IS NULL"],
+        )
     }
 
     /// List active facts ordered by materialized `importance_score`, excluding IDs in `exclude`.
@@ -929,6 +935,22 @@ impl<'a> FactStore<'a> {
         scope_ids: &[i64],
         fact_type: Option<&FactType>,
     ) -> Result<Vec<Fact>> {
+        self.list_active_in_period_inner(start, end, scope_ids, fact_type, &[])
+    }
+
+    /// Shared core for [`Self::list_active_in_period`] and
+    /// [`Self::list_undreamt_in_period`]. `extra_conditions` are additional
+    /// **non-parameterized** SQL predicates ANDed into the `WHERE` clause (they
+    /// must not reference bind parameters — they are appended verbatim, so callers
+    /// pass only trusted literals like a `json_extract(metadata, …) IS NULL` filter).
+    fn list_active_in_period_inner(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        scope_ids: &[i64],
+        fact_type: Option<&FactType>,
+        extra_conditions: &[&str],
+    ) -> Result<Vec<Fact>> {
         let start_str = start.to_rfc3339();
         let end_str = end.to_rfc3339();
         let dim = self.embed_dim;
@@ -957,6 +979,12 @@ impl<'a> FactStore<'a> {
             conditions.push(format!("fact_type = ?{param_idx}"));
         } else {
             ft_str = String::new();
+        }
+
+        // Non-parameterized predicates (e.g. the dream-cycle exclusion filter) are
+        // appended last so they never disturb the `?N` bind-parameter numbering above.
+        for cond in extra_conditions {
+            conditions.push((*cond).to_owned());
         }
 
         let where_clause = conditions.join(" AND ");
@@ -1208,6 +1236,42 @@ mod tests {
         // The marker carries the cycle id and is queryable on the row.
         let marked = store.get(a).unwrap();
         assert_eq!(marked.metadata["dream_cycle"]["cycle_id"], 1);
+    }
+
+    #[test]
+    fn list_undreamt_in_period_composes_with_fact_type_filter() {
+        // Regression guard for the SQL-pushdown refactor: the appended (non-param)
+        // dream-cycle predicate must not disturb the `?N` bind numbering of the
+        // fact_type filter. Mix types, mark one, and query a single type.
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let mut epi = make_fact("episodic", vec![0.1; DIM]);
+        epi.fact_type = FactType::Episodic;
+        let mut sem1 = make_fact("semantic one", vec![0.2; DIM]);
+        sem1.fact_type = FactType::Semantic;
+        let mut sem2 = make_fact("semantic two", vec![0.3; DIM]);
+        sem2.fact_type = FactType::Semantic;
+        store.insert(&epi).unwrap();
+        let s1 = store.insert(&sem1).unwrap();
+        let s2 = store.insert(&sem2).unwrap();
+
+        let start = "2000-01-01T00:00:00Z".parse().unwrap();
+        let end = "2100-01-01T00:00:00Z".parse().unwrap();
+
+        // Semantic-only, both undreamt → exactly the two semantic facts (no episodic).
+        let before = store
+            .list_undreamt_in_period(start, end, &[], Some(&FactType::Semantic))
+            .unwrap();
+        let mut ids: Vec<i64> = before.iter().map(|f| f.id).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![s1, s2]);
+
+        // Mark one semantic fact → it drops out; the type filter still holds.
+        store.mark_dream_cycled(&[s1], 1, Utc::now()).unwrap();
+        let after = store
+            .list_undreamt_in_period(start, end, &[], Some(&FactType::Semantic))
+            .unwrap();
+        assert_eq!(after.iter().map(|f| f.id).collect::<Vec<_>>(), vec![s2]);
     }
 
     #[test]


### PR DESCRIPTION
Two behavior-preserving perf optimizations on the DreamCycle read path, deferred from #594 (#49) and tracked in **#595**.

## Changes
1. **SQL-pushdown undreamt filter.** `FactStore::list_undreamt_in_period` now appends `json_extract(metadata, '$.dream_cycle') IS NULL` to the query (via a shared `list_active_in_period_inner` core) instead of fetching all active facts and filtering in Rust. Already-dream-cycled rows — and their embedding BLOBs — are never materialized.
2. **Batch `outcome_counts`.** New `get_outcome_counts_batch(&[FactId])` aggregates every window fact in one `GROUP BY fact_id, outcome` scan; `DefaultDreamCycle::run` pre-fetches once, eliminating the per-fact N+1. A fact with no outcomes (or an unknown id) is absent from the map → callers use `OutcomeCounts::default()`, matching the single-fact semantics.

## Behavior-preserving — proof
- `list_undreamt_in_period_composes_with_fact_type_filter`: the SQL filter composes with a `fact_type` filter (guards `?N` bind-numbering after appending the non-parameterized predicate).
- `get_outcome_counts_batch_matches_per_fact_loop`: the batch map equals N individual `get_outcome_counts` calls, including zero-outcome and nonexistent ids being absent; spot-checks exact tallies.
- The pre-existing `mark_dream_cycled_excludes_from_undreamt_selection` still passes against the SQL filter.

No public type/trait changes (only an additive `get_outcome_counts_batch` + `DreamContext::outcome_counts_batch`). Single-fact `get_outcome_counts` retained.

## Verification
`cargo build/test/clippy --workspace` (+ `--all-features`) green; `fmt --check` clean; 771 lib tests pass.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)