### PR TITLE
feat(mcp): wire query path to embed_query + embedding identity/asymmetry config

### DIFF
--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -47,7 +47,7 @@ embed_dim = 384  # Optional — probed from existing DB if omitted
 endpoint = "http://localhost:11434/v1/embeddings"
 model = "nomic-embed-text"
 api_key = "sk-..."   # Optional — for authenticated endpoints
-provider = "ollama"  # Serving backend: ollama | tei | openai (default: ollama). Feeds the fingerprint.
+provider = "ollama"  # Serving backend, e.g. ollama | tei | openai (default: ollama). Free-form; feeds the fingerprint.
 dimensions = 384     # Native model dimension (validated against the raw response)
 timeout_secs = 30
 ```

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -46,12 +46,33 @@ embed_dim = 384  # Optional — probed from existing DB if omitted
 [embedding]
 endpoint = "http://localhost:11434/v1/embeddings"
 model = "nomic-embed-text"
-api_key = "sk-..."  # Optional — for authenticated endpoints
-dimensions = 384
+api_key = "sk-..."   # Optional — for authenticated endpoints
+provider = "ollama"  # Serving backend: ollama | tei | openai (default: ollama). Feeds the fingerprint.
+dimensions = 384     # Native model dimension (validated against the raw response)
 timeout_secs = 30
 ```
 
-CLI flags override TOML values field-by-field (e.g., `--embed-api-key` overrides `api_key` in TOML while keeping `endpoint` and `model` from TOML).
+CLI flags override TOML values field-by-field (e.g., `--embed-api-key` overrides `api_key` in TOML while keeping `endpoint` and `model` from TOML; `--embed-provider` overrides `provider`).
+
+#### Asymmetric models (TEI / Qwen)
+
+Models like `Qwen/Qwen3-Embedding-0.6B` take a query-only instruction prefix and support Matryoshka (MRL) truncation. The MCP query path uses `embed_query` (prefix applied); `memory_add_fact` embeds documents prefix-free.
+
+```toml
+[engine]
+db_path = "/path/to/memory.db"
+embed_dim = 256       # The STORED dimension — must equal mrl_dim below
+
+[embedding]
+endpoint = "http://localhost:8080/v1/embeddings"
+model = "Qwen/Qwen3-Embedding-0.6B"
+provider = "tei"
+dimensions = 1024     # NATIVE dim the model emits (validated against the raw response)
+query_instruction = "Instruct: Given a search query, retrieve relevant memory facts.\nQuery: "
+mrl_dim = 256         # Truncate + L2-renormalize to this; must equal engine embed_dim
+```
+
+`mrl_dim` is the stored (post-truncation) dimension and **must equal** the engine's `embed_dim` — the server rejects a mismatch at startup. `dimensions` stays the native pre-truncation length.
 
 ### Claude Code Integration
 

