### PR TITLE
feat(core)!: EmbeddingFingerprint + required EmbeddingProvider::fingerprint()

### DIFF
--- a/benches/lifecycle_bench.rs
+++ b/benches/lifecycle_bench.rs
@@ -25,6 +25,7 @@
 
 use chrono::{Duration, Utc};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::traits::{
     ConsolidationConfig, EmbeddingProvider, ForgetPolicy, SummaryGenerator,
@@ -54,6 +55,9 @@ impl EmbeddingProvider for ConstEmbedder {
             })
             .collect();
         Ok(embedding)
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", self.dim)
     }
 }
 

--- a/benches/search_bench.rs
+++ b/benches/search_bench.rs
@@ -21,6 +21,7 @@
 //!   This is realistic for interactive use where the DB is already open.
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::search::cosine_similarity;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
@@ -45,6 +46,9 @@ impl EmbeddingProvider for ConstEmbedder {
             })
             .collect();
         Ok(embedding)
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", self.dim)
     }
 }
 

--- a/docs/design/adr/0015-cross-layer-embedding-identity-policy.md
+++ b/docs/design/adr/0015-cross-layer-embedding-identity-policy.md
@@ -1,0 +1,111 @@
+# ADR 0015: Cross-layer embedding-identity & mismatch parity policy
+
+**Status:** Accepted (2026-06-16)
+**Date:** 2026-06-16
+**Scope:** Cross-layer — **Memory** layer and **Knowledge** layer
+
+> **Redundant shared document.** This ADR is authored **identically** in both
+> repositories and defines a **single shared policy** with which both layers maintain
+> **complete parity**:
+>
+> - Memory layer: <https://github.com/dutiona/memory-engine>
+>   (`docs/design/adr/0015-cross-layer-embedding-identity-policy.md`)
+> - Knowledge layer: <https://github.com/dutiona/knowledge-base>
+>   (`docs/design/adr/0015-cross-layer-embedding-identity-policy.md`)
+>
+> A change to this policy MUST be applied to **both** copies in lockstep. Neither copy is
+> authoritative over the other; they are mirrors of one contract.
+
+## Context
+
+Both layers store vectors produced by an embedding model alongside the source text the
+vector is derived from. An embedding is only meaningful within the vector space of the
+**exact model** that produced it. Mixing spaces — querying a store built with model A
+using model B — yields cosine similarities that are numerically valid but semantically
+meaningless: **silent, undetected retrieval corruption**, the worst RAG failure mode.
+
+Prior state across the two layers:
+
+- **Knowledge layer** already records embedding-space metadata (its `embed_spaces`
+  registry) but performs **no model-identity validation** — only a runtime _dimension_
+  check at the provider. Dimension is **necessary but not sufficient**: two different
+  models at the same dimension pass the length check and corrupt retrieval silently.
+- **Memory layer** stored only `embed_dim` and likewise validated only vector length.
+
+Because the layers belong to one cognitive architecture and will eventually exchange and
+co-host embeddings, their identity and mismatch policy MUST be identical. Drift between
+them reintroduces exactly the silent-corruption risk this ADR removes.
+
+## Decision
+
+### 1. Canonical identity tuple
+
+An embedding store records an **identity tuple** with these fields and semantics in both
+layers (field **names** are normative to prevent drift):
+
+| Field                 | Type            | Meaning                                                                                                        |
+| --------------------- | --------------- | -------------------------------------------------------------------------------------------------------------- |
+| `model`               | string (slug)   | Model identity, e.g. `Qwen/Qwen3-Embedding-0.6B`. Operator-declared; **not** a weight hash (see Consequences). |
+| `provider`            | string          | Serving backend, e.g. `tei`, `ollama`, `openai`, `onnx`.                                                       |
+| `dim`                 | integer         | Stored vector dimension (post-truncation).                                                                     |
+| `matryoshka_base_dim` | integer \| null | Native model dimension before MRL truncation; `null` if untruncated.                                           |
+| `element_type`        | string          | Vector element storage type: `float32` (reserved: `int8`).                                                     |
+
+A single-active-space store (Memory layer today) records exactly one identity tuple. A
+multi-space store (Knowledge layer; Memory layer Wave 2) records one tuple per space; the
+tuple is the **degenerate single case** of the multi-space registry — identical field
+names and semantics, so neither layer diverges as it grows into multi-space.
+
+Layer-internal lifecycle fields (e.g. `status`, `table_name`, `chunk_count`,
+`chunk_strategy`) are **not** part of the shared contract and remain layer-specific.
+
+### 2. When the identity is recorded
+
+The identity tuple is written on the **first embedding write** to a store and is
+thereafter the store's fixed identity until an explicit, deliberate reconstruction
+changes it atomically (future work; see §4).
+
+### 3. Mismatch rule
+
+Two identity tuples are **compatible iff they are field-by-field equal**. When a
+configured embedding provider's identity does not equal the store's recorded identity,
+the operation MUST be **hard-rejected**:
+
+- A typed **error** is returned (Memory layer: `MemoryError::EmbeddingModelMismatch`;
+  Knowledge layer: the equivalent typed error). **Never a panic, never a warning that
+  proceeds, never silent.**
+- Enforcement happens at the **embedding boundary** (ingest and query). An eager check at
+  service startup is RECOMMENDED for fail-fast.
+- **Pre-computed / caller-supplied embeddings** MUST carry a declared `model` (and the
+  rest of the tuple as available) and are subject to the same rule; a bare vector with no
+  declared identity is rejected when a store identity exists.
+
+### 4. Reconstruction (forward-looking)
+
+Changing a store's identity (model/dim swap) is only legitimate via an explicit
+**reconstruction**: re-embed the stored source text under the new identity, then swap the
+identity tuple **atomically** with the vectors and invalidate any cached similarity
+artifacts (vector index, similarity edges/relations). Reconstruction is out of scope for
+the initial implementation in either layer but, when built, MUST preserve the identity
+tuple and mismatch rule above.
+
+## Consequences
+
+- **Slug-level identity, not weight-level.** `model` is operator-declared. It catches
+  configuration mistakes (the realistic failure) but **not** a silently re-pulled model
+  whose weights changed under the same slug, nor a server (e.g. TEI) that ignores the
+  request's model field. A content/weight hash is a future hardening, additive to this
+  tuple.
+- **Parity is a maintenance obligation.** Both repos carry this file and must change it in
+  lockstep. CI/audit in each repo SHOULD assert the two copies match.
+- **Knowledge layer reaches parity via follow-up work** (it currently has no mismatch
+  detection). Tracked in the `knowledge-base` repository, cross-referenced from this ADR.
+- **No data migration in either layer for adoption** where the store has no users; the
+  identity tuple is established on first write.
+
+## References
+
+- Memory-layer design: `docs/design/embedding-identity-and-tei-qwen-migration.md`
+  (<https://github.com/dutiona/memory-engine>).
+- Knowledge-layer prior art: the `embed_spaces` registry and `embed_swap.py`
+  reconstruction (<https://github.com/dutiona/knowledge-base>).

--- a/docs/design/adr/index.md
+++ b/docs/design/adr/index.md
@@ -19,4 +19,5 @@ Key design decisions, documented as ADRs. Each records the context, decision, an
 0012-decay-exemption-knowledge-shaped-facts
 0013-typestate-engine-builder
 0014-delta-based-cycle-report
+0015-cross-layer-embedding-identity-policy
 ```

--- a/docs/design/embedding-identity-and-tei-qwen-migration.md
+++ b/docs/design/embedding-identity-and-tei-qwen-migration.md
@@ -1,0 +1,196 @@
+# Design: Embedding model identity + TEI/Qwen migration
+
+**Status:** Approved design (2026-06-16)
+**Epic:** `epic(embedding): model-identity policy + TEI/Qwen migration`
+**Related ADR:** [0015 — Cross-layer embedding-identity & mismatch parity policy](adr/0015-cross-layer-embedding-identity-policy.md)
+
+## Context
+
+The embedding provider is on the **hot path**: every `add_fact` embeds content
+([`ingest.rs`](../../src/engine/ingest.rs)), and every query embeds the query text
+at the consumer layer ([MCP `tools/mod.rs`](../../memory-engine-mcp/src/tools/mod.rs)).
+Today an `all-MiniLM` model is served via an OpenAI/Ollama-compatible
+`/v1/embeddings` endpoint, consumed by the sync `HttpEmbeddingProvider`. Two problems
+drive this work:
+
+1. **Model fit.** We are moving to `Qwen/Qwen3-Embedding-0.6B` (multilingual + strong
+   code retrieval + Matryoshka), served by **HuggingFace Text Embeddings Inference
+   (TEI)** — a Rust, embedding-specialized server whose token-based **dynamic batching**
+   coalesces the bursts from ~5 concurrent agent sessions into single forward passes.
+   Qwen is **asymmetric**: queries take an instruction prefix, documents do not. The
+   current `EmbeddingProvider::embed(text)` cannot express that distinction.
+
+2. **Silent model mismatch.** The engine stores only `embed_dim` and validates _vector
+   length_. Dimension is **necessary but not sufficient** identity: two different models
+   at the same dimension pass the length check and then return vectors from incompatible
+   spaces — silently wrong retrieval, the worst RAG failure mode. We need a persisted
+   **model identity** and a hard mismatch error.
+
+**No users yet** → no back-compat to preserve, no data migration. We can break any
+existing shape cleanly.
+
+## Goals / Non-goals
+
+**In scope (Wave 0 + Wave 1):**
+
+- Persisted embedding **identity fingerprint** + hard mismatch detection (no panic).
+- Pre-computed-embedding submissions must declare a `model` that matches the fingerprint.
+- Asymmetric embedding trait (`embed_query` / `embed_query_batch`).
+- `HttpEmbeddingProvider` extended for TEI/Qwen: query instruction, MRL truncation,
+  fingerprint reporting.
+- Consumer wiring (MCP/CLI/config) + a gated TEI+Qwen smoke test.
+
+**Out of scope (Wave 2, future):**
+
+- Multiple embeddings per fact / multi-space coexistence.
+- Background embedding reconstruction (shadow space → backfill → atomic promote).
+- Weight-hash identity (slug-level identity only for now).
+- TEI `/info` authoritative-identity probe.
+
+## Cross-layer policy (shared contract)
+
+This is a **first-class constraint**: the embedding-identity and mismatch policy MUST
+be identical across the **Memory** layer (`memory-engine`) and the **Knowledge** layer
+(`knowledge-base`). KB today has a proven fingerprint schema (its `embed_spaces`
+registry) but **no mismatch detection**; ME leads on mismatch and **adopts KB's field
+names** to avoid drift. KB reaches parity via a separate tracked KB-repo track.
+
+The canonical policy lives in [ADR 0015](adr/0015-cross-layer-embedding-identity-policy.md),
+**redundantly authored in both repos**, pointing to both GitHub repositories.
+
+**Identity tuple (canonical, both layers):**
+
+| Field                 | Type          | Meaning                                                                 |
+| --------------------- | ------------- | ----------------------------------------------------------------------- |
+| `model`               | string (slug) | e.g. `Qwen/Qwen3-Embedding-0.6B` — operator-declared, not a weight hash |
+| `provider`            | string        | e.g. `tei`, `ollama`, `openai`                                          |
+| `dim`                 | int           | stored vector dimension (post-MRL)                                      |
+| `matryoshka_base_dim` | int?          | native dim before MRL truncation; `None` if not truncated               |
+| `element_type`        | string        | `float32` (room for `int8` later)                                       |
+
+ME's single-active-space is a **degenerate case** of KB's multi-space registry: same
+field names, same semantics, so ME can grow into multi-space (Wave 2) without a schema
+divergence to reconcile. KB-internal lifecycle fields (`status`, `table_name`,
+`chunk_count`, `chunk_strategy`) stay layer-specific.
+
+**Mismatch rule (canonical, both layers):** two stores are compatible **iff** their
+identity tuples are equal; otherwise the operation is **hard-rejected** (error, never
+panic, never silent).
+
+## Design
+
+### 1. Embedding identity fingerprint (`area:core`, `area:storage`)
+
+- New `EmbeddingFingerprint { model, provider, dim, matryoshka_base_dim, element_type }`.
+- New trait method `EmbeddingProvider::fingerprint(&self) -> EmbeddingFingerprint` so
+  providers declare their identity.
+- DB meta stores an `embedding_meta` record (replacing the bare `embed_dim`), written on
+  **first embedding write**; `schema_version` bump (no data migration — no users).
+
+### 2. Mismatch detection (`area:core`)
+
+- New `MemoryError::EmbeddingModelMismatch { expected: EmbeddingFingerprint, actual: EmbeddingFingerprint }`.
+- Enforced at the embedding boundary (ingest + query) by comparing
+  `provider.fingerprint()` against the stored `embedding_meta`. Optional eager check at
+  MCP server startup for fail-fast.
+
+### 3. Pre-computed embedding policy (`area:mcp`)
+
+- `memory_add_fact` / `memory_query` pre-computed `embedding` submissions MUST carry a
+  declared `model` (and the rest of the tuple as available); the engine checks it against
+  the fingerprint and hard-rejects mismatch. Closes the `PassthroughEmbedder` hole where
+  a same-dim foreign vector would otherwise slip through.
+
+### 4. Asymmetric embedding trait (`area:core`)
+
+```rust
+pub trait EmbeddingProvider: Send + Sync {
+    fn embed(&self, text: &str) -> Result<Vec<f32>>;                 // document
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> { /* default loop */ }
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>> { self.embed(text) }          // NEW
+    fn embed_query_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {              // NEW
+        self.embed_batch(texts)
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint;                                       // NEW
+}
+```
+
+Defaults make `embed_query` degrade to document semantics, so symmetric providers
+(`Mock`, `Hash`, `Passthrough`) are unaffected. **The core never embeds a query** — query
+embedding happens only at the consumer layer (MCP/CLI), because `MemoryQuery` takes a
+pre-computed vector. So the core's document-only call sites need no change.
+
+### 5. Provider extension — TEI/Qwen (`area:retrieval`)
+
+`HttpEmbeddingProvider` already speaks OpenAI `/v1/embeddings` = TEI's API verbatim. Add:
+
+- `query_instruction: Option<String>` — Qwen's query-only prefix (default:
+  `"Instruct: Given a search query, retrieve relevant memory facts.\nQuery: "`).
+  `embed_query*` prepend it; `embed*` (documents) stay prefix-free.
+- `mrl_dim: Option<usize>` — when set, truncate the returned vector and **renormalize to
+  unit L2**. Lives provider-side so the engine `dim` matches stored vectors.
+- `fingerprint()` → `{ model, provider: "tei", dim, matryoshka_base_dim, element_type: "float32" }`.
+
+### 6. Wiring & concurrency
+
+- MCP query path: `embed(text)` → `embed_query(text)`; `add_fact` stays on `embed`.
+- CLI: query subcommands → `embed_query`; ingest/bootstrap stay on `embed`/`embed_batch`.
+- Config (MCP + CLI): `model`, `provider`, `query_instruction`, `dim`, `mrl_dim`.
+- **Keep the sync trait + `spawn_blocking`.** Each session already embeds on its own
+  blocking thread with an independent HTTP call; the prior serialization was **server-side**
+  (Ollama has no batching). TEI's server-side dynamic batching fixes throughput with no
+  client coalescing.
+
+### 7. Migration
+
+**None.** No users → start clean: configure ME with Qwen/TEI, fresh DB adopts the new
+fingerprint on first write. The lossless re-embed path (content is stored alongside the
+vector — `facts.content` is source-of-truth, `facts.embedding` is derived) is deferred to
+Wave 2 as reusable tooling for _future_ model swaps.
+
+## Wave 0 — validation gate (smoke test)
+
+Runs **before** Wave 1, using the _existing_ provider + a _manually_ prefixed query (the
+new code does not exist yet). Two orthogonal axes, independently validatable:
+
+**Model axis (no new infra).** Ollama can serve the model today via the existing
+`HttpEmbeddingProvider` Ollama path — `ollama pull dengcao/Qwen3-Embedding-0.6B:Q8_0`
+(or `:F16`). This lets W0.1 start immediately, decoupled from any TEI standup:
+
+1. The model returns **1024-dim** vectors over the existing endpoint.
+2. A hand-prefixed query measurably **out-retrieves** an unprefixed one on a tiny labeled
+   set — proof the asymmetry is worth building.
+
+**Server axis (TEI standup).** Orthogonal throughput validation:
+
+3. TEI serves the same model over the OpenAI API and its server-side dynamic batching
+   absorbs ~5 concurrent embed bursts with no client change.
+
+The harness it leaves behind is promoted into the Wave 1 gated integration test (which
+additionally asserts the prefix is applied by `embed_query` and that a mismatch is
+hard-rejected). Note the `Q8_0`/`F16` Ollama quantizations are for _testing_; the
+production target is Qwen3-0.6B on TEI.
+
+## Wave breakdown / issue map
+
+- **Wave 0 (gate):** premise-validation spike (TEI+Qwen).
+- **Wave 1 (today):** identity fingerprint → mismatch detection → pre-computed policy →
+  `embed_query` → TEI/Qwen provider → MCP/CLI wiring → shared ADR → gated smoke test.
+  _Guardrail sub-issues land before the swap so the swap is protected as it lands._
+- **Wave 2 (future):** multi-embedding registry → background reconstruction
+  (shadow→backfill→promote) → HNSW rebuild + similarity-edge invalidation → real-time
+  concurrency-safety research.
+
+See the epic for the live sub-issue list and dependency links.
+
+## References
+
+- KB prior art: `embed_spaces` registry + `embed_swap.py` reconstruction
+  (`re_embed` / `create_space` / `backfill_space` / `promote_space`) in
+  [dutiona/knowledge-base](https://github.com/dutiona/knowledge-base). KB has **no**
+  mismatch detection — the parity gap this work closes on the ME side.
+- [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) (Apache-2.0,
+  MTEB-Code 75.41, MRL 32–1024, asymmetric query instruction).
+- [HuggingFace Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference)
+  (Rust, token-based dynamic batching, OpenAI-compatible `/v1/embeddings`).
+- [ADR 0015 — Cross-layer embedding-identity & mismatch parity policy](adr/0015-cross-layer-embedding-identity-policy.md)

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -8,6 +8,7 @@ design-choices
 roadmap
 research-basis
 schema-evolution-policy
+embedding-identity-and-tei-qwen-migration
 adr/index
 plans/2026-03-09-future-phases-design
 ```

--- a/examples/basic_roundtrip.rs
+++ b/examples/basic_roundtrip.rs
@@ -4,6 +4,7 @@
 // Example var names (fact1/fact2, event/edge) are intentionally short.
 #![allow(clippy::similar_names)]
 
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
@@ -16,6 +17,9 @@ struct DummyEmbedder;
 impl EmbeddingProvider for DummyEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
         Ok(vec![0.1; 4])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/examples/bi_temporal_query.rs
+++ b/examples/bi_temporal_query.rs
@@ -5,6 +5,7 @@
 //! Run with: `cargo run --example bi_temporal_query`
 
 use chrono::{Duration, Utc};
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
@@ -16,6 +17,9 @@ struct DummyEmbedder;
 impl EmbeddingProvider for DummyEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
         Ok(vec![0.1; 4])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/examples/custom_traits.rs
+++ b/examples/custom_traits.rs
@@ -4,6 +4,7 @@
 // Toy embedder: char codes (< 2^21) convert to f32 without precision loss.
 #![allow(clippy::cast_precision_loss)]
 
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::traits::{
@@ -31,6 +32,9 @@ impl EmbeddingProvider for SimpleEmbedder {
             }
         }
         Ok(v)
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/memory-engine-cli/examples/create_smoke_db.rs
+++ b/memory-engine-cli/examples/create_smoke_db.rs
@@ -1,9 +1,14 @@
-use memory_engine::{AddFactRequest, EmbeddingProvider, FactType, MemoryEngine};
+use memory_engine::{
+    AddFactRequest, EmbeddingFingerprint, EmbeddingProvider, FactType, MemoryEngine,
+};
 
 struct FakeEmbed;
 impl EmbeddingProvider for FakeEmbed {
     fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
         Ok(vec![0.1, 0.2, 0.3, 0.4])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -320,6 +320,7 @@ pub fn run(db: &Path, args: &BatchIngestArgs, format: OutputFormat) -> anyhow::R
     let embedder = HttpEmbeddingProvider::new(
         args.embed_url.clone(),
         args.embed_model.clone(),
+        "ollama".to_string(), // TODO(#618): provider should come from config/CLI
         args.embed_api_key.clone(),
         engine.embed_dim(),
         args.embed_timeout,
@@ -509,6 +510,9 @@ mod tests {
             fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
                 Ok(vec![0.1, 0.2, 0.3, 0.4])
             }
+            fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+                memory_engine::EmbeddingFingerprint::new("mock", "test", 4)
+            }
         }
 
         let engine = MemoryEngine::builder(4).build().unwrap();
@@ -535,6 +539,9 @@ mod tests {
         impl EmbeddingProvider for FakeEmbed {
             fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
                 Ok(vec![0.1, 0.2, 0.3, 0.4])
+            }
+            fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+                memory_engine::EmbeddingFingerprint::new("mock", "test", 4)
             }
         }
 
@@ -563,6 +570,9 @@ not valid json
             fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
                 Ok(vec![0.1, 0.2, 0.3, 0.4])
             }
+            fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+                memory_engine::EmbeddingFingerprint::new("mock", "test", 4)
+            }
         }
 
         let engine = MemoryEngine::builder(4).build().unwrap();
