### PR TITLE
feat(core): embedding model mismatch detection + MemoryError::EmbeddingModelMismatch

### DIFF
--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -74,7 +74,9 @@ mrl_dim = 256         # Truncate + L2-renormalize to this; must equal engine emb
 
 `mrl_dim` is the stored (post-truncation) dimension and **must equal** the engine's `embed_dim` — the server rejects a mismatch at startup. `dimensions` stays the native pre-truncation length.
 
-### Claude Code Integration
+#### Embedding-identity check (fail-fast)
+
+On startup the server verifies the configured provider's identity (`model`, `provider`, `dim`, MRL, element type) against the one the store was created with, and **refuses to start on a mismatch** (#614). This prevents the silent-corruption case where a different model — even at the same dimension — embeds queries into an incompatible vector space. A fresh store with nothing embedded yet has no recorded identity and accepts any provider; the identity is stamped on the first embedding write.
 
 Add to `.claude/settings.json`:
 

--- a/memory-engine-mcp/src/main.rs
+++ b/memory-engine-mcp/src/main.rs
@@ -81,6 +81,17 @@ async fn main() -> Result<(), BoxError> {
     // Use the resolved embed_dim (from DB probe or config), not the TOML value.
     let embedder = build_embedder(&cli, &mcp_config, embed_dim)?;
 
+    // 4b. Eager embedding-identity check (#614, §Design.2). The query path embeds at
+    // this layer and hands the engine a pre-computed vector, so the engine can't
+    // fingerprint-check per query — verify once at startup that the configured provider
+    // matches the store's recorded identity, and refuse to serve on a mismatch rather
+    // than silently returning wrong-vector-space query results.
+    if let Some(provider) = embedder.as_deref() {
+        engine
+            .verify_embedding_identity(provider)
+            .map_err(|e| format!("embedding identity check failed: {e}"))?;
+    }
+
     // 5. Initialize summary generator (optional — text only; embedding is done
     //    by the embedder, injected separately into consolidation per #116)
     let summary_gen = build_summary_generator(&cli, &mcp_config)?

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -20,7 +20,7 @@ use rmcp::model::{CallToolResult, Content, ErrorData, Tool};
 use serde_json::{Map, Value, json};
 
 use crate::depth::{self, Depth};
-use crate::embedding::{HttpEmbeddingProvider, PassthroughEmbedder};
+use crate::embedding::HttpEmbeddingProvider;
 use crate::error::{ValidationError, to_mcp_error};
 
 // ---------------------------------------------------------------------------
@@ -681,9 +681,13 @@ fn handle_add_fact(
     };
 
     let fact_id = if let Some(emb) = pre_computed {
-        let passthrough = PassthroughEmbedder::new(emb);
+        // Pre-computed vector: insert into the store's already-established embedding
+        // space without recording a model identity (the caller's vector carries no real
+        // fingerprint until #615 lets it declare a model). add_fact_precomputed requires
+        // the store to already have an identity, so #614 enforcement does not compare the
+        // caller's vector against the passthrough sentinel.
         engine
-            .add_fact(&req, &passthrough, None)
+            .add_fact_precomputed(&req, emb, None)
             .map_err(to_mcp_error)?
     } else {
         let emb = embedder.ok_or(ValidationError::NoEmbeddingProvider)?;

--- a/memory-engine-mcp/tests/embedding_integration.rs
+++ b/memory-engine-mcp/tests/embedding_integration.rs
@@ -639,7 +639,6 @@ async fn query_hybrid_with_http_embedder() {
         .await;
 
     let uri = server.uri();
-    let emb_clone = emb;
     let body = tokio::task::spawn_blocking(move || {
         let provider = HttpEmbeddingProvider::new(
             format!("{uri}/v1/embeddings"),
@@ -652,15 +651,13 @@ async fn query_hybrid_with_http_embedder() {
         .unwrap();
         let engine = MemoryEngine::builder(DIM).build().unwrap();
 
-        // Add a fact with pre-computed embedding (no provider needed)
+        // Add a fact via the HTTP embedder — a real-embedder write that also stamps the
+        // store's embedding identity (so the subsequent query has an identity to match).
         tools::dispatch(
             "memory_add_fact",
-            args(json!({
-                "content": "Tokio async runtime",
-                "embedding": emb_clone,
-            })),
+            args(json!({ "content": "Tokio async runtime" })),
             &engine,
-            None,
+            Some(&provider),
             None,
             DIM,
             &memory_engine::ActivityFilterConfig::default(),

--- a/memory-engine-mcp/tests/tool_roundtrip.rs
+++ b/memory-engine-mcp/tests/tool_roundtrip.rs
@@ -57,6 +57,25 @@ const fn make_embedder() -> TestEmbedder {
     TestEmbedder { dim: DIM }
 }
 
+/// Stamp the store's embedding identity via a real-embedder write. A fresh store has
+/// no identity, and #614 makes a precomputed `memory_add_fact` require a present one
+/// (it cannot establish identity from a sentinel). Mirrors `query_with_precomputed_embedding`.
+fn stamp_identity(engine: &MemoryEngine) {
+    engine
+        .add_fact(
+            &AddFactRequest {
+                content: "identity-seed".into(),
+                fact_type: memory_engine::types::FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+            &make_embedder(),
+            None,
+        )
+        .expect("stamp embedding identity");
+}
+
 fn args(pairs: Value) -> Map<String, Value> {
     match pairs {
         Value::Object(m) => m,
@@ -172,6 +191,7 @@ fn ingest_missing_required_field() {
 #[test]
 fn add_fact_with_precomputed_embedding() {
     let engine = make_engine();
+    stamp_identity(&engine);
     let emb = vec![0.1; DIM];
     let result = tools::dispatch(
         "memory_add_fact",
@@ -192,6 +212,7 @@ fn add_fact_with_precomputed_embedding() {
 #[test]
 fn add_fact_all_options() {
     let engine = make_engine();
+    stamp_identity(&engine);
     let emb = vec![0.2; DIM];
     let result = tools::dispatch(
         "memory_add_fact",

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use rusqlite::Connection;
 
 use crate::error::{ConflictError, MemoryError, Result};
 use crate::limits::{check_json_size, check_str_size};
@@ -71,31 +72,86 @@ impl MemoryEngine {
     /// `opts.importance` is set and outside `[0, 1]` (or non-finite); the
     /// request is rejected before any embedding, event, or fact is written.
     /// Returns errors from embedding computation, dimension validation, or DB insert.
-    // `conn` (write lock) is reused by `FactStore::new(&conn).insert(..)` at the
-    // block's return expression; clippy's nursery suggestion to drop it after
-    // scope resolution misses that transitive borrow and would not compile.
-    #[allow(clippy::significant_drop_tightening)]
     pub fn add_fact(
         &self,
         req: &AddFactRequest,
         embedder: &dyn EmbeddingProvider,
         classifier: Option<&dyn PersistenceClassifier>,
     ) -> Result<i64> {
-        let now = Utc::now();
-        // Reject an out-of-range importance BEFORE any work — the opts clone,
-        // embedding, or persisting: no event, no fact, no slow embedding call,
-        // and no (potentially expensive) metadata clone for an invalid request.
+        Self::validate_add_fact_request(req)?;
+        // Embed OUTSIDE the write lock (potentially slow)
+        let embedding = embedder.embed(&req.content)?;
+        // Record the provider's identity on the first embedding write (#613) — which,
+        // under #614, also rejects a fingerprint that disagrees with the stored one.
+        self.insert_fact_with_embedding(req, embedding, classifier, |conn| {
+            self.record_embedding_identity(conn, embedder)
+        })
+    }
+
+    /// Add a fact with a caller-supplied **pre-computed** embedding.
+    ///
+    /// Unlike [`add_fact`](Self::add_fact), this performs no embedding (the vector is
+    /// given) and does **not** record a model identity: a pre-computed vector carries no
+    /// real provider fingerprint (declaring its model is #615). Instead it requires the
+    /// store to **already** have a recorded identity
+    /// ([`require_present`](crate::store::embedding_meta::require_present)) and inserts
+    /// the dim-checked vector into that established space. On a fresh, never-embedded
+    /// store this errors — a pre-computed write cannot establish identity.
+    ///
+    /// This mirrors the `promote` and cycle `AddFact`/`Synthesize` pre-computed paths
+    /// (#613) and is the path the MCP `memory_add_fact` precomputed branch uses, so #614
+    /// enforcement does not compare the caller's vector against a sentinel fingerprint.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Internal` if the store has no recorded embedding identity,
+    /// `MemoryError::EmbeddingDimension` if the vector length is wrong, or any write
+    /// error.
+    pub fn add_fact_precomputed(
+        &self,
+        req: &AddFactRequest,
+        embedding: Vec<f32>,
+        classifier: Option<&dyn PersistenceClassifier>,
+    ) -> Result<i64> {
+        Self::validate_add_fact_request(req)?;
+        self.insert_fact_with_embedding(req, embedding, classifier, |conn| {
+            crate::store::embedding_meta::require_present(conn)
+        })
+    }
+
+    /// Validate an [`AddFactRequest`] before any expensive work (embedding, metadata
+    /// clone, write). Rejects an out-of-range importance and oversized content/metadata
+    /// (issue #572 / L10) so a hostile or malformed request fails fast and cheap.
+    fn validate_add_fact_request(req: &AddFactRequest) -> Result<()> {
         Self::validate_importance(req.opts.as_ref().and_then(|o| o.importance))?;
-        // Reject oversized content/metadata before any expensive work so a
-        // hostile request fails fast and cheap (issue #572 / L10).
         check_str_size(&req.content, "fact content")?;
         if let Some(metadata) = req.opts.as_ref().and_then(|o| o.metadata.as_ref()) {
             check_json_size(metadata, "fact metadata")?;
         }
+        Ok(())
+    }
+
+    /// Shared body of [`add_fact`](Self::add_fact) and
+    /// [`add_fact_precomputed`](Self::add_fact_precomputed): classify, resolve scope, and
+    /// insert the fact with its (already-obtained) `embedding` in a single write
+    /// transaction. `stamp_identity` runs inside that transaction *before* the insert —
+    /// either recording the provider identity (`add_fact`) or asserting one already
+    /// exists (`add_fact_precomputed`) — so a vector is never committed without an
+    /// established identity (the #614 silent-corruption landmine).
+    // The `conn` write lock is held until the block's end: `tx` borrows it and must
+    // commit before it drops, so clippy's nursery suggestion to drop `conn` right after
+    // `unchecked_transaction()` misses that transitive borrow and would not compile.
+    #[allow(clippy::significant_drop_tightening)]
+    fn insert_fact_with_embedding(
+        &self,
+        req: &AddFactRequest,
+        embedding: Vec<f32>,
+        classifier: Option<&dyn PersistenceClassifier>,
+        stamp_identity: impl FnOnce(&Connection) -> Result<()>,
+    ) -> Result<i64> {
+        let now = Utc::now();
         let opts = req.opts.clone().unwrap_or_default();
 
-        // Embed OUTSIDE the write lock (potentially slow)
-        let embedding = embedder.embed(&req.content)?;
         let base_importance = opts.importance.unwrap_or(0.5);
         let effective_created = opts.t_created.unwrap_or(now);
         let effective_last_accessed = opts.last_accessed.unwrap_or(now);
@@ -160,17 +216,17 @@ impl MemoryEngine {
                 is_pinned,
             };
 
-            // Atomic first-write: record the embedding identity (#613, ADR 0015 §2)
-            // and insert the fact in one transaction, so a vector is never committed
-            // without its identity (the #614 silent-corruption landmine). `add_fact`
-            // was previously a bare autocommit insert; a second autocommit statement
-            // for the identity would let a crash between them orphan the vector.
+            // Atomic first-write: stamp/verify the embedding identity (#613/#614, ADR
+            // 0015 §2) and insert the fact in one transaction, so a vector is never
+            // committed without an established identity (the #614 silent-corruption
+            // landmine). The insert was previously a bare autocommit; a second autocommit
+            // statement for the identity would let a crash between them orphan the vector.
             // Scope creation above stays autocommit (unchanged): an orphan scope on
             // rollback is a pre-existing, benign outcome, and the scope row + its
             // scope_tree cache entry commit together, independent of the fact — so no
             // cache desync is introduced.
             let tx = conn.unchecked_transaction()?;
-            self.record_embedding_identity(&tx, embedder)?;
+            stamp_identity(&tx)?;
             let id = FactStore::new(&tx, self.embed_dim).insert(&new_fact)?;
             tx.commit()?;
             id

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -442,6 +442,28 @@ impl MemoryEngine {
         Ok(())
     }
 
+    /// Verify a provider's identity matches the store's recorded embedding identity —
+    /// a fail-fast check for consumer startup (#614, §Design.2).
+    ///
+    /// The query path embeds at the consumer layer and hands the engine a *pre-computed*
+    /// vector, so the engine cannot fingerprint-check per query. This one-shot check
+    /// catches a misconfigured provider — one whose vector space differs from the one
+    /// the store was built with — **before** any query silently returns
+    /// wrong-vector-space results. A fresh store with no recorded identity is compatible
+    /// with any provider (nothing to disagree with).
+    ///
+    /// This is read-only and does not establish the identity (that happens lazily on the
+    /// first embedding *write*, via [`record_embedding_identity`](Self::record_embedding_identity)).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::EmbeddingModelMismatch`] if the provider's fingerprint
+    /// disagrees with the store's recorded identity.
+    pub fn verify_embedding_identity(&self, provider: &dyn EmbeddingProvider) -> Result<()> {
+        let candidate = provider.fingerprint();
+        self.with_read(|conn| crate::store::embedding_meta::check_compatible(conn, &candidate))
+    }
+
     /// Whether this engine was opened in read-only mode.
     #[must_use]
     pub const fn is_read_only(&self) -> bool {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -449,18 +449,27 @@ impl MemoryEngine {
     /// vector, so the engine cannot fingerprint-check per query. This one-shot check
     /// catches a misconfigured provider — one whose vector space differs from the one
     /// the store was built with — **before** any query silently returns
-    /// wrong-vector-space results. A fresh store with no recorded identity is compatible
-    /// with any provider (nothing to disagree with).
+    /// wrong-vector-space results. On a **fresh** store (no recorded identity) there is
+    /// no model to disagree with, but the provider's `dim` must still match this engine's
+    /// configured dimension — otherwise every subsequent write/query would fail on
+    /// `EmbeddingDimension`, so we fail fast here too (mirroring `record_if_absent`).
     ///
     /// This is read-only and does not establish the identity (that happens lazily on the
     /// first embedding *write*, via [`record_embedding_identity`](Self::record_embedding_identity)).
     ///
     /// # Errors
     ///
-    /// Returns [`MemoryError::EmbeddingModelMismatch`] if the provider's fingerprint
+    /// Returns [`MemoryError::EmbeddingDimension`] if the provider's dimension differs
+    /// from this engine's, or [`MemoryError::EmbeddingModelMismatch`] if its fingerprint
     /// disagrees with the store's recorded identity.
     pub fn verify_embedding_identity(&self, provider: &dyn EmbeddingProvider) -> Result<()> {
         let candidate = provider.fingerprint();
+        if candidate.dim != self.embed_dim {
+            return Err(MemoryError::EmbeddingDimension {
+                expected: self.embed_dim,
+                actual: candidate.dim,
+            });
+        }
         self.with_read(|conn| crate::store::embedding_meta::check_compatible(conn, &candidate))
     }
 

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -205,7 +205,7 @@ fn embed_dim_validation_rejects_mismatch() {
 
 #[test]
 fn first_add_fact_records_embedding_meta() {
-    // A second embedder with a DIFFERENT fingerprint, to prove write-once below.
+    // A second embedder with a DIFFERENT fingerprint, to prove mismatch rejection below.
     struct OtherEmbedder {
         dim: usize,
     }
@@ -219,7 +219,7 @@ fn first_add_fact_records_embedding_meta() {
     }
 
     // The embedding identity is established on the FIRST embedding write (#613,
-    // ADR 0015 §2) and is write-once thereafter.
+    // ADR 0015 §2); a later differing fingerprint is rejected, not overwritten (#614).
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     assert!(
         engine
@@ -248,16 +248,67 @@ fn first_add_fact_records_embedding_meta() {
         "first write records the embedder's fingerprint"
     );
 
-    // Write-once: a second add with a DIFFERENT fingerprint leaves it unchanged.
-    engine
+    // #614 enforcement: a second add with a DIFFERENT fingerprint is hard-rejected
+    // (not silently ignored), and the stored identity is left untouched.
+    let err = engine
         .add_fact(&req("b"), &OtherEmbedder { dim: DIM }, None)
-        .unwrap();
+        .unwrap_err();
+    assert!(
+        matches!(err, MemoryError::EmbeddingModelMismatch { .. }),
+        "a differing later fingerprint must be rejected, got {err:?}"
+    );
     assert_eq!(
         engine
             .with_read(crate::store::embedding_meta::load)
             .unwrap(),
         Some(expected),
-        "identity is write-once; a differing later fingerprint does not overwrite it"
+        "stored identity is unchanged after a rejected mismatched write"
+    );
+}
+
+#[test]
+fn verify_embedding_identity_enforces_match() {
+    // The eager fail-fast check (#614, §Design.2) consumed by MCP startup.
+    struct OtherEmbedder {
+        dim: usize,
+    }
+    impl EmbeddingProvider for OtherEmbedder {
+        fn embed(&self, _t: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.7; self.dim])
+        }
+        fn fingerprint(&self) -> EmbeddingFingerprint {
+            EmbeddingFingerprint::new("other-model", "other-provider", self.dim)
+        }
+    }
+
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    // Fresh store has no identity yet -> any provider is compatible.
+    engine
+        .verify_embedding_identity(&MockEmbedder { dim: DIM })
+        .expect("fresh store compatible with any provider");
+
+    // Stamp the identity via a real embedding write.
+    let req = AddFactRequest {
+        content: "a".into(),
+        fact_type: FactType::Semantic,
+        source_event_id: None,
+        scope: None,
+        opts: None,
+    };
+    engine
+        .add_fact(&req, &MockEmbedder { dim: DIM }, None)
+        .unwrap();
+
+    // Matching provider -> Ok; differing provider -> EmbeddingModelMismatch.
+    engine
+        .verify_embedding_identity(&MockEmbedder { dim: DIM })
+        .expect("matching provider passes the eager check");
+    let err = engine
+        .verify_embedding_identity(&OtherEmbedder { dim: DIM })
+        .expect_err("differing provider must fail the eager check");
+    assert!(
+        matches!(err, MemoryError::EmbeddingModelMismatch { .. }),
+        "expected EmbeddingModelMismatch, got {err:?}"
     );
 }
 

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -282,10 +282,19 @@ fn verify_embedding_identity_enforces_match() {
     }
 
     let engine = MemoryEngine::builder(DIM).build().unwrap();
-    // Fresh store has no identity yet -> any provider is compatible.
+    // Fresh store has no identity yet -> any same-dim provider is compatible.
     engine
         .verify_embedding_identity(&MockEmbedder { dim: DIM })
-        .expect("fresh store compatible with any provider");
+        .expect("fresh store compatible with any same-dim provider");
+    // ...but a wrong-dim provider still fails fast on a fresh store (would otherwise
+    // fail on every later write/query).
+    let dim_err = engine
+        .verify_embedding_identity(&MockEmbedder { dim: DIM + 1 })
+        .expect_err("wrong-dim provider must fail the eager check on a fresh store");
+    assert!(
+        matches!(dim_err, MemoryError::EmbeddingDimension { .. }),
+        "expected EmbeddingDimension, got {dim_err:?}"
+    );
 
     // Stamp the identity via a real embedding write.
     let req = AddFactRequest {

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -313,6 +313,48 @@ fn verify_embedding_identity_enforces_match() {
 }
 
 #[test]
+fn add_fact_precomputed_requires_present_identity() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let req = AddFactRequest {
+        content: "p".into(),
+        fact_type: FactType::Semantic,
+        source_event_id: None,
+        scope: None,
+        opts: None,
+    };
+
+    // Fresh store: a pre-computed write cannot establish identity -> rejected
+    // (consistent with promote / cycle AddFact). The error is the require_present guard.
+    let err = engine
+        .add_fact_precomputed(&req, vec![0.5; DIM], None)
+        .expect_err("precomputed add on a fresh store must require an identity");
+    assert!(
+        matches!(err, MemoryError::Internal(_)),
+        "expected require_present Internal error, got {err:?}"
+    );
+
+    // Stamp the identity via a real embedder, then a pre-computed add succeeds — with NO
+    // model comparison, so the passthrough-style sentinel can't trigger a false mismatch
+    // (the #614 regression). This is the documented memory_add_fact precomputed workflow.
+    engine
+        .add_fact(&req, &MockEmbedder { dim: DIM }, None)
+        .unwrap();
+    let id = engine
+        .add_fact_precomputed(&req, vec![0.6; DIM], None)
+        .expect("precomputed add into a stamped store succeeds");
+    assert!(id > 0);
+
+    // Dimension is still enforced on the pre-computed vector.
+    let dim_err = engine
+        .add_fact_precomputed(&req, vec![0.6; DIM + 3], None)
+        .expect_err("wrong-dimension precomputed vector must be rejected");
+    assert!(
+        matches!(dim_err, MemoryError::EmbeddingDimension { .. }),
+        "expected EmbeddingDimension, got {dim_err:?}"
+    );
+}
+
+#[test]
 fn noop_bootstrap_does_not_stamp_identity() {
     // #643: bootstrapping a session that creates zero facts (here an empty reader)
     // must NOT record the embedding identity. Previously the engine stamped before

--- a/src/error.rs
+++ b/src/error.rs
@@ -402,6 +402,23 @@ pub enum MemoryError {
     #[error("invalid embedding dimension: expected {expected}, got {actual}")]
     EmbeddingDimension { expected: usize, actual: usize },
 
+    /// The embedding provider's identity does not match the one the store was created
+    /// with (#614, ADR 0015). Vector *dimension* alone is insufficient identity: two
+    /// different models at the same dimension occupy incompatible vector spaces, so
+    /// silently mixing them corrupts retrieval — the worst RAG failure mode. This is a
+    /// hard error, never a panic and never a silent default.
+    ///
+    /// `expected` is the store's recorded identity (authoritative); `actual` is the
+    /// current provider's fingerprint. Boxed to keep [`MemoryError`] small.
+    #[error(
+        "embedding model mismatch: store was created with {expected:?}, \
+         but the provider reports {actual:?}"
+    )]
+    EmbeddingModelMismatch {
+        expected: Box<crate::types::EmbeddingFingerprint>,
+        actual: Box<crate::types::EmbeddingFingerprint>,
+    },
+
     /// A precondition or input-validation conflict; see [`ConflictError`] for the
     /// specific cause (incompatible query options, out-of-range parameters,
     /// malformed scope labels, restore/dump preconditions, or a consumer-trait

--- a/src/store/embedding_meta.rs
+++ b/src/store/embedding_meta.rs
@@ -16,9 +16,11 @@
 //! path is the deliberate exception: it records meta-first (before the first file)
 //! because, lacking a wrapping transaction, deferral would expose an orphan-vector
 //! crash window — it trades a harmless no-op stamp for crash safety.
-//! Mismatch *enforcement* (rejecting a differing model) is **#614** — it switches
-//! the [`record_if_absent`] present-branch from "return stored" to "compare and
-//! reject". The call sites do not change when that lands.
+//! Mismatch *enforcement* (rejecting a differing model) is **#614**: the
+//! [`record_if_absent`] present-branch compares `candidate == stored` and returns
+//! [`MemoryError::EmbeddingModelMismatch`] on any difference; [`check_compatible`] is
+//! the read-only counterpart used for the eager fail-fast check at consumer startup.
+//! The write-path call sites did not change when this landed.
 
 use rusqlite::Connection;
 
@@ -85,21 +87,25 @@ pub fn store(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
 /// the vector, lifted to the identity tuple. It is **not** model-identity
 /// enforcement (#614).
 ///
-/// **This is the seam #614 extends**: it will switch the "already recorded" branch
-/// from *return stored* to *compare `candidate == stored`, else
-/// `Err(EmbeddingModelMismatch)`*. Returning the authoritative stored tuple (not
-/// `()`) is deliberate so the caller and #614 share one value to reason about.
+/// When an identity is already recorded, `candidate` must **equal** it or this returns
+/// [`MemoryError::EmbeddingModelMismatch`] (#614) — mixing two models' vectors in one
+/// space silently corrupts retrieval. On a match, the stored tuple is returned
+/// unchanged. Returning the authoritative stored tuple (not `()`) lets the caller
+/// reason about the established identity.
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::EmbeddingDimension` if `candidate.dim != expected_dim`
-/// (nothing is persisted), or any [`load`] / [`store`] error.
+/// Returns [`MemoryError::EmbeddingModelMismatch`] if an identity is recorded and
+/// `candidate` differs from it; `MemoryError::EmbeddingDimension` if no identity is
+/// recorded and `candidate.dim != expected_dim` (nothing is persisted); or any
+/// [`load`] / [`store`] error.
 pub fn record_if_absent(
     conn: &Connection,
     candidate: &EmbeddingFingerprint,
     expected_dim: usize,
 ) -> Result<EmbeddingFingerprint> {
     if let Some(stored) = load(conn)? {
+        ensure_match(&stored, candidate)?;
         return Ok(stored);
     }
     if candidate.dim != expected_dim {
@@ -110,6 +116,39 @@ pub fn record_if_absent(
     }
     store(conn, candidate)?;
     Ok(candidate.clone())
+}
+
+/// Verify a candidate identity is compatible with the store's recorded one, without
+/// writing. Returns `Ok(())` on a fresh store (no identity yet — nothing to disagree
+/// with) or when `candidate` equals the stored tuple.
+///
+/// This is the read-only counterpart to [`record_if_absent`], used for the **eager
+/// fail-fast check** at consumer startup (#614, §Design.2): the query path embeds at
+/// the consumer and hands the engine a pre-computed vector, so the engine cannot
+/// fingerprint-check per query — this check catches a misconfigured provider once,
+/// before any query silently returns wrong-vector-space results.
+///
+/// # Errors
+///
+/// Returns [`MemoryError::EmbeddingModelMismatch`] if an identity is recorded and
+/// `candidate` differs from it, or any [`load`] error.
+pub fn check_compatible(conn: &Connection, candidate: &EmbeddingFingerprint) -> Result<()> {
+    load(conn)?.map_or_else(|| Ok(()), |stored| ensure_match(&stored, candidate))
+}
+
+/// Reject a `candidate` that differs from the `stored` identity (#614).
+///
+/// Equality is field-by-field over the whole tuple (`EmbeddingFingerprint: Eq`), so a
+/// difference in *any* identity field — `model`, `provider`, `dim`,
+/// `matryoshka_base_dim`, or `element_type` — is a mismatch.
+fn ensure_match(stored: &EmbeddingFingerprint, candidate: &EmbeddingFingerprint) -> Result<()> {
+    if stored == candidate {
+        return Ok(());
+    }
+    Err(MemoryError::EmbeddingModelMismatch {
+        expected: Box::new(stored.clone()),
+        actual: Box::new(candidate.clone()),
+    })
 }
 
 /// Require that a store has a recorded embedding identity before a
@@ -173,16 +212,61 @@ mod tests {
     }
 
     #[test]
-    fn record_if_absent_returns_stored_when_present() {
-        // The #614-seam contract: today "stored wins"; #614 will make a differing
-        // candidate an error. This test is *extended*, not rewritten, when #614 lands.
+    fn record_if_absent_returns_stored_when_candidate_matches() {
+        // Idempotent re-record with the SAME identity returns the stored tuple.
+        let conn = fresh_conn();
+        let a = EmbeddingFingerprint::new("model-a", "tei", 8);
+        store(&conn, &a).expect("store a");
+        let returned = record_if_absent(&conn, &a, 8).expect("record matching");
+        assert_eq!(returned, a);
+        assert_eq!(load(&conn).expect("load"), Some(a));
+    }
+
+    #[test]
+    fn record_if_absent_rejects_model_mismatch() {
+        // #614 enforcement: a DIFFERENT identity at the same dim is hard-rejected,
+        // and the stored identity is left untouched.
         let conn = fresh_conn();
         let a = EmbeddingFingerprint::new("model-a", "tei", 8);
         let b = EmbeddingFingerprint::new("model-b", "ollama", 8);
         store(&conn, &a).expect("store a");
-        let returned = record_if_absent(&conn, &b, 8).expect("record b");
-        assert_eq!(returned, a, "stored tuple wins, candidate ignored");
-        assert_eq!(load(&conn).expect("load"), Some(a));
+        let err = record_if_absent(&conn, &b, 8).expect_err("model mismatch must error");
+        match err {
+            MemoryError::EmbeddingModelMismatch { expected, actual } => {
+                assert_eq!(*expected, a, "expected = authoritative stored identity");
+                assert_eq!(*actual, b, "actual = differing candidate");
+            }
+            other => panic!("expected EmbeddingModelMismatch, got {other:?}"),
+        }
+        assert_eq!(
+            load(&conn).expect("load"),
+            Some(a),
+            "stored identity unchanged"
+        );
+    }
+
+    #[test]
+    fn check_compatible_ok_on_fresh_store() {
+        // No identity recorded yet -> nothing to disagree with.
+        let conn = fresh_conn();
+        let fp = EmbeddingFingerprint::new("model-a", "tei", 8);
+        check_compatible(&conn, &fp).expect("fresh store is compatible with anything");
+    }
+
+    #[test]
+    fn check_compatible_ok_on_match_err_on_differ() {
+        let conn = fresh_conn();
+        let a = EmbeddingFingerprint::new("model-a", "tei", 8);
+        store(&conn, &a).expect("store a");
+        // Same identity -> Ok (no write, read-only check).
+        check_compatible(&conn, &a).expect("matching identity is compatible");
+        // Differ in matryoshka_base_dim only -> still a mismatch (full-tuple equality).
+        let mrl = EmbeddingFingerprint::with_matryoshka("model-a", "tei", 8, 16);
+        let err = check_compatible(&conn, &mrl).expect_err("differing tuple must error");
+        assert!(
+            matches!(err, MemoryError::EmbeddingModelMismatch { .. }),
+            "expected EmbeddingModelMismatch, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

§Design.2 of the embedding-identity spec — turns mismatch **enforcement** on. This is the Wave-1 guardrail the #612 (`EmbeddingFingerprint`) and #613 (`embedding_meta` persistence) work was built toward.

- **`MemoryError::EmbeddingModelMismatch { expected, actual }`** — boxed fingerprints (keeps the enum small). Carries the full identity tuple on both sides because *any* field (`model`/`provider`/`dim`/`matryoshka_base_dim`/`element_type`) could be the culprit.
- **Write-boundary enforcement** — `record_if_absent`'s present-branch now compares `candidate == stored` (full-tuple equality, shared `ensure_match` helper) and hard-rejects a difference instead of silently returning the stored tuple. Enforces at *every* embedding write (ingest, batch, consolidate, bootstrap) with **zero call-site change** — exactly as the module was pre-designed for.
- **`check_compatible`** — read-only counterpart for the eager path.
- **`MemoryEngine::verify_embedding_identity(&dyn EmbeddingProvider)`** — engine-level eager check. The query path embeds at the *consumer* and hands the engine a pre-computed vector, so the engine can't fingerprint-check per query; this one-shot check catches a misconfigured provider.
- **MCP startup wiring** — `main.rs` calls it after building the embedder and **refuses to serve on a mismatch** (§Design.2 "optional eager check"), so wrong-vector-space queries fail fast instead of returning silently-wrong results.

## Why it matters

Vector *dimension* alone is insufficient identity. Two different models at the same dim pass the length check and then return vectors from incompatible spaces — "silently wrong retrieval, the worst RAG failure mode" (the spec's words). This PR makes that a hard error, never a panic, never silent.

## Behavior change

`record_if_absent` was previously "write-once, stored wins" (#613). A differing later fingerprint is now **rejected**. The engine test `first_add_fact_records_embedding_meta` is updated accordingly (its second-write assertion flips from silently-unchanged to error-and-unchanged).

## Tests

- `embedding_meta`: `record_if_absent` match-returns-stored / differ-rejects / dim-mismatch; `check_compatible` fresh-ok / match-ok / differ-errs (incl. a matryoshka-only difference).
- `engine`: `first_add_fact_records_embedding_meta` (updated), `verify_embedding_identity_enforces_match` (fresh→ok, match→ok, differ→err).
- All write paths (consolidate/bootstrap) already use the seam — full suite confirms no regression.

> Note: the MCP *startup* wiring (4-line guarded call in `main.rs`) delegates to the engine-tested `verify_embedding_identity`; `main()`'s startup flow isn't unit-testable without refactoring, so it's covered by the engine method's tests + reasoning.

## Verification

- `cargo test --workspace` ✅ (838 lib + all integration suites)
- `cargo test --all-features` ✅ 987 passed
- `cargo clippy --workspace --all-targets` ✅ / `--all-features` ✅ clean
- `cargo fmt --check` ✅ exit 0

Closes the Wave-1 guardrail of epic #610.

Fixes #614