--- a/memory-engine-mcp/src/config.rs
+++ b/memory-engine-mcp/src/config.rs
@@ -44,8 +44,31 @@ pub struct EmbeddingSection {
     /// API key (optional — for authenticated endpoints).
     pub api_key: Option<String>,
 
-    /// Expected embedding dimensions. Used to validate responses.
+    /// Operator-declared serving backend (`"ollama"`, `"tei"`, `"openai"`). Cannot be
+    /// sniffed from the endpoint (Ollama and TEI both speak `/v1/embeddings`); it feeds
+    /// the [`EmbeddingFingerprint`](memory_engine::EmbeddingFingerprint) identity, so it
+    /// must reflect the real backend. Defaults to `"ollama"` for back-compat.
+    #[serde(default = "default_provider")]
+    pub provider: String,
+
+    /// Expected embedding dimensions. This is the **native** dimension the model emits
+    /// and the provider validates raw responses against. With Matryoshka truncation
+    /// ([`mrl_dim`](Self::mrl_dim)), the engine stores the *truncated* `mrl_dim` while
+    /// this stays the native (pre-truncation) length.
     pub dimensions: usize,
+
+    /// Optional query-only instruction prefix for asymmetric models (e.g. Qwen). Applied
+    /// by the query path (`embed_query`); the document path (`add_fact`/`embed`) is never
+    /// prefixed. `None` = symmetric (no prefix).
+    #[serde(default)]
+    pub query_instruction: Option<String>,
+
+    /// Optional Matryoshka (MRL) truncation target. When set, each returned vector is
+    /// sliced to `mrl_dim` and L2-renormalized. Must equal the engine `embed_dim` (the
+    /// engine stores post-truncation vectors) and be `<= dimensions`. `None` = no
+    /// truncation (store the native vector).
+    #[serde(default)]
+    pub mrl_dim: Option<usize>,
 
     /// HTTP timeout in seconds. Default: 30.
     #[serde(default = "default_timeout")]
@@ -68,6 +91,10 @@ pub struct SummarySection {
     /// HTTP timeout in seconds. Default: 120 (LLM inference is slower than embedding).
     #[serde(default = "default_summary_timeout")]
     pub timeout_secs: u64,
+}
+
+fn default_provider() -> String {
+    "ollama".to_string()
 }
 
 const fn default_timeout() -> u64 {

--- a/memory-engine-mcp/src/config.rs
+++ b/memory-engine-mcp/src/config.rs
@@ -44,10 +44,11 @@ pub struct EmbeddingSection {
     /// API key (optional — for authenticated endpoints).
     pub api_key: Option<String>,
 
-    /// Operator-declared serving backend (`"ollama"`, `"tei"`, `"openai"`). Cannot be
-    /// sniffed from the endpoint (Ollama and TEI both speak `/v1/embeddings`); it feeds
+    /// Operator-declared serving backend (e.g. `"ollama"`, `"tei"`, `"openai"`). Cannot
+    /// be sniffed from the endpoint (Ollama and TEI both speak `/v1/embeddings`); it feeds
     /// the [`EmbeddingFingerprint`](memory_engine::EmbeddingFingerprint) identity, so it
-    /// must reflect the real backend. Defaults to `"ollama"` for back-compat.
+    /// must reflect the real backend. Free-form (like `model`); unrecognized values warn
+    /// at startup but are accepted. Defaults to `"ollama"` for back-compat.
     #[serde(default = "default_provider")]
     pub provider: String,
 

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -32,7 +32,8 @@ struct Cli {
     #[arg(long, env = "MEMORY_MCP_EMBED_API_KEY")]
     embed_api_key: Option<String>,
 
-    /// Embedding serving backend (`ollama`, `tei`, `openai`) — feeds the fingerprint.
+    /// Embedding serving backend (e.g. `ollama`, `tei`, `openai`) — operator-declared,
+    /// feeds the fingerprint. Free-form; unrecognized values warn but are accepted.
     #[arg(long, env = "MEMORY_MCP_EMBED_PROVIDER")]
     embed_provider: Option<String>,
 
@@ -100,6 +101,10 @@ async fn main() -> Result<(), BoxError> {
 ///
 /// CLI flags override TOML values (endpoint, model, `api_key`) when provided,
 /// enabling operators to inject runtime secrets via env/CLI.
+/// Recognized embedding backends. `provider` is free-form (it feeds the fingerprint),
+/// but a value outside this set warns at startup to catch typos.
+const KNOWN_PROVIDERS: [&str; 3] = ["ollama", "tei", "openai"];
+
 fn build_embedder(
     cli: &Cli,
     mcp_config: &config::McpConfig,
@@ -135,14 +140,25 @@ fn build_embedder(
         return Ok(None);
     };
 
-    // `expected_dim` is the NATIVE dim the model emits (validated against the raw
-    // response). Without MRL it equals the engine's stored `embed_dim`. With MRL the
-    // provider truncates to `mrl_dim`, so the native dim comes from the config's
-    // `dimensions` field while the engine stores (and probes) the truncated `mrl_dim`.
-    let native_dim = match mrl_dim {
-        Some(_) => base.map_or(embed_dim, |b| b.dimensions),
-        None => embed_dim,
-    };
+    // `native_dim` is the dimension the model emits — what the provider validates the
+    // raw HTTP response against. With MRL the provider truncates to `mrl_dim`, so the
+    // native dim comes from the config's `dimensions`; without MRL native == stored ==
+    // `embed_dim`. Always read `dimensions` (falling back to `embed_dim` only on the
+    // CLI-only path with no `[embedding]` section) so a `dimensions != embed_dim`
+    // misconfig surfaces at startup instead of failing cryptically on the first embed.
+    let native_dim = base.map_or(embed_dim, |b| b.dimensions);
+
+    // `provider` is stamped verbatim into the persisted fingerprint (#614), like the
+    // equally free-form `model`. We don't hard-restrict it — custom OpenAI-compatible
+    // backends are valid — but warn on an unrecognized value to catch typos before they
+    // bake a bogus identity into a fresh store.
+    if !KNOWN_PROVIDERS.contains(&provider.as_str()) {
+        tracing::warn!(
+            provider = %provider,
+            "embedding provider is not one of {KNOWN_PROVIDERS:?}; it is stamped into the \
+             persisted embedding fingerprint as-is — check for a typo"
+        );
+    }
 
     let mut provider =
         embedding::HttpEmbeddingProvider::new(url, mdl, provider, api_key, native_dim, timeout)
@@ -165,6 +181,14 @@ fn build_embedder(
         provider = provider
             .with_mrl_dim(target)
             .map_err(|e| format!("invalid embedding.mrl_dim: {e}"))?;
+    } else if native_dim != embed_dim {
+        // No truncation: the native dim the provider validates against must equal the
+        // engine's stored dim. An unequal pair is a misconfiguration — surface it now.
+        return Err(format!(
+            "embedding.dimensions ({native_dim}) must equal the engine embed_dim ({embed_dim}) \
+             when MRL is disabled (native and stored dimensions are identical without truncation)"
+        )
+        .into());
     }
 
     Ok(Some(Arc::new(provider)))

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -32,6 +32,10 @@ struct Cli {
     #[arg(long, env = "MEMORY_MCP_EMBED_API_KEY")]
     embed_api_key: Option<String>,
 
+    /// Embedding serving backend (`ollama`, `tei`, `openai`) — feeds the fingerprint.
+    #[arg(long, env = "MEMORY_MCP_EMBED_PROVIDER")]
+    embed_provider: Option<String>,
+
     /// Summary / chat-completions endpoint URL (for consolidation).
     #[arg(long, env = "MEMORY_MCP_SUMMARY_URL")]
     summary_url: Option<String>,
@@ -116,25 +120,54 @@ fn build_embedder(
         .embed_api_key
         .clone()
         .or_else(|| base.and_then(|b| b.api_key.clone()));
+    // `provider` feeds the fingerprint (#614); source it from CLI > TOML, defaulting to
+    // "ollama" (also EmbeddingSection's serde default) for the CLI-only / legacy path.
+    let provider = cli
+        .embed_provider
+        .clone()
+        .or_else(|| base.map(|b| b.provider.clone()))
+        .unwrap_or_else(|| "ollama".to_string());
     let timeout = base.map_or(30, |b| b.timeout_secs);
+    let query_instruction = base.and_then(|b| b.query_instruction.clone());
+    let mrl_dim = base.and_then(|b| b.mrl_dim);
 
-    match (endpoint, model) {
-        (Some(url), Some(mdl)) => Ok(Some(Arc::new(
-            // TODO(#618): `provider` is hardcoded; source it from config/CLI so the
-            // fingerprint reflects the real backend. Per ADR 0015 ordering, #618 must
-            // land before #614 turns mismatch enforcement on (else it checks a constant).
-            embedding::HttpEmbeddingProvider::new(
-                url,
-                mdl,
-                "ollama".to_string(),
-                api_key,
-                embed_dim,
-                timeout,
-            )
-            .map_err(|e| format!("failed to create embedding provider: {e}"))?,
-        ))),
-        _ => Ok(None),
+    let (Some(url), Some(mdl)) = (endpoint, model) else {
+        return Ok(None);
+    };
+
+    // `expected_dim` is the NATIVE dim the model emits (validated against the raw
+    // response). Without MRL it equals the engine's stored `embed_dim`. With MRL the
+    // provider truncates to `mrl_dim`, so the native dim comes from the config's
+    // `dimensions` field while the engine stores (and probes) the truncated `mrl_dim`.
+    let native_dim = match mrl_dim {
+        Some(_) => base.map_or(embed_dim, |b| b.dimensions),
+        None => embed_dim,
+    };
+
+    let mut provider =
+        embedding::HttpEmbeddingProvider::new(url, mdl, provider, api_key, native_dim, timeout)
+            .map_err(|e| format!("failed to create embedding provider: {e}"))?;
+
+    if let Some(instruction) = query_instruction {
+        provider = provider.with_query_instruction(instruction);
     }
+    if let Some(target) = mrl_dim {
+        // The engine stores post-truncation vectors, so the MRL target MUST equal the
+        // engine's `embed_dim`; otherwise the engine would reject every truncated vector.
+        // Fail loudly here at startup rather than on the first embed call.
+        if target != embed_dim {
+            return Err(format!(
+                "embedding.mrl_dim ({target}) must equal the engine embed_dim ({embed_dim}): \
+                 the engine stores post-truncation vectors"
+            )
+            .into());
+        }
+        provider = provider
+            .with_mrl_dim(target)
+            .map_err(|e| format!("invalid embedding.mrl_dim: {e}"))?;
+    }
+
+    Ok(Some(Arc::new(provider)))
 }
 
 /// Load configuration from TOML file with CLI overrides.

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -725,7 +725,10 @@ fn handle_query(
             if let Some(emb) = pre_emb {
                 query = query.embedding(emb);
             } else if let Some(emb_provider) = embedder {
-                let emb = emb_provider.embed(&text).map_err(to_mcp_error)?;
+                // Query path uses embed_query, applying the asymmetric instruction prefix
+                // for models like Qwen (#618). add_fact stays on the document `embed`: it
+                // passes the provider to engine.add_fact, which calls embed() internally.
+                let emb = emb_provider.embed_query(&text).map_err(to_mcp_error)?;
                 query = query.embedding(emb);
             } else if let Some(mode) = explicit_mode {
                 // User explicitly asked for vector/hybrid but no embedder available

--- a/memory-engine-mcp/tests/config_merge.rs
+++ b/memory-engine-mcp/tests/config_merge.rs
@@ -69,6 +69,54 @@ timeout_secs = 60
 }
 
 #[test]
+fn embedding_provider_defaults_to_ollama() {
+    // A legacy config without `provider` still parses; defaults to "ollama" so the
+    // fingerprint reflects the historical hardcoded backend. (#618)
+    let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+embed_dim = 384
+
+[embedding]
+endpoint = "http://localhost:11434/v1/embeddings"
+model = "nomic-embed-text"
+dimensions = 384
+"#;
+    let config: McpConfig = toml::from_str(toml_str).unwrap();
+    let emb = config.embedding.unwrap();
+    assert_eq!(emb.provider, "ollama");
+    assert_eq!(emb.query_instruction, None);
+    assert_eq!(emb.mrl_dim, None);
+}
+
+#[test]
+fn embedding_asymmetric_tei_qwen_config_parses() {
+    // Full asymmetric TEI/Qwen config: explicit provider, query_instruction, mrl_dim. (#618)
+    let toml_str = r#"
+[engine]
+db_path = "/tmp/test.db"
+embed_dim = 256
+
+[embedding]
+endpoint = "http://localhost:8080/v1/embeddings"
+model = "Qwen/Qwen3-Embedding-0.6B"
+provider = "tei"
+dimensions = 1024
+query_instruction = "Instruct: retrieve\nQuery: "
+mrl_dim = 256
+"#;
+    let config: McpConfig = toml::from_str(toml_str).unwrap();
+    let emb = config.embedding.unwrap();
+    assert_eq!(emb.provider, "tei");
+    assert_eq!(emb.dimensions, 1024); // native
+    assert_eq!(emb.mrl_dim, Some(256)); // stored (== engine embed_dim)
+    assert_eq!(
+        emb.query_instruction.as_deref(),
+        Some("Instruct: retrieve\nQuery: ")
+    );
+}
+
+#[test]
 fn unknown_field_rejected() {
     let toml_str = r#"
 [engine]
@@ -145,7 +193,10 @@ fn embedding_field_merge_cli_over_toml() {
         endpoint: "http://toml-host:11434/v1/embeddings".into(),
         model: "toml-model".into(),
         api_key: None,
+        provider: "ollama".into(),
         dimensions: 384,
+        query_instruction: None,
+        mrl_dim: None,
         timeout_secs: 30,
     };
 

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -694,7 +694,9 @@ async fn sole_input(server: &MockServer) -> Value {
     let reqs = server.received_requests().await.expect("recording enabled");
     assert_eq!(reqs.len(), 1, "expected exactly one embedding request");
     let body: Value = serde_json::from_slice(&reqs[0].body).expect("request body is JSON");
-    body.get("input").cloned().expect("request has an 'input' field")
+    body.get("input")
+        .cloned()
+        .expect("request has an 'input' field")
 }
 
 #[tokio::test]

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -683,3 +683,102 @@ async fn query_hybrid_with_http_embedder() {
     .unwrap();
     assert!(body["count"].as_u64().unwrap() >= 1);
 }
+
+// ---------------------------------------------------------------------------
+// Asymmetric query path (#618): memory_query uses embed_query (prefix applied),
+// memory_add_fact stays on the document embed (no prefix).
+// ---------------------------------------------------------------------------
+
+/// Parse the JSON `input` field of the single request the mock server received.
+async fn sole_input(server: &MockServer) -> Value {
+    let reqs = server.received_requests().await.expect("recording enabled");
+    assert_eq!(reqs.len(), 1, "expected exactly one embedding request");
+    let body: Value = serde_json::from_slice(&reqs[0].body).expect("request body is JSON");
+    body.get("input").cloned().expect("request has an 'input' field")
+}
+
+#[tokio::test]
+async fn query_path_applies_query_instruction_prefix() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "index": 0, "embedding": emb }]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "Qwen/Qwen3-Embedding-0.6B".into(),
+            "tei".to_string(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap()
+        .with_query_instruction("Q-PREFIX: ");
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        // A vector-mode query with text forces server-side query embedding.
+        let _ = tools::dispatch(
+            "memory_query",
+            args(json!({ "text": "search terms", "mode": "vector" })),
+            &engine,
+            Some(&provider),
+            None,
+            DIM,
+            &memory_engine::ActivityFilterConfig::default(),
+        );
+    })
+    .await
+    .unwrap();
+
+    // The query embedding request must carry the instruction prefix.
+    assert_eq!(sole_input(&server).await, json!("Q-PREFIX: search terms"));
+}
+
+#[tokio::test]
+async fn add_fact_path_does_not_apply_query_instruction() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "index": 0, "embedding": emb }]
+        })))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    tokio::task::spawn_blocking(move || {
+        let provider = HttpEmbeddingProvider::new(
+            format!("{uri}/v1/embeddings"),
+            "Qwen/Qwen3-Embedding-0.6B".into(),
+            "tei".to_string(),
+            None,
+            DIM,
+            5,
+        )
+        .unwrap()
+        .with_query_instruction("Q-PREFIX: ");
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        // add_fact embeds the document via engine.add_fact -> embed (no prefix).
+        let _ = tools::dispatch(
+            "memory_add_fact",
+            args(json!({ "content": "document text" })),
+            &engine,
+            Some(&provider),
+            None,
+            DIM,
+            &memory_engine::ActivityFilterConfig::default(),
+        );
+    })
+    .await
+    .unwrap();
+
+    // Documents are embedded prefix-free even when a query instruction is configured.
+    assert_eq!(sole_input(&server).await, json!("document text"));
+}