@@ -588,6 +598,9 @@ not valid json
         impl EmbeddingProvider for FakeEmbed {
             fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
                 Ok(vec![0.1, 0.2, 0.3, 0.4])
+            }
+            fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+                memory_engine::EmbeddingFingerprint::new("mock", "test", 4)
             }
         }
 

--- a/memory-engine-cli/src/commands/bootstrap.rs
+++ b/memory-engine-cli/src/commands/bootstrap.rs
@@ -189,6 +189,7 @@ pub fn run(db: &Path, args: &BootstrapArgs, format: OutputFormat) -> anyhow::Res
     let embedder = HttpEmbeddingProvider::new(
         args.embed_url.clone(),
         args.embed_model.clone(),
+        "ollama".to_string(), // TODO(#618): provider should come from config/CLI
         args.embed_api_key.clone(),
         engine.embed_dim(),
         args.embed_timeout,
@@ -238,6 +239,9 @@ mod tests {
     impl EmbeddingProvider for FakeEmbed {
         fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
             Ok(vec![0.0; 4])
+        }
+        fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+            memory_engine::EmbeddingFingerprint::new("mock", "test", 4)
         }
     }
 

--- a/memory-engine-cli/src/embedding.rs
+++ b/memory-engine-cli/src/embedding.rs
@@ -1,3 +1,4 @@
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::error::MemoryError;
 use memory_engine::traits::EmbeddingProvider;
 
