### PR TITLE
fix(consolidation): inherit chain-wide max importance_score across multi-duplicate merges

### DIFF
--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -480,11 +480,52 @@ mod tests {
 
         let active = store.list_active(None).unwrap();
         assert_eq!(active.len(), 1);
+        // Pin the collapse topology: A is the survivor. The 0.8-vs-0.5 regression
+        // value is order-sensitive — it assumes the merge order A→B then A→C, which
+        // holds because `local_dedup` scans `list_active` in rowid (insertion) order.
+        // That ordering is not yet guaranteed by the query (no ORDER BY — #495); when
+        // that lands this coupling becomes a contract rather than an SQLite default.
+        assert_eq!(active[0].id, a);
         assert_eq!(active[0].content, "A");
         assert!(
             (active[0].importance_score - 0.8).abs() < f64::EPSILON,
             "survivor must hold the chain-wide max importance_score 0.8, got {} \
              (the stale-read bug overwrites B's 0.8 with C's 0.5)",
+            active[0].importance_score
+        );
+    }
+
+    /// Regression for #264 (loser-side propagation): a fact that absorbs a high
+    /// `importance_score` *as a survivor* and is then itself expired *as a loser*
+    /// must pass the absorbed score on to its final survivor. This exercises the
+    /// `running_scores.get(&loser.id)` branch — the half of the fix the pure-survivor
+    /// chain test above cannot reach.
+    #[test]
+    fn survivor_then_loser_propagates_absorbed_score() {
+        let (conn, dim) = setup();
+        // Near-duplicates with ASCENDING base importance so the expiry rule (expire
+        // the lower-importance fact) makes B survive L, then A survive B:
+        //   L(imp 0.2) loses to B(imp 0.5) → B absorbs L's high score 0.9
+        //   B(imp 0.5) loses to A(imp 0.8) → A must inherit that 0.9 via the map
+        let l = insert_fact(&conn, dim, "L", vec![1.0, 0.0, 0.0, 0.0], 0.2);
+        let b = insert_fact(&conn, dim, "B", vec![0.99, 0.01, 0.0, 0.0], 0.5);
+        let a = insert_fact(&conn, dim, "A", vec![0.98, 0.02, 0.0, 0.0], 0.8);
+
+        let store = FactStore::new(&conn, dim);
+        store.update_importance_score(l, 0.9).unwrap(); // the score that must survive two hops
+        store.update_importance_score(b, 0.1).unwrap();
+        store.update_importance_score(a, 0.1).unwrap();
+
+        let (removed, _) = local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+        assert_eq!(removed, 2, "L collapses onto B, then B onto A");
+
+        let active = store.list_active(None).unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, a);
+        assert!(
+            (active[0].importance_score - 0.9).abs() < f64::EPSILON,
+            "final survivor must inherit the score absorbed by an intermediate \
+             survivor (0.9), got {} (stale-read bug reads B's in-memory 0.1)",
             active[0].importance_score
         );
     }

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -65,6 +65,12 @@ pub fn local_dedup(
 
     let mut expired_ids = std::collections::HashSet::new();
     let mut duplicates_removed = 0;
+    // Running maximum `importance_score` per surviving fact id (#264). The
+    // in-memory `active_facts` Vec is never updated after a DB write, so within a
+    // multi-duplicate chain a survivor's in-memory score goes stale once an earlier
+    // merge has already written a higher value. This map is the live source of
+    // truth consulted by `inherit_max_importance`.
+    let mut running_scores: std::collections::HashMap<i64, f64> = std::collections::HashMap::new();
 
     for new_fact in &new_facts {
         if expired_ids.contains(&new_fact.id) || new_fact.is_pinned {
@@ -102,7 +108,7 @@ pub fn local_dedup(
                 } else {
                     (new_fact, &candidate)
                 };
-                inherit_max_importance(&fact_store, survivor, loser)?;
+                inherit_max_importance(&fact_store, survivor, loser, &mut running_scores)?;
 
                 // If the new_fact itself was expired, stop comparing it
                 if expire_id == new_fact.id {
@@ -118,14 +124,53 @@ pub fn local_dedup(
 
 /// Inherit the higher importance values from `loser` into `survivor`.
 ///
-/// Called after a dedup merge to ensure the surviving fact retains the
-/// maximum base importance and `importance_score` across the merged pair.
-fn inherit_max_importance(fact_store: &FactStore<'_>, survivor: &Fact, loser: &Fact) -> Result<()> {
+/// Called after a dedup merge to ensure the surviving fact retains the maximum
+/// base `importance` and `importance_score` across the merged pair — and,
+/// crucially, across an entire chain of merges onto the same survivor.
+///
+/// `running_scores` tracks the live maximum `importance_score` per fact id so the
+/// decision never reads a stale in-memory value (#264): the in-memory `Fact` is
+/// not updated after a DB write, so an earlier merge's higher inherited score
+/// would otherwise be invisible — and overwritten — by a later, lower one. A fact
+/// absent from the map has never been written, so its in-memory score equals the
+/// DB value and is a safe fallback. The `loser` is consulted through the map too,
+/// so a fact that absorbed a high score before itself being expired passes that
+/// score on to its own survivor.
+fn inherit_max_importance(
+    fact_store: &FactStore<'_>,
+    survivor: &Fact,
+    loser: &Fact,
+    running_scores: &mut std::collections::HashMap<i64, f64>,
+) -> Result<()> {
+    // Base `importance` inheritance is a structural no-op under the current expiry
+    // rule: dedup always expires the lower-importance fact (ties broken by id), so
+    // the survivor's `importance` is always >= the loser's and the guard below can
+    // never fire. It is kept as a defensive symmetric guard; the assert documents
+    // and enforces the invariant so a future change to the expiry rule that breaks
+    // it (re-introducing the #264 staleness for this field) fails loudly in tests.
+    debug_assert!(
+        loser.importance <= survivor.importance,
+        "expiry invariant violated: loser.importance ({}) > survivor.importance ({}); \
+         base-importance inheritance would need the same running-max fix as importance_score",
+        loser.importance,
+        survivor.importance
+    );
     if loser.importance > survivor.importance {
         fact_store.update_importance(survivor.id, loser.importance)?;
     }
-    if loser.importance_score > survivor.importance_score {
-        fact_store.update_importance_score(survivor.id, loser.importance_score)?;
+
+    // `importance_score`: compare live (not in-memory) maxima for both facts.
+    let survivor_score = running_scores
+        .get(&survivor.id)
+        .copied()
+        .unwrap_or(survivor.importance_score);
+    let loser_score = running_scores
+        .get(&loser.id)
+        .copied()
+        .unwrap_or(loser.importance_score);
+    if loser_score > survivor_score {
+        fact_store.update_importance_score(survivor.id, loser_score)?;
+        running_scores.insert(survivor.id, loser_score);
     }
     Ok(())
 }
@@ -400,6 +445,46 @@ mod tests {
         assert!(
             (active[0].importance_score - 0.8).abs() < f64::EPSILON,
             "expected importance_score 0.8, got {}",
+            active[0].importance_score
+        );
+    }
+
+    /// Regression for #264: when a chain of 3+ near-duplicates collapses onto a
+    /// single survivor, that survivor must inherit the MAXIMUM `importance_score`
+    /// across the whole chain — not whichever loser it happened to merge with last.
+    ///
+    /// The pre-fix bug read the survivor's *stale in-memory* score on every merge:
+    /// the in-memory `active_facts` Vec is never updated after a DB write, so a
+    /// later, lower loser score (C's 0.5) silently overwrote an earlier, higher one
+    /// (B's 0.8). The existing `survivor_inherits_max_importance` test only exercises
+    /// the two-fact case and cannot catch this.
+    #[test]
+    fn survivor_inherits_max_importance_across_multi_duplicate_chain() {
+        let (conn, dim) = setup();
+        // Three near-duplicates (all pairwise cosine > 0.90) with EQUAL base
+        // importance, so the tie-break (higher id expires) makes the lowest-id fact
+        // (A) the sole survivor that B and C both merge into.
+        let a = insert_fact(&conn, dim, "A", vec![1.0, 0.0, 0.0, 0.0], 0.5);
+        let b = insert_fact(&conn, dim, "B", vec![0.99, 0.01, 0.0, 0.0], 0.5);
+        let c = insert_fact(&conn, dim, "C", vec![0.98, 0.02, 0.0, 0.0], 0.5);
+
+        // Survivor A starts LOW; the chain-wide maximum is B's 0.8. C (merged last)
+        // is 0.5 — the value the stale-read bug wrongly leaves behind.
+        let store = FactStore::new(&conn, dim);
+        store.update_importance_score(a, 0.3).unwrap();
+        store.update_importance_score(b, 0.8).unwrap(); // the true maximum
+        store.update_importance_score(c, 0.5).unwrap();
+
+        let (removed, _) = local_dedup(&conn, dim, 0.90, None, Utc::now()).unwrap();
+        assert_eq!(removed, 2, "B and C both collapse onto A");
+
+        let active = store.list_active(None).unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].content, "A");
+        assert!(
+            (active[0].importance_score - 0.8).abs() < f64::EPSILON,
+            "survivor must hold the chain-wide max importance_score 0.8, got {} \
+             (the stale-read bug overwrites B's 0.8 with C's 0.5)",
             active[0].importance_score
         );
     }


### PR DESCRIPTION
## What

Wave 1 of the **#253 consolidation super-qa sweep**. Fixes the stale-in-memory-`importance_score` correctness bug in the dedup pass.

## The bug (#264)

`inherit_max_importance` read the survivor's `importance_score` from the in-memory `active_facts` Vec, which is never updated after a DB write. In a chain of 3+ near-duplicates collapsing onto one survivor, each merge re-read the stale in-memory value, so a later loser with a *lower* score silently overwrote a higher score an earlier merge had already written.

Concrete: facts A(0.3), B(0.8), C(0.5), equal base importance, ids A<B<C → A survives both merges. A inherits B's 0.8, then the second merge reads A's *stale* 0.3, sees C's 0.5 > 0.3, and overwrites A back down to 0.5. Correct max is 0.8.

## The fix

- Track the running maximum `importance_score` per fact id in a `HashMap`, consulted (not the stale in-memory `Fact`) for **both** survivor and loser. Fallback to the in-memory value is provably safe: an entry exists iff a write occurred, so absence ⇒ DB == in-memory. Consulting the loser through the map handles the survivor→loser transition in longer chains.
- Base `importance` is a structural no-op under the "expire the lower-importance fact" rule (survivor ≥ loser always); a `debug_assert` documents + enforces that invariant so a future expiry-rule change that breaks it fails loudly in tests.

## Tests

- New `survivor_inherits_max_importance_across_multi_duplicate_chain` — fails on pre-fix code (0.5 instead of 0.8), passes after.
- All 26 consolidation tests + full workspace suite pass; `clippy --workspace --all-targets --all-features` and `fmt --check` clean.

Closes #264. Part of #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)