### PR TITLE
feat(core): asymmetric embedding — embed_query/embed_query_batch (default to embed)

### DIFF
--- a/docs/design/embedding-identity-and-tei-qwen-migration.md
+++ b/docs/design/embedding-identity-and-tei-qwen-migration.md
@@ -116,7 +116,7 @@ pub trait EmbeddingProvider: Send + Sync {
     fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> { /* default loop */ }
     fn embed_query(&self, text: &str) -> Result<Vec<f32>> { self.embed(text) }          // NEW
     fn embed_query_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {              // NEW
-        self.embed_batch(texts)
+        texts.iter().map(|t| self.embed_query(t)).collect()                            // loop embed_query
     }
     fn fingerprint(&self) -> EmbeddingFingerprint;                                       // NEW
 }
@@ -126,6 +126,14 @@ Defaults make `embed_query` degrade to document semantics, so symmetric provider
 (`Mock`, `Hash`, `Passthrough`) are unaffected. **The core never embeds a query** — query
 embedding happens only at the consumer layer (MCP/CLI), because `MemoryQuery` takes a
 pre-computed vector. So the core's document-only call sites need no change.
+
+**`embed_query_batch` defaults to looping `embed_query`, not delegating to `embed_batch`**
+(corrected from an earlier draft during #616 review). This mirrors how `embed_batch` loops
+`embed`, and makes the default **correct by construction**: a provider that overrides only
+`embed_query` (a query prefix) still gets prefixed batch queries, with no silent leak into
+document space — the exact silent-mismatch failure this epic exists to prevent. Native-batch
+providers (TEI) override `embed_query_batch` for a single round-trip: correctness is the
+default, batch efficiency is the opt-in.
 
 ### 5. Provider extension — TEI/Qwen (`area:retrieval`)
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -37,6 +37,52 @@ pub trait EmbeddingProvider: Send + Sync {
         texts.iter().map(|t| self.embed(t)).collect()
     }
 
+    /// Compute an embedding vector for a **query** string.
+    ///
+    /// Asymmetric models (e.g. `Qwen3-Embedding` via TEI) prepend a query-only
+    /// instruction prefix here, while [`embed`](Self::embed) (documents) stays
+    /// prefix-free. The default delegates to [`embed`](Self::embed), so symmetric
+    /// providers (`Mock`, `Hash`, `Passthrough`) need no change and queries embed
+    /// identically to documents.
+    ///
+    /// The **core never calls this** — [`MemoryQuery`](crate::MemoryQuery) carries a
+    /// pre-computed vector, so query embedding happens only at the consumer layer
+    /// (MCP/CLI). The method lives on the provider trait so that consumer layer has a
+    /// single place to express the asymmetry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if embedding computation fails.
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
+        self.embed(text)
+    }
+
+    /// Compute embedding vectors for multiple **query** strings in a single call.
+    ///
+    /// The default delegates to [`embed_batch`](Self::embed_batch) (document
+    /// semantics) — **not** a private loop over [`embed_query`](Self::embed_query) —
+    /// so a provider that overrides only `embed_batch` for a single-round-trip API
+    /// still gets one batched call for queries. Asymmetric providers override this to
+    /// apply the query prefix per element.
+    ///
+    /// # Contract
+    ///
+    /// The returned `Vec` **must** have the same length as `texts`. Each element
+    /// corresponds positionally to the input query at that index.
+    ///
+    /// **If you override [`embed_query`](Self::embed_query) to apply asymmetric query
+    /// handling (e.g. an instruction prefix), you MUST also override this method.**
+    /// The default routes through [`embed_batch`](Self::embed_batch) — *document*
+    /// semantics — so leaving it at default while overriding the single-query path
+    /// silently produces unprefixed batch-query embeddings (wrong vector space).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any embedding computation fails.
+    fn embed_query_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        self.embed_batch(texts)
+    }
+
     /// Declare this provider's [`EmbeddingFingerprint`] — the identity of the vector
     /// space it produces (`model`, `provider`, `dim`, ...).
     ///
@@ -800,6 +846,86 @@ mod tests {
             }
         }
         assert!(Failing.embed_batch(&["a"]).is_err());