@@ -25,5 +26,11 @@ impl EmbeddingProvider for PassthroughEmbedder {
             )));
         }
         Ok(vec![self.embedding.clone()])
+    }
+
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        // TODO(#615): pre-computed embedding has no declared model identity; sentinel
+        // names the hole #615 will enforce against.
+        EmbeddingFingerprint::new("precomputed", "passthrough", self.embedding.len())
     }
 }

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -24,6 +24,9 @@ fn create_test_db() -> (TempDir, PathBuf) {
         fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
         }
+        fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+            memory_engine::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     engine
@@ -134,6 +137,9 @@ fn stats_plain_includes_max_depth_and_page_count() {
     impl memory_engine::EmbeddingProvider for FakeEmbed {
         fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
+        }
+        fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+            memory_engine::EmbeddingFingerprint::new("mock", "test", 4)
         }
     }
 
@@ -252,6 +258,9 @@ fn create_temporal_db() -> (TempDir, PathBuf) {
     impl memory_engine::EmbeddingProvider for FakeEmbed {
         fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
+        }
+        fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+            memory_engine::EmbeddingFingerprint::new("mock", "test", 4)
         }
     }
 

--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -1,3 +1,4 @@
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::error::MemoryError;
 use memory_engine::traits::EmbeddingProvider;
 
