### PR TITLE
feat(mcp): cognitive pipeline endpoints (dream_cycle, get_recent_insights)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Read these docs when working on the relevant area:
 
 ## Status
 
-Phase 4a ✅ (inspection APIs, import/export, bootstrap, reranker). Phase 4b in progress: CLI inspector ✅ (`memory-engine-cli`), MCP server ✅ (`memory-engine-mcp`, 10 P0 tools + tiered depth). P1 tools (#95) and P2 tools (#96) pending. Then Phase 5 (cognitive pipelines — DreamCycle, outcome tracking, provenance). See **GitHub Projects** ([Roadmap board #6](https://github.com/users/dutiona/projects/6)) for open issues and the dependency graph; `docs/ROADMAP.md` is a frozen historical reference.
+Phase 4a ✅ (inspection APIs, import/export, bootstrap, reranker). Phase 4b in progress: CLI inspector ✅ (`memory-engine-cli`), MCP server ✅ (`memory-engine-mcp`, 21 tools + tiered depth). P2 tools (#96) pending. Phase 5a cognitive pipeline ✅: DreamCycle (#49) + its MCP endpoints (#225, `memory_dream_cycle` / `memory_apply_cycle_report` / `memory_get_recent_insights`). Then the rest of Phase 5 (outcome tracking, provenance). See **GitHub Projects** ([Roadmap board #6](https://github.com/users/dutiona/projects/6)) for open issues and the dependency graph; `docs/ROADMAP.md` is a frozen historical reference.
 
 <!-- pm-contract:start -->
 

--- a/docs/advanced/dream-cycle.md
+++ b/docs/advanced/dream-cycle.md
@@ -28,6 +28,14 @@ flowchart LR
 `run_dream_cycle` returns the unapplied report; the caller inspects it and calls
 `apply_cycle_report`. This split is what lets a consumer gate promotion on review.
 
+**Exposed via MCP.** The `memory_dream_cycle`, `memory_apply_cycle_report`, and
+`memory_get_recent_insights` tools surface this pipeline over the Model Context
+Protocol. `memory_dream_cycle` carries an `apply` flag (default `true`) that
+collapses produce-and-apply into one call for the daily-hook ergonomic, while
+`apply:false` preserves the review gate by returning the report for a later
+`memory_apply_cycle_report`. See
+[MCP Server → Cognitive Pipeline](../reference/mcp-server.md#cognitive-pipeline-memory_dream_cycle-memory_apply_cycle_report-memory_get_recent_insights).
+
 ## The delta vocabulary
 
 | Delta                                 | Effect on apply                                                                                                                                                     |

--- a/docs/plans/2026-06-16-mcp-cognitive-endpoints-advisor.md
+++ b/docs/plans/2026-06-16-mcp-cognitive-endpoints-advisor.md
@@ -1,0 +1,23 @@
+# Advisor Review — MCP Cognitive Endpoints (#225)
+
+## Availability
+
+`advisor()` is **not available** in this environment. Per the user's standing budget preference
+(prefer adversarial subagent reviewers over external-model quota), the advisor's critical-review
+role was covered by **two independent clean-slate subagent reviewers** (Step 3b mandatory + one
+adversarial specialist):
+
+- `…-subagent-review.md` — general-purpose, fresh-eyes (line-ref verification + structural completeness).
+- (adversarial rust-specialist findings folded into the same artifact's "Adversarial" section.)
+
+The plan is complex (>5 files, >1 subsystem), which triggers Step 4; the full Codex/Gemini/agy tmux
+loop was deliberately substituted by the two subagents above per the budget preference. The
+`gemini-code-assist[bot]` will also auto-review the PR.
+
+## Resolution
+
+Not applicable — `advisor()` did not run. Findings + resolutions are recorded in the subagent-review
+artifact. Net: the adversarial pass found 1 BLOCKER (T3 `extra_conditions` can't carry a bind param;
+switched to a standalone query + trusted-literal `json_type` predicate) + 2 HIGH (T7 non-object
+metadata normalization; T4 explicit early-return on unknown scope) + several LOW (re-export line,
+`#[must_use]`, CycleError mis-tier note) — all addressed in the plan before approval.

--- a/docs/plans/2026-06-16-mcp-cognitive-endpoints-subagent-review.md
+++ b/docs/plans/2026-06-16-mcp-cognitive-endpoints-subagent-review.md
@@ -1,0 +1,36 @@
+# Subagent Review — MCP Cognitive Endpoints (#225)
+
+Two clean-slate reviewers: a general-purpose fresh-eyes pass and an adversarial rust-specialist.
+
+## Clean-slate (general-purpose) — verdict: LGTM with minor fixes
+
+All load-bearing line-refs verified accurate: `run_dream_cycle`/`apply_cycle_report` exist; `CycleReport`
+is `Serialize+Deserialize` and NOT `#[non_exhaustive]`; `to_mcp_error` lacks a `Cycle` arm; `handle_flush_insights`
+stamps only `source`; `FactStore::list_by_scopes_recent`, `ScopeTree::resolve_path`/`subtree` exist as described.
+Documentation/Testing/Verification sections substantive.
+
+- [MEDIUM] T7 inherits a silent-skip on non-object metadata (marker dropped for malformed input).
+- [LOW] T2 re-export line is the unbraced `pub use engine::cognitive::DreamContext;`.
+- [LOW] grounding note cites the wrong store idiom for T3 (`extra_conditions` verbatim vs `list_by_scopes_recent` params).
+- [LOW] document the "non-null value present" contract on the generic store method; pin the `{"insight": null}` edge.
+- [LOW] decision A generic method justified (quarantine marker is a real second consumer); decision E (empty-vec) correct given lazy scope creation.
+
+## Adversarial (rust-specialist)
+
+- **[BLOCKER] T3** — `extra_conditions` is documented non-parameterized ("appended verbatim; must not reference bind parameters"), so `json_extract(metadata, '$.' || ?2)` would bind `?2` to the OUTER query's param, not `marker_key`. Fix: standalone query (mirror `list_by_scopes_recent` with real `params!`) + trusted-literal `format!("json_type(metadata, '$.{marker_key}') IS NOT NULL")`. Prefer `json_type` over `json_extract` (codebase idiom; robust on absent vs present-null).
+- **[HIGH] T7** — normalize non-object metadata to `{}` before stamping (don't rely on the `if let Value::Object` no-op silently dropping the load-bearing marker). Mirror `promote_in_conn`.
+- **[HIGH] T4** — `subtree(unknown_id)` returns the singleton `[id]`, not empty; must early-return `Ok(vec![])` on `resolve_path → None`, never call `subtree` on a fallback id.
+- [HIGH→noted] T9 — `CycleReport` round-trips cleanly (incl. `PromotionProvenance.lineage_id` `skip_serializing/default`); the `scope_id` in an `AddFact` delta is a DB-internal id the client could edit — document apply_cycle_report's report-trust boundary.
+- [MEDIUM] T1 — `CycleError → invalid_params` is right for `apply_cycle_report`; a hypothetical `run_dream_cycle` Cycle error would mis-tier, but `DefaultDreamCycle` never returns one. Acceptable; noted.
+- [MEDIUM] T8 — `get_bool` exists; `.unwrap_or(true)` default correct.
+- [LOW] T6 — add `#[must_use]` to `ok_serialized` to match `ok_json`.
+
+## Resolution
+
+- [BLOCKER] T3 extra_conditions/bind-param clash → **Fixed**: rewrote T3 to a standalone `list_by_scopes_recent`-style query with a trusted-literal `json_type(metadata, '$.{marker_key}') IS NOT NULL` predicate; rustdoc states marker_key is a trusted engine const (never client input); added the `{"insight": null}` exclusion test case.
+- [HIGH] T7 non-object metadata → **Fixed**: T7 now normalizes metadata to `{}` before stamping + adds a non-object-input test.
+- [HIGH] T4 subtree-singleton trap → **Fixed**: T4 now has the explicit `match resolve_path { Some(id)=>subtree(id), None=>return Ok(vec![]) }` snippet.
+- [HIGH→noted] scope_id trust → **Documented**: noted as apply_cycle_report's report-trust boundary (the tool round-trips a dream_cycle output; arbitrary client-edited reports are validated for fact existence/bounds but trust internal scope_id). No code change.
+- [MEDIUM] T1 mis-tier → **Documented** in T1 (common-case tiering correct; DefaultDreamCycle never returns Cycle).
+- [LOW] T2 unbraced re-export → **Fixed** in T2 wording. [LOW] T6 `#[must_use]` → folded into T6. [LOW] grounding citation → superseded by the rewritten T3. [LOW] non-null-present contract → folded into T3 rustdoc requirement.
+- Clean-slate confirmed no blockers and verified all line-refs; client-CycleReport deserialization + json_type predicate are injection-safe.

--- a/docs/plans/2026-06-16-mcp-cognitive-endpoints.md
+++ b/docs/plans/2026-06-16-mcp-cognitive-endpoints.md
@@ -133,3 +133,15 @@ Per-task disposition (T0–T14). Plan size: 15 tasks. Modified: 2 (T3, T12). Add
 | T14 — Git ops | In progress | Commit → PR → `/super-review` → rebase+re-gate → squash-merge (pending user authorization). |
 
 **Decision E (unknown-scope semantics):** shipped as empty-vec (not `NotFound`), per the fixed decision. Flagged for reviewer preference.
+
+### Review Round 1 (3 adversarial subagent reviewers + gemini bot)
+
+Reviewers: correctness/SQL (rust-specialist), security/boundary (code-reviewer), tests/contract (test-engineer). Findings actioned in commit `fix(...)` on this branch:
+
+- **[HIGH] `memory_apply_cycle_report` validation bypass** (security lens): a client-supplied `CycleReport` with an `AddFact` delta skipped the `validate_importance` / `check_str_size` / `check_json_size` guards the trusted `add_fact` path enforces — letting a hostile report write out-of-range `importance` (no column CHECK → poisons Ebbinghaus decay) or oversized payloads. **Fixed** in `validate_report` (engine, shared by all DreamCycle consumers — correct altitude), with two engine tests (`add_fact_out_of_range_importance_rejected`, `add_fact_oversized_content_rejected`). Required widening `MemoryEngine::validate_importance` to `pub(crate)`.
+- **[HIGH] `limit=0` slipped through** (tests lens): schema declares `minimum:1` but the handler accepted `limit=0` → silent empty result. **Fixed** with an explicit guard in `handle_get_recent_insights` + test `get_recent_insights_limit_zero_is_invalid_params`.
+- **[HIGH] empty-store `dream_cycle` untested** + MEDIUM gaps: added `dream_cycle_on_empty_store_succeeds_with_no_deltas`, `apply_cycle_report_missing_report_key_is_invalid_params`, `get_recent_insights_sparse_depth_shapes_facts`, and a 2-insight batch writer→reader roundtrip (`flush_two_insights_then_get_recent_returns_both`).
+- **[MEDIUM] json_extract/json_type asymmetry**: added a docstring cross-reference to the complementary `list_undreamt_in_period` (presence vs absence predicate).
+- **Dispositioned, no change:** `pub` (not `pub(crate)`) on `list_active_by_metadata_key_recent` — kept to match its sibling `list_by_scopes_recent`; `FactStore` is crate-internal so it is effectively `pub(crate)` at the boundary, and a `debug_assert` + rustdoc contract guard the trusted-literal interpolation. CycleError mis-tier for a hypothetical buggy custom `DreamCycle` — documented/benign with the shipped `DefaultDreamCycle`.
+
+Gate after fixes: workspace 1110 passed / 4 ignored; `--all-features` 926 passed / 4 ignored; clippy exit 0; fmt clean.

--- a/docs/plans/2026-06-16-mcp-cognitive-endpoints.md
+++ b/docs/plans/2026-06-16-mcp-cognitive-endpoints.md
@@ -109,3 +109,27 @@ Acceptance: all green; no clippy findings in new code; new MCP tools dispatch en
 - **`#[non_exhaustive]` serde passthrough** — `to_value` means #57/#578 field/variant additions flow to the wire automatically (no adapter edit).
 - **Unknown-scope semantics (decision E)** — empty-vec chosen; reviewer may prefer NotFound.
 - **`unsafe_code = forbid`** — satisfied (pure Rust, no FFI).
+
+## Post-Implementation Audit
+
+Per-task disposition (T0–T14). Plan size: 15 tasks. Modified: 2 (T3, T12). Added work: 1 (extra roundtrip test). Divergence ≈ 13% — below the 30% advisor-arbitration threshold.
+
+| Task | Status | Notes |
+| ---- | ------ | ----- |
+| T0 — Baseline | Implemented | Worktree off latest `origin/main` (incl. merged #49 + #595); workspace green. |
+| T1 — `CycleError → invalid_params` | Implemented | Mapping + `cycle_maps_to_invalid_params` test, exactly as planned. |
+| T2 — `INSIGHT_MARKER_KEY` const | Implemented | Const in `cognitive.rs`; `lib.rs` re-export converted to braced group. |
+| **T3 — Generic store query** | **Modified** | **The plan prescribed `json_type(metadata, '$.{key}') IS NOT NULL`; the shipped code uses `json_extract(...) IS NOT NULL`.** The store-level unit test (written first) caught the planned predicate as *wrong* for the present-`null` case: SQLite `json_type` returns the text `'null'` (not SQL `NULL`) for `{"insight": null}`, so that fact was incorrectly included (`[5,2,1]` vs expected `[2,1]`). `json_extract` collapses both absent-key AND present-`null` to SQL `NULL`, returning a value only for present-non-null — the correct "key present with a non-null value" contract. This **reverses** the plan/reviewer suggestion, which had conflated #595's *absent-key* case (where `json_type` is right) with this *non-null-value* case. Trusted-literal interpolation + rustdoc contract retained as planned. |
+| T4 — Engine method | Implemented | `list_recent_insights` with explicit `resolve_path → None ⇒ Ok(vec![])` early-return (the HIGH fix). |
+| T5 — Engine integration test | Implemented | `tests/recent_insights_test.rs`, public-API, subtree/newest-first/limit/expired/unknown-scope. |
+| T6 — `ok_serialized` helper | Implemented | Next to `ok_json`; serde failure → `internal_error`. |
+| T7 — `flush_insights` stamps marker | Implemented | Non-object metadata normalized to `{}` before stamping `source` + marker (the HIGH fix); marker always lands. |
+| T8 — `memory_dream_cycle` | Implemented | `apply` flag (default true); `{report, did_apply, applied?}`; no consolidation, no embedder. |
+| T9 — `memory_apply_cycle_report` | Implemented | `from_value::<CycleReport>` (fail → `invalid_params`) → apply → `ok_serialized`. |
+| T10 — `memory_get_recent_insights` | Implemented | `project_path` required, `limit` default 20, tiered depth; unknown scope → empty. |
+| T11 — MCP integration tests | Implemented + **Added** | `cognitive_tools.rs` (5 dispatch tests) as planned. **Added** a wiremock writer→reader roundtrip in `embedding_integration.rs` — it surfaced a *test-fidelity* bug (the OpenAI mock omitted the `index` field that the `embed_batch` parser requires; `flush_insights` uses the batch path). Fixed the mock; product code was correct. |
+| **T12 — Docs** | **Modified** | The `mcp-server.md` tool table was already **stale** (claimed 18 tools; code had 23 pre-#225 — 3 P2 + 2 Phase-5a outcome tools were undocumented). Rather than ship a half-correct "21", the table was completed to the true **26** (incl. the 5 previously-missing rows + the 3 new cognitive tools) and the headline count corrected. Also added a "Cognitive Pipeline" subsection, an "Exposed via MCP" note in `dream-cycle.md`, and the `CLAUDE.md` status line. **Collateral:** the count-assertion test `all_tool_definitions_returns_23` → `_returns_26` was updated (would otherwise fail the workspace gate); the doc-drift fix lands in this PR, no separate issue needed. |
+| T13 — Verification gate | Implemented | `cargo build/test --workspace` green; MCP crate 125 passed; `cargo test --all-features` 924 passed / 4 ignored; `cargo clippy --workspace --all-targets` exit 0; `cargo fmt --check` clean. |
+| T14 — Git ops | In progress | Commit → PR → `/super-review` → rebase+re-gate → squash-merge (pending user authorization). |
+
+**Decision E (unknown-scope semantics):** shipped as empty-vec (not `NotFound`), per the fixed decision. Flagged for reviewer preference.

--- a/docs/plans/2026-06-16-mcp-cognitive-endpoints.md
+++ b/docs/plans/2026-06-16-mcp-cognitive-endpoints.md
@@ -1,0 +1,111 @@
+# Implementation Plan — MCP Cognitive Endpoints (#225)
+
+**Issue:** dutiona/memory-engine#225 — `feat(mcp): cognitive pipeline endpoints (dream_cycle, get_recent_insights)`
+**Worktree:** `.worktrees/feat-225-mcp-cognitive-endpoints` (branch off `origin/main`; includes merged #49 DreamCycle + #595 perf)
+**Scope:** FIXED by user decisions 2026-06-16 (D1/D2/D3 below). Exposes the Phase-5a cognitive pipeline (shipped in #49) as MCP tools. Prereqs #49/#48/#55/#63 all closed.
+
+> **Synthesis note.** Three-lens judge panel (drafts in `./2026-06-16-mcp-cognitive-endpoints-drafts/`). Spine = architecture-first (reusable core method, shared marker const, error-mapping fix); + risk-first sequencing (error-map + marker-predicate first; read-only/empty-store/scope tests); + mvp-first independently-testable tools.
+
+## Fixed decisions
+
+- **D1** — one `memory_dream_cycle` tool, `apply: bool` (default true): produce via `run_dream_cycle`, and if `apply`, `apply_cycle_report`. `apply=false` dry-runs (returns unapplied report). Plus a separate `memory_apply_cycle_report` tool (the gated path).
+- **D2** — `dream_cycle` does **not** consolidate. Consolidation stays the existing `memory_consolidate` tool. `DefaultDreamCycle` (#49) is pure: cluster/promote/rescore/quarantine.
+- **D3** — insights are stored as facts; `memory_flush_insights` will stamp an insight marker, and `memory_get_recent_insights` returns marked facts by project scope, newest-first, limited.
+
+## Grounding — verified facts (line refs at plan time)
+
+- **Core API from #49 (pub, re-exported from crate root):** `MemoryEngine::run_dream_cycle(&dyn DreamCycle) -> Result<CycleReport>` (`engine/cognitive.rs:189`, verifies write access → `ReadOnly`); `MemoryEngine::apply_cycle_report(&CycleReport) -> Result<ApplyResult>` (`engine/cycle/apply.rs:67`, validate-then-apply, hard-fail); `DefaultDreamCycle::with_defaults()` (`engine/cycle/default_impl.rs`, pure, guards empty buckets `< MIN_PTS=3`); `CycleReport`/`ApplyResult` derive `Serialize+Deserialize`, **not** `#[non_exhaustive]` (`engine/cycle/report.rs:129-152`); round-trip proven (`report.rs` tests).
+- **MCP tool pattern (`memory-engine-mcp/src/tools/mod.rs`):** `all_tool_definitions() -> Vec<Tool>` with inline `tool_def(name, desc, json!({...}))` (~:30-370); `dispatch()` match (~:377-419) threads `engine, embedder, summary_gen, embed_dim, filter_config`; handlers are `fn handle_*(args, engine, ...) -> Result<CallToolResult, ErrorData>` using `get_str/get_bool/get_usize/get_depth` + `ok_json`. `server.rs` auto-picks new tools (no change). Tool naming: `memory_*` (house convention, all 23 tools).
+- **`handle_flush_insights` (~:838-939) — DISCREPANCY:** the issue says it stamps `{"insight":true}`; it actually stamps only `metadata.source = "pre_compaction_flush"` (~:896-899). So there is **no** insight marker to read today — this plan adds it.
+- **Error mapping (`memory-engine-mcp/src/error.rs:5-65`):** `MemoryError::Cycle(CycleError)` (`error.rs:431`) is **unmapped** → falls to `other => internal_error`. `ReadOnly → invalid_request`, `Conflict → invalid_params`, `EmbeddingDimension → invalid_params` already exist.
+- **Scope resolution:** read-only `ScopeTree::resolve_path(path) -> Option<id>` (`scope/tree.rs:63`) + `subtree(id)` (inclusive BFS, `:107`). Do **NOT** use the private `resolve_scope_ids` (returns ancestors) or the write-requiring `ensure_scope_path`.
+- **Recency query precedent:** `FactStore::list_by_scopes_recent` (`store/facts.rs:901`) — active + scope `json_each` filter + `t_created DESC` + limit (`t_created` indexed since schema v11). The new method = this + a metadata-marker predicate, via the trusted-literal `extra_conditions` idiom (`facts.rs:947-994`).
+- **`--all-features` is load-bearing:** `apply_cycle_report` has `#[cfg(feature="ann")]` HNSW branches.
+
+## Decisions flagged for review
+
+| #   | Decision                                                                                                                                                                                                                             | Rationale                                                                                                                                                                                                              | Alt                                                                                                              |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| A   | New **generic** store method `FactStore::list_active_by_metadata_key_recent(scope_ids, marker_key, limit)` + **named** engine method `MemoryEngine::list_recent_insights(scope_path, limit)` (fixes `marker_key=INSIGHT_MARKER_KEY`) | Reuse (quarantine/other markers can read via same path) below; clear intent above. Mirrors `list_due`/`FactStore::list_due` split                                                                                      | insight-specific store method (3rd near-dup of list_by_scopes_recent)                                            |
+| B   | Insight marker = structured object `{"insight": {"flushed_at": <rfc3339>}}` keyed by a shared `pub const INSIGHT_MARKER_KEY: &str = "insight"` in `engine/cognitive.rs`, re-exported from `lib.rs`, imported by the MCP writer       | Single source of truth (writer in MCP, reader in core can't drift); object mirrors the quarantine-marker shape; `flushed_at` is a future query handle; read predicate `IS NOT NULL` matches object or bool identically | bare `{"insight":true}` (throws away flush time); const in MCP (reader is in core — must live in the shared dep) |
+| C   | `dream_cycle`/`apply_cycle_report` serialize reports via `serde_json::to_value` + one shared `ok_serialized` helper                                                                                                                  | `CycleReport`/`ApplyResult` derive clean serde; `#[non_exhaustive]` fields flow through automatically (no adapter edit when #57/#578 extend)                                                                           | bespoke wrapper struct (must edit on every core change)                                                          |
+| D   | `CycleError → invalid_params` arm in `to_mcp_error`                                                                                                                                                                                  | a client-supplied bad report is a **client** error, not a server fault; sits with `Conflict`                                                                                                                           | leave unmapped (mis-tiers as INTERNAL_ERROR)                                                                     |
+| E   | Unknown `project_path` → **empty vec** (not error)                                                                                                                                                                                   | list/query convention; project scope nodes are created lazily, so a new project legitimately has no node yet                                                                                                           | `NotFound` (catches client typos but errors on not-yet-created projects) — **flag for reviewer**                 |
+| F   | Scope semantics = **subtree** (resolve_path + subtree, inclusive)                                                                                                                                                                    | a "project" is a node; insights may be filed at it or under it; matches `ScopeQuery::Subtree`                                                                                                                          | exact-only (misses nested); ancestors (leaks parent project)                                                     |
+
+## Implementation Tasks
+
+> TDD: failing test first. Sequenced risk-first — the error-map arm + the marker predicate (the two non-obvious correctness points) land before the tool surface that depends on them.
+
+- [ ] **T0 — Baseline.** On `feat-225-mcp-cognitive-endpoints` at latest `origin/main`. Capture green `cargo build --workspace && cargo test --workspace`.
+- [ ] **T1 — `CycleError → invalid_params` mapping (risk-first: do early).** Add `MemoryError::Cycle(e) => ErrorData::invalid_params(format!("cycle error: {e}"), None)` to `to_mcp_error` (`memory-engine-mcp/src/error.rs`), next to the `Conflict` arm. Unit test `cycle_maps_to_invalid_params` (mirror existing mapping tests). **Note (review):** this tiers ALL `MemoryError::Cycle` as a client error. It is exactly right for `apply_cycle_report` (the report is client-supplied); `run_dream_cycle` could in principle return `Cycle` from a buggy consumer cycle, but the shipped `DefaultDreamCycle` never does (only `NotFound`/`Database`), so the common-case tiering is correct. Acceptable.
+- [ ] **T2 — Insight marker const.** `pub const INSIGHT_MARKER_KEY: &str = "insight";` in `src/engine/cognitive.rs` (doc: single source of truth, writer+reader). Re-export from `src/lib.rs` — the existing line is the **unbraced** `pub use engine::cognitive::DreamContext;`, so convert it to a braced group `pub use engine::cognitive::{DreamContext, INSIGHT_MARKER_KEY};` (or add a second `pub use`).
+- [ ] **T3 — Generic store query (TDD). [BLOCKER fix applied].** Add `FactStore::list_active_by_metadata_key_recent(&self, scope_ids: &[i64], marker_key: &str, limit: usize) -> Result<Vec<Fact>>` in `src/store/facts.rs` as a **standalone query mirroring `list_by_scopes_recent`** (real `params![scope_json, limit_i64]`, `FACT_COLUMNS` via `format!`, `t_created DESC`). Do **NOT** route through `list_active_in_period_inner`'s `extra_conditions` — that idiom is documented non-parameterized (appended verbatim) and cannot carry an extra bind param, so `'$.' || ?key` would collide with the outer query's `?N`. Build the marker predicate as a **trusted-literal** `format!("json_type(metadata, '$.{marker_key}') IS NOT NULL", …)` — `json_type` is the established codebase idiom (#595's `list_undreamt`) and robustly treats absent-key and present-`null` as excluded, present-non-null (our `{flushed_at:…}` object) as included. Rustdoc MUST state: `marker_key` is a **trusted engine const, never client input** (it is interpolated into SQL); contract = "key present with a non-null value". Store-level unit test FIRST: seed (a) 2 marked active in-scope at distinct `t_created`, (b) 1 marked expired, (c) 1 marked out-of-scope, (d) 1 active in-scope unmarked, (e) 1 with `{"insight": null}` → only (a) returns, newest-first; `limit=1` returns newest only; (e) excluded.
+- [ ] **T4 — Engine method.** `MemoryEngine::list_recent_insights(&self, scope_path: &str, limit: usize) -> Result<Vec<Fact>>` in `src/engine/inspect.rs`. **[HIGH fix]** Resolve scope with an explicit early-return — `subtree(unknown_id)` returns the singleton `[id]`, NOT empty, so you must branch on `resolve_path` returning `None`:
+  ```rust
+  let scope_ids = {
+      let tree = self.scope_tree.read();
+      match tree.resolve_path(scope_path) {
+          Some(id) => tree.subtree(id),   // inclusive subtree
+          None => return Ok(Vec::new()),  // unknown project → empty (decision E)
+      }
+  };
+  self.with_read(|conn| FactStore::new(conn, self.embed_dim)
+      .list_active_by_metadata_key_recent(&scope_ids, INSIGHT_MARKER_KEY, limit))
+  ```
+  Do NOT call `subtree` on a fallback id.
+- [ ] **T5 — Engine integration test (TDD).** NEW `tests/recent_insights_test.rs` (public-API, mirror `dream_cycle_test.rs`): nested scopes `project:p` + `project:p/sub`; add facts with/without the `insight` marker at both levels + an expired marked fact; assert subtree scoping + newest-first + limit + expired-excluded + unknown-scope-empty.
+- [ ] **T6 — Shared serialization helper.** `ok_serialized<T: Serialize>(&T)` next to `ok_json` in `tools/mod.rs` (serde failure → `internal_error`, since the value is engine-produced).
+- [ ] **T7 — Correct `handle_flush_insights` to stamp the marker.** At `tools/mod.rs:~896-899`, additionally `m.insert(INSIGHT_MARKER_KEY.to_owned(), json!({"flushed_at": Utc::now().to_rfc3339()}))` (keep `source`). `use memory_engine::INSIGHT_MARKER_KEY;`. **[HIGH fix]** The existing code only stamps inside `if let Value::Object(ref mut m) = metadata`, so a client passing non-object `metadata` (e.g. `"foo"`, `42`) silently gets neither `source` nor the (now load-bearing) insight marker — the fact becomes invisible to `get_recent_insights`. Normalize first, mirroring `promote_in_conn` (cognitive.rs:~291): `let mut metadata = match obj.get("metadata").cloned().unwrap_or(json!({})) { Value::Object(m) => Value::Object(m), _ => json!({}) };` so the marker always lands. Add a test case for non-object metadata input. Verify existing flush tests assert on ids/`source`/counts, not metadata-equality (additive change).
+- [ ] **T8 — `memory_dream_cycle`.** `tool_def` schema (`apply: bool` default true) + dispatch arm + `handle_dream_cycle(args, engine)`: `DefaultDreamCycle::with_defaults()` → `run_dream_cycle`; if `get_bool("apply").unwrap_or(true)` → `apply_cycle_report`. Output `{report, applied?, did_apply}`. No embedder. No consolidation.
+- [ ] **T9 — `memory_apply_cycle_report`.** `tool_def` schema (`report` object, required) + dispatch arm + handler: `serde_json::from_value::<CycleReport>` (failure → `invalid_params`) → `apply_cycle_report` → `ok_serialized(&applied)`.
+- [ ] **T10 — `memory_get_recent_insights`.** `tool_def` schema (`project_path` required, `limit` default 20, `depth` enum) + dispatch arm + handler: `list_recent_insights` → `depth::shape_fact` → `{insights, count}` envelope (mirror `handle_list_due`).
+- [ ] **T11 — MCP integration tests.** NEW `memory-engine-mcp/tests/cognitive_tools.rs` (dispatch directly, mirror `tools.rs`/`tool_roundtrip.rs`): see Testing.
+- [ ] **T12 — Docs** (see Documentation).
+- [ ] **T13 — Full workspace + all-features verification gate** (see Verification).
+- [ ] **T14 — Git ops:** plan issue, commit, PR, `/super-review`, squash-merge.
+
+## Documentation
+
+- `docs/reference/mcp-server.md` — add the 3 tools to the tool table, bump the tool count, document the `apply` flag + the `dream_cycle(apply=false)`→`apply_cycle_report` round-trip, and that `memory_flush_insights` now stamps an `insight` marker consumed by `memory_get_recent_insights`.
+- `docs/advanced/dream-cycle.md` — add an "Exposed via MCP" subsection (note consolidation is NOT bundled; stays `memory_consolidate`).
+- Rustdoc on `INSIGHT_MARKER_KEY`, `list_recent_insights`, `list_active_by_metadata_key_recent` (Errors sections; single-source-of-truth note on the const).
+- Root `CLAUDE.md` Status line if it enumerates MCP tool count.
+
+## Testing
+
+- **Core unit (T3):** the store-query matrix above (active/expired/in-scope/out-of-scope/marked/unmarked + newest-first + limit).
+- **Core integration (T5):** `recent_insights_test.rs` — subtree scoping, ordering, limit, expired-excluded, unknown-scope-empty.
+- **MCP error-map unit (T1):** `MemoryError::Cycle(CycleError::UnknownFact(7)) → INVALID_PARAMS`.
+- **MCP integration (T11):** (a) `dream_cycle apply=true` → `did_apply==true`, `report.deltas` non-empty, `applied.promoted==1` (seed a 3-fact identical-embedding Semantic cluster via the test embedder); (b) `dream_cycle apply=false` → store unchanged, then feed `result.report` into `apply_cycle_report` → `applied.promoted==1` (proves the serde round-trip across the boundary); (c) `apply_cycle_report` with an `AdjustScore` on a non-existent fact → `INVALID_PARAMS` (proves the new mapping end-to-end); (d) malformed `report` JSON → `invalid_params`; (e) `flush_insights(scope=project:p)` → `get_recent_insights(project:p)` returns them newest-first, an unrelated `add_fact` excluded (writer→reader marker proof); (f) `limit` truncates + `depth:sparse` shapes.
+- **Regression:** `dream_cycle_test.rs` stays green (core API unchanged); existing `flush_insights` tests stay green after the additive marker.
+- N/A: e2e (no live MCP transport harness; dispatch-level integration is the established MCP test layer).
+
+## Verification
+
+```bash
+cd .worktrees/feat-225-mcp-cognitive-endpoints
+cargo build --workspace && cargo test --workspace
+cargo clippy --workspace --all-targets        # all=deny; pedantic+nursery=warn — keep new code clean
+cargo fmt --check
+cargo test --all-features                      # exercises apply_cycle_report's ann HNSW branch
+cargo test -p memory-engine-mcp                # new cognitive_tools.rs + existing tool tests
+cargo doc --no-deps                            # rustdoc on new public items
+```
+
+Acceptance: all green; no clippy findings in new code; new MCP tools dispatch end-to-end; `flush → get_recent_insights` round-trips.
+
+## Git ops
+
+- Worktree exists. **Plan issue:** `type:plan` + `area:mcp`, link #225 + this draft; link under #221/#554 via `addSubIssue`. Keep auto-close verbs (`Closes #225`) out of intermediate commits — only in the final PR body.
+- Atomic Conventional Commits (no co-author): `feat(mcp): map CycleError to invalid_params`; `feat(core): INSIGHT_MARKER_KEY + list_recent_insights`; `feat(mcp): expose dream_cycle/apply_cycle_report/get_recent_insights (#225)`; `docs(mcp): document cognitive tools`.
+- PR against `main`; `/super-review` (expect gemini bot); rebase + re-gate before merge (CLEAN ≠ semantically safe); squash-merge; delete branch; remove worktree.
+
+## Risks / watch-items
+
+- **Marker drift** — structurally prevented by the shared `INSIGHT_MARKER_KEY`; the flush→get_recent_insights test fails loudly if they diverge.
+- **`flush_insights` test regression** — additive metadata; confirm no test asserts metadata-equality (T7).
+- **CycleError mis-tier** — closed by T1 + its test.
+- **`#[non_exhaustive]` serde passthrough** — `to_value` means #57/#578 field/variant additions flow to the wire automatically (no adapter edit).
+- **Unknown-scope semantics (decision E)** — empty-vec chosen; reviewer may prefer NotFound.
+- **`unsafe_code = forbid`** — satisfied (pure Rust, no FFI).

--- a/docs/plans/2026-06-16-mcp-cognitive-endpoints.md
+++ b/docs/plans/2026-06-16-mcp-cognitive-endpoints.md
@@ -145,3 +145,14 @@ Reviewers: correctness/SQL (rust-specialist), security/boundary (code-reviewer),
 - **Dispositioned, no change:** `pub` (not `pub(crate)`) on `list_active_by_metadata_key_recent` — kept to match its sibling `list_by_scopes_recent`; `FactStore` is crate-internal so it is effectively `pub(crate)` at the boundary, and a `debug_assert` + rustdoc contract guard the trusted-literal interpolation. CycleError mis-tier for a hypothetical buggy custom `DreamCycle` — documented/benign with the shipped `DefaultDreamCycle`.
 
 Gate after fixes: workspace 1110 passed / 4 ignored; `--all-features` 926 passed / 4 ignored; clippy exit 0; fmt clean.
+
+### Review Round 2 (gemini-code-assist bot)
+
+The bot raised 4 findings, all on the "validate-at-boundary, never silently coerce" theme — consistent with the MCP server's stated contract. All adopted (committed as a second `fix(...)`):
+
+- **[security-high] `marker_key` runtime guard**: replaced the `debug_assert` (compiled out in release) with a real runtime check returning `ConflictError::QueryValidation`. The bot suggested `MemoryError::InvalidArgument` — that variant does **not** exist (the bot is type-blind); used the real `QueryValidation` variant. Store test `list_active_by_metadata_key_recent_rejects_non_identifier_key`.
+- **[medium] flush_insights non-object metadata**: reverted the earlier normalize-to-`{}` to a per-entry rejection into `failed[]` (matches the batch-failure pattern; the client learns, sibling insights still flush). This supersedes the Round-1 normalization. Test `flush_insights_non_object_metadata_is_rejected`.
+- **[medium] `apply` malformed → invalid_params** (it mutates; silent-true is a footgun). Test `dream_cycle_malformed_apply_is_invalid_params`.
+- **[medium] `limit` malformed → invalid_params** (strengthened the Round-1 `limit==0` guard to reject strings/negatives/zero/non-integers). Test `get_recent_insights_malformed_limit_is_invalid_params`.
+
+Gate after Round 2: workspace 1114 passed / 4 ignored; clippy exit 0; fmt clean.

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## What
 
-A stdio-based MCP server binary that exposes memory-engine as 18 tools (10 P0 + 5 P1 + 3 activity stream) for autonomous AI agents. Part of the four-layer cognitive architecture (Knowledge → Memory → Wisdom → Intelligence) — this crate bridges Memory to Intelligence via the Model Context Protocol.
+A stdio-based MCP server binary that exposes memory-engine as 26 tools (10 P0 + 5 P1 + 3 P2 + 2 Phase-5a outcome + 3 cognitive + 3 activity stream) for autonomous AI agents. Part of the four-layer cognitive architecture (Knowledge → Memory → Wisdom → Intelligence) — this crate bridges Memory to Intelligence via the Model Context Protocol.
 
 ## Why
 
@@ -70,26 +70,34 @@ Add to `.claude/settings.json`:
 
 ### Tools
 
-| Tool                        | Priority | Purpose                                | Depth                |
-| --------------------------- | -------- | -------------------------------------- | -------------------- |
-| `memory_ingest`             | P0       | Append event to log                    | —                    |
-| `memory_add_fact`           | P0       | Add fact with embedding                | —                    |
-| `memory_query`              | P0       | Hybrid FTS + vector search             | sparse/standard/full |
-| `memory_resume_context`     | P0       | 5-tier cognitive boot                  | sparse/standard/full |
-| `memory_list_due`           | P0       | Scheduled fact surfacing               | sparse/standard/full |
-| `memory_next_due_time`      | P0       | Next scheduled time                    | —                    |
-| `memory_explain_fact`       | P0       | Fact provenance                        | sparse/standard/full |
-| `memory_get_fact`           | P0       | Single fact by ID                      | sparse/standard/full |
-| `memory_statistics`         | P0       | Aggregate stats                        | —                    |
-| `memory_flush_insights`     | P0       | Batch pre-compaction capture           | —                    |
-| `memory_consolidate`        | P1       | Dedup + cluster facts into summaries   | —                    |
-| `memory_forget`             | P1       | Ebbinghaus decay pruning               | —                    |
-| `memory_dump_state`         | P1       | Export snapshot (JSON/SQLite)          | —                    |
-| `memory_pin_fact`           | P1       | Make fact unforgettable                | —                    |
-| `memory_unpin_fact`         | P1       | Allow forgetting a pinned fact         | —                    |
-| `memory_record_activity`    | Activity | Record tool invocation with dedup      | —                    |
-| `memory_checkpoint_session` | Activity | Checkpoint session state (LWW)         | —                    |
-| `memory_load_context`       | Activity | Load project context for session start | sparse/standard/full |
+| Tool                         | Priority  | Purpose                                | Depth                |
+| ---------------------------- | --------- | -------------------------------------- | -------------------- |
+| `memory_ingest`              | P0        | Append event to log                    | —                    |
+| `memory_add_fact`            | P0        | Add fact with embedding                | —                    |
+| `memory_query`               | P0        | Hybrid FTS + vector search             | sparse/standard/full |
+| `memory_resume_context`      | P0        | 5-tier cognitive boot                  | sparse/standard/full |
+| `memory_list_due`            | P0        | Scheduled fact surfacing               | sparse/standard/full |
+| `memory_next_due_time`       | P0        | Next scheduled time                    | —                    |
+| `memory_explain_fact`        | P0        | Fact provenance                        | sparse/standard/full |
+| `memory_get_fact`            | P0        | Single fact by ID                      | sparse/standard/full |
+| `memory_statistics`          | P0        | Aggregate stats                        | —                    |
+| `memory_flush_insights`      | P0        | Batch pre-compaction capture           | —                    |
+| `memory_consolidate`         | P1        | Dedup + cluster facts into summaries   | —                    |
+| `memory_forget`              | P1        | Ebbinghaus decay pruning               | —                    |
+| `memory_dump_state`          | P1        | Export snapshot (JSON/SQLite)          | —                    |
+| `memory_pin_fact`            | P1        | Make fact unforgettable                | —                    |
+| `memory_unpin_fact`          | P1        | Allow forgetting a pinned fact         | —                    |
+| `memory_replay_events`       | P2        | Replay the event log                   | —                    |
+| `memory_fact_history`        | P2        | Bi-temporal history of a fact          | —                    |
+| `memory_bootstrap_session`   | P2        | Seed a session from prior memory       | sparse/standard/full |
+| `memory_record_outcome`      | Phase 5a  | Record an outcome for a fact           | —                    |
+| `memory_outcome_counts`      | Phase 5a  | Aggregate outcome counts               | —                    |
+| `memory_dream_cycle`         | Cognitive | Run the DreamCycle (`apply` flag)      | —                    |
+| `memory_apply_cycle_report`  | Cognitive | Apply a previously-produced report     | —                    |
+| `memory_get_recent_insights` | Cognitive | Recent flushed insights by scope       | sparse/standard/full |
+| `memory_record_activity`     | Activity  | Record tool invocation with dedup      | —                    |
+| `memory_checkpoint_session`  | Activity  | Checkpoint session state (LWW)         | —                    |
+| `memory_load_context`        | Activity  | Load project context for session start | sparse/standard/full |
 
 ### Tiered Depth
 
@@ -146,6 +154,18 @@ Exports the full engine snapshot. Formats: `json`, `sqlite`. Client-supplied pat
 ### Pin / Unpin
 
 `memory_pin_fact` and `memory_unpin_fact` toggle a fact's persistence. Pinned facts are immune to `memory_forget`.
+
+### Cognitive Pipeline (`memory_dream_cycle`, `memory_apply_cycle_report`, `memory_get_recent_insights`)
+
+These expose the Phase-5a [DreamCycle](../advanced/dream-cycle.md) over MCP. The engine separates _producing_ a cycle report (a pure analysis pass, no mutation) from _applying_ it (the mutating step). The MCP surface offers both the ergonomic one-call form and the explicit two-step gate:
+
+| Tool                         | Behavior                                                                                                                                                                                                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `memory_dream_cycle`         | Runs `DefaultDreamCycle::with_defaults()` and returns the `CycleReport`. `apply` (bool, default `true`) controls whether the report is applied in the same call. Returns `{ report, did_apply, applied? }` — `applied` present only when `did_apply` is true. |
+| `memory_apply_cycle_report`  | Applies a report produced by an earlier `apply:false` run (serde round-trips across the boundary). Malformed JSON or a report referencing an unknown fact → `invalid_params`. Returns the `ApplyResult`.                                                      |
+| `memory_get_recent_insights` | Returns facts flushed via `memory_flush_insights`, scoped to `project_path`'s subtree, newest-first, capped by `limit` (default 20). An unknown `project_path` returns an empty list, not an error. Honors tiered `depth`.                                    |
+
+The dream cycle does **not** run consolidation — it is a lightweight, idempotent-by-report analysis pass. The `apply:false` → `memory_apply_cycle_report` split lets an agent review the proposed deltas before committing them. `memory_get_recent_insights` reads the same shared insight marker (`INSIGHT_MARKER_KEY`) that `memory_flush_insights` stamps, so the writer and reader cannot drift.
 
 ### Activity Stream (`memory_record_activity`)
 

--- a/memory-engine-mcp/src/error.rs
+++ b/memory-engine-mcp/src/error.rs
@@ -14,6 +14,11 @@ pub fn to_mcp_error(err: MemoryError) -> ErrorData {
 
         MemoryError::Conflict(msg) => ErrorData::invalid_params(format!("conflict: {msg}"), None),
 
+        // A dream-cycle report that fails validation/application is a client-input
+        // error (the report is client-supplied to `memory_apply_cycle_report`), so it
+        // maps to invalid_params alongside `Conflict` — not the internal-error default.
+        MemoryError::Cycle(e) => ErrorData::invalid_params(format!("cycle error: {e}"), None),
+
         MemoryError::Database(e) => ErrorData::internal_error(format!("database error: {e}"), None),
 
         MemoryError::Serialization(e) => {
@@ -125,6 +130,15 @@ mod tests {
         let err = MemoryError::Database(rusqlite::Error::QueryReturnedNoRows);
         let mcp = to_mcp_error(err);
         assert_eq!(mcp.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn cycle_maps_to_invalid_params() {
+        use memory_engine::error::CycleError;
+        let err = MemoryError::Cycle(CycleError::UnknownFact(7));
+        let mcp = to_mcp_error(err);
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(mcp.message.contains("cycle error"));
     }
 
     #[test]

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -952,25 +952,31 @@ fn handle_flush_insights(
             }
         }
 
-        // Normalize non-object metadata to {} so the (load-bearing) insight marker
-        // always lands — a client passing e.g. `"metadata": "foo"` must not silently
-        // drop the marker and make the fact invisible to get_recent_insights.
-        let mut metadata = match obj.get("metadata").cloned().unwrap_or(json!({})) {
-            Value::Object(m) => Value::Object(m),
-            _ => json!({}),
+        // Metadata must be absent/null or an object — a present non-object (e.g.
+        // `"metadata": "foo"`) is a malformed entry, rejected into `failed` rather than
+        // silently coerced (which would also drop the load-bearing insight marker). The
+        // marker is then always stamped onto a valid object, so a flushed insight is
+        // never invisible to get_recent_insights.
+        let mut metadata = match obj.get("metadata") {
+            None | Some(Value::Null) => serde_json::Map::new(),
+            Some(Value::Object(m)) => m.clone(),
+            Some(v) => {
+                failed.push(
+                    json!({ "index": i, "error": format!("metadata must be an object, got {v}") }),
+                );
+                continue;
+            }
         };
-        if let Value::Object(ref mut m) = metadata {
-            m.insert("source".to_owned(), json!("pre_compaction_flush"));
-            // Insight marker read by memory_get_recent_insights (shared INSIGHT_MARKER_KEY).
-            m.insert(
-                INSIGHT_MARKER_KEY.to_owned(),
-                json!({ "flushed_at": Utc::now().to_rfc3339() }),
-            );
-        }
+        metadata.insert("source".to_owned(), json!("pre_compaction_flush"));
+        // Insight marker read by memory_get_recent_insights (shared INSIGHT_MARKER_KEY).
+        metadata.insert(
+            INSIGHT_MARKER_KEY.to_owned(),
+            json!({ "flushed_at": Utc::now().to_rfc3339() }),
+        );
 
         let opts = AddFactOptions {
             importance,
-            metadata: Some(metadata),
+            metadata: Some(Value::Object(metadata)),
             ..Default::default()
         };
 
@@ -1528,7 +1534,18 @@ fn handle_dream_cycle(
     args: Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let apply = get_bool(&args, "apply").unwrap_or(true);
+    // `apply` mutates the store, so a present-but-malformed value must NOT silently
+    // fall back to `true` — reject it. Absent/null → default true.
+    let apply = match args.get("apply") {
+        None | Some(Value::Null) => true,
+        Some(Value::Bool(b)) => *b,
+        Some(v) => {
+            return Err(ErrorData::invalid_params(
+                format!("'apply' must be a boolean, got {v}"),
+                None,
+            ));
+        }
+    };
     let cycle = DefaultDreamCycle::with_defaults();
     let report = engine.run_dream_cycle(&cycle).map_err(to_mcp_error)?;
 
@@ -1566,13 +1583,22 @@ fn handle_get_recent_insights(
 ) -> Result<CallToolResult, ErrorData> {
     let project_path = get_str(&args, "project_path")
         .ok_or_else(|| ErrorData::invalid_params("missing 'project_path'", None))?;
-    let limit = get_usize(&args, "limit").unwrap_or(20);
-    // The schema declares `minimum: 1`; enforce it here since the MCP layer does not
-    // validate args against the schema. A silent `limit=0` would return an empty list
-    // indistinguishable from "no insights exist".
-    if limit == 0 {
-        return Err(ErrorData::invalid_params("'limit' must be >= 1", None));
-    }
+    // The schema declares `limit` as an integer `minimum: 1`; the MCP layer does not
+    // validate args against the schema, so enforce it here. A present-but-malformed
+    // value (string, negative, 0) is rejected rather than silently defaulting to 20 or
+    // returning an empty list indistinguishable from "no insights exist". Absent → 20.
+    let limit = match args.get("limit") {
+        None | Some(Value::Null) => 20,
+        Some(v) => match v.as_u64().and_then(|n| usize::try_from(n).ok()) {
+            Some(n) if n >= 1 => n,
+            _ => {
+                return Err(ErrorData::invalid_params(
+                    format!("'limit' must be an integer >= 1, got {v}"),
+                    None,
+                ));
+            }
+        },
+    };
     let depth_level = get_depth(&args)?;
 
     let facts = engine

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use memory_engine::ResumeConfig;
 use memory_engine::bootstrap::{BootstrapConfig, KeywordExtractor};
 use memory_engine::engine::MemoryEngine;
 use memory_engine::inspect_types::{DumpFormat, FactExplanation, ReplayFilter, ReplayOrder};
@@ -15,12 +14,14 @@ use memory_engine::traits::{
 use memory_engine::types::{
     AddFactOptions, AddFactRequest, EventType, FactType, NewEvent, Outcome,
 };
+use memory_engine::ResumeConfig;
+use memory_engine::{CycleReport, DefaultDreamCycle, INSIGHT_MARKER_KEY};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 
 use crate::depth::{self, Depth};
 use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
-use crate::error::{ValidationError, to_mcp_error};
+use crate::error::{to_mcp_error, ValidationError};
 
 // ---------------------------------------------------------------------------
 // Tool definitions (JSON schemas)
@@ -363,6 +364,41 @@ pub fn all_tool_definitions() -> Vec<Tool> {
                 "required": ["scope"]
             }),
         ),
+        // Phase 5a: Cognitive pipeline (dream cycle) tools (#225)
+        tool_def(
+            "memory_dream_cycle",
+            "Run the dream-cycle cognitive pipeline (cluster → promote → rescore → quarantine) and return a delta-based CycleReport. With apply=true (default) the report is applied immediately; with apply=false it is returned unapplied for review and applied later via memory_apply_cycle_report. Does NOT run consolidation (use memory_consolidate for that).",
+            json!({
+                "type": "object",
+                "properties": {
+                    "apply": { "type": "boolean", "default": true, "description": "Apply the produced report immediately. If false, return the unapplied report for review." }
+                }
+            }),
+        ),
+        tool_def(
+            "memory_apply_cycle_report",
+            "Apply a CycleReport (as returned by memory_dream_cycle with apply=false) to the store, returning an ApplyResult. The whole report is validated before any mutation; a malformed or stale report is rejected without changing the store.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "report": { "type": "object", "description": "A CycleReport JSON object produced by memory_dream_cycle (apply=false)." }
+                },
+                "required": ["report"]
+            }),
+        ),
+        tool_def(
+            "memory_get_recent_insights",
+            "Return recent model-logged insights (facts flushed via memory_flush_insights) within a project scope subtree, newest-first.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "project_path": { "type": "string", "description": "Scope path of the project (e.g. 'project:memory-engine'). Insights anywhere in this subtree are returned." },
+                    "limit": { "type": "integer", "minimum": 1, "default": 20, "description": "Max insights to return (newest-first)." },
+                    "depth": { "type": "string", "enum": ["sparse", "standard", "full"], "default": "standard" }
+                },
+                "required": ["project_path"]
+            }),
+        ),
     ]
 }
 
@@ -427,6 +463,10 @@ pub fn dispatch(
         "memory_record_activity" => handle_record_activity(args, engine, embedder, filter_config),
         "memory_checkpoint_session" => handle_checkpoint_session(args, engine),
         "memory_load_context" => handle_load_context(args, engine),
+        // Phase 5a: Cognitive pipeline (dream cycle) (#225)
+        "memory_dream_cycle" => handle_dream_cycle(args, engine),
+        "memory_apply_cycle_report" => handle_apply_cycle_report(args, engine),
+        "memory_get_recent_insights" => handle_get_recent_insights(args, engine),
         _ => Err(ErrorData::invalid_params(
             format!("unknown tool: {name}"),
             None,
@@ -528,6 +568,15 @@ fn require_f64_if_present(args: &Map<String, Value>, key: &str) -> Result<Option
 
 fn ok_json(value: Value) -> Result<CallToolResult, ErrorData> {
     Ok(CallToolResult::success(vec![Content::json(value)?]))
+}
+
+/// Serialize an engine-produced value into a tool result. A serde failure maps to an
+/// internal error (the value is engine-produced, so failure is a server bug).
+#[must_use = "the serialized tool result must be returned to the caller"]
+fn ok_serialized<T: serde::Serialize>(value: &T) -> Result<CallToolResult, ErrorData> {
+    let v = serde_json::to_value(value)
+        .map_err(|e| ErrorData::internal_error(format!("serialize: {e}"), None))?;
+    ok_json(v)
 }
 
 // ---------------------------------------------------------------------------
@@ -903,9 +952,20 @@ fn handle_flush_insights(
             }
         }
 
-        let mut metadata = obj.get("metadata").cloned().unwrap_or_else(|| json!({}));
+        // Normalize non-object metadata to {} so the (load-bearing) insight marker
+        // always lands — a client passing e.g. `"metadata": "foo"` must not silently
+        // drop the marker and make the fact invisible to get_recent_insights.
+        let mut metadata = match obj.get("metadata").cloned().unwrap_or(json!({})) {
+            Value::Object(m) => Value::Object(m),
+            _ => json!({}),
+        };
         if let Value::Object(ref mut m) = metadata {
             m.insert("source".to_owned(), json!("pre_compaction_flush"));
+            // Insight marker read by memory_get_recent_insights (shared INSIGHT_MARKER_KEY).
+            m.insert(
+                INSIGHT_MARKER_KEY.to_owned(),
+                json!({ "flushed_at": Utc::now().to_rfc3339() }),
+            );
         }
 
         let opts = AddFactOptions {
@@ -1457,6 +1517,66 @@ fn handle_load_context(
         .map_err(to_mcp_error)?;
 
     ok_json(depth::shape_project_context(&ctx, depth_level))
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5a: Cognitive pipeline (dream cycle) handlers (#225)
+// ---------------------------------------------------------------------------
+
+/// Run the dream-cycle pipeline, optionally applying the report (default: apply).
+fn handle_dream_cycle(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let apply = get_bool(&args, "apply").unwrap_or(true);
+    let cycle = DefaultDreamCycle::with_defaults();
+    let report = engine.run_dream_cycle(&cycle).map_err(to_mcp_error)?;
+
+    let report_json = serde_json::to_value(&report)
+        .map_err(|e| ErrorData::internal_error(format!("serialize report: {e}"), None))?;
+
+    if apply {
+        let applied = engine.apply_cycle_report(&report).map_err(to_mcp_error)?;
+        let applied_json = serde_json::to_value(&applied)
+            .map_err(|e| ErrorData::internal_error(format!("serialize apply result: {e}"), None))?;
+        ok_json(json!({ "report": report_json, "applied": applied_json, "did_apply": true }))
+    } else {
+        ok_json(json!({ "report": report_json, "did_apply": false }))
+    }
+}
+
+/// Apply a client-supplied `CycleReport` (the gated path).
+fn handle_apply_cycle_report(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let report_val = args
+        .get("report")
+        .ok_or_else(|| ErrorData::invalid_params("missing 'report'", None))?;
+    let report: CycleReport = serde_json::from_value(report_val.clone())
+        .map_err(|e| ErrorData::invalid_params(format!("invalid CycleReport: {e}"), None))?;
+    let applied = engine.apply_cycle_report(&report).map_err(to_mcp_error)?;
+    ok_serialized(&applied)
+}
+
+/// Return recent insight facts in a project scope subtree, newest-first.
+fn handle_get_recent_insights(
+    args: Map<String, Value>,
+    engine: &MemoryEngine,
+) -> Result<CallToolResult, ErrorData> {
+    let project_path = get_str(&args, "project_path")
+        .ok_or_else(|| ErrorData::invalid_params("missing 'project_path'", None))?;
+    let limit = get_usize(&args, "limit").unwrap_or(20);
+    let depth_level = get_depth(&args)?;
+
+    let facts = engine
+        .list_recent_insights(&project_path, limit)
+        .map_err(to_mcp_error)?;
+    let shaped: Vec<Value> = facts
+        .iter()
+        .map(|f| depth::shape_fact(f, depth_level, None))
+        .collect();
+    ok_json(json!({ "insights": shaped, "count": shaped.len() }))
 }
 
 #[cfg(test)]

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1567,6 +1567,12 @@ fn handle_get_recent_insights(
     let project_path = get_str(&args, "project_path")
         .ok_or_else(|| ErrorData::invalid_params("missing 'project_path'", None))?;
     let limit = get_usize(&args, "limit").unwrap_or(20);
+    // The schema declares `minimum: 1`; enforce it here since the MCP layer does not
+    // validate args against the schema. A silent `limit=0` would return an empty list
+    // indistinguishable from "no insights exist".
+    if limit == 0 {
+        return Err(ErrorData::invalid_params("'limit' must be >= 1", None));
+    }
     let depth_level = get_depth(&args)?;
 
     let facts = engine

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use memory_engine::ResumeConfig;
 use memory_engine::bootstrap::{BootstrapConfig, KeywordExtractor};
 use memory_engine::engine::MemoryEngine;
 use memory_engine::inspect_types::{DumpFormat, FactExplanation, ReplayFilter, ReplayOrder};
@@ -14,14 +15,13 @@ use memory_engine::traits::{
 use memory_engine::types::{
     AddFactOptions, AddFactRequest, EventType, FactType, NewEvent, Outcome,
 };
-use memory_engine::ResumeConfig;
 use memory_engine::{CycleReport, DefaultDreamCycle, INSIGHT_MARKER_KEY};
 use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::depth::{self, Depth};
 use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
-use crate::error::{to_mcp_error, ValidationError};
+use crate::error::{ValidationError, to_mcp_error};
 
 // ---------------------------------------------------------------------------
 // Tool definitions (JSON schemas)
@@ -1531,7 +1531,7 @@ fn handle_load_context(
 
 /// Run the dream-cycle pipeline, optionally applying the report (default: apply).
 fn handle_dream_cycle(
-    args: Map<String, Value>,
+    args: &Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
     // `apply` mutates the store, so a present-but-malformed value must NOT silently
@@ -1564,7 +1564,7 @@ fn handle_dream_cycle(
 
 /// Apply a client-supplied `CycleReport` (the gated path).
 fn handle_apply_cycle_report(
-    args: Map<String, Value>,
+    args: &Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
     let report_val = args
@@ -1578,10 +1578,10 @@ fn handle_apply_cycle_report(
 
 /// Return recent insight facts in a project scope subtree, newest-first.
 fn handle_get_recent_insights(
-    args: Map<String, Value>,
+    args: &Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let project_path = get_str(&args, "project_path")
+    let project_path = get_str(args, "project_path")
         .ok_or_else(|| ErrorData::invalid_params("missing 'project_path'", None))?;
     // The schema declares `limit` as an integer `minimum: 1`; the MCP layer does not
     // validate args against the schema, so enforce it here. A present-but-malformed
@@ -1599,7 +1599,7 @@ fn handle_get_recent_insights(
             }
         },
     };
-    let depth_level = get_depth(&args)?;
+    let depth_level = get_depth(args)?;
 
     let facts = engine
         .list_recent_insights(&project_path, limit)

--- a/memory-engine-mcp/tests/cognitive_tools.rs
+++ b/memory-engine-mcp/tests/cognitive_tools.rs
@@ -200,6 +200,39 @@ fn get_recent_insights_limit_zero_is_invalid_params() {
 }
 
 #[test]
+fn get_recent_insights_malformed_limit_is_invalid_params() {
+    let (engine, _d) = engine();
+    seed(&engine, "insight", Some("project:p"), true);
+    // A present-but-wrong-type limit must reject, not silently default to 20.
+    for bad in [json!("ten"), json!(-3), json!(1.5)] {
+        let err = call(
+            &engine,
+            "memory_get_recent_insights",
+            args(&[("project_path", json!("project:p")), ("limit", bad.clone())]),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.code,
+            ErrorCode::INVALID_PARAMS,
+            "limit {bad} must reject"
+        );
+    }
+}
+
+#[test]
+fn dream_cycle_malformed_apply_is_invalid_params() {
+    let (engine, _d) = engine();
+    // `apply` mutates; a present-but-non-bool value must reject, not default to true.
+    let err = call(
+        &engine,
+        "memory_dream_cycle",
+        args(&[("apply", json!("yes"))]),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[test]
 fn get_recent_insights_sparse_depth_shapes_facts() {
     let (engine, _d) = engine();
     seed(&engine, "insight one", Some("project:p"), true);

--- a/memory-engine-mcp/tests/cognitive_tools.rs
+++ b/memory-engine-mcp/tests/cognitive_tools.rs
@@ -1,0 +1,204 @@
+//! Dispatch-level integration tests for the Phase-5a cognitive MCP tools (#225):
+//! `memory_dream_cycle`, `memory_apply_cycle_report`, `memory_get_recent_insights`.
+
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
+use memory_engine::{INSIGHT_MARKER_KEY, MemoryEngine};
+use memory_engine_mcp::tools;
+use rmcp::model::{CallToolResult, ErrorCode, ErrorData, RawContent};
+use serde_json::{Map, Value, json};
+
+const DIM: usize = 3;
+
+struct FakeEmbed;
+impl EmbeddingProvider for FakeEmbed {
+    fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
+        Ok(vec![0.1, 0.2, 0.3]) // identical for all → one DBSCAN cluster
+    }
+}
+
+fn engine() -> (MemoryEngine, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let e = MemoryEngine::builder(DIM)
+        .path(dir.path().join("t.db"))
+        .build()
+        .unwrap();
+    (e, dir)
+}
+
+fn args(pairs: &[(&str, Value)]) -> Map<String, Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), v.clone()))
+        .collect()
+}
+
+fn cfg() -> memory_engine::ActivityFilterConfig {
+    memory_engine::ActivityFilterConfig::default()
+}
+
+fn call(
+    engine: &MemoryEngine,
+    name: &str,
+    a: Map<String, Value>,
+) -> Result<CallToolResult, ErrorData> {
+    tools::dispatch(name, a, engine, None, None, DIM, &cfg())
+}
+
+fn extract_json(result: &CallToolResult) -> Value {
+    match &result.content[0].raw {
+        RawContent::Text(t) => serde_json::from_str(&t.text).unwrap(),
+        _ => panic!("expected text content"),
+    }
+}
+
+/// Seed a Semantic fact directly (dispatch's add_fact needs an HTTP embedder).
+fn seed(engine: &MemoryEngine, content: &str, scope: Option<&str>, insight: bool) -> i64 {
+    let metadata =
+        insight.then(|| json!({ INSIGHT_MARKER_KEY: { "flushed_at": "2024-01-01T00:00:00Z" } }));
+    let req = AddFactRequest {
+        content: content.into(),
+        fact_type: FactType::Semantic,
+        source_event_id: None,
+        scope: scope.map(Into::into),
+        opts: Some(AddFactOptions {
+            metadata,
+            ..Default::default()
+        }),
+    };
+    engine.add_fact(&req, &FakeEmbed, None).unwrap()
+}
+
+#[test]
+fn dream_cycle_apply_true_runs_and_applies() {
+    let (engine, _d) = engine();
+    for i in 0..3 {
+        seed(&engine, &format!("pattern {i}"), None, false);
+    }
+    let body = extract_json(
+        &call(
+            &engine,
+            "memory_dream_cycle",
+            args(&[("apply", json!(true))]),
+        )
+        .unwrap(),
+    );
+    assert_eq!(body["did_apply"], json!(true));
+    assert!(!body["report"]["deltas"].as_array().unwrap().is_empty());
+    assert_eq!(
+        body["applied"]["promoted"],
+        json!(1),
+        "the 3-fact cluster promotes one representative"
+    );
+}
+
+#[test]
+fn dream_cycle_dry_run_then_apply_roundtrips() {
+    let (engine, _d) = engine();
+    for i in 0..3 {
+        seed(&engine, &format!("pattern {i}"), None, false);
+    }
+    // Dry-run: produce but do not apply.
+    let dry = extract_json(
+        &call(
+            &engine,
+            "memory_dream_cycle",
+            args(&[("apply", json!(false))]),
+        )
+        .unwrap(),
+    );
+    assert_eq!(dry["did_apply"], json!(false));
+    assert!(dry.get("applied").is_none());
+
+    // Feed the unapplied report back through apply_cycle_report (serde round-trip across the boundary).
+    let report = dry["report"].clone();
+    let applied = extract_json(
+        &call(
+            &engine,
+            "memory_apply_cycle_report",
+            args(&[("report", report)]),
+        )
+        .unwrap(),
+    );
+    assert_eq!(applied["promoted"], json!(1));
+}
+
+#[test]
+fn apply_cycle_report_unknown_fact_is_invalid_params() {
+    let (engine, _d) = engine();
+    // Hand-built report: AdjustScore on a nonexistent fact → CycleError::UnknownFact → invalid_params.
+    let report = json!({
+        "deltas": [ { "AdjustScore": { "fact_id": 999_999, "adjustment": 1 } } ],
+        "identity": { "anchors": [], "core": [], "predictions": [] },
+        "metadata": {
+            "cycle_id": 0, "ran_at": "2026-06-16T00:00:00Z",
+            "time_window": { "start": "2026-06-16T00:00:00Z", "end": "2026-06-16T00:00:00Z" },
+            "facts_selected": 0, "method_version": "test", "processed_ids": []
+        }
+    });
+    let err = call(
+        &engine,
+        "memory_apply_cycle_report",
+        args(&[("report", report)]),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[test]
+fn apply_cycle_report_malformed_json_is_invalid_params() {
+    let (engine, _d) = engine();
+    let err = call(
+        &engine,
+        "memory_apply_cycle_report",
+        args(&[("report", json!({ "deltas": "nonsense" }))]),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[test]
+fn get_recent_insights_returns_marked_facts_scoped_and_limited() {
+    let (engine, _d) = engine();
+    seed(&engine, "insight one", Some("project:p"), true);
+    seed(&engine, "insight two", Some("project:p/sub"), true); // subtree
+    seed(&engine, "ordinary", Some("project:p"), false); // unmarked → excluded
+    seed(
+        &engine,
+        "other project insight",
+        Some("project:other"),
+        true,
+    ); // out of subtree → excluded
+
+    let body = extract_json(
+        &call(
+            &engine,
+            "memory_get_recent_insights",
+            args(&[("project_path", json!("project:p"))]),
+        )
+        .unwrap(),
+    );
+    assert_eq!(body["count"], json!(2), "only the two in-subtree insights");
+
+    // limit truncates.
+    let limited = extract_json(
+        &call(
+            &engine,
+            "memory_get_recent_insights",
+            args(&[("project_path", json!("project:p")), ("limit", json!(1))]),
+        )
+        .unwrap(),
+    );
+    assert_eq!(limited["count"], json!(1));
+
+    // unknown project → empty, not an error.
+    let empty = extract_json(
+        &call(
+            &engine,
+            "memory_get_recent_insights",
+            args(&[("project_path", json!("project:nope"))]),
+        )
+        .unwrap(),
+    );
+    assert_eq!(empty["count"], json!(0));
+}

--- a/memory-engine-mcp/tests/cognitive_tools.rs
+++ b/memory-engine-mcp/tests/cognitive_tools.rs
@@ -158,6 +158,73 @@ fn apply_cycle_report_malformed_json_is_invalid_params() {
 }
 
 #[test]
+fn apply_cycle_report_missing_report_key_is_invalid_params() {
+    let (engine, _d) = engine();
+    // The `report` key is absent entirely (distinct from present-but-malformed).
+    let err = call(&engine, "memory_apply_cycle_report", args(&[])).unwrap_err();
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[test]
+fn dream_cycle_on_empty_store_succeeds_with_no_deltas() {
+    let (engine, _d) = engine();
+    // No facts seeded: DefaultDreamCycle guards empty/under-min buckets, so the cycle
+    // must succeed (not error) and produce an empty delta set.
+    let body = extract_json(
+        &call(
+            &engine,
+            "memory_dream_cycle",
+            args(&[("apply", json!(true))]),
+        )
+        .unwrap(),
+    );
+    assert_eq!(body["did_apply"], json!(true));
+    assert!(
+        body["report"]["deltas"].as_array().unwrap().is_empty(),
+        "empty store yields no deltas"
+    );
+}
+
+#[test]
+fn get_recent_insights_limit_zero_is_invalid_params() {
+    let (engine, _d) = engine();
+    seed(&engine, "insight", Some("project:p"), true);
+    // Schema declares minimum:1; limit=0 must be rejected, not silently empty.
+    let err = call(
+        &engine,
+        "memory_get_recent_insights",
+        args(&[("project_path", json!("project:p")), ("limit", json!(0))]),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[test]
+fn get_recent_insights_sparse_depth_shapes_facts() {
+    let (engine, _d) = engine();
+    seed(&engine, "insight one", Some("project:p"), true);
+    let body = extract_json(
+        &call(
+            &engine,
+            "memory_get_recent_insights",
+            args(&[
+                ("project_path", json!("project:p")),
+                ("depth", json!("sparse")),
+            ]),
+        )
+        .unwrap(),
+    );
+    assert_eq!(body["count"], json!(1));
+    // Sparse shaping drops heavy fields (embedding/content_hash) but keeps id + content.
+    let fact = &body["insights"][0];
+    assert!(fact["id"].as_i64().is_some());
+    assert!(
+        fact.get("embedding").is_none(),
+        "sparse must omit embedding"
+    );
+}
+
+#[test]
 fn get_recent_insights_returns_marked_facts_scoped_and_limited() {
     let (engine, _d) = engine();
     seed(&engine, "insight one", Some("project:p"), true);

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -549,6 +549,61 @@ async fn flush_insights_partial_failure() {
     assert_eq!(body["failed_count"].as_u64().unwrap(), 2);
 }
 
+/// A present-but-non-object `metadata` is rejected per-entry into `failed` (not
+/// silently coerced to `{}`), while a sibling insight with valid metadata still flushes.
+#[tokio::test(flavor = "multi_thread")]
+async fn flush_insights_non_object_metadata_is_rejected() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+    // Only the one valid insight reaches the batch embed → 1 indexed embedding.
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "index": 0, "embedding": emb }]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let result = tools::dispatch(
+            "memory_flush_insights",
+            args(json!({
+                "insights": [
+                    { "content": "valid", "metadata": { "k": "v" } },
+                    { "content": "bad meta", "metadata": "not-an-object" }
+                ]
+            })),
+            &engine,
+            Some(&provider),
+            None,
+            DIM,
+            &memory_engine::ActivityFilterConfig::default(),
+        );
+        unwrap_ok(result)
+    })
+    .await
+    .unwrap();
+    assert_eq!(body["added"].as_u64().unwrap(), 1);
+    assert_eq!(body["failed_count"].as_u64().unwrap(), 1);
+    assert_eq!(body["failed"][0]["index"], json!(1));
+    assert!(
+        body["failed"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("metadata must be an object")
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Query with server-side embedding
 // ---------------------------------------------------------------------------

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -251,6 +251,69 @@ async fn flush_insights_then_get_recent_insights_roundtrip() {
     );
 }
 
+/// Two insights flushed in one batch must BOTH be readable — guards against a
+/// batch-indexing bug that drops or reorders the second item (the single-insight
+/// roundtrip above cannot catch that).
+#[tokio::test]
+async fn flush_two_insights_then_get_recent_returns_both() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                { "index": 0, "embedding": emb.clone() },
+                { "index": 1, "embedding": emb }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "test-model".into(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap();
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let cfg = memory_engine::ActivityFilterConfig::default();
+
+        unwrap_ok(tools::dispatch(
+            "memory_flush_insights",
+            args(json!({ "insights": [
+                { "content": "insight alpha", "scope": "project:p" },
+                { "content": "insight beta", "scope": "project:p" }
+            ] })),
+            &engine,
+            Some(&provider),
+            None,
+            DIM,
+            &cfg,
+        ));
+        unwrap_ok(tools::dispatch(
+            "memory_get_recent_insights",
+            args(json!({ "project_path": "project:p" })),
+            &engine,
+            None,
+            None,
+            DIM,
+            &cfg,
+        ))
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        body["count"].as_i64().unwrap(),
+        2,
+        "both flushed insights must be readable"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Dimension mismatch from remote server
 // ---------------------------------------------------------------------------

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -175,6 +175,83 @@ async fn direct_format_embedding() {
 }
 
 // ---------------------------------------------------------------------------
+// flush_insights → get_recent_insights round-trip (#225)
+// ---------------------------------------------------------------------------
+
+/// Proves the writer (memory_flush_insights stamps the shared INSIGHT_MARKER_KEY)
+/// connects to the reader (memory_get_recent_insights queries that marker).
+#[tokio::test]
+async fn flush_insights_then_get_recent_insights_roundtrip() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        // `index` is REQUIRED for the batch (`embed_batch`) parse path that
+        // `flush_insights` exercises via `add_facts_batch` — the OpenAI batch
+        // parser sorts by it for order-safety. (The single-embed path tolerates
+        // its absence, which is why the other tests omit it.)
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "index": 0, "embedding": emb }]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let body = tokio::task::spawn_blocking(move || {
+        let provider =
+            HttpEmbeddingProvider::new(format!("{uri}/v1/embeddings"), "test-model".into(), None, DIM, 5)
+                .unwrap();
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let cfg = memory_engine::ActivityFilterConfig::default();
+
+        // Writer: flush an insight scoped to project:p (creates the scope, stamps the marker).
+        unwrap_ok(tools::dispatch(
+            "memory_flush_insights",
+            args(json!({ "insights": [{ "content": "re-gate before merge", "scope": "project:p" }] })),
+            &engine,
+            Some(&provider),
+            None,
+            DIM,
+            &cfg,
+        ));
+        // Add a plain (non-insight) fact in the same scope — must be excluded.
+        unwrap_ok(tools::dispatch(
+            "memory_add_fact",
+            args(json!({ "content": "ordinary fact", "scope": "project:p" })),
+            &engine,
+            Some(&provider),
+            None,
+            DIM,
+            &cfg,
+        ));
+        // Reader.
+        unwrap_ok(tools::dispatch(
+            "memory_get_recent_insights",
+            args(json!({ "project_path": "project:p" })),
+            &engine,
+            None,
+            None,
+            DIM,
+            &cfg,
+        ))
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        body["count"].as_i64().unwrap(),
+        1,
+        "only the flushed insight is returned"
+    );
+    assert!(
+        body["insights"][0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("re-gate")
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Dimension mismatch from remote server
 // ---------------------------------------------------------------------------
 

--- a/memory-engine-mcp/tests/tool_roundtrip.rs
+++ b/memory-engine-mcp/tests/tool_roundtrip.rs
@@ -763,12 +763,12 @@ fn unknown_tool_returns_error() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn all_tool_definitions_returns_23() {
+fn all_tool_definitions_returns_26() {
     let defs = tools::all_tool_definitions();
     assert_eq!(
         defs.len(),
-        23,
-        "expected 10 P0 + 5 P1 + 3 P2 + 2 Phase 5a + 3 activity stream tools"
+        26,
+        "expected 10 P0 + 5 P1 + 3 P2 + 2 Phase 5a outcome + 3 activity stream + 3 cognitive (#225) tools"
     );
 }
 

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -20,6 +20,15 @@ use crate::search::strategy::VectorSearchStrategy;
 pub use crate::traits::{DreamCycle, InsightStream};
 pub use crate::types::Insight;
 
+/// Top-level `metadata` key marking a fact captured via the pre-compaction insight
+/// flush. Written by the MCP `memory_flush_insights` tool and read by
+/// [`MemoryEngine::list_recent_insights`](crate::MemoryEngine::list_recent_insights).
+///
+/// Defined once here so the writer (MCP crate) and the reader (core) share a single
+/// literal and cannot drift. The stamped value is an object (e.g.
+/// `{"flushed_at": <rfc3339>}`); readers match on key *presence with a non-null value*.
+pub const INSIGHT_MARKER_KEY: &str = "insight";
+
 /// Capability-restricted handle passed to [`DreamCycle::run`].
 ///
 /// Exposes only the operations a `DreamCycle` consumer needs:

--- a/src/engine/cycle/apply.rs
+++ b/src/engine/cycle/apply.rs
@@ -282,6 +282,15 @@ impl MemoryEngine {
                             actual: nf.embedding.len(),
                         });
                     }
+                    // Parity with the trusted `add_fact` ingest path: a report can be
+                    // client-supplied (via the `memory_apply_cycle_report` MCP tool), so
+                    // an `AddFact` delta must clear the same importance/payload guards.
+                    // Without this, a hostile report could write an out-of-range
+                    // `importance` (no column CHECK → poisons Ebbinghaus decay globally)
+                    // or an oversized `content`/`metadata` that ordinary ingest forbids.
+                    Self::validate_importance(Some(nf.importance))?;
+                    crate::limits::check_str_size(&nf.content, "fact content")?;
+                    crate::limits::check_json_size(&nf.metadata, "fact metadata")?;
                 }
                 CycleDelta::AdjustScore {
                     fact_id,
@@ -717,6 +726,50 @@ mod tests {
             .apply_cycle_report(&report(vec![CycleDelta::AddFact(nf)], vec![]))
             .unwrap_err();
         assert!(matches!(err, MemoryError::EmbeddingDimension { .. }));
+    }
+
+    /// A client-supplied report (via `memory_apply_cycle_report`) must not bypass the
+    /// importance guard the trusted `add_fact` path enforces: an out-of-range
+    /// `importance` would otherwise persist (no column CHECK) and poison decay/forget
+    /// ranking. The whole report is rejected and nothing is written.
+    #[test]
+    fn add_fact_out_of_range_importance_rejected() {
+        let engine = engine();
+        let nf = NewFact::builder("hostile", vec![0.1, 0.2, 0.3, 0.4], FactType::Semantic)
+            .importance(5.0) // outside [0, 1]
+            .scope_id(1)
+            .build();
+        let err = engine
+            .apply_cycle_report(&report(vec![CycleDelta::AddFact(nf)], vec![]))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::Conflict(crate::error::ConflictError::PolicyParameter(_))
+        ));
+        // Nothing was written — validation runs before any delta is applied.
+        let stats = engine.statistics().unwrap();
+        assert_eq!(
+            stats.facts.total, 0,
+            "rejected report must not write any fact"
+        );
+    }
+
+    /// Same boundary, payload-size dimension: an oversized `content` in an `AddFact`
+    /// delta is rejected with the same guard `add_fact` uses (issue #572 / L10).
+    #[test]
+    fn add_fact_oversized_content_rejected() {
+        let engine = engine();
+        let huge = "x".repeat(crate::limits::MAX_PAYLOAD_BYTES + 1);
+        let nf = NewFact::builder(huge, vec![0.1, 0.2, 0.3, 0.4], FactType::Semantic)
+            .scope_id(1)
+            .build();
+        let err = engine
+            .apply_cycle_report(&report(vec![CycleDelta::AddFact(nf)], vec![]))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::Conflict(crate::error::ConflictError::PayloadTooLarge { .. })
+        ));
     }
 
     #[test]

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -47,7 +47,7 @@ impl MemoryEngine {
     /// loudly rather than clamping silently, mirroring the typed
     /// `Conflict(PolicyParameter)` errors raised elsewhere for out-of-range
     /// policy parameters. `None` is always valid (the engine default is used).
-    fn validate_importance(importance: Option<f64>) -> Result<()> {
+    pub(crate) fn validate_importance(importance: Option<f64>) -> Result<()> {
         if let Some(v) = importance {
             if !v.is_finite() || !(0.0..=1.0).contains(&v) {
                 return Err(MemoryError::Conflict(ConflictError::PolicyParameter(

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -20,6 +20,39 @@ impl MemoryEngine {
         })
     }
 
+    /// List recent insight facts within a project scope subtree, newest-first.
+    ///
+    /// Returns active facts whose `metadata` carries the insight marker
+    /// ([`INSIGHT_MARKER_KEY`](crate::INSIGHT_MARKER_KEY)) — written by the MCP
+    /// `memory_flush_insights` tool — anywhere in the subtree rooted at `scope_path`,
+    /// ordered `t_created` DESC and capped at `limit`. An unknown `scope_path` yields
+    /// an empty vec: a not-yet-created project legitimately has no scope node, so this
+    /// is "no insights" rather than an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn list_recent_insights(
+        &self,
+        scope_path: &str,
+        limit: usize,
+    ) -> Result<Vec<crate::types::Fact>> {
+        // Resolve the scope subtree under a short-lived read lock. `subtree(unknown_id)`
+        // would return a singleton, so branch on `resolve_path` returning `None` and
+        // early-return empty — never call `subtree` with a fallback id.
+        let scope_ids = {
+            let tree = self.scope_tree.read();
+            match tree.resolve_path(scope_path) {
+                Some(id) => tree.subtree(id),
+                None => return Ok(Vec::new()),
+            }
+        };
+        self.with_read(|conn| {
+            crate::store::facts::FactStore::new(conn, self.embed_dim)
+                .list_active_by_metadata_key_recent(&scope_ids, crate::INSIGHT_MARKER_KEY, limit)
+        })
+    }
+
     /// Replay a segment of the event log for debugging.
     ///
     /// Supports filtering by time range, ID range, session, and event type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub use traits::{
 pub use types::*;
 
 // Phase 5a cognitive pipeline re-exports
-pub use engine::cognitive::DreamContext;
+pub use engine::cognitive::{DreamContext, INSIGHT_MARKER_KEY};
 pub use engine::cycle::{
     ApplyResult, CycleAnomaly, CycleContext, CycleDelta, CycleMetadata, CycleReport,
     DefaultDreamCycle, IMPORTANCE_STEP, IdentityOutput, MAX_ADJUSTMENT, TimeWindow,

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -949,10 +949,13 @@ impl<'a> FactStore<'a> {
     /// `marker_key` **MUST** be a trusted caller-supplied literal (an engine const
     /// such as [`INSIGHT_MARKER_KEY`](crate::INSIGHT_MARKER_KEY)): it is interpolated
     /// into the SQL JSON path, **never bound**, so it must never carry client input.
-    /// A `debug_assert` guards against a non-identifier key in tests.
+    /// A runtime guard rejects a non-identifier key in **all** build profiles
+    /// (not just `debug`), since the key is interpolated into SQL.
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::Conflict(ConflictError::QueryValidation)` if
+    /// `marker_key` is not a non-empty `[A-Za-z0-9_]+` identifier.
     /// Returns `MemoryError::Database` on query failure.
     pub fn list_active_by_metadata_key_recent(
         &self,
@@ -960,13 +963,21 @@ impl<'a> FactStore<'a> {
         marker_key: &str,
         limit: usize,
     ) -> Result<Vec<Fact>> {
-        debug_assert!(
-            !marker_key.is_empty()
-                && marker_key
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '_'),
-            "marker_key must be a trusted identifier literal, got {marker_key:?}"
-        );
+        // Defense in depth: although every current caller passes a trusted engine
+        // const, this is a runtime check (not a `debug_assert`, which compiles out in
+        // release) because `marker_key` is interpolated into the SQL JSON path. A
+        // future caller wiring client input here cannot silently open an injection.
+        if marker_key.is_empty()
+            || !marker_key
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            return Err(MemoryError::Conflict(
+                crate::error::ConflictError::QueryValidation(format!(
+                    "marker_key must be a non-empty alphanumeric/underscore identifier, got {marker_key:?}"
+                )),
+            ));
+        }
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
         let dim = self.embed_dim;
@@ -1438,6 +1449,26 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    /// The runtime guard rejects a non-identifier `marker_key` in ALL build profiles
+    /// (the key is interpolated into SQL) — a release build must not skip it.
+    #[test]
+    fn list_active_by_metadata_key_recent_rejects_non_identifier_key() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        for bad in ["", "in'sight", "$.x", "a b", "a;b"] {
+            let err = store
+                .list_active_by_metadata_key_recent(&[1], bad, 10)
+                .unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    MemoryError::Conflict(crate::error::ConflictError::QueryValidation(_))
+                ),
+                "key {bad:?} should be rejected as QueryValidation, got {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -940,6 +940,12 @@ impl<'a> FactStore<'a> {
     /// here — it returns the text `'null'` for a present-null value, so
     /// `json_type(...) IS NOT NULL` would wrongly include `{"<key>": null}`.)
     ///
+    /// Contrast `list_undreamt_in_period`, which uses `json_type(...) IS NULL` for the
+    /// *complementary* (absence) predicate — there `json_type` is the correct idiom
+    /// because `json_extract(...) IS NULL` would conflate absent with present-`null`.
+    /// The two methods diverge by design: `json_extract` for presence, `json_type` for
+    /// absence.
+    ///
     /// `marker_key` **MUST** be a trusted caller-supplied literal (an engine const
     /// such as [`INSIGHT_MARKER_KEY`](crate::INSIGHT_MARKER_KEY)): it is interpolated
     /// into the SQL JSON path, **never bound**, so it must never carry client input.

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -928,6 +928,59 @@ impl<'a> FactStore<'a> {
             .map_err(MemoryError::Database)
     }
 
+    /// List active facts in `scope_ids` whose `metadata` JSON carries the top-level
+    /// key `marker_key` with a non-null value, ordered by `t_created` DESC (newest
+    /// first), capped at `limit`.
+    ///
+    /// Matched with `json_extract(metadata, '$.<marker_key>') IS NOT NULL`.
+    /// `json_extract` collapses an **absent** key and a present-`null` value both to
+    /// SQL NULL, returning the value only when the key is present with a non-null
+    /// value — exactly "key present with a non-null value" (the marker is always a
+    /// non-null object, e.g. `{"flushed_at": …}`). (Note: `json_type` would NOT work
+    /// here — it returns the text `'null'` for a present-null value, so
+    /// `json_type(...) IS NOT NULL` would wrongly include `{"<key>": null}`.)
+    ///
+    /// `marker_key` **MUST** be a trusted caller-supplied literal (an engine const
+    /// such as [`INSIGHT_MARKER_KEY`](crate::INSIGHT_MARKER_KEY)): it is interpolated
+    /// into the SQL JSON path, **never bound**, so it must never carry client input.
+    /// A `debug_assert` guards against a non-identifier key in tests.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn list_active_by_metadata_key_recent(
+        &self,
+        scope_ids: &[i64],
+        marker_key: &str,
+        limit: usize,
+    ) -> Result<Vec<Fact>> {
+        debug_assert!(
+            !marker_key.is_empty()
+                && marker_key
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_'),
+            "marker_key must be a trusted identifier literal, got {marker_key:?}"
+        );
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
+        let dim = self.embed_dim;
+        // marker_key is a trusted const (see doc) — interpolated, not bound, because
+        // `json_extract` paths cannot be parameterized portably. `json_extract` (not
+        // `json_type`) gives "present with a non-null value" semantics.
+        let marker_predicate = format!("json_extract(metadata, '$.{marker_key}') IS NOT NULL");
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {FACT_COLUMNS} FROM facts
+             WHERE t_expired IS NULL
+               AND scope_id IN (SELECT value FROM json_each(?1))
+               AND {marker_predicate}
+             ORDER BY t_created DESC
+             LIMIT ?2"
+        ))?;
+        let rows = stmt.query_map(params![scope_json, limit_i64], |row| row_to_fact(row, dim))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(MemoryError::Database)
+    }
+
     /// List active facts whose validity interval overlaps the given period `[start, end)`.
     ///
     /// A fact with `[t_valid, t_invalid)` overlaps `[start, end)` when:
@@ -1319,6 +1372,65 @@ mod tests {
             undreamt,
             vec![a],
             "present-null must be treated as dreamt (matching serde get().is_none())"
+        );
+    }
+
+    #[test]
+    fn list_active_by_metadata_key_recent_filters_marker_scope_active_recency() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+
+        // Two marked active in-scope facts at distinct t_created (newest = m2).
+        let mut m1 = make_fact("marked older", vec![0.1; DIM]);
+        m1.metadata = serde_json::json!({"insight": {"flushed_at": "x"}});
+        m1.t_created = "2024-01-01T00:00:00Z".parse().unwrap();
+        let mut m2 = make_fact("marked newer", vec![0.2; DIM]);
+        m2.metadata = serde_json::json!({"insight": {"flushed_at": "y"}});
+        m2.t_created = "2024-06-01T00:00:00Z".parse().unwrap();
+        // Marked but expired → excluded.
+        let mut expired = make_fact("marked expired", vec![0.3; DIM]);
+        expired.metadata = serde_json::json!({"insight": {"flushed_at": "z"}});
+        expired.t_expired = Some("2024-07-01T00:00:00Z".parse().unwrap());
+        // Active in-scope but unmarked → excluded.
+        let unmarked = make_fact("unmarked", vec![0.4; DIM]);
+        // Marker key present but null → excluded (presence-of-non-null contract).
+        let mut null_marker = make_fact("null marker", vec![0.5; DIM]);
+        null_marker.metadata = serde_json::json!({"insight": null});
+
+        let id1 = store.insert(&m1).unwrap();
+        let id2 = store.insert(&m2).unwrap();
+        store.insert(&expired).unwrap();
+        store.insert(&unmarked).unwrap();
+        store.insert(&null_marker).unwrap();
+
+        // All facts are in root scope (id 1).
+        let got: Vec<i64> = store
+            .list_active_by_metadata_key_recent(&[1], "insight", 10)
+            .unwrap()
+            .iter()
+            .map(|f| f.id)
+            .collect();
+        assert_eq!(
+            got,
+            vec![id2, id1],
+            "only marked active in-scope, newest-first"
+        );
+
+        // limit truncates to the newest.
+        let top1: Vec<i64> = store
+            .list_active_by_metadata_key_recent(&[1], "insight", 1)
+            .unwrap()
+            .iter()
+            .map(|f| f.id)
+            .collect();
+        assert_eq!(top1, vec![id2]);
+
+        // A scope with no facts → empty (scope filter holds).
+        assert!(
+            store
+                .list_active_by_metadata_key_recent(&[999], "insight", 10)
+                .unwrap()
+                .is_empty()
         );
     }
 

--- a/tests/recent_insights_test.rs
+++ b/tests/recent_insights_test.rs
@@ -1,0 +1,116 @@
+//! Integration test for `MemoryEngine::list_recent_insights` (#225).
+//!
+//! Public-API only: add facts carrying the insight marker across a nested scope
+//! subtree and assert subtree-scoped, newest-first, limited, active-only retrieval.
+
+use memory_engine::{
+    AddFactOptions, AddFactRequest, EmbeddingProvider, FactType, INSIGHT_MARKER_KEY, MemoryEngine,
+    MemoryError,
+};
+
+const DIM: usize = 4;
+
+struct FixedEmbed;
+impl EmbeddingProvider for FixedEmbed {
+    fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
+        Ok(vec![0.1, 0.2, 0.3, 0.4])
+    }
+}
+
+/// Add a fact, optionally insight-marked, at `scope`, with an explicit `t_created`
+/// (controls recency ordering).
+fn add(engine: &MemoryEngine, content: &str, scope: &str, marked: bool, t_created: &str) -> i64 {
+    let metadata = if marked {
+        Some(serde_json::json!({ INSIGHT_MARKER_KEY: { "flushed_at": t_created } }))
+    } else {
+        Some(serde_json::json!({ "source": "manual" }))
+    };
+    let req = AddFactRequest {
+        content: content.into(),
+        fact_type: FactType::Semantic,
+        source_event_id: None,
+        scope: Some(scope.into()),
+        opts: Some(AddFactOptions {
+            metadata,
+            t_created: Some(t_created.parse().unwrap()),
+            ..Default::default()
+        }),
+    };
+    engine.add_fact(&req, &FixedEmbed, None).unwrap()
+}
+
+#[test]
+fn list_recent_insights_subtree_newest_first_limited_active_only() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+
+    // Marked insights at the project node and a child node (subtree).
+    let at_root = add(
+        &engine,
+        "insight at p",
+        "project:p",
+        true,
+        "2024-01-01T00:00:00Z",
+    );
+    let at_child = add(
+        &engine,
+        "insight at p/sub",
+        "project:p/sub",
+        true,
+        "2024-06-01T00:00:00Z",
+    );
+    // An unmarked fact in-scope → excluded.
+    add(
+        &engine,
+        "plain fact",
+        "project:p",
+        false,
+        "2024-07-01T00:00:00Z",
+    );
+    // A marked insight in a DIFFERENT project → excluded by subtree scoping.
+    add(
+        &engine,
+        "other project",
+        "project:other",
+        true,
+        "2024-08-01T00:00:00Z",
+    );
+
+    // Subtree of project:p, newest-first → child (Jun) before root (Jan); excludes plain + other.
+    let got: Vec<i64> = engine
+        .list_recent_insights("project:p", 10)
+        .unwrap()
+        .iter()
+        .map(|f| f.id)
+        .collect();
+    assert_eq!(
+        got,
+        vec![at_child, at_root],
+        "subtree, marked-only, newest-first"
+    );
+
+    // limit truncates to newest.
+    let top1: Vec<i64> = engine
+        .list_recent_insights("project:p", 1)
+        .unwrap()
+        .iter()
+        .map(|f| f.id)
+        .collect();
+    assert_eq!(top1, vec![at_child]);
+
+    // Exact child scope returns only the child's insight.
+    let child: Vec<i64> = engine
+        .list_recent_insights("project:p/sub", 10)
+        .unwrap()
+        .iter()
+        .map(|f| f.id)
+        .collect();
+    assert_eq!(child, vec![at_child]);
+
+    // Unknown project → empty (not an error).
+    assert!(
+        engine
+            .list_recent_insights("project:does-not-exist", 10)
+            .unwrap()
+            .is_empty()
+    );
+}


### PR DESCRIPTION
Closes #225.

## What

Exposes the Phase-5a cognitive pipeline (#49) over MCP as three new tools, taking the server from 23 to **26** tools:

| Tool | Behavior |
| ---- | -------- |
| `memory_dream_cycle` | Runs `DefaultDreamCycle::with_defaults()`; `apply` flag (default `true`) collapses produce-and-apply into one call. `apply:false` returns the unapplied `CycleReport` for the review gate. Returns `{report, did_apply, applied?}`. |
| `memory_apply_cycle_report` | Applies a client-supplied report (serde round-trips across the boundary). Malformed JSON / unknown-fact → `invalid_params`. |
| `memory_get_recent_insights` | Returns facts flushed via `memory_flush_insights`, scoped to a project subtree, newest-first, capped by `limit` (default 20). Unknown scope → empty list. Tiered depth. |

## Why

#225 was written before #49 split the cycle into a pure *produce* step (`run_dream_cycle`) and a mutating *apply* step (`apply_cycle_report`). The `apply` flag bridges the daily-hook ergonomic (one call) with the review gate (`apply:false` then `memory_apply_cycle_report`).

## Design decisions (fixed with the issue owner)

- **D1** — one `memory_dream_cycle` with an `apply` flag, plus a separate `memory_apply_cycle_report`.
- **D2** — the dream cycle does **not** run consolidation (lightweight analysis pass).
- **D3** — `flush_insights` stamps a shared `INSIGHT_MARKER_KEY`; `get_recent_insights` queries it by subtree scope. A new core method (`MemoryEngine::list_recent_insights`) + generic store query (`FactStore::list_active_by_metadata_key_recent`) + shared const prevent writer/reader drift.
- **E** — unknown scope → empty vec (not `NotFound`).

## Notable implementation notes

- **`json_extract`, not `json_type`** — the store query uses `json_extract(metadata, '$.{key}') IS NOT NULL`. The plan/review originally prescribed `json_type`, but the store-level unit test caught that `json_type` returns text `'null'` (not SQL `NULL`) for `{"insight": null}`, wrongly including present-`null` markers. `json_extract` correctly implements "key present with a non-null value". The marker key is a trusted engine const (never client input) interpolated into SQL.
- **Hostile metadata** — `handle_flush_insights` normalizes non-object `metadata` to `{}` before stamping, so a client passing `"metadata": "foo"` can't make a flushed insight invisible to the reader.
- **Doc drift corrected** — the `mcp-server.md` tool table was already stale (listed 18; code had 23). It now reflects the true 26, including 5 previously-undocumented tools.

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo test -p memory-engine-mcp` green (incl. `cognitive_tools.rs`, count assertion = 26)
- [x] `cargo test -p memory-engine-mcp --test embedding_integration flush_insights_then_get_recent_insights_roundtrip` (writer→reader proof)
- [x] `cargo test --all-features` green
- [x] `cargo clippy --workspace --all-targets` exit 0
- [x] `cargo fmt --check` clean

Plan + full audit: `docs/plans/2026-06-16-mcp-cognitive-endpoints.md`.