+    }
+
+    // --- EmbeddingProvider::embed_query / embed_query_batch defaults (#616) ---
+
+    #[test]
+    #[allow(clippy::cast_precision_loss)] // test data, precision irrelevant
+    fn embed_query_default_delegates_to_embed() {
+        // A symmetric provider leaves both query methods at their defaults, so a
+        // query embeds identically to a document — Mock/Hash/Passthrough are
+        // unaffected by the asymmetric trait extension.
+        struct Symmetric;
+        impl EmbeddingProvider for Symmetric {
+            fn embed(&self, text: &str) -> crate::error::Result<Vec<f32>> {
+                Ok(vec![text.len() as f32])
+            }
+            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+                crate::types::EmbeddingFingerprint::new("mock", "test", 1)
+            }
+        }
+        let p = Symmetric;
+        assert_eq!(p.embed_query("hello").unwrap(), p.embed("hello").unwrap());
+    }
+
+    #[test]
+    #[allow(clippy::cast_precision_loss)] // test data, precision irrelevant
+    fn embed_query_batch_default_routes_through_embed_batch() {
+        // The default `embed_query_batch` must delegate to `embed_batch` (the
+        // overridable batch seam), NOT loop `embed` itself. This guarantees an
+        // asymmetric provider that overrides only `embed_batch` (e.g. a single-
+        // HTTP-round-trip TEI provider) still gets a single batch call for queries.
+        struct BatchCounter {
+            batch_calls: std::sync::atomic::AtomicUsize,
+        }
+        impl EmbeddingProvider for BatchCounter {
+            fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
+                Ok(vec![0.0])
+            }
+            fn embed_batch(&self, texts: &[&str]) -> crate::error::Result<Vec<Vec<f32>>> {
+                self.batch_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Ok(texts.iter().map(|t| vec![t.len() as f32]).collect())
+            }
+            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+                crate::types::EmbeddingFingerprint::new("mock", "test", 1)
+            }
+        }
+        let p = BatchCounter {
+            batch_calls: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let out = p.embed_query_batch(&["a", "bb", "ccc"]).unwrap();
+        assert_eq!(out, vec![vec![1.0], vec![2.0], vec![3.0]]);
+        assert_eq!(
+            p.batch_calls.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "embed_query_batch must route through embed_batch exactly once"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::cast_precision_loss)] // test data, precision irrelevant
+    fn embed_query_override_does_not_affect_documents() {
+        // An asymmetric provider overrides the query path (here: prefix the text)
+        // while documents stay on the prefix-free `embed`. Proves the two paths are
+        // independently dispatchable through the trait object (vtable).
+        struct Asymmetric;
+        impl EmbeddingProvider for Asymmetric {
+            fn embed(&self, text: &str) -> crate::error::Result<Vec<f32>> {
+                Ok(vec![text.len() as f32])
+            }
+            fn embed_query(&self, text: &str) -> crate::error::Result<Vec<f32>> {
+                // Simulate a query instruction prefix lengthening the input.
+                self.embed(&format!("Q:{text}"))
+            }
+            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
+                crate::types::EmbeddingFingerprint::new("mock", "test", 1)
+            }
+        }
+        let p: &dyn EmbeddingProvider = &Asymmetric;
+        assert_eq!(p.embed("hi").unwrap(), vec![2.0]);
+        assert_eq!(p.embed_query("hi").unwrap(), vec![4.0]); // "Q:hi" → len 4
     }
 
     // --- PersistenceClassifier default ---

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -59,28 +59,26 @@ pub trait EmbeddingProvider: Send + Sync {
 
     /// Compute embedding vectors for multiple **query** strings in a single call.
     ///
-    /// The default delegates to [`embed_batch`](Self::embed_batch) (document
-    /// semantics) — **not** a private loop over [`embed_query`](Self::embed_query) —
-    /// so a provider that overrides only `embed_batch` for a single-round-trip API
-    /// still gets one batched call for queries. Asymmetric providers override this to
-    /// apply the query prefix per element.
+    /// The default loops [`embed_query`](Self::embed_query) sequentially — mirroring
+    /// how [`embed_batch`](Self::embed_batch) loops [`embed`](Self::embed). This makes
+    /// the default **correct by construction**: an asymmetric provider that overrides
+    /// only `embed_query` (e.g. to prepend a query instruction prefix) automatically
+    /// gets prefixed batch queries too, with no silent document-space leak.
+    ///
+    /// Providers with a native batch API (e.g. `OpenAI`/TEI `/v1/embeddings`) should
+    /// override this for a single HTTP round-trip — correctness is the default;
+    /// batch efficiency is the opt-in.
     ///
     /// # Contract
     ///
     /// The returned `Vec` **must** have the same length as `texts`. Each element
     /// corresponds positionally to the input query at that index.
     ///
-    /// **If you override [`embed_query`](Self::embed_query) to apply asymmetric query
-    /// handling (e.g. an instruction prefix), you MUST also override this method.**
-    /// The default routes through [`embed_batch`](Self::embed_batch) — *document*
-    /// semantics — so leaving it at default while overriding the single-query path
-    /// silently produces unprefixed batch-query embeddings (wrong vector space).
-    ///
     /// # Errors
     ///
     /// Returns an error if any embedding computation fails.
     fn embed_query_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
-        self.embed_batch(texts)
+        texts.iter().map(|t| self.embed_query(t)).collect()
     }
 
     /// Declare this provider's [`EmbeddingFingerprint`] — the identity of the vector