@@ -16,6 +17,7 @@ use memory_engine::traits::EmbeddingProvider;
 /// let provider = HttpEmbeddingProvider::new(
 ///     "http://localhost:11434/v1/embeddings".to_string(),
 ///     "nomic-embed-text".to_string(),
+///     "ollama".to_string(),
 ///     None,
 ///     768,
 ///     30,
@@ -26,6 +28,7 @@ pub struct HttpEmbeddingProvider {
     client: reqwest::blocking::Client,
     endpoint: String,
     model: String,
+    provider: String,
     api_key: Option<String>,
     expected_dim: usize,
 }
@@ -34,9 +37,18 @@ impl HttpEmbeddingProvider {
     /// # Errors
     ///
     /// Returns an error if the HTTP client cannot be constructed (e.g., TLS init failure).
+    /// `provider` is the operator-declared serving backend (e.g. `"ollama"`, `"tei"`,
+    /// `"openai"`). It **cannot** be sniffed from the endpoint — Ollama and TEI both
+    /// speak `/v1/embeddings` — so it is an explicit argument: it feeds
+    /// [`EmbeddingProvider::fingerprint`] and must reflect the real backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be constructed (e.g., TLS init failure).
     pub fn new(
         endpoint: String,
         model: String,
+        provider: String,
         api_key: Option<String>,
         expected_dim: usize,
         timeout_secs: u64,
@@ -49,6 +61,7 @@ impl HttpEmbeddingProvider {
             client,
             endpoint,
             model,
+            provider,
             api_key,
             expected_dim,
         })
@@ -278,6 +291,10 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
 
         Ok(embeddings)
     }
+
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new(self.model.clone(), self.provider.clone(), self.expected_dim)
+    }
 }
 
 /// Truncate `s` to at most `max` bytes for an error message, snapping the cut
@@ -457,6 +474,7 @@ mod tests {
         let provider = HttpEmbeddingProvider::new(
             "http://127.0.0.1:0/v1/embeddings".to_string(),
             "test-model".to_string(),
+            "test-provider".to_string(),
             None,
             768,
             5,
@@ -474,6 +492,7 @@ mod tests {
         let provider = HttpEmbeddingProvider::new(
             "http://127.0.0.1:0/v1/embeddings".to_string(),
             "test-model".to_string(),
+            "test-provider".to_string(),
             None,
             3,
             5,
@@ -495,6 +514,7 @@ mod tests {
         let provider = HttpEmbeddingProvider::new(
             "http://127.0.0.1:0/v1/embeddings".to_string(),
             "test-model".to_string(),
+            "test-provider".to_string(),
             None,
             2,
             5,
@@ -512,6 +532,7 @@ mod tests {
         let provider = HttpEmbeddingProvider::new(
             "http://127.0.0.1:0/v1/embeddings".to_string(),
             "test-model".to_string(),
+            "test-provider".to_string(),
             None,
             2,
             5,
@@ -522,5 +543,22 @@ mod tests {
             .validate_embedding(&[0.1, f32::INFINITY], None)
             .unwrap_err();
         assert!(err.to_string().contains("Inf"));
+    }
+
+    #[test]
+    fn fingerprint_reports_configured_identity() {
+        let provider = HttpEmbeddingProvider::new(
+            "http://127.0.0.1:0/v1/embeddings".to_string(),
+            "qwen3-0.6b".to_string(),
+            "tei".to_string(),
+            None,
+            1024,
+            5,
+        )
+        .expect("client build should not fail");
+        assert_eq!(
+            provider.fingerprint(),
+            EmbeddingFingerprint::new("qwen3-0.6b", "tei", 1024)
+        );
     }
 }

--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -34,9 +34,8 @@ pub struct HttpEmbeddingProvider {
 }
 
 impl HttpEmbeddingProvider {
-    /// # Errors
+    /// Build an HTTP embedding provider.
     ///
-    /// Returns an error if the HTTP client cannot be constructed (e.g., TLS init failure).
     /// `provider` is the operator-declared serving backend (e.g. `"ollama"`, `"tei"`,
     /// `"openai"`). It **cannot** be sniffed from the endpoint — Ollama and TEI both
     /// speak `/v1/embeddings` — so it is an explicit argument: it feeds

--- a/memory-engine-embed/src/lib.rs
+++ b/memory-engine-embed/src/lib.rs
@@ -12,6 +12,7 @@
 //! let provider = HttpEmbeddingProvider::new(
 //!     "http://localhost:11434/v1/embeddings".to_string(),
 //!     "nomic-embed-text".to_string(),
+//!     "ollama".to_string(),   // serving backend (operator-declared)
 //!     None,   // no API key needed for local Ollama
 //!     768,    // expected embedding dimension
 //!     30,     // HTTP timeout in seconds

--- a/memory-engine-mcp/src/embedding.rs
+++ b/memory-engine-mcp/src/embedding.rs
@@ -1,5 +1,6 @@
 pub use memory_engine_embed::HttpEmbeddingProvider;
 
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::error::MemoryError;
 use memory_engine::traits::EmbeddingProvider;
 
@@ -31,6 +32,13 @@ impl EmbeddingProvider for PassthroughEmbedder {
             )));
         }
         Ok(vec![self.embedding.clone()])
+    }
+
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        // TODO(#615): a pre-computed embedding carries no real model identity. The
+        // sentinel names the hole #615 will enforce against — the caller must declare
+        // the `model` its vector came from so it can be checked against the store.
+        EmbeddingFingerprint::new("precomputed", "passthrough", self.embedding.len())
     }
 }
 
@@ -66,5 +74,14 @@ mod tests {
                 .to_string()
                 .contains("cannot batch-embed 2 texts")
         );
+    }
+
+    #[test]
+    fn passthrough_fingerprint_is_sentinel_with_real_dim() {
+        let provider = PassthroughEmbedder::new(vec![0.1, 0.2, 0.3]);
+        let fp = provider.fingerprint();
+        assert_eq!(fp.model, "precomputed");
+        assert_eq!(fp.provider, "passthrough");
+        assert_eq!(fp.dim, 3);
     }
 }

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -120,8 +120,18 @@ fn build_embedder(
 
     match (endpoint, model) {
         (Some(url), Some(mdl)) => Ok(Some(Arc::new(
-            embedding::HttpEmbeddingProvider::new(url, mdl, api_key, embed_dim, timeout)
-                .map_err(|e| format!("failed to create embedding provider: {e}"))?,
+            // TODO(#618): `provider` is hardcoded; source it from config/CLI so the
+            // fingerprint reflects the real backend. Per ADR 0015 ordering, #618 must
+            // land before #614 turns mismatch enforcement on (else it checks a constant).
+            embedding::HttpEmbeddingProvider::new(
+                url,
+                mdl,
+                "ollama".to_string(),
+                api_key,
+                embed_dim,
+                timeout,
+            )
+            .map_err(|e| format!("failed to create embedding provider: {e}"))?,
         ))),
         _ => Ok(None),
     }

--- a/memory-engine-mcp/tests/cognitive_tools.rs
+++ b/memory-engine-mcp/tests/cognitive_tools.rs
@@ -15,6 +15,9 @@ impl EmbeddingProvider for FakeEmbed {
     fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
         Ok(vec![0.1, 0.2, 0.3]) // identical for all → one DBSCAN cluster
     }
+    fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+        memory_engine::EmbeddingFingerprint::new("mock", "test", 3)
+    }
 }
 
 fn engine() -> (MemoryEngine, tempfile::TempDir) {

--- a/memory-engine-mcp/tests/depth_shaping.rs
+++ b/memory-engine-mcp/tests/depth_shaping.rs
@@ -33,6 +33,10 @@ impl EmbeddingProvider for TestEmbedder {
         }
         Ok(embedding)
     }
