### PR TITLE
feat(storage): persist embedding_meta, replace embed_dim; schema_version bump

### DIFF
--- a/docs/design/embedding-identity-and-tei-qwen-migration.md
+++ b/docs/design/embedding-identity-and-tei-qwen-migration.md
@@ -81,6 +81,13 @@ panic, never silent).
 
 ### 1. Embedding identity fingerprint (`area:core`, `area:storage`)
 
+> **Status: delivered.** The type + trait method landed in #612 (`EmbeddingFingerprint` +
+> `EmbeddingProvider::fingerprint()`). The persistence landed in **#613** (schema v11→v12):
+> the `store::embedding_meta` typed boundary (`load`/`store`/`record_if_absent`) records the
+> tuple on the first embedding write, the open path validates dim against it, and the bare
+> `embed_dim` config key is dropped. Mismatch **enforcement** remains #614 (the seam
+> `record_if_absent` extends).
+
 - New `EmbeddingFingerprint { model, provider, dim, matryoshka_base_dim, element_type }`.
 - New trait method `EmbeddingProvider::fingerprint(&self) -> EmbeddingFingerprint` so
   providers declare their identity.

--- a/docs/design/schema-evolution-policy.md
+++ b/docs/design/schema-evolution-policy.md
@@ -72,6 +72,22 @@ Each migration runs inside a transaction. On failure, the transaction rolls back
 8. Run `cargo test` — the insta snapshot test will fail with a pending snapshot. Review and accept the new snapshot.
 9. Verify all property-based migration tests still pass (they exercise the full chain).
 
+### Config-Only Migrations (no DDL delta)
+
+Some migrations change only `config` rows, not table/index/trigger DDL — e.g. **v11→v12**
+(#613, ADR 0015), which replaces the bare `embed_dim` config key with the richer
+`embedding_meta` identity tuple (`DELETE FROM config WHERE key = 'embed_dim'`; the tuple is
+written lazily on the first embedding write, so no backfill). For these:
+
+- Steps 4–5 (live DDL constants, frozen DDL snapshot) are **N/A** — the table shape is
+  unchanged, so `TABLES_VM_DDL` would be byte-identical to the prior version.
+- **The DDL snapshot does NOT guard a config-only migration.** `deterministic_schema_dump`
+  projects only `sqlite_master` (DDL); config rows are invisible to it, and the DDL is
+  identical across the bump. The dedicated migration test (e.g.
+  `migrate_v11_to_v12_drops_embed_dim`) is therefore the **load-bearing guard** — it must
+  inject the legacy config row before migrating so the change is exercised non-vacuously
+  ("snapshot green ≠ migration correct").
+
 ## Event Envelope Versioning
 
 Events in the append-only log carry a per-event-type revision via the `event_revision` column.

--- a/docs/reference/crate-layout.md
+++ b/docs/reference/crate-layout.md
@@ -56,6 +56,7 @@ memory_engine (lib.rs)
 : SQLite persistence layer. Sub-modules handle distinct tables:
 
 - `store::schema` -- DDL, migrations, `get_config`/`set_config`.
+- `store::embedding_meta` -- typed persistence of the canonical `EmbeddingFingerprint` identity tuple (`load`/`store`/`record_if_absent`); single owner of the on-disk encoding (ADR 0015), recorded on the first embedding write. The degenerate single-space case of the Knowledge layer's multi-space registry; Wave 2 (#622) generalizes it here.
 - `store::events` -- `EventStore` (insert, get).
 - `store::facts` -- `FactStore` (insert, get, list_active, expire, update importance).
 - `store::summaries` -- `SummaryStore` (insert, list by level).

--- a/memory-engine-cli/src/commands/add_fact.rs
+++ b/memory-engine-cli/src/commands/add_fact.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use clap::ValueEnum;
 use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 
-use crate::db::open_engine_writable;
+use crate::db::open_engine_writable_with_dim;
 use crate::embedding::PassthroughEmbedder;
 use crate::output::{self, OutputFormat, parse_datetime};
 
@@ -113,7 +113,11 @@ pub fn run(db: &Path, args: &AddFactArgs, format: OutputFormat) -> anyhow::Resul
         None => None,
     };
 
-    let engine = open_engine_writable(db)?;
+    // Derive the engine dimension from the supplied embedding rather than peeking
+    // the database: this works on a freshly-created, never-embedded store (which
+    // has no recorded dimension under #613). If the store was previously embedded
+    // at a different dimension, the engine's open path rejects the mismatch.
+    let engine = open_engine_writable_with_dim(db, embedding.len())?;
     let fact_type: FactType = args.fact_type.into();
 
     let req = AddFactRequest {

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -9,7 +9,7 @@ use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 use memory_engine_embed::HttpEmbeddingProvider;
 use serde::{Deserialize, Serialize};
 
-use crate::db::open_engine_writable;
+use crate::db::{open_engine_writable, open_engine_writable_with_dim};
 use crate::output::{OutputFormat, print_json};
 
 // ---------------------------------------------------------------------------
@@ -312,6 +312,11 @@ pub fn run(db: &Path, args: &BatchIngestArgs, format: OutputFormat) -> anyhow::R
         MemoryEngine::builder(embed_dim)
             .path(db.to_path_buf())
             .build()?
+    } else if let Some(dim) = args.embed_dim {
+        // Existing DB: accept an explicit --embed-dim so a never-embedded store (no
+        // recorded identity yet under #613) is still writable. The engine's open path
+        // rejects a mismatch against any recorded identity.
+        open_engine_writable_with_dim(db, dim)?
     } else {
         open_engine_writable(db)?
     };

--- a/memory-engine-cli/src/commands/bootstrap.rs
+++ b/memory-engine-cli/src/commands/bootstrap.rs
@@ -18,7 +18,7 @@ use memory_engine::bootstrap::{
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine_embed::HttpEmbeddingProvider;
 
-use crate::db::open_engine_writable;
+use crate::db::{open_engine_writable, open_engine_writable_with_dim};
 use crate::output::{OutputFormat, print_json};
 
 // ---------------------------------------------------------------------------
@@ -181,6 +181,11 @@ pub fn run(db: &Path, args: &BootstrapArgs, format: OutputFormat) -> anyhow::Res
         MemoryEngine::builder(embed_dim)
             .path(db.to_path_buf())
             .build()?
+    } else if let Some(dim) = args.embed_dim {
+        // Existing DB: accept an explicit --embed-dim so a never-embedded store (no
+        // recorded identity yet under #613) is still writable. The engine's open path
+        // rejects a mismatch against any recorded identity.
+        open_engine_writable_with_dim(db, dim)?
     } else {
         open_engine_writable(db)?
     };

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -2,9 +2,15 @@ use std::path::Path;
 
 use memory_engine::MemoryEngine;
 
-/// Peek `embed_dim` from an existing `SQLite` database's `config` table.
+/// Peek the embedding dimension from an existing `SQLite` database.
 ///
