### PR TITLE
enhancement(storage): defer embedding_meta stamping until a vector is written

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -414,6 +414,20 @@ fn bootstrap_within_savepoint(
         }
     }
 
+    // Stamp the embedding identity on first write (#613, ADR 0015 §2) — but only once
+    // a fact vector has actually been written (#643). Done here, at the tail of the
+    // savepoint, so the identity commits atomically with the facts it describes (the
+    // outer RELEASE/ROLLBACK covers it). `insert_or_reinforce` only writes a new
+    // vector when it *creates* a row, so `facts_created` is the precise gate: a
+    // session that parses to zero episodes, or only reinforces existing facts, writes
+    // no new vector and leaves the store unstamped — letting a later real first write
+    // with a different embedder establish the true identity (the #614-enforcement
+    // landmine this averts). The `embedder.fingerprint()` and `embed_dim` are the same
+    // values the engine's `record_embedding_identity` seam would have used.
+    if report.facts_created > 0 {
+        crate::store::embedding_meta::record_if_absent(conn, &embedder.fingerprint(), embed_dim)?;
+    }
+
     Ok(())
 }
 

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -84,13 +84,6 @@ pub fn consolidate(
 
     let tx = conn.unchecked_transaction()?;
 
-    // Record the embedding identity on first write (#613, ADR 0015 §2), inside the
-    // transaction so it commits atomically with any summary vectors. Consolidation
-    // embeds summary text via `embedder` into the same vector space, so it is a
-    // legitimate first-write path; `record_if_absent` is a no-op once an identity
-    // exists (the usual case — facts were ingested before consolidation runs).
-    crate::store::embedding_meta::record_if_absent(&tx, &embedder.fingerprint(), embed_dim)?;
-
     let (duplicates_removed, expired_ids) =
         local_dedup(&tx, embed_dim, config.dedup_threshold, last, now)?;
 
@@ -101,6 +94,19 @@ pub fn consolidate(
     let clusters_created =
         cluster_fusion(&tx, generator, embedder, embed_dim, config.min_cluster_size)?;
     let global_summaries = global_integration(&tx, generator, embedder, embed_dim)?;
+
+    // Record the embedding identity on first write (#613, ADR 0015 §2) — but only
+    // once a summary vector has actually been written (#643). `local_dedup` only
+    // expires rows; `cluster_fusion`/`global_integration` are the sole vector
+    // writers here, so gating on their counts defers the stamp past a vector-less
+    // run (dedup-only, or a no-op on a sparse store). Done inside `tx`, so the
+    // identity still commits atomically with the summaries it describes. A no-op
+    // run leaves the store unstamped, so a later real first write with a different
+    // embedder establishes the true identity instead of inheriting a stale one
+    // (the #614-enforcement landmine).
+    if clusters_created > 0 || global_summaries > 0 {
+        crate::store::embedding_meta::record_if_absent(&tx, &embedder.fingerprint(), embed_dim)?;
+    }
 
     // Only advance the watermark if dedup actually ran. When skipped, facts
     // ingested during the over-cap period must be retried on the next run.
@@ -265,6 +271,64 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn dedup_only_consolidation_does_not_stamp_identity() {
+        // #643: a consolidation pass that writes NO summary vector (here a dedup-only
+        // run — three near-duplicates collapse to a lone survivor that cannot form a
+        // cluster) must not record the embedding identity. Stamping on a vector-less
+        // run lets a later real first write with a *different* embedder inherit the
+        // stale identity — precisely the #614-era staleness this deferral averts.
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        seed_cluster(&conn);
+
+        let (stats, _) =
+            consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &default_config()).unwrap();
+        // No cluster/global summary is produced, so no summary vector is written.
+        assert_eq!(stats.clusters_created, 0);
+        assert_eq!(stats.global_summaries, 0);
+
+        assert!(
+            crate::store::embedding_meta::load(&conn).unwrap().is_none(),
+            "a vector-less consolidation must not stamp the embedding identity"
+        );
+
+        // The harm averted: a later real first writer with a DIFFERENT embedder now
+        // wins, instead of inheriting the no-op run's identity under #614 enforcement.
+        let other = crate::types::EmbeddingFingerprint::new("other-model", "other-provider", DIM);
+        let recorded = crate::store::embedding_meta::record_if_absent(&conn, &other, DIM).unwrap();
+        assert_eq!(
+            recorded, other,
+            "the first real writer wins after a no-op consolidation"
+        );
+    }
+
+    #[test]
+    fn summary_writing_consolidation_stamps_identity() {
+        // Mirror of the above: a pass that DOES write summary vectors records the
+        // identity atomically, inside the same transaction.
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        // A single-linkage chain (see `cluster_and_global_summaries_created`) that
+        // forms one cluster and one global summary without any near-duplicate expiry.
+        insert_fact(&conn, "a", vec![1.0, 0.0, 0.0, 0.0], 0.5);
+        insert_fact(&conn, "b", vec![0.8829, 0.4695, 0.0, 0.0], 0.5);
+        insert_fact(&conn, "c", vec![0.5592, 0.829, 0.0, 0.0], 0.5);
+
+        let (stats, _) =
+            consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &default_config()).unwrap();
+        assert!(
+            stats.clusters_created > 0 || stats.global_summaries > 0,
+            "this fixture must write at least one summary vector"
+        );
+
+        assert_eq!(
+            crate::store::embedding_meta::load(&conn).unwrap(),
+            Some(MockEmbedder.fingerprint()),
+            "a summary-writing consolidation records the embedder's fingerprint"
         );
     }
 

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -52,10 +52,9 @@ impl MemoryEngine {
     ) -> Result<crate::bootstrap::BootstrapReport> {
         let conn = self.write_conn()?;
         let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
-        // Stamp the embedding identity on first write (#613), before the inner
-        // import. The inner savepoint commits facts atomically; meta-first ordering
-        // keeps a crash benign (identity declared, no facts).
-        self.record_embedding_identity(&conn, embedder)?;
+        // The embedding identity is stamped (#613) inside the session savepoint, gated
+        // on a fact actually being written (#643) — see `bootstrap_within_savepoint`.
+        // A no-op session (zero extracted facts) therefore leaves the store unstamped.
         crate::bootstrap::bootstrap_session_inner(
             &conn,
             self.embed_dim,
@@ -93,8 +92,10 @@ impl MemoryEngine {
     ) -> Result<crate::bootstrap::BootstrapReport> {
         let conn = self.write_conn()?;
         let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
-        // Stamp the embedding identity on first write (#613), before the inner import.
-        self.record_embedding_identity(&conn, embedder)?;
+        // Each session is stamped (#613) inside its own savepoint, gated on a fact
+        // being written (#643) — see `bootstrap_within_savepoint`. This preserves
+        // per-session independence (each commits its identity atomically with its
+        // facts) and leaves an empty/no-op directory unstamped.
         crate::bootstrap::bootstrap_directory_inner(
             &conn,
             self.embed_dim,
@@ -139,10 +140,14 @@ impl MemoryEngine {
     ) -> Result<crate::bootstrap::BootstrapReport> {
         let conn = self.write_conn()?;
         let scope_id = self.ensure_bootstrap_scope(&conn, config.scope.as_deref())?;
-        // Stamp the embedding identity on first write (#613). This path is
-        // autocommit-per-file (no wrapping savepoint), so meta-first ordering here is
-        // what keeps it crash-safe (Codex review BLOCKER): identity is recorded before
-        // any file's fact, so no vector is ever committed without its identity.
+        // Stamp the embedding identity on first write (#613) — and, unlike the
+        // savepoint paths above, this one MUST stay meta-first (#643). It is
+        // autocommit-per-file (no wrapping savepoint), so each file commits its
+        // vector independently; deferring the stamp until after a vector is written
+        // would reopen the orphan-vector crash window (a vector committed before its
+        // identity). Recording before the first file keeps a crash benign: identity
+        // declared, possibly no facts — the same harmless no-op-stamp #643 removes
+        // from the deferrable paths, retained here because it is the crash-safe choice.
         self.record_embedding_identity(&conn, embedder)?;
         crate::bootstrap::memory_dir::bootstrap_memory_directory_inner(
             &conn,

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -314,6 +314,15 @@ fn noop_bootstrap_then_real_write_records_real_embedder() {
             None,
         )
         .unwrap();
+    // The store must be left UNSTAMPED by the no-op run (the crux of #643): this is
+    // what lets the first real writer below establish the identity.
+    assert!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap()
+            .is_none(),
+        "no-op bootstrap must leave the store unstamped"
+    );
     // First real write with embedder B establishes the identity.
     let req = AddFactRequest {
         content: "real".into(),
@@ -356,6 +365,89 @@ fn bootstrap_creating_facts_stamps_identity() {
             .unwrap(),
         Some(MockEmbedder { dim: DIM }.fingerprint()),
         "a fact-creating bootstrap records the embedder's fingerprint"
+    );
+}
+
+#[test]
+fn noop_bootstrap_directory_does_not_stamp_identity() {
+    // #643 names all three bootstrap wrappers. `bootstrap_directory` stamps each
+    // session inside its own savepoint; an empty directory processes no session, so
+    // the store must be left unstamped.
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let report = engine
+        .bootstrap_directory(
+            dir.path(),
+            &MockEmbedder { dim: DIM },
+            &crate::KeywordExtractor,
+            &crate::BootstrapConfig::default(),
+            None,
+        )
+        .unwrap();
+    assert_eq!(report.facts_created, 0, "empty directory creates no facts");
+    assert!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap()
+            .is_none(),
+        "a fact-less directory bootstrap must not stamp the embedding identity"
+    );
+}
+
+#[test]
+fn bootstrap_directory_creating_facts_stamps_identity() {
+    // Positive guard for the multi-file path: a directory with a fact-producing
+    // session records the embedder identity (inside that session's savepoint).
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("session.jsonl"),
+        include_str!("../../tests/fixtures/success_session.jsonl"),
+    )
+    .unwrap();
+    let report = engine
+        .bootstrap_directory(
+            dir.path(),
+            &MockEmbedder { dim: DIM },
+            &crate::KeywordExtractor,
+            &crate::BootstrapConfig::default(),
+            None,
+        )
+        .unwrap();
+    assert!(report.facts_created > 0, "fixture should create facts");
+    assert_eq!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap(),
+        Some(MockEmbedder { dim: DIM }.fingerprint()),
+        "a fact-creating directory bootstrap records the embedder's fingerprint"
+    );
+}
+
+#[test]
+fn memory_directory_stamps_identity_even_when_empty() {
+    // The deliberately RETAINED meta-first path (#643): `bootstrap_memory_directory`
+    // is autocommit-per-file, so it stamps BEFORE the first file for crash safety.
+    // An empty directory therefore still stamps — the harmless no-op stamp the other
+    // paths shed, kept here as the crash-safe choice. Pinning it guards against a
+    // future refactor that "consistently" defers this path and reopens the
+    // orphan-vector window.
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    engine
+        .bootstrap_memory_directory(
+            dir.path(),
+            &MockEmbedder { dim: DIM },
+            &crate::BootstrapConfig::default(),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap(),
+        Some(MockEmbedder { dim: DIM }.fingerprint()),
+        "memory-directory import is meta-first: it stamps even with no files"
     );
 }
 

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -262,6 +262,104 @@ fn first_add_fact_records_embedding_meta() {
 }
 
 #[test]
+fn noop_bootstrap_does_not_stamp_identity() {
+    // #643: bootstrapping a session that creates zero facts (here an empty reader)
+    // must NOT record the embedding identity. Previously the engine stamped before
+    // the inner import ran, so a no-op bootstrap permanently fixed the identity even
+    // though no vector was written.
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let report = engine
+        .bootstrap_session(
+            std::io::Cursor::new(""),
+            &MockEmbedder { dim: DIM },
+            &crate::KeywordExtractor,
+            &crate::BootstrapConfig::default(),
+            None,
+        )
+        .unwrap();
+    assert_eq!(report.facts_created, 0, "empty session creates no facts");
+    assert!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap()
+            .is_none(),
+        "a fact-less bootstrap must not stamp the embedding identity"
+    );
+}
+
+#[test]
+fn noop_bootstrap_then_real_write_records_real_embedder() {
+    // #643 (the #614-era harm): a no-op bootstrap with embedder A must not shadow a
+    // later real first write with a different embedder B — B is the true identity.
+    struct EmbedderB {
+        dim: usize,
+    }
+    impl EmbeddingProvider for EmbedderB {
+        fn embed(&self, _t: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.7; self.dim])
+        }
+        fn fingerprint(&self) -> EmbeddingFingerprint {
+            EmbeddingFingerprint::new("model-b", "provider-b", self.dim)
+        }
+    }
+
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    // No-op bootstrap with embedder A (MockEmbedder): zero facts ⇒ no stamp.
+    engine
+        .bootstrap_session(
+            std::io::Cursor::new(""),
+            &MockEmbedder { dim: DIM },
+            &crate::KeywordExtractor,
+            &crate::BootstrapConfig::default(),
+            None,
+        )
+        .unwrap();
+    // First real write with embedder B establishes the identity.
+    let req = AddFactRequest {
+        content: "real".into(),
+        fact_type: FactType::Semantic,
+        source_event_id: None,
+        scope: None,
+        opts: None,
+    };
+    engine
+        .add_fact(&req, &EmbedderB { dim: DIM }, None)
+        .unwrap();
+    assert_eq!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap(),
+        Some(EmbedderB { dim: DIM }.fingerprint()),
+        "the real first writer's identity must win, not the no-op bootstrap's"
+    );
+}
+
+#[test]
+fn bootstrap_creating_facts_stamps_identity() {
+    // Positive guard: a bootstrap that DOES create facts records the embedder
+    // identity (atomically, inside the session savepoint).
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let fixture = include_str!("../../tests/fixtures/success_session.jsonl");
+    let report = engine
+        .bootstrap_session(
+            std::io::Cursor::new(fixture),
+            &MockEmbedder { dim: DIM },
+            &crate::KeywordExtractor,
+            &crate::BootstrapConfig::default(),
+            None,
+        )
+        .unwrap();
+    assert!(report.facts_created > 0, "fixture should create facts");
+    assert_eq!(
+        engine
+            .with_read(crate::store::embedding_meta::load)
+            .unwrap(),
+        Some(MockEmbedder { dim: DIM }.fingerprint()),
+        "a fact-creating bootstrap records the embedder's fingerprint"
+    );
+}
+
+#[test]
 fn read_only_open_of_unstamped_db_is_ok() {
     // D6 behavior change: previously a read-only open of a DB with no persisted
     // dim errored ("open read-write first"). Now identity is written on first

--- a/src/store/embedding_meta.rs
+++ b/src/store/embedding_meta.rs
@@ -7,8 +7,15 @@
 //! `EmbeddingFingerprint` values — never the JSON layout or the config key.
 //!
 //! The identity is established **lazily on the first embedding write** (ADR 0015
-//! §2): [`record_if_absent`] is called by every embed-then-persist path before it
-//! inserts a vector, so the store's identity is never older than its first vector.
+//! §2): [`record_if_absent`] is called by every embed-then-persist path *as a vector
+//! is written*, so the store's identity is never older than — and never recorded
+//! without — its first vector. The transactional paths (`add_fact`, `add_facts_batch`,
+//! `consolidate`, the bootstrap-session savepoint) record inside the same
+//! transaction, gated on a vector actually being committed (#643), so a no-op run
+//! leaves the store unstamped. The autocommit-per-file `bootstrap_memory_directory`
+//! path is the deliberate exception: it records meta-first (before the first file)
+//! because, lacking a wrapping transaction, deferral would expose an orphan-vector
+//! crash window — it trades a harmless no-op stamp for crash safety.
 //! Mismatch *enforcement* (rejecting a differing model) is **#614** — it switches
 //! the [`record_if_absent`] present-branch from "return stored" to "compare and
 //! reject". The call sites do not change when that lands.


### PR DESCRIPTION
## Summary

Records the embedding identity (`embedding_meta`, ADR 0015 §2) **as close to the actual vector write as possible**, instead of at the *start* of an embed-and-persist operation. Closes #643 (Epic #610, Wave 1 follow-up; flagged by PR #642's Codex super-review and `chatgpt-codex-connector[bot]`).

## Problem

`record_if_absent` is **write-once**. Two paths stamped the configured embedder's identity *before* it was known whether a vector would commit:

- `consolidate` — at the top of the transaction, before clustering may produce zero summaries.
- `bootstrap_session` / `bootstrap_directory` — before the inner import, which may extract zero facts.

A **no-op** run (dedup-only consolidation, empty/no-op bootstrap) therefore permanently fixed a *stale* identity. Under #614 enforcement, a later real first write with a **different** embedder would inherit it and be hard-rejected — silent corruption.

## Fix — record where the vector lands

| Path | Change |
| --- | --- |
| `consolidate` | Stamp moved **after** `cluster_fusion`/`global_integration`, gated on `clusters_created > 0 \|\| global_summaries > 0` (the only summary-vector writers; `local_dedup` merely expires). Still inside the same `tx` → atomicity unchanged. |
| `bootstrap_session` / `bootstrap_directory` | Stamp moved into `bootstrap_within_savepoint`, gated on `facts_created > 0`. One chokepoint fixes both wrappers and **preserves per-session independence** (each session commits its identity atomically with its facts). |
| `bootstrap_memory_directory` | **Kept meta-first** (the constraint #643 calls out explicitly). It is autocommit-per-file; deferring would reopen the orphan-vector crash window. The harmless early stamp is retained *only* here, as the crash-safe choice. |
| `add_fact` / `add_facts_batch` | **Unchanged** — both already record inside their txn/savepoint and cannot no-op (empty batch returns early; a single add always inserts), so a vector is always written. |

The tension between deferred-in-transaction and meta-first-in-autocommit is resolved explicitly, per the issue's request.

## Tests (TDD — RED first)

- `dedup_only_consolidation_does_not_stamp_identity` — vector-less consolidation leaves the store unstamped; a later first writer with a different embedder wins.
- `summary_writing_consolidation_stamps_identity` — positive guard against over-deferral.
- `noop_bootstrap_does_not_stamp_identity` — fact-less bootstrap leaves the store unstamped.
- `noop_bootstrap_then_real_write_records_real_embedder` — the literal #614-era harm: `model-b` (real write) wins over the no-op bootstrap's `mock`.
- `bootstrap_creating_facts_stamps_identity` — positive guard.

## Verification

- `cargo test --workspace` — 1183 passed, 4 ignored
- `cargo test --all-features --lib` — 863 passed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --check` — clean