@@ -871,36 +869,40 @@ mod tests {
 
     #[test]
     #[allow(clippy::cast_precision_loss)] // test data, precision irrelevant
-    fn embed_query_batch_default_routes_through_embed_batch() {
-        // The default `embed_query_batch` must delegate to `embed_batch` (the
-        // overridable batch seam), NOT loop `embed` itself. This guarantees an
-        // asymmetric provider that overrides only `embed_batch` (e.g. a single-
-        // HTTP-round-trip TEI provider) still gets a single batch call for queries.
-        struct BatchCounter {
-            batch_calls: std::sync::atomic::AtomicUsize,
+    fn embed_query_batch_default_loops_embed_query() {
+        // The default `embed_query_batch` must loop `embed_query` (the asymmetric
+        // singular seam), NOT delegate to `embed_batch`. This guarantees that an
+        // asymmetric provider overriding only `embed_query` (a query prefix) still
+        // gets prefixed batch queries — correctness by default, no silent leak into
+        // document space. Batch efficiency is the explicit opt-in (override this).
+        struct QueryCounter {
+            query_calls: std::sync::atomic::AtomicUsize,
         }
-        impl EmbeddingProvider for BatchCounter {
-            fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
-                Ok(vec![0.0])
+        impl EmbeddingProvider for QueryCounter {
+            fn embed(&self, text: &str) -> crate::error::Result<Vec<f32>> {
+                Ok(vec![text.len() as f32])
             }
-            fn embed_batch(&self, texts: &[&str]) -> crate::error::Result<Vec<Vec<f32>>> {
-                self.batch_calls
+            fn embed_query(&self, text: &str) -> crate::error::Result<Vec<f32>> {
+                self.query_calls
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                Ok(texts.iter().map(|t| vec![t.len() as f32]).collect())
+                // Simulate a query prefix: documents would NOT see this.
+                self.embed(&format!("Q:{text}"))
             }
             fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
                 crate::types::EmbeddingFingerprint::new("mock", "test", 1)
             }
         }
-        let p = BatchCounter {
-            batch_calls: std::sync::atomic::AtomicUsize::new(0),
+        let p = QueryCounter {
+            query_calls: std::sync::atomic::AtomicUsize::new(0),
         };
         let out = p.embed_query_batch(&["a", "bb", "ccc"]).unwrap();
-        assert_eq!(out, vec![vec![1.0], vec![2.0], vec![3.0]]);
+        // Each element carries the "Q:" prefix length offset (+2), proving the
+        // default routed through the overridden `embed_query`, not `embed`/`embed_batch`.
+        assert_eq!(out, vec![vec![3.0], vec![4.0], vec![5.0]]);
         assert_eq!(
-            p.batch_calls.load(std::sync::atomic::Ordering::Relaxed),
-            1,
-            "embed_query_batch must route through embed_batch exactly once"
+            p.query_calls.load(std::sync::atomic::Ordering::Relaxed),
+            3,
+            "embed_query_batch default must call embed_query once per input"
         );
     }
 


### PR DESCRIPTION
## What

Adds two **default** methods to `EmbeddingProvider` (`area:core`, §Design.4 of the embedding-identity spec):

```rust
fn embed_query(&self, text: &str) -> Result<Vec<f32>> { self.embed(text) }
fn embed_query_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> { self.embed_batch(texts) }
```

## Why

`Qwen3-Embedding` (the target model for epic #610) is **asymmetric**: queries take an instruction prefix, documents do not. `embed(text)` alone cannot express that. These methods give the consumer layer (MCP/CLI, wired in #618/#619) a single place to express the asymmetry.

Both **default to their document counterparts**, so the ~30 existing providers (symmetric test doubles + `HttpEmbeddingProvider`) compile and behave unchanged — no call-site churn, unlike the required `fingerprint()` in #612.

## Design notes

- **The core never calls `embed_query`.** `MemoryQuery` carries a pre-computed vector; query embedding lives only at the consumer layer. The methods sit on the provider trait purely so that layer has one asymmetry seam.
- **`embed_query_batch` delegates to `embed_batch`, not a loop over `embed_query`** — preserves single-round-trip batching for HTTP providers. ⚠️ **Latent footgun, documented in the contract:** a provider overriding only `embed_query` (not `embed_query_batch`) silently gets unprefixed (document-semantic) batch queries. The real asymmetric provider (#617) overrides both, so it never bites in practice — but the doc comment now warns implementers explicitly. (Flagging for reviewer judgment: an alternative default looping `embed_query` would trade batch-efficiency for prefix-consistency.)

## Tests

3 new trait tests: default delegation, batch routes-through-`embed_batch`-once (call-counter), and asymmetric override leaves documents prefix-free (via `&dyn` vtable).

## Verification

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ 1181 passed
- `cargo test --all-features` ✅ 975 passed
- `cargo clippy --workspace --all-targets` ✅ clean
- `cargo fmt --check` ✅ clean

Wave 1 of epic #610. Unblocks #617 / #618 / #619.

Fixes #616