+
+    fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+        memory_engine::EmbeddingFingerprint::new("mock", "test", self.dim)
+    }
 }
 
 fn make_engine() -> MemoryEngine {

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -64,6 +64,7 @@ async fn openai_format_embedding() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -108,6 +109,7 @@ async fn ollama_format_embedding() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "nomic-embed-text".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -152,6 +154,7 @@ async fn direct_format_embedding() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "custom-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -199,7 +202,14 @@ async fn flush_insights_then_get_recent_insights_roundtrip() {
     let uri = server.uri();
     let body = tokio::task::spawn_blocking(move || {
         let provider =
-            HttpEmbeddingProvider::new(format!("{uri}/v1/embeddings"), "test-model".into(), None, DIM, 5)
+            HttpEmbeddingProvider::new(
+                format!("{uri}/v1/embeddings"),
+                "test-model".into(),
+                "test-provider".to_string(),
+                None,
+                DIM,
+                5,
+            )
                 .unwrap();
         let engine = MemoryEngine::builder(DIM).build().unwrap();
         let cfg = memory_engine::ActivityFilterConfig::default();
@@ -274,6 +284,7 @@ async fn flush_two_insights_then_get_recent_returns_both() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -336,6 +347,7 @@ async fn wrong_dimension_from_server() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -377,6 +389,7 @@ async fn server_500_propagates_error() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -425,6 +438,7 @@ async fn bearer_auth_sent_when_configured() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             Some("test-key-123".into()),
             DIM,
             5,
@@ -473,6 +487,7 @@ async fn flush_insights_with_http_embedder() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -520,6 +535,7 @@ async fn flush_insights_partial_failure() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -569,6 +585,7 @@ async fn flush_insights_non_object_metadata_is_rejected() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,
@@ -627,6 +644,7 @@ async fn query_hybrid_with_http_embedder() {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
             "test-model".into(),
+            "test-provider".to_string(),
             None,
             DIM,
             5,

--- a/memory-engine-mcp/tests/query_mode_inference.rs
+++ b/memory-engine-mcp/tests/query_mode_inference.rs
@@ -37,6 +37,10 @@ impl EmbeddingProvider for TestEmbedder {
         }
         Ok(embedding)
     }
+
+    fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+        memory_engine::EmbeddingFingerprint::new("mock", "test", self.dim)
+    }
 }
 
 fn make_engine() -> MemoryEngine {

--- a/memory-engine-mcp/tests/tool_roundtrip.rs
+++ b/memory-engine-mcp/tests/tool_roundtrip.rs
@@ -37,6 +37,10 @@ impl EmbeddingProvider for TestEmbedder {
         }
         Ok(embedding)
     }
+
+    fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+        memory_engine::EmbeddingFingerprint::new("mock", "test", self.dim)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/memory-engine-mcp/tests/tools.rs
+++ b/memory-engine-mcp/tests/tools.rs
@@ -18,6 +18,9 @@ impl EmbeddingProvider for FakeEmbed {
     fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
         Ok(vec![0.1, 0.2, 0.3])
     }
+    fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+        memory_engine::EmbeddingFingerprint::new("mock", "test", 3)
+    }
 }
 
 fn test_engine() -> (MemoryEngine, tempfile::TempDir) {

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -56,7 +56,7 @@ macro_rules! delegate_blocking {
 ///
 /// use memory_engine::async_engine::AsyncMemoryEngine;
 /// use memory_engine::{
-///     AddFactRequest, EmbeddingProvider, FactType, MemoryEngine, MemoryError,
+///     AddFactRequest, EmbeddingFingerprint, EmbeddingProvider, FactType, MemoryEngine, MemoryError,
 /// };
 ///
 /// // Deterministic, dependency-free embedder (see the crate-level example).
@@ -70,6 +70,9 @@ macro_rules! delegate_blocking {
 ///             v[b as usize % self.dim] += 1.0;
 ///         }
 ///         Ok(v)
+///     }
+///     fn fingerprint(&self) -> EmbeddingFingerprint {
+///         EmbeddingFingerprint::new("mock", "test", self.dim)
 ///     }
 /// }
 ///
@@ -673,6 +676,10 @@ mod tests {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![0.5; self.dim])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", self.dim)
+        }
     }
 
     #[tokio::test]
@@ -876,6 +883,10 @@ mod tests {
     impl EmbeddingProvider for PanickingEmbedder {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             panic!("deliberate panic inside delegate_blocking! instance arm");
+        }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", DIM)
         }
     }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -517,6 +517,10 @@ mod tests {
         fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
             panic!("embed() must not be called in this test");
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     /// JSONL with two valid entries but neither carries a `sessionId`.

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -174,6 +174,10 @@ mod tests {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![0.5; self.embed_dim])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", self.embed_dim)
+        }
     }
 
     fn insert_fact(conn: &Connection, dim: usize, content: &str, embedding: Vec<f32>) -> i64 {

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -118,6 +118,10 @@ mod tests {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![0.5; self.embed_dim])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", self.embed_dim)
+        }
     }
 
     #[test]

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -155,6 +155,10 @@ mod tests {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![0.5; DIM])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", DIM)
+        }
     }
 
     fn default_config() -> ConsolidationConfig {

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
 
-use crate::engine::MemoryEngine;
 use crate::engine::cycle::{
     CycleContext, CycleMetadata, CycleOutcome, CycleReport, SkipReason, TimeWindow,
 };
+use crate::engine::MemoryEngine;
 use crate::error::{MemoryError, MigrationError, Result};
 use crate::search::hybrid::{SearchQuery, SearchResult};
 use crate::store::facts::FactStore;
@@ -450,8 +450,8 @@ impl MemoryEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::MemoryEngine;
     use crate::engine::cycle::{CycleContext, CycleMetadata, CycleReport, IdentityOutput};
+    use crate::engine::MemoryEngine;
     use crate::error::MemoryError;
     use crate::types::{FactType, Insight, PromoteRequest, PromotionProvenance};
 
@@ -524,6 +524,10 @@ mod tests {
         impl EmbeddingProvider for FixedEmbed {
             fn embed(&self, _text: &str) -> Result<Vec<f32>> {
                 Ok(vec![0.1, 0.2, 0.3, 0.4])
+            }
+
+            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+                crate::types::EmbeddingFingerprint::new("mock", "test", 4)
             }
         }
 

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
 
+use crate::engine::MemoryEngine;
 use crate::engine::cycle::{
     CycleContext, CycleMetadata, CycleOutcome, CycleReport, SkipReason, TimeWindow,
 };
-use crate::engine::MemoryEngine;
 use crate::error::{MemoryError, MigrationError, Result};
 use crate::search::hybrid::{SearchQuery, SearchResult};
 use crate::store::facts::FactStore;
@@ -450,8 +450,8 @@ impl MemoryEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::cycle::{CycleContext, CycleMetadata, CycleReport, IdentityOutput};
     use crate::engine::MemoryEngine;
+    use crate::engine::cycle::{CycleContext, CycleMetadata, CycleReport, IdentityOutput};
     use crate::error::MemoryError;
     use crate::types::{FactType, Insight, PromoteRequest, PromotionProvenance};
 

--- a/src/engine/cycle/apply.rs
+++ b/src/engine/cycle/apply.rs
@@ -387,6 +387,10 @@ mod tests {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     fn engine() -> MemoryEngine {

--- a/src/engine/cycle/default_impl.rs
+++ b/src/engine/cycle/default_impl.rs
@@ -51,7 +51,8 @@ const METHOD_VERSION: &str = "dbscan-v1";
 ///
 /// ```
 /// use memory_engine::{
-///     AddFactRequest, DefaultDreamCycle, EmbeddingProvider, FactType, MemoryEngine, MemoryError,
+///     AddFactRequest, DefaultDreamCycle, EmbeddingFingerprint, EmbeddingProvider, FactType,
+///     MemoryEngine, MemoryError,
 /// };
 ///
 /// // A trivial embedder (the consumer normally injects a real one).
@@ -59,6 +60,9 @@ const METHOD_VERSION: &str = "dbscan-v1";
 /// impl EmbeddingProvider for Embed {
 ///     fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
 ///         Ok(vec![1.0, 0.0])
+///     }
+///     fn fingerprint(&self) -> EmbeddingFingerprint {
+///         EmbeddingFingerprint::new("mock", "test", 2)
 ///     }
 /// }
 ///
@@ -265,7 +269,7 @@ mod tests {
     use super::*;
     use crate::engine::MemoryEngine;
     use crate::traits::EmbeddingProvider;
-    use crate::types::{AddFactOptions, AddFactRequest, FactType, Outcome};
+    use crate::types::{AddFactOptions, AddFactRequest, EmbeddingFingerprint, FactType, Outcome};
 
     const DIM: usize = 4;
 
@@ -273,6 +277,10 @@ mod tests {
     impl EmbeddingProvider for FixedEmbed {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![1.0, 0.0, 0.0, 0.0])
+        }
+
+        fn fingerprint(&self) -> EmbeddingFingerprint {
+            EmbeddingFingerprint::new("mock", "test", 4)
         }
     }
 

--- a/src/engine/dormant.rs
+++ b/src/engine/dormant.rs
@@ -78,6 +78,10 @@ mod tests {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(self.0.clone())
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", self.0.len())
+        }
     }
 
     fn add_fact_with_importance(

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -429,6 +429,10 @@ mod tests {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     /// An oversized event payload is rejected by `ingest` before it touches the

--- a/src/engine/lineage.rs
+++ b/src/engine/lineage.rs
@@ -91,6 +91,10 @@ mod tests {
         fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     fn engine_with_facts() -> MemoryEngine {

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -6,7 +6,10 @@ use crate::traits::{
     ConflictArbiter, ConsolidationConfig, CrudDecision, EmbeddingProvider, ForgetPolicy,
     PersistenceClassifier, SummaryGenerator,
 };
-use crate::types::{AddFactOptions, AddFactRequest, EventType, Fact, FactType, NewEvent, NewFact};
+use crate::types::{
+    AddFactOptions, AddFactRequest, EmbeddingFingerprint, EventType, Fact, FactType, NewEvent,
+    NewFact,
+};
 
 const DIM: usize = 4;
 
@@ -17,6 +20,10 @@ struct MockEmbedder {
 impl EmbeddingProvider for MockEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>> {
         Ok(vec![0.5; self.dim])
+    }
+
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", self.dim)
     }
 }
 
@@ -2850,6 +2857,10 @@ fn embed_batch_default_impl_loops_embed() {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(vec![0.1; self.dim])
         }
+
+        fn fingerprint(&self) -> EmbeddingFingerprint {
+            EmbeddingFingerprint::new("mock", "test", self.dim)
+        }
     }
 
     let embedder = CountingEmbedder {
@@ -2993,6 +3004,9 @@ fn add_facts_batch_rejects_embedding_count_mismatch() {
             // Always return exactly 1 embedding regardless of input
             Ok(vec![vec![0.5; DIM]])
         }
+        fn fingerprint(&self) -> EmbeddingFingerprint {
+            EmbeddingFingerprint::new("mock", "test", DIM)
+        }
     }
 
     let engine = MemoryEngine::builder(DIM).build().unwrap();
@@ -3038,6 +3052,9 @@ fn add_facts_batch_rollback_on_insert_failure() {
                 *last = vec![0.5; DIM + 1]; // wrong dim
             }
             Ok(results)
+        }
+        fn fingerprint(&self) -> EmbeddingFingerprint {
+            EmbeddingFingerprint::new("mock", "test", DIM)
         }
     }
 

--- a/src/inspect/dump.rs
+++ b/src/inspect/dump.rs
@@ -276,6 +276,10 @@ mod tests {
         fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     #[test]

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -219,6 +219,10 @@ mod tests {
         fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     #[test]

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -446,6 +446,10 @@ mod tests {
         fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     // --- Compression detection tests ---

--- a/src/inspect/statistics.rs
+++ b/src/inspect/statistics.rs
@@ -141,6 +141,10 @@ mod tests {
         fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
             Ok(vec![0.1, 0.2, 0.3, 0.4])
         }
+
+        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@
 //!
 //! ```
 //! use memory_engine::{
-//!     AddFactRequest, EmbeddingProvider, FactType, MemoryEngine, MemoryError, MemoryQuery,
+//!     AddFactRequest, EmbeddingFingerprint, EmbeddingProvider, FactType, MemoryEngine, MemoryError,
+//!     MemoryQuery,
 //! };
 //!
 //! // A deterministic, dependency-free embedder: hash each byte into a fixed-dim
@@ -45,6 +46,9 @@
 //!             v[b as usize % self.dim] += 1.0;
 //!         }
 //!         Ok(v)
+//!     }
+//!     fn fingerprint(&self) -> EmbeddingFingerprint {
+//!         EmbeddingFingerprint::new("mock", "test", self.dim)
 //!     }
 //! }
 //!

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -16,7 +16,8 @@ const DEFAULT_LIMIT: usize = 50;
 ///
 /// ```
 /// use memory_engine::{
-///     AddFactRequest, EmbeddingProvider, FactType, MemoryEngine, MemoryError, MemoryQuery,
+///     AddFactRequest, EmbeddingFingerprint, EmbeddingProvider, FactType, MemoryEngine, MemoryError,
+///     MemoryQuery,
 /// };
 ///
 /// // Deterministic, dependency-free embedder (see the crate-level example).
@@ -30,6 +31,9 @@ const DEFAULT_LIMIT: usize = 50;
 ///             v[b as usize % self.dim] += 1.0;
 ///         }
 ///         Ok(v)
+///     }
+///     fn fingerprint(&self) -> EmbeddingFingerprint {
+///         EmbeddingFingerprint::new("mock", "test", self.dim)
 ///     }
 /// }
 ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::search::hybrid::SearchResult;
-use crate::types::Fact;
+use crate::types::{EmbeddingFingerprint, Fact};
 
 // --- Phase 1: Embedding provider (fully used) ---
 
@@ -36,6 +36,18 @@ pub trait EmbeddingProvider: Send + Sync {
     fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
         texts.iter().map(|t| self.embed(t)).collect()
     }
+
+    /// Declare this provider's [`EmbeddingFingerprint`] — the identity of the vector
+    /// space it produces (`model`, `provider`, `dim`, ...).
+    ///
+    /// **No default impl, by design.** A placeholder fingerprint would let the
+    /// mismatch guard (issue #614) compare two placeholders, find them equal, and
+    /// admit incompatible vector spaces — the exact silent corruption this identity
+    /// exists to prevent. Every provider declares its real identity.
+    ///
+    /// The returned identity describes the **document** vector space this provider
+    /// writes, and must stay congruent with what the provider actually computes.
+    fn fingerprint(&self) -> EmbeddingFingerprint;
 }
 
 // --- Phase 2 placeholder traits and types ---
@@ -646,8 +658,14 @@ mod tests {
             fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
                 Ok(vec![0.0])
             }
+            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+                crate::types::EmbeddingFingerprint::new("mock", "test", 1)
+            }
         }
-        let _: &dyn EmbeddingProvider = &Dummy;
+        let provider: &dyn EmbeddingProvider = &Dummy;
+        // fingerprint() must be callable through the trait object (vtable) — guards
+        // against the new required method accidentally breaking object-safety.
+        assert_eq!(provider.fingerprint().dim, 1);
     }
 
     #[test]
@@ -710,6 +728,9 @@ mod tests {
                 self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 Ok(vec![1.0, 2.0])
             }
+            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+                crate::types::EmbeddingFingerprint::new("mock", "test", 2)
+            }
         }
         let c = Counter(std::sync::atomic::AtomicUsize::new(0));
         let results = c.embed_batch(&["a", "b", "c"]).unwrap();