-/// Opens a transient read-only connection and reads the `embed_dim` key.
+/// Reads the persisted identity from the `embedding_meta` config row (#613,
+/// ADR 0015) and extracts its `dim`. Falls back to the legacy bare `embed_dim`
+/// key for pre-#613 databases. Errors if neither is present — a database that was
+/// created but never had an embedding written has no recorded dimension; write
+/// commands that know the dimension from their input (e.g. `add-fact`'s
+/// `--embedding`) should use [`open_engine_writable_with_dim`] instead of peeking.
+///
 /// Distinct from the import path's snapshot-header reader (see
 /// `peek_embed_dim_from_snapshot` in `commands::import`).
 ///
@@ -12,6 +18,8 @@ use memory_engine::MemoryEngine;
 /// the database's embedding dimension. (`db` is a private module, so this is not part
 /// of any public API.)
 pub fn peek_embed_dim_from_db(path: &Path) -> anyhow::Result<usize> {
+    use rusqlite::OptionalExtension;
+
     anyhow::ensure!(
         path.is_file(),
         "database not found (or is a directory): {}",
@@ -22,19 +30,44 @@ pub fn peek_embed_dim_from_db(path: &Path) -> anyhow::Result<usize> {
         path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
-    let raw: String = conn
+
+    // Preferred: the embedding_meta identity tuple records `dim` (#613).
+    let meta_raw: Option<String> = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'embedding_meta'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    if let Some(raw) = meta_raw {
+        let meta: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("corrupt embedding_meta in config table: {e}"))?;
+        let dim = meta
+            .get("dim")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| anyhow::anyhow!("embedding_meta is missing a numeric 'dim' field"))?;
+        return usize::try_from(dim)
+            .map_err(|_| anyhow::anyhow!("embedding_meta 'dim' out of range"));
+    }
+
+    // Legacy fallback: a pre-#613 database carried a bare `embed_dim` key.
+    let legacy: Option<String> = conn
         .query_row(
             "SELECT value FROM config WHERE key = 'embed_dim'",
             [],
             |row| row.get::<_, String>(0),
         )
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "database has no embed_dim in config table — is this a memory-engine database? ({e})"
-            )
-        })?;
-    raw.parse()
-        .map_err(|_| anyhow::anyhow!("invalid embed_dim value in config table"))
+        .optional()?;
+    if let Some(raw) = legacy {
+        return raw
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid embed_dim value in config table"));
+    }
+
+    anyhow::bail!(
+        "database has no embedding identity yet (nothing has been embedded) — \
+         add a fact first, or is this a memory-engine database?"
+    )
 }
 
 /// Peek the live `schema_version` from an existing database's `config` table.