### PR DESCRIPTION
## What

§Design.6 of the embedding-identity spec — wires the MCP to the asymmetric provider (#617). Two parts:

**1. Query path → `embed_query`** ([tools/mod.rs](memory-engine-mcp/src/tools/mod.rs)): `handle_query` now calls `embed_query` instead of `embed`, so asymmetric models (Qwen) get their query instruction prefix. `memory_add_fact` is unchanged — it passes the provider to `engine.add_fact`, which calls the document `embed()` internally, so documents stay prefix-free.

**2. Config** ([config.rs](memory-engine-mcp/src/config.rs) + [main.rs](memory-engine-mcp/src/main.rs)): `EmbeddingSection` gains:
- `provider` (default `"ollama"`) — feeds the #614 fingerprint; **replaces the hardcoded `"ollama"` `TODO(#618)`** in `build_embedder`. Also a `--embed-provider` CLI override.
- `query_instruction` — the query-only prefix.
- `mrl_dim` — Matryoshka truncation target.

## The MRL dim model

The subtle part. With MRL truncation, two dimensions diverge:
- **`dimensions`** = the **native** dim the model emits → the provider's `expected_dim` (validates the raw response).
- **`mrl_dim`** = the **stored** dim after truncation → must equal the engine's `embed_dim` (the engine stores post-truncation vectors).

`build_embedder` enforces `mrl_dim == embed_dim` **loudly at startup** rather than letting every embed call fail at runtime. Without MRL, native == stored == `embed_dim` (unchanged behavior).

## Tests

- **2 wiremock e2e** ([embedding_integration.rs](memory-engine-mcp/tests/embedding_integration.rs)): a `memory_query` request carries the `Q-PREFIX: ` instruction (asserted via the captured request body); a `memory_add_fact` request is prefix-free — proving the asymmetry end-to-end through MCP dispatch.
- **2 config-parse** ([config_merge.rs](memory-engine-mcp/tests/config_merge.rs)): legacy config defaults `provider` to `"ollama"`; full TEI/Qwen asymmetric config parses.

## Verification

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ 1208 passed
- `cargo clippy --workspace --all-targets` ✅ clean
- `cargo fmt --check` ✅ clean

Wave 1 of epic #610. Unblocks #614 (the MCP eager mismatch check consumes this config + provider identity).

Fixes #618