@@ -727,6 +748,9 @@ mod tests {
             fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
                 Ok(vec![0.0])
             }
+            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+                crate::types::EmbeddingFingerprint::new("mock", "test", 1)
+            }
         }
         assert!(Dummy.embed_batch(&[]).unwrap().is_empty());
     }
@@ -739,6 +763,9 @@ mod tests {
                 Err(crate::error::MemoryError::Conflict(
                     crate::error::ConflictError::Arbitration("boom".into()),
                 ))
+            }
+            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+                crate::types::EmbeddingFingerprint::new("mock", "test", 1)
             }
         }
         assert!(Failing.embed_batch(&["a"]).is_err());

--- a/src/types.rs
+++ b/src/types.rs
@@ -854,6 +854,72 @@ pub struct ProjectContext {
     pub relevant_facts: Vec<Fact>,
 }
 
+/// Identity of the embedding model that produced a stored vector.
+///
+/// The canonical **identity tuple** shared across the Memory and Knowledge layers
+/// (see ADR 0015, `docs/design/adr/0015-cross-layer-embedding-identity-policy.md`).
+///
+/// An embedding is only meaningful within the vector space of the exact model that
+/// produced it. Vector *dimension* alone is insufficient identity — two different
+/// models can share a dimension and silently corrupt retrieval. This tuple is the
+/// full identity; mismatch detection (issue #614) compares two fingerprints with
+/// [`PartialEq`]/[`Eq`].
+///
+/// # Cross-layer parity contract
+///
+/// The field **names** (`model`, `provider`, `dim`, `matryoshka_base_dim`,
+/// `element_type`) are **normative** and shared verbatim with the `knowledge-base`
+/// repository's `embed_spaces` registry. Do not rename without updating ADR 0015 in
+/// both repos. `model` is an operator-declared slug, not a weight hash.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EmbeddingFingerprint {
+    /// Model identity slug, e.g. `"Qwen/Qwen3-Embedding-0.6B"`. Operator-declared.
+    pub model: String,
+    /// Serving backend, e.g. `"tei"`, `"ollama"`, `"openai"`.
+    pub provider: String,
+    /// Stored vector dimension (post-truncation). Literal field name `dim` per ADR 0015.
+    pub dim: usize,
+    /// Native model dimension before Matryoshka (MRL) truncation; `None` if untruncated.
+    pub matryoshka_base_dim: Option<usize>,
+    /// Vector element storage type: `"float32"` today (reserved: `"int8"`).
+    pub element_type: String,
+}
+
+impl EmbeddingFingerprint {
+    /// The default vector element type (`"float32"`).
+    pub const ELEMENT_F32: &'static str = "float32";
+
+    /// Construct a fingerprint for an untruncated `float32` embedding space.
+    ///
+    /// Sets `matryoshka_base_dim` to `None` and `element_type` to
+    /// [`ELEMENT_F32`](Self::ELEMENT_F32).
+    #[must_use]
+    pub fn new(model: impl Into<String>, provider: impl Into<String>, dim: usize) -> Self {
+        Self {
+            model: model.into(),
+            provider: provider.into(),
+            dim,
+            matryoshka_base_dim: None,
+            element_type: Self::ELEMENT_F32.to_string(),
+        }
+    }
+
+    /// Construct a fingerprint for a Matryoshka-truncated `float32` embedding space,
+    /// recording the native `base_dim` the model emits before truncation to `dim`.
+    #[must_use]
+    pub fn with_matryoshka(
+        model: impl Into<String>,
+        provider: impl Into<String>,
+        dim: usize,
+        base_dim: usize,
+    ) -> Self {
+        Self {
+            matryoshka_base_dim: Some(base_dim),
+            ..Self::new(model, provider, dim)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1265,5 +1331,73 @@ mod tests {
         let json = serde_json::to_string(&rec).unwrap();
         let back: LineageRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(rec, back);
+    }
+
+    // --- EmbeddingFingerprint (#612) ---
+
+    #[test]
+    fn fingerprint_new_sets_float32_untruncated_defaults() {
+        let fp = EmbeddingFingerprint::new("m", "p", 768);
+        assert_eq!(fp.model, "m");
+        assert_eq!(fp.provider, "p");
+        assert_eq!(fp.dim, 768);
+        assert_eq!(fp.matryoshka_base_dim, None);
+        assert_eq!(fp.element_type, EmbeddingFingerprint::ELEMENT_F32);
+        assert_eq!(fp.element_type, "float32");
+    }
+
+    #[test]
+    fn fingerprint_with_matryoshka_records_base_dim() {
+        let fp = EmbeddingFingerprint::with_matryoshka("qwen", "tei", 512, 1024);
+        assert_eq!(fp.dim, 512);
+        assert_eq!(fp.matryoshka_base_dim, Some(1024));
+        assert_eq!(fp.element_type, "float32");
+    }
+
+    #[test]
+    fn fingerprint_eq_requires_every_field() {
+        // Equality is the #614 mismatch contract: any differing field => incompatible.
+        let base = EmbeddingFingerprint::new("m", "p", 768);
+        assert_eq!(base, EmbeddingFingerprint::new("m", "p", 768));
+        assert_ne!(base, EmbeddingFingerprint::new("other", "p", 768));
+        assert_ne!(base, EmbeddingFingerprint::new("m", "other", 768));
+        assert_ne!(base, EmbeddingFingerprint::new("m", "p", 384));
+        assert_ne!(
+            base,
+            EmbeddingFingerprint::with_matryoshka("m", "p", 768, 1024)
+        );
+        let mut int8 = EmbeddingFingerprint::new("m", "p", 768);
+        int8.element_type = "int8".to_string();
+        assert_ne!(base, int8);
+    }
+
+    #[test]
+    fn fingerprint_hash_consistent_with_eq() {
+        let mut set = std::collections::HashSet::new();
+        set.insert(EmbeddingFingerprint::new("m", "p", 768));
+        assert!(set.contains(&EmbeddingFingerprint::new("m", "p", 768)));
+        assert!(!set.contains(&EmbeddingFingerprint::new("m", "p", 384)));
+    }
+
+    #[test]
+    fn fingerprint_serde_pins_adr0015_key_set() {
+        // The JSON key set is the normative ME<->KB parity contract (ADR 0015):
+        // a field rename MUST break this test.
+        let fp = EmbeddingFingerprint::with_matryoshka("qwen", "tei", 512, 1024);
+        let v = serde_json::to_value(&fp).unwrap();
+        let mut keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "dim",
+                "element_type",
+                "matryoshka_base_dim",
+                "model",
+                "provider"
+            ]
+        );
+        let back: EmbeddingFingerprint = serde_json::from_value(v).unwrap();
+        assert_eq!(fp, back);
     }
 }