@@ -89,6 +122,26 @@ pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
 /// schema migration creates a WAL-safe backup first.
 pub fn open_engine_writable(path: &Path) -> anyhow::Result<MemoryEngine> {
     let embed_dim = peek_embed_dim_from_db(path)?;
+    open_engine_writable_with_dim(path, embed_dim)
+}
+
+/// Open a `MemoryEngine` with **write** capability using an explicitly known
+/// dimension, **without** peeking the database.
+///
+/// For write commands that know the dimension from their own input (e.g.
+/// `add-fact` derives it from the `--embedding` length), so they work against a
+/// freshly-created, never-embedded database that has no recorded dimension yet.
+/// If the database *was* previously embedded at a different dimension, the
+/// engine's open path rejects the mismatch against the stored `embedding_meta`.
+pub fn open_engine_writable_with_dim(
+    path: &Path,
+    embed_dim: usize,
+) -> anyhow::Result<MemoryEngine> {
+    anyhow::ensure!(
+        path.is_file(),
+        "database not found (or is a directory): {}",
+        path.display()
+    );
     let backup_dir = path.parent().map(Path::to_path_buf);
     let mut builder = MemoryEngine::builder(embed_dim).path(path.to_path_buf());
     if let Some(dir) = backup_dir {

--- a/memory-engine-cli/tests/add_fact.rs
+++ b/memory-engine-cli/tests/add_fact.rs
@@ -248,6 +248,23 @@ fn add_fact_temporal_inconsistency() {
 #[test]
 fn add_fact_embedding_dimension_mismatch() {
     let (_dir, db_path) = create_empty_db();
+    // Under #613 the dimension is established on the first embedding write, not at
+    // DB creation. First establish dim=4 with a valid embedding...
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "add-fact",
+            "--content",
+            "seed",
+            "--fact-type",
+            "semantic",
+            "--embedding",
+            EMBEDDING_JSON, // 4-dim
+        ])
+        .assert()
+        .success();
+    // ...then a 2-dim embedding disagrees with the recorded identity → rejected.
     cli()
         .args([
             "--db",
@@ -258,7 +275,7 @@ fn add_fact_embedding_dimension_mismatch() {
             "--fact-type",
             "semantic",
             "--embedding",
-            "[0.1, 0.2]", // 2-dim, DB expects 4
+            "[0.1, 0.2]", // 2-dim, store is dim 4
         ])
         .assert()
         .failure()

--- a/memory-engine-mcp/src/config.rs
+++ b/memory-engine-mcp/src/config.rs
@@ -78,14 +78,20 @@ const fn default_summary_timeout() -> u64 {
     120
 }
 
-/// Probe `embed_dim` from an existing database by reading the config table.
+/// Probe the embedding dimension from an existing database.
 ///
-/// Mirrors the pattern from `memory-engine-cli/src/db.rs`.
+/// Reads the persisted identity from the `embedding_meta` config row (#613,
+/// ADR 0015) and extracts its `dim`, falling back to the legacy bare `embed_dim`
+/// key for pre-#613 databases. Mirrors `peek_embed_dim_from_db` in
+/// `memory-engine-cli/src/db.rs`.
 ///
 /// # Errors
 ///
-/// Returns an error if the database doesn't exist or has no `embed_dim` config.
+/// Returns an error if the database doesn't exist, has no recorded embedding
+/// identity yet (nothing embedded), or the stored value is malformed.
 pub fn probe_embed_dim(db_path: &Path) -> Result<usize, String> {
+    use rusqlite::OptionalExtension;
+
     if !db_path.is_file() {
         return Err(format!(
             "database path is not a file or does not exist: {}",
@@ -98,17 +104,41 @@ pub fn probe_embed_dim(db_path: &Path) -> Result<usize, String> {
     )
     .map_err(|e| format!("cannot open database: {e}"))?;
 
-    let dim_str: String = conn
+    // Preferred: the embedding_meta identity tuple records `dim` (#613).
+    let meta_raw: Option<String> = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'embedding_meta'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| format!("config query failed: {e}"))?;
+    if let Some(raw) = meta_raw {
+        let meta: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| format!("corrupt embedding_meta in config table: {e}"))?;
+        let dim = meta
+            .get("dim")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| "embedding_meta is missing a numeric 'dim' field".to_owned())?;
+        return usize::try_from(dim).map_err(|_| "embedding_meta 'dim' out of range".to_owned());
+    }
+
+    // Legacy fallback: a pre-#613 database carried a bare `embed_dim` key.
+    let legacy: Option<String> = conn
         .query_row(
             "SELECT value FROM config WHERE key = 'embed_dim'",
             [],
             |row| row.get(0),
         )
-        .map_err(|_| "database has no embed_dim in config table".to_owned())?;
+        .optional()
+        .map_err(|e| format!("config query failed: {e}"))?;
+    if let Some(dim_str) = legacy {
+        return dim_str
+            .parse::<usize>()
+            .map_err(|e| format!("invalid embed_dim value '{dim_str}': {e}"));
+    }
 
-    dim_str
-        .parse::<usize>()
-        .map_err(|e| format!("invalid embed_dim value '{dim_str}': {e}"))
+    Err("database has no embedding identity yet (nothing has been embedded)".to_owned())
 }
 
 #[cfg(test)]

--- a/memory-engine-mcp/tests/config_merge.rs
+++ b/memory-engine-mcp/tests/config_merge.rs
@@ -190,10 +190,20 @@ fn probe_embed_dim_from_existing_db() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
 
-    // Create a real database with known embed_dim
+    // Create a real database with a known dimension. Under #613 the dimension is
+    // recorded on the first embedding write, so seed the identity directly.
     let engine = MemoryEngine::builder(384)
         .path(db_path.clone())
         .build()
+        .unwrap();
+    engine
+        .set_config(
+            "embedding_meta",
+            &serde_json::to_string(&memory_engine::EmbeddingFingerprint::new(
+                "test", "test", 384,
+            ))
+            .unwrap(),
+        )
         .unwrap();
     drop(engine);
 
@@ -216,6 +226,15 @@ fn probe_embed_dim_different_dimensions() {
     let engine = MemoryEngine::builder(768)
         .path(db_path.clone())
         .build()
+        .unwrap();
+    engine
+        .set_config(
+            "embedding_meta",
+            &serde_json::to_string(&memory_engine::EmbeddingFingerprint::new(
+                "test", "test", 768,
+            ))
+            .unwrap(),
+        )
         .unwrap();
     drop(engine);
 

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -84,6 +84,13 @@ pub fn consolidate(
 
     let tx = conn.unchecked_transaction()?;
 
+    // Record the embedding identity on first write (#613, ADR 0015 §2), inside the
+    // transaction so it commits atomically with any summary vectors. Consolidation
+    // embeds summary text via `embedder` into the same vector space, so it is a
+    // legitimate first-write path; `record_if_absent` is a no-op once an identity
+    // exists (the usual case — facts were ingested before consolidation runs).
+    crate::store::embedding_meta::record_if_absent(&tx, &embedder.fingerprint(), embed_dim)?;
+
     let (duplicates_removed, expired_ids) =
         local_dedup(&tx, embed_dim, config.dedup_threshold, last, now)?;
 

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -52,6 +52,10 @@ impl MemoryEngine {
     ) -> Result<crate::bootstrap::BootstrapReport> {
         let conn = self.write_conn()?;
         let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
+        // Stamp the embedding identity on first write (#613), before the inner
+        // import. The inner savepoint commits facts atomically; meta-first ordering
+        // keeps a crash benign (identity declared, no facts).
+        self.record_embedding_identity(&conn, embedder)?;
         crate::bootstrap::bootstrap_session_inner(
             &conn,
             self.embed_dim,
@@ -89,6 +93,8 @@ impl MemoryEngine {
     ) -> Result<crate::bootstrap::BootstrapReport> {
         let conn = self.write_conn()?;
         let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
+        // Stamp the embedding identity on first write (#613), before the inner import.
+        self.record_embedding_identity(&conn, embedder)?;
         crate::bootstrap::bootstrap_directory_inner(
             &conn,
             self.embed_dim,
@@ -133,6 +139,11 @@ impl MemoryEngine {
     ) -> Result<crate::bootstrap::BootstrapReport> {
         let conn = self.write_conn()?;
         let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
+        // Stamp the embedding identity on first write (#613). This path is
+        // autocommit-per-file (no wrapping savepoint), so meta-first ordering here is
+        // what keeps it crash-safe (Codex review BLOCKER): identity is recorded before
+        // any file's fact, so no vector is ever committed without its identity.
+        self.record_embedding_identity(&conn, embedder)?;
         crate::bootstrap::memory_dir::bootstrap_memory_directory_inner(
             &conn,
             self.embed_dim,

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -389,6 +389,20 @@ impl MemoryEngine {
             });
         }
 
+        // #613/#615 — promotion identity guard. `promote` is public and inserts a
+        // fact from a PRE-COMPUTED `req.embedding` with no live `EmbeddingProvider`,
+        // so it can be the literal first write on a fresh store. #613 cannot stamp the
+        // identity here (no fingerprint to read; declaring a `model` for a pre-computed
+        // vector is #615). Reject promotion into a store that has no recorded identity
+        // yet — otherwise this path would commit a vector with no `embedding_meta`, the
+        // #614 silent-corruption landmine. Invisible in normal use: any prior
+        // add_fact/bootstrap/consolidate has already stamped the store's identity.
+        if crate::store::embedding_meta::load(conn)?.is_none() {
+            return Err(MemoryError::Internal(
+                "cannot promote into a store with no embedding identity; write a fact first".into(),
+            ));
+        }
+
         // Ensure metadata is an object (normalize non-objects to avoid silent provenance loss)
         let mut metadata = match req.metadata.clone() {
             serde_json::Value::Object(map) => serde_json::Value::Object(map),
@@ -745,6 +759,43 @@ mod tests {
                 }
             ),
             "expected EmbeddingDimension, got: {err}"
+        );
+    }
+
+    #[test]
+    fn promote_into_unstamped_store_is_rejected() {
+        // `promote` is public and inserts a PRE-COMPUTED vector with no live
+        // embedder, so it can be the literal first write on a fresh store. #613
+        // cannot stamp the identity here, so it guards: promotion into a store with
+        // no recorded `embedding_meta` is rejected (Codex review HIGH). After a real
+        // embedding write establishes the identity, promotion succeeds.
+        let engine = MemoryEngine::builder(4).build().unwrap();
+        let req = PromoteRequest {
+            content: "promoted wisdom".into(),
+            fact_type: FactType::Semantic,
+            embedding: vec![0.1, 0.2, 0.3, 0.4], // correct dim — dim check passes
+            importance: 0.9,
+            metadata: serde_json::json!({}),
+            scope: None,
+            source_fact_ids: vec![],
+            provenance: stub_provenance(),
+        };
+
+        let err = engine.promote_with_lineage(&req).unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Internal(ref m) if m.contains("no embedding identity")),
+            "expected the identity guard error, got: {err:?}"
+        );
+
+        // add_source_facts embeds via add_fact, which records the identity at dim 4.
+        let source_ids = add_source_facts(&engine, &[1, 2]);
+        let ok_req = PromoteRequest {
+            source_fact_ids: source_ids,
+            ..req
+        };
+        assert!(
+            engine.promote_with_lineage(&ok_req).is_ok(),
+            "promotion succeeds once the store has an embedding identity"
         );
     }
 

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -391,17 +391,11 @@ impl MemoryEngine {
 
         // #613/#615 — promotion identity guard. `promote` is public and inserts a
         // fact from a PRE-COMPUTED `req.embedding` with no live `EmbeddingProvider`,
-        // so it can be the literal first write on a fresh store. #613 cannot stamp the
-        // identity here (no fingerprint to read; declaring a `model` for a pre-computed
-        // vector is #615). Reject promotion into a store that has no recorded identity
-        // yet — otherwise this path would commit a vector with no `embedding_meta`, the
-        // #614 silent-corruption landmine. Invisible in normal use: any prior
-        // add_fact/bootstrap/consolidate has already stamped the store's identity.
-        if crate::store::embedding_meta::load(conn)?.is_none() {
-            return Err(MemoryError::Internal(
-                "cannot promote into a store with no embedding identity; write a fact first".into(),
-            ));
-        }
+        // so it can be the literal first write on a fresh store. Reject promotion into
+        // a store with no recorded identity (shared with the cycle AddFact/Synthesize
+        // guard); invisible in normal use, where a prior real embedding write already
+        // stamped the store.
+        crate::store::embedding_meta::require_present(conn)?;
 
         // Ensure metadata is an object (normalize non-objects to avoid silent provenance loss)
         let mut metadata = match req.metadata.clone() {

--- a/src/engine/cycle/apply.rs
+++ b/src/engine/cycle/apply.rs
@@ -79,6 +79,20 @@ impl MemoryEngine {
         let tx = conn
             .unchecked_transaction()
             .map_err(MemoryError::Database)?;
+
+        // #613 — `AddFact` / `Synthesize` insert PRE-COMPUTED-embedding facts with no
+        // live `EmbeddingProvider`, so they cannot stamp the store's identity. Reject
+        // them against an un-stamped store (a `Promote` delta self-guards in
+        // `promote_in_conn`). Normally a no-op: a populated store applying a cycle
+        // already has a recorded identity.
+        if report
+            .deltas
+            .iter()
+            .any(|d| matches!(d, CycleDelta::AddFact(_) | CycleDelta::Synthesize { .. }))
+        {
+            crate::store::embedding_meta::require_present(&tx)?;
+        }
+
         let mut result = ApplyResult::default();
         // (fact_id, embedding) pairs to notify HNSW about after commit.
         #[cfg(feature = "ann")]
@@ -486,7 +500,21 @@ mod tests {
     }
 
     fn engine() -> MemoryEngine {
-        MemoryEngine::builder(DIM).build().unwrap()
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        // Stamp the embedding identity so apply tests can apply pre-computed-vector
+        // deltas (AddFact/Synthesize) — #613 requires a recorded identity for those.
+        // This mirrors production, where facts (and thus the identity) exist before a
+        // cycle runs. Same fingerprint FixedEmbed records, so a later `add()` is a no-op.
+        engine
+            .set_config(
+                "embedding_meta",
+                &serde_json::to_string(&crate::types::EmbeddingFingerprint::new(
+                    "mock", "test", DIM,
+                ))
+                .unwrap(),
+            )
+            .unwrap();
+        engine
     }
 
     fn add(engine: &MemoryEngine, content: &str) -> i64 {
@@ -528,6 +556,38 @@ mod tests {
             identity: IdentityOutput::empty(),
             metadata: meta(processed),
         }
+    }
+
+    #[test]
+    fn apply_add_fact_into_unstamped_store_is_rejected() {
+        // #613 guard: AddFact carries a pre-computed vector with no live embedder, so
+        // it cannot stamp identity. Applying it to a store with no recorded identity is
+        // rejected. Uses a raw builder, bypassing the identity-seeding `engine()` helper.
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let nf = NewFact {
+            content: "derived pattern".into(),
+            content_hash: String::new(),
+            embedding: vec![0.1, 0.2, 0.3, 0.4],
+            fact_type: FactType::Semantic,
+            t_created: "2026-06-16T00:30:00Z".parse().unwrap(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: "2026-06-16T00:30:00Z".parse().unwrap(),
+            metadata: serde_json::json!({}),
+            scope_id: 1,
+            is_pinned: false,
+        };
+        let err = engine
+            .apply_cycle_report(&report(vec![CycleDelta::AddFact(nf)], vec![]))
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Internal(ref m) if m.contains("no embedding identity")),
+            "expected the identity guard error, got: {err:?}"
+        );
     }
 
     fn stub_provenance() -> PromotionProvenance {

--- a/src/engine/equivalence.rs
+++ b/src/engine/equivalence.rs
@@ -172,10 +172,24 @@ fn equiv_embed_dim_mismatch_is_migration_error() {
     use crate::error::MemoryError;
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("dim.db");
-    let _ = MemoryEngine::builder(768)
-        .path(path.clone())
-        .build()
-        .unwrap();
+    {
+        let engine = MemoryEngine::builder(768)
+            .path(path.clone())
+            .build()
+            .unwrap();
+        // The embedding identity (incl. dim) is recorded on the first embedding
+        // write (#613), not at open. Seed it via the config facade to pin dim=768
+        // without standing up an embedder in this builder-equivalence module.
+        engine
+            .set_config(
+                "embedding_meta",
+                &serde_json::to_string(&crate::types::EmbeddingFingerprint::new(
+                    "mock", "test", 768,
+                ))
+                .unwrap(),
+            )
+            .unwrap();
+    }
     let err = MemoryEngine::builder(384).path(path).build().unwrap_err();
     assert!(
         matches!(err, MemoryError::Migration(_)),

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -160,7 +160,20 @@ impl MemoryEngine {
                 is_pinned,
             };
 
-            FactStore::new(&conn, self.embed_dim).insert(&new_fact)?
+            // Atomic first-write: record the embedding identity (#613, ADR 0015 §2)
+            // and insert the fact in one transaction, so a vector is never committed
+            // without its identity (the #614 silent-corruption landmine). `add_fact`
+            // was previously a bare autocommit insert; a second autocommit statement
+            // for the identity would let a crash between them orphan the vector.
+            // Scope creation above stays autocommit (unchanged): an orphan scope on
+            // rollback is a pre-existing, benign outcome, and the scope row + its
+            // scope_tree cache entry commit together, independent of the fact — so no
+            // cache desync is introduced.
+            let tx = conn.unchecked_transaction()?;
+            self.record_embedding_identity(&tx, embedder)?;
+            let id = FactStore::new(&tx, self.embed_dim).insert(&new_fact)?;
+            tx.commit()?;
+            id
         }; // DB lock released = committed
 
         #[cfg(feature = "ann")]
@@ -331,6 +344,11 @@ impl MemoryEngine {
             let result = (|| -> Result<(Vec<i64>, Vec<i64>)> {
                 let scope_store = ScopeStore::new(&conn);
                 let store = FactStore::new(&conn, self.embed_dim);
+
+                // Record the embedding identity on first write (#613), inside the
+                // savepoint so it commits atomically with the batch (write-once;
+                // a no-op on every subsequent batch).
+                self.record_embedding_identity(&conn, embedder)?;
 
                 // Resolve scopes INSIDE the savepoint so they roll back on error.
                 let (scope_ids, scope_ids_to_cache) =

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -15,7 +15,7 @@ use crate::store::schema::{get_config, set_config};
 use crate::store::scopes::ScopeStore;
 use crate::store::summaries::SummaryStore;
 use crate::store::upcaster::UpcasterRegistry;
-use crate::traits::Reranker;
+use crate::traits::{EmbeddingProvider, Reranker};
 use crate::types::{ConsolidationLevel, Fact};
 
 mod activity;
@@ -227,10 +227,10 @@ impl MemoryEngine {
         // 1. Validate embed_dim (must happen first — ensures schema is ready).
         if pool.is_read_only() {
             let conn = pool.read()?;
-            Self::validate_embed_dim(&conn, embed_dim)?;
+            Self::validate_embed_dim_against_meta(&conn, embed_dim)?;
         } else {
             let conn = pool.write();
-            Self::validate_or_set_embed_dim(&conn, embed_dim)?;
+            Self::validate_embed_dim_against_meta(&conn, embed_dim)?;
         }
 
         // 2. Try snapshot fast path (file-backed engines only).
@@ -386,44 +386,60 @@ impl MemoryEngine {
         false
     }
 
-    fn validate_or_set_embed_dim(conn: &Connection, embed_dim: usize) -> Result<()> {
-        if let Some(stored) = get_config(conn, "embed_dim")? {
-            let stored_dim: usize = stored.parse().map_err(|_| {
-                MigrationError::Incompatible(format!("invalid stored embed_dim: {stored}"))
-            })?;
-            if stored_dim != embed_dim {
+    /// Validate the configured `embed_dim` against the persisted embedding identity
+    /// — read-only, never writes. Shared by the read-write and read-only open paths.
+    ///
+    /// If an `embedding_meta` tuple is recorded (#613), its `dim` MUST equal the
+    /// runtime `embed_dim` from `EngineConfig`. If none is recorded yet (a fresh
+    /// store, or one that has only ingested events and never embedded a fact), this
+    /// is a no-op: the identity is established lazily on the first embedding write
+    /// (ADR 0015 §2), not at open — open holds no `EmbeddingProvider` and so cannot
+    /// write it. A read-only open of an un-embedded store is therefore `Ok`: an
+    /// empty store has no identity to disagree with, and the runtime dimension always
+    /// comes from `EngineConfig`.
+    fn validate_embed_dim_against_meta(conn: &Connection, embed_dim: usize) -> Result<()> {
+        if let Some(fp) = crate::store::embedding_meta::load(conn)? {
+            if fp.dim != embed_dim {
                 return Err(MigrationError::EmbedDimMismatch {
-                    stored: stored_dim,
+                    stored: fp.dim,
                     requested: embed_dim,
                 }
                 .into());
             }
-        } else {
-            set_config(conn, "embed_dim", &embed_dim.to_string())?;
         }
         Ok(())
     }
 
-    /// Validate stored `embed_dim` matches requested — read-only, never writes.
-    fn validate_embed_dim(conn: &Connection, embed_dim: usize) -> Result<()> {
-        if let Some(stored) = get_config(conn, "embed_dim")? {
-            let stored_dim: usize = stored.parse().map_err(|_| {
-                MigrationError::Incompatible(format!("invalid stored embed_dim: {stored}"))
-            })?;
-            if stored_dim != embed_dim {
-                return Err(MigrationError::EmbedDimMismatch {
-                    stored: stored_dim,
-                    requested: embed_dim,
-                }
-                .into());
-            }
-            Ok(())
-        } else {
-            Err(MigrationError::Incompatible(
-                "embed_dim not set in database; open in read-write mode first".to_string(),
-            )
-            .into())
-        }
+    /// Record the embedding identity on the first embedding write (#613, ADR 0015 §2).
+    ///
+    /// Idempotent and cheap after the first call: [`embedding_meta::record_if_absent`]
+    /// returns the stored tuple without writing once an identity exists. Every code
+    /// path that embeds-then-persists (ingest, batch ingest) calls this **before**
+    /// inserting the derived vector, under the same write transaction, so the store's
+    /// identity is never older than its first vector.
+    ///
+    /// Free-function persist paths that hold no `&self` (consolidation, bootstrap)
+    /// call [`embedding_meta::record_if_absent`] directly with their `embed_dim`; this
+    /// method is the thin `&self` convenience for the engine's own ingest methods.
+    ///
+    /// **This is the seam #614 extends** — enforcement is added inside
+    /// `record_if_absent`; this method's call sites do not change when it lands.
+    ///
+    /// [`embedding_meta::record_if_absent`]: crate::store::embedding_meta::record_if_absent
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`embedding_meta::record_if_absent`] errors, including
+    /// `MemoryError::EmbeddingDimension` when the provider's declared `dim` disagrees
+    /// with this engine's vector dimension.
+    pub(crate) fn record_embedding_identity(
+        &self,
+        conn: &Connection,
+        embedder: &dyn EmbeddingProvider,
+    ) -> Result<()> {
+        let fp = embedder.fingerprint();
+        crate::store::embedding_meta::record_if_absent(conn, &fp, self.embed_dim)?;
+        Ok(())
     }
 
     /// Whether this engine was opened in read-only mode.

--- a/src/engine/restore.rs
+++ b/src/engine/restore.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use crate::error::{ConflictError, MemoryError, Result};
 use crate::pool::ConnectionPool;
-use crate::store::schema::get_config;
 use crate::store::upcaster::UpcasterRegistry;
 
 use super::{EngineConfig, MemoryEngine};
@@ -130,24 +129,27 @@ impl MemoryEngine {
             e
         };
 
-        // Probe the copied DB for embed_dim validation.
+        // Probe the copied DB for embedding-identity dim validation (#613).
         let probe = crate::store::schema::open_connection(&config.path.to_string_lossy())
             .map_err(cleanup)?;
-        let db_dim: usize = get_config(&probe, "embed_dim")
-            .map_err(cleanup)?
-            .and_then(|v| v.parse().ok())
-            .ok_or_else(|| {
-                let _ = std::fs::remove_file(&config.path);
-                MemoryError::Internal("backup has no embed_dim in config".into())
-            })?;
+        let db_meta = crate::store::embedding_meta::load(&probe).map_err(cleanup)?;
         drop(probe);
 
-        if config.embed_dim != db_dim {
-            let _ = std::fs::remove_file(&config.path);
-            return Err(MemoryError::EmbeddingDimension {
-                expected: config.embed_dim,
-                actual: db_dim,
-            });
+        // A backup that recorded an identity must agree on dimension. A backup with
+        // no identity yet (never embedded) is valid and skips the check — the identity
+        // is re-established on its first embedding write. Legacy v11 backups carried a
+        // bare `embed_dim` and no `embedding_meta`, so they would also skip the check;
+        // this is acceptable because there are no users and no pre-existing v11 backups
+        // (ADR 0015 §"No data migration"), and a v11 backup would need the v11→v12
+        // migration on open regardless.
+        if let Some(fp) = db_meta {
+            if config.embed_dim != fp.dim {
+                let _ = std::fs::remove_file(&config.path);
+                return Err(MemoryError::EmbeddingDimension {
+                    expected: config.embed_dim,
+                    actual: fp.dim,
+                });
+            }
         }
 
         Self::open_from_config(config, None).inspect_err(|_| {

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -172,21 +172,113 @@ fn embed_dim_validation_rejects_mismatch() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test.db");
 
-    // First open with dim=768
+    // First open with dim=768 and write a fact: the embedding identity (incl. dim)
+    // is recorded on the FIRST embedding write (#613, ADR 0015 §2), not at open.
     {
-        let _engine = MemoryEngine::builder(768)
+        let engine = MemoryEngine::builder(768)
             .path(db_path.clone())
             .build()
             .unwrap();
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: "seed".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                &MockEmbedder { dim: 768 },
+                None,
+            )
+            .unwrap();
     }
 
-    // Second open with dim=384 should fail
+    // Second open with dim=384 should fail (recorded identity dim=768 != 384).
     let err = MemoryEngine::builder(384)
         .path(db_path)
         .build()
         .unwrap_err();
     assert!(matches!(err, MemoryError::Migration(_)));
     assert!(err.to_string().contains("mismatch"));
+}
+
+#[test]
+fn first_add_fact_records_embedding_meta() {
+    // A second embedder with a DIFFERENT fingerprint, to prove write-once below.
+    struct OtherEmbedder {
+        dim: usize,
+    }
+    impl EmbeddingProvider for OtherEmbedder {
+        fn embed(&self, _t: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.7; self.dim])
+        }
+        fn fingerprint(&self) -> EmbeddingFingerprint {
+            EmbeddingFingerprint::new("other-model", "other-provider", self.dim)
+        }
+    }
+
+    // The embedding identity is established on the FIRST embedding write (#613,
+    // ADR 0015 §2) and is write-once thereafter.
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    assert!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap()
+            .is_none(),
+        "no identity before any write"
+    );
+
+    let expected = MockEmbedder { dim: DIM }.fingerprint();
+    let req = |c: &str| AddFactRequest {
+        content: c.into(),
+        fact_type: FactType::Semantic,
+        source_event_id: None,
+        scope: None,
+        opts: None,
+    };
+    engine
+        .add_fact(&req("a"), &MockEmbedder { dim: DIM }, None)
+        .unwrap();
+    assert_eq!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap(),
+        Some(expected.clone()),
+        "first write records the embedder's fingerprint"
+    );
+
+    // Write-once: a second add with a DIFFERENT fingerprint leaves it unchanged.
+    engine
+        .add_fact(&req("b"), &OtherEmbedder { dim: DIM }, None)
+        .unwrap();
+    assert_eq!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap(),
+        Some(expected),
+        "identity is write-once; a differing later fingerprint does not overwrite it"
+    );
+}
+
+#[test]
+fn read_only_open_of_unstamped_db_is_ok() {
+    // D6 behavior change: previously a read-only open of a DB with no persisted
+    // dim errored ("open read-write first"). Now identity is written on first
+    // embed, so read-only-opening an un-embedded store is Ok — there is nothing to
+    // validate, and the runtime dim always comes from EngineConfig.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ro_unstamped.db");
+    {
+        // Open read-write, never write a fact ⇒ no embedding_meta recorded.
+        let _e = MemoryEngine::builder(DIM).path(&path).build().unwrap();
+    }
+    let engine = MemoryEngine::builder(DIM)
+        .path(&path)
+        .read_only(true)
+        .build()
+        .unwrap();
+    assert!(engine.pool.is_read_only());
 }
 
 #[test]
@@ -3507,7 +3599,21 @@ fn builder_embed_dim_mismatch_is_rejected() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("dim.db");
     {
-        let _engine = MemoryEngine::builder(DIM).path(&path).build().unwrap();
+        let engine = MemoryEngine::builder(DIM).path(&path).build().unwrap();
+        // Identity (incl. dim) is recorded on the first embedding write (#613).
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: "seed".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                &MockEmbedder { dim: DIM },
+                None,
+            )
+            .unwrap();
     }
     // Re-opening with a different embed_dim must fail (parity with `open`).
     let err = MemoryEngine::builder(DIM + 1)

--- a/src/inspect/restore.rs
+++ b/src/inspect/restore.rs
@@ -640,9 +640,16 @@ mod tests {
             .unwrap();
         assert_eq!(root_label, "root");
 
-        // Verify config imported (embed_dim should be present).
-        let embed_dim_cfg = get_config(&conn, "embed_dim").unwrap();
-        assert_eq!(embed_dim_cfg, Some("4".to_string()));
+        // Verify the embedding identity (#613) round-trips through dump→restore via
+        // the generic config-copy loop (embedding_meta is a config row, not in
+        // MANAGED_CONFIG_KEYS). The bare `embed_dim` key no longer exists.
+        assert!(get_config(&conn, "embed_dim").unwrap().is_none());
+        let meta = crate::store::embedding_meta::load(&conn).unwrap();
+        assert_eq!(
+            meta.map(|fp| fp.dim),
+            Some(4),
+            "embedding_meta dim survives restore"
+        );
     }
 
     #[test]

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_empty_engine_dump.snap
@@ -2,7 +2,7 @@
 source: src/inspect/dump.rs
 expression: snapshot
 ---
-schema_version: 11
+schema_version: 12
 storage_epoch: 1
 embed_dim: 4
 facts: []
@@ -16,5 +16,5 @@ scopes:
 events: []
 lineage: []
 config:
-  schema_version: "11"
+  schema_version: "12"
   storage_epoch: "1"

--- a/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
+++ b/src/inspect/snapshots/memory_engine__inspect__dump__tests__snapshot_populated_engine_dump.snap
@@ -2,7 +2,7 @@
 source: src/inspect/dump.rs
 expression: snapshot
 ---
-schema_version: 11
+schema_version: 12
 storage_epoch: 1
 embed_dim: 4
 facts:

--- a/src/store/embedding_meta.rs
+++ b/src/store/embedding_meta.rs
@@ -105,6 +105,30 @@ pub fn record_if_absent(
     Ok(candidate.clone())
 }
 
+/// Require that a store has a recorded embedding identity before a
+/// **pre-computed-embedding** write (one with no live `EmbeddingProvider` to
+/// fingerprint — `promote`, or a cycle `AddFact`/`Synthesize` delta).
+///
+/// Such a write cannot establish the identity itself (#613 has no fingerprint to
+/// record; declaring a model for a pre-computed vector is #615), so committing it
+/// against an un-stamped store would leave a vector with no `embedding_meta` — the
+/// #614 silent-corruption landmine. Reject it instead; the store must first be
+/// stamped by a real embedding write (`add_fact`/bootstrap/consolidate).
+///
+/// # Errors
+///
+/// Returns `MemoryError::Internal` when no identity is recorded.
+pub fn require_present(conn: &Connection) -> Result<()> {
+    if load(conn)?.is_none() {
+        return Err(MemoryError::Internal(
+            "cannot write a pre-computed embedding to a store with no embedding identity; \
+             write a fact first"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/store/embedding_meta.rs
+++ b/src/store/embedding_meta.rs
@@ -1,0 +1,194 @@
+//! Typed persistence for the canonical embedding identity tuple (ADR 0015).
+//!
+//! Single owner of the on-disk encoding: the Memory layer records exactly one
+//! [`EmbeddingFingerprint`], the degenerate single case of the Knowledge layer's
+//! multi-space `embed_spaces` registry. Wave 2 (#622) generalizes this module
+//! (value → table) without changing call sites, which speak only in
+//! `EmbeddingFingerprint` values — never the JSON layout or the config key.
+//!
+//! The identity is established **lazily on the first embedding write** (ADR 0015
+//! §2): [`record_if_absent`] is called by every embed-then-persist path before it
+//! inserts a vector, so the store's identity is never older than its first vector.
+//! Mismatch *enforcement* (rejecting a differing model) is **#614** — it switches
+//! the [`record_if_absent`] present-branch from "return stored" to "compare and
+//! reject". The call sites do not change when that lands.
+
+use rusqlite::Connection;
+
+use crate::error::{MemoryError, MigrationError, Result};
+use crate::store::schema::{get_config, set_config};
+use crate::types::EmbeddingFingerprint;
+
+/// Config key under which the JSON-encoded identity tuple is stored.
+///
+/// Wave 2 (#622) retires this single-value key for an `embedding_spaces` table;
+/// until then it is the one and only persisted location of the identity.
+pub const EMBEDDING_META_KEY: &str = "embedding_meta";
+
+/// Load the persisted embedding identity, if one has been recorded.
+///
+/// Returns `Ok(None)` on a fresh store (nothing embedded yet). Absence is a normal
+/// state, not an error: the tuple is established on the first embedding write.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on query failure, or
+/// `MemoryError::Migration(MigrationError::Incompatible)` if the value is present
+/// but not valid `EmbeddingFingerprint` JSON — a hard error, never a silent default,
+/// because the stored `dim` drives vector deserialization.
+pub fn load(conn: &Connection) -> Result<Option<EmbeddingFingerprint>> {
+    get_config(conn, EMBEDDING_META_KEY)?.map_or_else(
+        || Ok(None),
+        |raw| {
+            serde_json::from_str(&raw).map(Some).map_err(|e| {
+                MigrationError::Incompatible(format!(
+                    "corrupt {EMBEDDING_META_KEY} config value: {e}"
+                ))
+                .into()
+            })
+        },
+    )
+}
+
+/// Unconditionally persist the identity tuple, overwriting any existing value.
+///
+/// This is the upsert writer used by [`record_if_absent`] (first-write path) and
+/// reserved for restore/import, where the tuple is reconstructed from a snapshot.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Serialization` if encoding fails (cannot happen for a
+/// valid fingerprint) or `MemoryError::Database` on write failure.
+pub fn store(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
+    let json = serde_json::to_string(fp)?;
+    set_config(conn, EMBEDDING_META_KEY, &json)
+}
+
+/// Write-once recording of the identity on the first embedding write.
+///
+/// If no identity is recorded, guards `candidate.dim == expected_dim` then persists
+/// `candidate` and returns it. If one is already recorded, returns the **stored**
+/// tuple unchanged (the candidate is ignored).
+///
+/// The `expected_dim` guard lives here — not in the engine seam — so that every
+/// path inherits it, including the `consolidate` free function which calls this
+/// directly rather than through the engine method. The guard refuses to persist an
+/// internally inconsistent tuple (claims dim D while the engine stores dim-E
+/// vectors); it is the dimension contract `FactStore::insert` already enforces on
+/// the vector, lifted to the identity tuple. It is **not** model-identity
+/// enforcement (#614).
+///
+/// **This is the seam #614 extends**: it will switch the "already recorded" branch
+/// from *return stored* to *compare `candidate == stored`, else
+/// `Err(EmbeddingModelMismatch)`*. Returning the authoritative stored tuple (not
+/// `()`) is deliberate so the caller and #614 share one value to reason about.
+///
+/// # Errors
+///
+/// Returns `MemoryError::EmbeddingDimension` if `candidate.dim != expected_dim`
+/// (nothing is persisted), or any [`load`] / [`store`] error.
+pub fn record_if_absent(
+    conn: &Connection,
+    candidate: &EmbeddingFingerprint,
+    expected_dim: usize,
+) -> Result<EmbeddingFingerprint> {
+    if let Some(stored) = load(conn)? {
+        return Ok(stored);
+    }
+    if candidate.dim != expected_dim {
+        return Err(MemoryError::EmbeddingDimension {
+            expected: expected_dim,
+            actual: candidate.dim,
+        });
+    }
+    store(conn, candidate)?;
+    Ok(candidate.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::schema::{init_schema, open_memory};
+
+    fn fresh_conn() -> Connection {
+        let conn = open_memory().expect("open in-memory db");
+        init_schema(&conn).expect("init schema");
+        conn
+    }
+
+    #[test]
+    fn load_none_on_fresh() {
+        let conn = fresh_conn();
+        assert!(load(&conn).expect("load").is_none());
+    }
+
+    #[test]
+    fn store_then_load_roundtrip() {
+        let conn = fresh_conn();
+        // with_matryoshka exercises Some(base_dim) + the non-default fields.
+        let fp =
+            EmbeddingFingerprint::with_matryoshka("Qwen/Qwen3-Embedding-0.6B", "tei", 1024, 1024);
+        store(&conn, &fp).expect("store");
+        assert_eq!(load(&conn).expect("load"), Some(fp));
+    }
+
+    #[test]
+    fn record_if_absent_writes_when_absent() {
+        let conn = fresh_conn();
+        let fp = EmbeddingFingerprint::new("model-a", "tei", 8);
+        let returned = record_if_absent(&conn, &fp, 8).expect("record");
+        assert_eq!(returned, fp);
+        assert_eq!(load(&conn).expect("load"), Some(fp));
+    }
+
+    #[test]
+    fn record_if_absent_returns_stored_when_present() {
+        // The #614-seam contract: today "stored wins"; #614 will make a differing
+        // candidate an error. This test is *extended*, not rewritten, when #614 lands.
+        let conn = fresh_conn();
+        let a = EmbeddingFingerprint::new("model-a", "tei", 8);
+        let b = EmbeddingFingerprint::new("model-b", "ollama", 8);
+        store(&conn, &a).expect("store a");
+        let returned = record_if_absent(&conn, &b, 8).expect("record b");
+        assert_eq!(returned, a, "stored tuple wins, candidate ignored");
+        assert_eq!(load(&conn).expect("load"), Some(a));
+    }
+
+    #[test]
+    fn record_if_absent_rejects_dim_mismatch() {
+        let conn = fresh_conn();
+        let fp = EmbeddingFingerprint::new("model-a", "tei", 16);
+        let err = record_if_absent(&conn, &fp, 8).expect_err("dim mismatch must error");
+        assert!(
+            matches!(
+                err,
+                MemoryError::EmbeddingDimension {
+                    expected: 8,
+                    actual: 16
+                }
+            ),
+            "expected EmbeddingDimension, got {err:?}"
+        );
+        assert!(
+            load(&conn).expect("load").is_none(),
+            "nothing persisted on mismatch"
+        );
+    }
+
+    #[test]
+    fn store_overwrites() {
+        let conn = fresh_conn();
+        let a = EmbeddingFingerprint::new("model-a", "tei", 8);
+        let b = EmbeddingFingerprint::new("model-b", "tei", 8);
+        store(&conn, &a).expect("store a");
+        store(&conn, &b).expect("store b");
+        assert_eq!(load(&conn).expect("load"), Some(b));
+    }
+
+    #[test]
+    fn load_errors_on_corrupt_json() {
+        let conn = fresh_conn();
+        set_config(&conn, EMBEDDING_META_KEY, "{not json").expect("set raw");
+        assert!(load(&conn).is_err(), "corrupt JSON must be a hard error");
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,6 +7,7 @@ pub mod activities;
 pub mod archive_manifest;
 pub mod checkpoints;
 pub mod edges;
+pub mod embedding_meta;
 pub mod events;
 pub mod facts;
 pub mod lineage;

--- a/src/store/schema/migrations.rs
+++ b/src/store/schema/migrations.rs
@@ -342,3 +342,19 @@ pub(super) fn migrate_v10_to_v11(conn: &Connection) -> Result<()> {
     conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_facts_created ON facts(t_created);")?;
     Ok(())
 }
+
+/// Replace the bare `embed_dim` config key with the `embedding_meta` identity
+/// tuple (issue #613, ADR 0015).
+///
+/// No DDL change — the identity is a `config` row written on the first embedding
+/// write, not a column. No data migration: the engine had no users at the v11→v12
+/// boundary, so any pre-existing `embed_dim` is **dropped** rather than upgraded
+/// (we lack `model`/`provider` to synthesize a full, *correct* tuple — a fabricated
+/// `model:"unknown"` would be a wrong identity that #614 would then hard-reject on
+/// every subsequent write). The identity is re-established on the next embedding
+/// write. The `DELETE` is idempotent (a no-op on a fresh v12 DB that never had the
+/// key), and runs inside the migration framework's per-step transaction.
+pub(super) fn migrate_v11_to_v12(conn: &Connection) -> Result<()> {
+    conn.execute_batch("DELETE FROM config WHERE key = 'embed_dim';")?;
+    Ok(())
+}

--- a/src/store/schema/mod.rs
+++ b/src/store/schema/mod.rs
@@ -7,7 +7,7 @@ use crate::error::{MemoryError, MigrationError, Result};
 mod migrations;
 
 /// Current schema version. Bump when adding migrations.
-pub const CURRENT_SCHEMA_VERSION: u32 = 11;
+pub const CURRENT_SCHEMA_VERSION: u32 = 12;
 
 /// Storage epoch — coarse-grained compatibility gate.
 ///
@@ -182,6 +182,7 @@ const MIGRATIONS: &[(MigrationFn, bool)] = &[
     (migrations::migrate_v8_to_v9, false),
     (migrations::migrate_v9_to_v10, false),
     (migrations::migrate_v10_to_v11, false),
+    (migrations::migrate_v11_to_v12, false),
 ];
 
 /// Run forward-only migrations from the current schema version to
@@ -1083,11 +1084,56 @@ CREATE TABLE IF NOT EXISTS config (
     }
 
     #[test]
-    fn config_no_default_embed_dim() {
+    fn config_no_default_embedding_meta() {
+        // A fresh v12 DB has neither the legacy `embed_dim` key nor an
+        // `embedding_meta` tuple — identity is established on the first embedding
+        // write (#613, ADR 0015 §2), not at schema init.
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
-        let dim = get_config(&conn, "embed_dim").unwrap();
-        assert!(dim.is_none());
+        assert!(get_config(&conn, "embed_dim").unwrap().is_none());
+        assert!(
+            crate::store::embedding_meta::load(&conn).unwrap().is_none(),
+            "fresh DB must have no embedding_meta"
+        );
+    }
+
+    #[test]
+    fn migrate_v11_to_v12_drops_embed_dim() {
+        // The migration deletes the legacy `embed_dim` config key. A fresh v12 DB
+        // has no such key, so the DELETE would be vacuous — we must INJECT an
+        // `embed_dim` row and roll `schema_version` back to 11 to actually exercise
+        // the migration step (review MEDIUM-1).
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        set_config(&conn, "embed_dim", "768").unwrap();
+        set_config(&conn, "schema_version", "11").unwrap();
+        assert_eq!(
+            get_config(&conn, "embed_dim").unwrap().as_deref(),
+            Some("768")
+        );
+
+        migrate(&conn, None).unwrap();
+
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap().as_deref(),
+            Some("12"),
+            "schema_version bumped to 12"
+        );
+        assert!(
+            get_config(&conn, "embed_dim").unwrap().is_none(),
+            "legacy embed_dim key dropped"
+        );
+        assert!(
+            crate::store::embedding_meta::load(&conn).unwrap().is_none(),
+            "no backfill: embedding_meta stays absent until first embed"
+        );
+
+        // Idempotent: re-running migrate from v12 is a no-op and does not error.
+        migrate(&conn, None).unwrap();
+        assert_eq!(
+            get_config(&conn, "schema_version").unwrap().as_deref(),
+            Some("12")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #613. Wave 1 of Epic #610.

Persists the embedding identity tuple (`EmbeddingFingerprint`, from #612) into the SQLite `config` table on the **first embedding write**, replacing the bare `embed_dim` key. This is the **persistence half** of the cross-layer embedding-identity policy (ADR 0015); mismatch *enforcement* extends the same seam in a later issue.

## Scope boundary (persistence only)
- Mismatch enforcement (`EmbeddingModelMismatch`) → #614 — this PR builds the seam it extends, no enforcement code.
- Pre-computed-`model` validation → #615 · real provider/dim config wiring → #618 · multi-space registry → Wave 2 #622.

## What changed
**Core (`area:storage`, `area:core`)**
- New typed boundary `store::embedding_meta` (`load`/`store`/`record_if_absent`) — single owner of the on-disk JSON encoding; the dim-consistency guard lives in `record_if_absent(…, expected_dim)`.
- Engine seam `record_embedding_identity`, called **before insert** by every embed-and-persist entry point (add_fact, add_facts_batch, all 3 bootstrap wrappers, consolidate). `add_fact` gains an explicit transaction so meta+fact commit atomically — it was a bare autocommit insert where a crash could orphan a vector (the enforcement landmine).
- **Promote guard**: `promote` is public and inserts a pre-computed vector with no live embedder, so it can be a first write — it now rejects promotion into a store with no recorded identity.
- Open path unified into `validate_embed_dim_against_meta` (RW+RO). A read-only open of a never-embedded store is now `Ok` (was an error).
- Migration v11→v12 drops the legacy `embed_dim` key (no backfill — no users). A config-only migration isn't guarded by the DDL snapshot, so a dedicated non-vacuous migration test is the guard.

**Consumers**
- CLI/MCP discover a store's dimension from `embedding_meta.dim` with a legacy `embed_dim` fallback; `add-fact` derives its dim from `--embedding` (no-peek opener) so it works on a freshly-created, never-embedded DB.
- Restore probe reads `embedding_meta`; dump/restore carry it via the generic config loop (`EngineSnapshot` unchanged — typed field deferred to #614).

## Breaking
Schema bump 11→12; `embed_dim` config key removed; read-only open of an un-embedded store no longer errors. No data migration (no users).

## Review & verification
3-lens super-plan → clean-slate subagent review → **Codex + agy** (Gemini decommissioned, not used). Codex caught a real BLOCKER (the autocommit `bootstrap_memory_directory` first-write path) and 2 HIGH (public `promote` reachability; restore legacy-backup scope) — all addressed.

The CLI/MCP dimension-discovery rework was a user-directed scope addition (the original plan wrongly marked CLI/MCP "N/A"; the `cargo test --workspace` gate caught it).

Gates: `cargo fmt --check` ✓ · `clippy --workspace --all-targets --all-features -- -D warnings` exit 0 ✓ · `test --workspace` all suites ok ✓ · `test --all-features` 838+ pass ✓. Rebased onto current `main` (#641) and re-gated green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)