--- a/tests/activity_stream_test.rs
+++ b/tests/activity_stream_test.rs
@@ -10,6 +10,9 @@ impl memory_engine::EmbeddingProvider for ZeroEmbedder {
     fn embed(&self, _text: &str) -> memory_engine::error::Result<Vec<f32>> {
         Ok(vec![0.0; self.0])
     }
+    fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+        memory_engine::EmbeddingFingerprint::new("mock", "test", self.0)
+    }
 }
 
 const DIM: usize = 4;

--- a/tests/ann_recall_test.rs
+++ b/tests/ann_recall_test.rs
@@ -10,6 +10,7 @@
 
 use std::collections::HashSet;
 
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::search::SearchConfig;
 use memory_engine::search::hybrid::{SearchMode, SearchQuery};
@@ -32,6 +33,9 @@ impl EmbeddingProvider for Blake3Embedder {
                 (f32::from(byte) / 255.0).mul_add(2.0, -1.0)
             })
             .collect())
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", DIM)
     }
 }
 

--- a/tests/archive_test.rs
+++ b/tests/archive_test.rs
@@ -2,6 +2,7 @@
 
 use chrono::{Duration, Utc};
 use memory_engine::ArchivePolicy;
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::MemoryQuery;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
@@ -29,6 +30,9 @@ impl EmbeddingProvider for TestEmbedder {
             }
         }
         Ok(embedding)
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", DIM)
     }
 }
 

--- a/tests/bootstrap_dryrun.rs
+++ b/tests/bootstrap_dryrun.rs
@@ -19,7 +19,8 @@ use std::sync::Mutex;
 use chrono::{DateTime, Datelike, Utc};
 use memory_engine::traits::PersistenceClassifier;
 use memory_engine::{
-    BootstrapConfig, EmbeddingProvider, Fact, KeywordExtractor, MemoryEngine, MemoryError,
+    BootstrapConfig, EmbeddingFingerprint, EmbeddingProvider, Fact, KeywordExtractor, MemoryEngine,
+    MemoryError,
 };
 
 /// Zero-vector embedder (dim 4) — retrieval is irrelevant to this audit.
@@ -27,6 +28,9 @@ struct TestEmbedder;
 impl EmbeddingProvider for TestEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
         Ok(vec![0.0; 4])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/tests/bootstrap_memory_dir.rs
+++ b/tests/bootstrap_memory_dir.rs
@@ -18,13 +18,18 @@ use std::path::{Path, PathBuf};
 
 use chrono::Datelike;
 use memory_engine::types::FactType;
-use memory_engine::{BootstrapConfig, EmbeddingProvider, MemoryEngine, MemoryError};
+use memory_engine::{
+    BootstrapConfig, EmbeddingFingerprint, EmbeddingProvider, MemoryEngine, MemoryError,
+};
 
 /// Zero-vector embedder (dim 4) — retrieval is irrelevant here.
 struct TestEmbedder;
 impl EmbeddingProvider for TestEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
         Ok(vec![0.0; 4])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -4,7 +4,8 @@ use std::io::Cursor;
 
 use chrono::Utc;
 use memory_engine::{
-    BootstrapConfig, EmbeddingProvider, KeywordExtractor, MemoryEngine, MemoryError,
+    BootstrapConfig, EmbeddingFingerprint, EmbeddingProvider, KeywordExtractor, MemoryEngine,
+    MemoryError,
 };
 
 /// Dummy embedder for testing — returns a fixed-length zero vector.
@@ -13,6 +14,9 @@ struct TestEmbedder;
 impl EmbeddingProvider for TestEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
         Ok(vec![0.0; 4])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/tests/dream_cycle_test.rs
+++ b/tests/dream_cycle_test.rs
@@ -8,8 +8,8 @@
 
 use memory_engine::inspect::{ExpiredReason, FactState};
 use memory_engine::{
-    AddFactOptions, AddFactRequest, CycleDelta, DefaultDreamCycle, EmbeddingProvider, FactType,
-    MemoryEngine, MemoryError, Outcome,
+    AddFactOptions, AddFactRequest, CycleDelta, DefaultDreamCycle, EmbeddingFingerprint,
+    EmbeddingProvider, FactType, MemoryEngine, MemoryError, Outcome,
 };
 use tempfile::tempdir;
 
@@ -28,6 +28,9 @@ impl EmbeddingProvider for TagEmbed {
             [0.0, 0.0, 1.0, 0.0]
         };
         Ok(v.to_vec())
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/tests/eval/helpers.rs
+++ b/tests/eval/helpers.rs
@@ -4,6 +4,7 @@
 //! (e.g., `ann_recall_test.rs` uses intentionally different embedder variants).
 
 use chrono::{DateTime, Duration, Utc};
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
 use memory_engine::traits::{
@@ -45,6 +46,9 @@ impl EmbeddingProvider for TestEmbedder {
             }
         }
         Ok(embedding)
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", DIM)
     }
 }
 

--- a/tests/inspect_test.rs
+++ b/tests/inspect_test.rs
@@ -4,6 +4,7 @@
 //! No direct store access — edges are generated via `consolidate()` or `resolve_conflict()`.
 
 use chrono::{Duration, Utc};
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
 use memory_engine::inspect::types::*;
@@ -16,6 +17,9 @@ struct TestEmbed;
 impl EmbeddingProvider for TestEmbed {
     fn embed(&self, _text: &str) -> Result<Vec<f32>> {
         Ok(vec![0.25; DIM])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", DIM)
     }
 }
 

--- a/tests/phase3b_lifecycle_test.rs
+++ b/tests/phase3b_lifecycle_test.rs
@@ -1,6 +1,7 @@
 //! Phase 3b integration test: full lifecycle with pinned facts, future memory, and forgetting.
 
 use chrono::Utc;
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::ResumeConfig;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
@@ -27,6 +28,9 @@ impl EmbeddingProvider for TestEmbedder {
             }
         }
         Ok(embedding)
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", DIM)
     }
 }
 

--- a/tests/recent_insights_test.rs
+++ b/tests/recent_insights_test.rs
@@ -4,8 +4,8 @@
 //! subtree and assert subtree-scoped, newest-first, limited, active-only retrieval.
 
 use memory_engine::{
-    AddFactOptions, AddFactRequest, EmbeddingProvider, FactType, INSIGHT_MARKER_KEY, MemoryEngine,
-    MemoryError,
+    AddFactOptions, AddFactRequest, EmbeddingFingerprint, EmbeddingProvider, FactType,
+    INSIGHT_MARKER_KEY, MemoryEngine, MemoryError,
 };
 
 const DIM: usize = 4;
@@ -14,6 +14,9 @@ struct FixedEmbed;
 impl EmbeddingProvider for FixedEmbed {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
         Ok(vec![0.1, 0.2, 0.3, 0.4])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/tests/restore_roundtrip_test.rs
+++ b/tests/restore_roundtrip_test.rs
@@ -1,5 +1,6 @@
 //! Integration tests for import/export round-trips.
 
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::EmbeddingProvider;
 use memory_engine::engine::{EngineConfig, MemoryEngine};
 use memory_engine::inspect_types::DumpFormat;
@@ -11,6 +12,9 @@ struct FakeEmbed;
 impl EmbeddingProvider for FakeEmbed {
     fn embed(&self, _text: &str) -> memory_engine::error::Result<Vec<f32>> {
         Ok(vec![0.1, 0.2, 0.3, 0.4])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", 4)
     }
 }
 

--- a/tests/roundtrip_test.rs
+++ b/tests/roundtrip_test.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
 use memory_engine::search::hybrid::{MatchType, SearchMode, SearchQuery};
@@ -30,6 +31,9 @@ impl EmbeddingProvider for TestEmbedder {
             }
         }
         Ok(embedding)
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", self.dim)
     }
 }
 


### PR DESCRIPTION
## Summary

Wave-1 foundation for the embedding model-identity policy (epic #610). Adds the canonical **identity tuple** as a Rust type and makes every `EmbeddingProvider` declare its identity, so later issues can persist it (#613), detect mismatches (#614), and gate pre-computed vectors (#615).

- **`EmbeddingFingerprint`** (`src/types.rs`): `{ model, provider, dim, matryoshka_base_dim, element_type }` — field names **normative** per ADR 0015 (shared verbatim with `knowledge-base`). Derives `Eq`+`Hash` (the #614 mismatch contract) + serde. `new`/`with_matryoshka` constructors + `ELEMENT_F32` const.
- **`EmbeddingProvider::fingerprint()`** (`src/traits.rs`): **required, no default** — a placeholder would let #614 equate incompatible vector spaces (the silent corruption this exists to prevent). Object-safe.

## ⚠️ BREAKING CHANGE

`EmbeddingProvider` gains a required `fingerprint()` method; all implementors must provide it. No external users yet, so no migration. ~57 impls across all 4 crates updated.

- `HttpEmbeddingProvider` gains an operator-declared **`provider`** field — it *cannot* be sniffed (Ollama and TEI both serve `/v1/embeddings`), so an honest fingerprint requires it. `::new()` goes 5→6 args (~19 callers updated).
- `PassthroughEmbedder` reports a non-spoofing sentinel (`precomputed`/`passthrough`, real dim) — `TODO(#615)`.

## Load-bearing ordering constraint (ADR 0015)

The hardcoded `provider` in MCP/CLI wiring is a temporary seam (`TODO(#618)`). **#618 (real provider config) MUST land before #614 turns mismatch enforcement on** — else the guard checks a possibly-lying constant. Recorded in the design doc + code comments because #612 introduces the seam.

## Scope

**In:** the type, the trait method, all impls, `provider` field, tests. **Out (TODO-markered):** DB persistence (#613), mismatch detection (#614), pre-computed policy (#615), `embed_query` (#616), TEI instruction/MRL (#617), config wiring (#618/#619).

## Heads-up: incidental clippy cleanup (not introduced here)

CI runs clippy with `-D warnings --all-features`. This branch surfaced **5 pre-existing doc-lint warnings** in #603's files (`cognitive.rs`, `embedding_integration.rs`, `cognitive_tools.rs`) — outside every #612 diff hunk, byte-identical to `main`. They're fixed here (trivial: 4 backticks + 1 paragraph break) to keep the gate green. **This implies `main`'s clippy job likely currently carries this debt** — worth a separate look.

## Verification (all green)

`cargo build --workspace` · `cargo test --workspace --all-features` · `cargo test --workspace --all-features --doc` · `cargo clippy --workspace --all-targets --all-features -- -D warnings` · `cargo fmt --check`

## Docs

Design spec `docs/design/embedding-identity-and-tei-qwen-migration.md` + ADR `docs/design/adr/0015-cross-layer-embedding-identity-policy.md` (mirrored to `knowledge-base` via KB #469).

Closes #612 · Epic #610
