### PR TITLE
feat(consolidation): make cluster_threshold configurable; seal ConsolidationConfig

### DIFF
--- a/benches/lifecycle_bench.rs
+++ b/benches/lifecycle_bench.rs
@@ -197,10 +197,10 @@ fn bench_consolidation(c: &mut Criterion) {
                 |(engine, _dir)| {
                     let generator = ConcatSummaryGenerator;
                     let embedder = ConstEmbedder { dim: DIM };
-                    let config = ConsolidationConfig {
-                        dedup_threshold: 0.95,
-                        min_cluster_size: 3,
-                    };
+                    let config = ConsolidationConfig::builder()
+                        .dedup_threshold(0.95)
+                        .min_cluster_size(3)
+                        .build();
                     engine.consolidate(&generator, &embedder, &config).unwrap();
                 },
             );

--- a/examples/custom_traits.rs
+++ b/examples/custom_traits.rs
@@ -132,10 +132,10 @@ fn main() -> Result<(), MemoryError> {
     let stats = engine.consolidate(
         &summarizer,
         &embedder,
-        &ConsolidationConfig {
-            dedup_threshold: 0.99, // high threshold to catch near-exact duplicates
-            min_cluster_size: 2,
-        },
+        &ConsolidationConfig::builder()
+            .dedup_threshold(0.99) // high threshold to catch near-exact duplicates
+            .min_cluster_size(2)
+            .build(),
     )?;
     println!(
         "\nConsolidation: {} duplicates removed, {} clusters, {} global summaries",

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -203,6 +203,7 @@ pub fn all_tool_definitions() -> Vec<Tool> {
                 "type": "object",
                 "properties": {
                     "dedup_threshold": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "Cosine similarity threshold for deduplication (default: 0.92)" },
+                    "cluster_threshold": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "Cosine similarity threshold for clustering related facts; looser than dedup (default: 0.85)" },
                     "min_cluster_size": { "type": "integer", "minimum": 2, "description": "Minimum facts to form a cluster (default: 3)" }
                 }
             }),
@@ -1127,6 +1128,17 @@ fn handle_consolidate(
         .into());
     }
 
+    // Clustering threshold is configurable symmetrically with dedup (#344); looser
+    // than dedup by default. Same f64→f32 narrowing rationale as above.
+    #[allow(clippy::cast_possible_truncation)]
+    let cluster_threshold = get_f64(args, "cluster_threshold").unwrap_or(0.85) as f32;
+    if !(0.0..=1.0).contains(&cluster_threshold) {
+        return Err(ValidationError::Other(format!(
+            "cluster_threshold must be in [0.0, 1.0], got {cluster_threshold}"
+        ))
+        .into());
+    }
+
     let min_cluster_size = get_usize(args, "min_cluster_size").unwrap_or(3);
     if min_cluster_size < 2 {
         return Err(ValidationError::Other(format!(
@@ -1135,10 +1147,11 @@ fn handle_consolidate(
         .into());
     }
 
-    let config = ConsolidationConfig {
-        dedup_threshold,
-        min_cluster_size,
-    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(dedup_threshold)
+        .cluster_threshold(cluster_threshold)
+        .min_cluster_size(min_cluster_size)
+        .build();
 
     let stats = engine
         .consolidate(generator, embedder, &config)

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1112,34 +1112,38 @@ fn handle_flush_insights(
 /// size floor) are unit-testable directly: the handler short-circuits on a missing
 /// provider *before* it would run, so an integration test with no providers can
 /// never reach this validation (#344 review).
-fn parse_consolidate_config(
-    args: &Map<String, Value>,
-) -> Result<ConsolidationConfig, ValidationError> {
-    // f64→f32 narrowing is intentional: thresholds are similarity scores in [0,1],
-    // well within f32's exact range.
+fn parse_consolidate_config(args: &Map<String, Value>) -> Result<ConsolidationConfig, ErrorData> {
+    // `require_f64_if_present` rejects a present-but-wrong-type value (e.g.
+    // `"0.95"`) instead of silently falling back to the default — `get_f64` would
+    // return None on a type mismatch and hide the bad input. f64→f32 narrowing is
+    // intentional: thresholds are similarity scores in [0,1], within f32's range.
     #[allow(clippy::cast_possible_truncation)]
-    let dedup_threshold = get_f64(args, "dedup_threshold").unwrap_or(0.92) as f32;
+    let dedup_threshold = require_f64_if_present(args, "dedup_threshold")?.unwrap_or(0.92) as f32;
     if !(0.0..=1.0).contains(&dedup_threshold) {
-        return Err(ValidationError::Other(format!(
-            "dedup_threshold must be in [0.0, 1.0], got {dedup_threshold}"
-        )));
+        return Err(ErrorData::invalid_params(
+            format!("dedup_threshold must be in [0.0, 1.0], got {dedup_threshold}"),
+            None,
+        ));
     }
 
     // Clustering threshold is configurable symmetrically with dedup (#344); looser
-    // than dedup by default. Same narrowing rationale as above.
+    // than dedup by default.
     #[allow(clippy::cast_possible_truncation)]
-    let cluster_threshold = get_f64(args, "cluster_threshold").unwrap_or(0.85) as f32;
+    let cluster_threshold =
+        require_f64_if_present(args, "cluster_threshold")?.unwrap_or(0.85) as f32;
     if !(0.0..=1.0).contains(&cluster_threshold) {
-        return Err(ValidationError::Other(format!(
-            "cluster_threshold must be in [0.0, 1.0], got {cluster_threshold}"
-        )));
+        return Err(ErrorData::invalid_params(
+            format!("cluster_threshold must be in [0.0, 1.0], got {cluster_threshold}"),
+            None,
+        ));
     }
 
     let min_cluster_size = get_usize(args, "min_cluster_size").unwrap_or(3);
     if min_cluster_size < 2 {
-        return Err(ValidationError::Other(format!(
-            "min_cluster_size must be >= 2, got {min_cluster_size}"
-        )));
+        return Err(ErrorData::invalid_params(
+            format!("min_cluster_size must be >= 2, got {min_cluster_size}"),
+            None,
+        ));
     }
 
     Ok(ConsolidationConfig::builder()
@@ -1758,9 +1762,10 @@ mod tests {
         let err =
             parse_consolidate_config(&cfg_args(&[("dedup_threshold", json!(2.0))])).unwrap_err();
         assert!(
-            err.to_string()
+            err.message
                 .contains("dedup_threshold must be in [0.0, 1.0]"),
-            "{err}"
+            "{}",
+            err.message
         );
     }
 
@@ -1770,9 +1775,10 @@ mod tests {
         let err =
             parse_consolidate_config(&cfg_args(&[("cluster_threshold", json!(2.0))])).unwrap_err();
         assert!(
-            err.to_string()
+            err.message
                 .contains("cluster_threshold must be in [0.0, 1.0]"),
-            "{err}"
+            "{}",
+            err.message
         );
     }
 
@@ -1781,8 +1787,22 @@ mod tests {
         let err =
             parse_consolidate_config(&cfg_args(&[("min_cluster_size", json!(1))])).unwrap_err();
         assert!(
-            err.to_string().contains("min_cluster_size must be >= 2"),
-            "{err}"
+            err.message.contains("min_cluster_size must be >= 2"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn parse_consolidate_config_rejects_wrong_type_threshold() {
+        // A present-but-wrong-type value must be REJECTED, not silently defaulted
+        // (gemini + codex review): `"0.95"` (string) is not a number.
+        let err = parse_consolidate_config(&cfg_args(&[("cluster_threshold", json!("0.95"))]))
+            .unwrap_err();
+        assert!(
+            err.message.contains("cluster_threshold must be a number"),
+            "{}",
+            err.message
         );
     }
 

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1106,6 +1106,49 @@ fn handle_flush_insights(
 // P1 tool handlers
 // ---------------------------------------------------------------------------
 
+/// Parse + validate the `memory_consolidate` tuning args into a [`ConsolidationConfig`].
+///
+/// Extracted from the handler so the range checks (thresholds in `[0,1]`, cluster
+/// size floor) are unit-testable directly: the handler short-circuits on a missing
+/// provider *before* it would run, so an integration test with no providers can
+/// never reach this validation (#344 review).
+fn parse_consolidate_config(
+    args: &Map<String, Value>,
+) -> Result<ConsolidationConfig, ValidationError> {
+    // f64→f32 narrowing is intentional: thresholds are similarity scores in [0,1],
+    // well within f32's exact range.
+    #[allow(clippy::cast_possible_truncation)]
+    let dedup_threshold = get_f64(args, "dedup_threshold").unwrap_or(0.92) as f32;
+    if !(0.0..=1.0).contains(&dedup_threshold) {
+        return Err(ValidationError::Other(format!(
+            "dedup_threshold must be in [0.0, 1.0], got {dedup_threshold}"
+        )));
+    }
+
+    // Clustering threshold is configurable symmetrically with dedup (#344); looser
+    // than dedup by default. Same narrowing rationale as above.
+    #[allow(clippy::cast_possible_truncation)]
+    let cluster_threshold = get_f64(args, "cluster_threshold").unwrap_or(0.85) as f32;
+    if !(0.0..=1.0).contains(&cluster_threshold) {
+        return Err(ValidationError::Other(format!(
+            "cluster_threshold must be in [0.0, 1.0], got {cluster_threshold}"
+        )));
+    }
+
+    let min_cluster_size = get_usize(args, "min_cluster_size").unwrap_or(3);
+    if min_cluster_size < 2 {
+        return Err(ValidationError::Other(format!(
+            "min_cluster_size must be >= 2, got {min_cluster_size}"
+        )));
+    }
+
+    Ok(ConsolidationConfig::builder()
+        .dedup_threshold(dedup_threshold)
+        .cluster_threshold(cluster_threshold)
+        .min_cluster_size(min_cluster_size)
+        .build())
+}
+
 fn handle_consolidate(
     args: &Map<String, Value>,
     engine: &MemoryEngine,
@@ -1117,41 +1160,7 @@ fn handle_consolidate(
     // SummaryGenerator, so consolidation now requires an embedder too.
     let embedder = embedder.ok_or(ValidationError::NoEmbeddingProvider)?;
 
-    // f64→f32 narrowing is intentional: dedup_threshold is a similarity score in [0,1],
-    // well within f32's exact range; the loss of sub-microsecond precision is acceptable.
-    #[allow(clippy::cast_possible_truncation)]
-    let dedup_threshold = get_f64(args, "dedup_threshold").unwrap_or(0.92) as f32;
-    if !(0.0..=1.0).contains(&dedup_threshold) {
-        return Err(ValidationError::Other(format!(
-            "dedup_threshold must be in [0.0, 1.0], got {dedup_threshold}"
-        ))
-        .into());
-    }
-
-    // Clustering threshold is configurable symmetrically with dedup (#344); looser
-    // than dedup by default. Same f64→f32 narrowing rationale as above.
-    #[allow(clippy::cast_possible_truncation)]
-    let cluster_threshold = get_f64(args, "cluster_threshold").unwrap_or(0.85) as f32;
-    if !(0.0..=1.0).contains(&cluster_threshold) {
-        return Err(ValidationError::Other(format!(
-            "cluster_threshold must be in [0.0, 1.0], got {cluster_threshold}"
-        ))
-        .into());
-    }
-
-    let min_cluster_size = get_usize(args, "min_cluster_size").unwrap_or(3);
-    if min_cluster_size < 2 {
-        return Err(ValidationError::Other(format!(
-            "min_cluster_size must be >= 2, got {min_cluster_size}"
-        ))
-        .into());
-    }
-
-    let config = ConsolidationConfig::builder()
-        .dedup_threshold(dedup_threshold)
-        .cluster_threshold(cluster_threshold)
-        .min_cluster_size(min_cluster_size)
-        .build();
+    let config = parse_consolidate_config(args)?;
 
     let stats = engine
         .consolidate(generator, embedder, &config)
@@ -1732,8 +1741,70 @@ fn handle_get_recent_insights(
 
 #[cfg(test)]
 mod tests {
-    use super::{default_dump_name, default_dump_path};
+    use super::{default_dump_name, default_dump_path, parse_consolidate_config};
+    use serde_json::json;
     use std::collections::HashSet;
+
+    /// Build a `memory_consolidate` argument map from key/value pairs.
+    fn cfg_args(pairs: &[(&str, serde_json::Value)]) -> serde_json::Map<String, serde_json::Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn parse_consolidate_config_rejects_out_of_range_dedup_threshold() {
+        let err =
+            parse_consolidate_config(&cfg_args(&[("dedup_threshold", json!(2.0))])).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("dedup_threshold must be in [0.0, 1.0]"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_consolidate_config_rejects_out_of_range_cluster_threshold() {
+        // #344: this is the path the provider-less integration test could not reach.
+        let err =
+            parse_consolidate_config(&cfg_args(&[("cluster_threshold", json!(2.0))])).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cluster_threshold must be in [0.0, 1.0]"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_consolidate_config_rejects_tiny_min_cluster_size() {
+        let err =
+            parse_consolidate_config(&cfg_args(&[("min_cluster_size", json!(1))])).unwrap_err();
+        assert!(
+            err.to_string().contains("min_cluster_size must be >= 2"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_consolidate_config_applies_defaults_and_overrides() {
+        // Empty args → MCP-level defaults (dedup 0.92, cluster 0.85, min 3).
+        let cfg = parse_consolidate_config(&cfg_args(&[])).unwrap();
+        assert!((cfg.dedup_threshold - 0.92).abs() < f32::EPSILON);
+        assert!((cfg.cluster_threshold - 0.85).abs() < f32::EPSILON);
+        assert_eq!(cfg.min_cluster_size, 3);
+
+        // Provided values flow through to the config.
+        let cfg = parse_consolidate_config(&cfg_args(&[
+            ("dedup_threshold", json!(0.7)),
+            ("cluster_threshold", json!(0.6)),
+            ("min_cluster_size", json!(5)),
+        ]))
+        .unwrap();
+        assert!((cfg.dedup_threshold - 0.7).abs() < f32::EPSILON);
+        assert!((cfg.cluster_threshold - 0.6).abs() < f32::EPSILON);
+        assert_eq!(cfg.min_cluster_size, 5);
+    }
 
     /// Regression for #546: with a *frozen* timestamp and pid, the only thing
     /// that can keep default dump names distinct is the process-global atomic

--- a/memory-engine-mcp/tests/tools.rs
+++ b/memory-engine-mcp/tests/tools.rs
@@ -226,17 +226,10 @@ fn test_consolidate_validation() {
     );
     assert!(result.is_err());
 
-    // cluster_threshold out of range (#344)
-    let result = tools::dispatch(
-        "memory_consolidate",
-        args(&[("cluster_threshold", json!(2.0))]),
-        &engine,
-        None,
-        None,
-        3,
-        &memory_engine::ActivityFilterConfig::default(),
-    );
-    assert!(result.is_err());
+    // NOTE: cluster_threshold range validation (#344) is unit-tested directly in
+    // tools/mod.rs `parse_consolidate_config` tests — a provider-less dispatch here
+    // short-circuits on NoSummaryProvider before reaching threshold validation, so
+    // it cannot honestly exercise that path.
 
     // min_cluster_size too small
     let result = tools::dispatch(

--- a/memory-engine-mcp/tests/tools.rs
+++ b/memory-engine-mcp/tests/tools.rs
@@ -226,6 +226,18 @@ fn test_consolidate_validation() {
     );
     assert!(result.is_err());
 
+    // cluster_threshold out of range (#344)
+    let result = tools::dispatch(
+        "memory_consolidate",
+        args(&[("cluster_threshold", json!(2.0))]),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    );
+    assert!(result.is_err());
+
     // min_cluster_size too small
     let result = tools::dispatch(
         "memory_consolidate",

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -7,16 +7,15 @@ use crate::store::summaries::SummaryStore;
 use crate::traits::{EmbeddingProvider, SummaryGenerator};
 use crate::types::{ConsolidationLevel, Fact, NewSummary};
 
-/// Cluster threshold for grouping related facts (lower than dedup threshold).
-const CLUSTER_SIMILARITY_THRESHOLD: f32 = 0.85;
-
 /// Cluster fusion pass.
 ///
 /// Clears prior cluster-level summaries before creating new ones (idempotent).
-/// Groups active facts by similarity (greedy single-linkage clustering).
-/// For each cluster >= `min_cluster_size`, calls `SummaryGenerator` to create a
-/// summary, then `EmbeddingProvider` to embed it into the fact vector space.
-/// Stores summaries via `SummaryStore` with `level=Cluster`.
+/// Groups active facts by similarity (greedy single-linkage clustering) at
+/// `cluster_threshold` (cosine; lower than the dedup threshold so clustering is
+/// looser than dedup). For each cluster >= `min_cluster_size`, calls
+/// `SummaryGenerator` to create a summary, then `EmbeddingProvider` to embed it
+/// into the fact vector space. Stores summaries via `SummaryStore` with
+/// `level=Cluster`.
 ///
 /// Returns number of clusters created.
 ///
@@ -33,6 +32,7 @@ pub fn cluster_fusion(
     embedder: &dyn EmbeddingProvider,
     embed_dim: usize,
     min_cluster_size: usize,
+    cluster_threshold: f32,
 ) -> Result<usize> {
     // Safety cap lifted to the shared `super::MAX_FACTS_FOR_CLUSTERING` (#345) so
     // the dedup and cluster caps live in one place with their divergent skip
@@ -56,7 +56,7 @@ pub fn cluster_fusion(
     summary_store.delete_by_level(&ConsolidationLevel::Cluster)?;
 
     // Greedy single-linkage clustering
-    let clusters = greedy_cluster(&active_facts, CLUSTER_SIMILARITY_THRESHOLD);
+    let clusters = greedy_cluster(&active_facts, cluster_threshold);
 
     let mut clusters_created = 0;
     for cluster in &clusters {
@@ -219,7 +219,7 @@ mod tests {
 
         let mock_gen = MockGenerator;
         let mock_embed = MockEmbedder { embed_dim: dim };
-        let clusters = cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 3).unwrap();
+        let clusters = cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 3, 0.85).unwrap();
         assert_eq!(clusters, 2);
 
         let summaries = SummaryStore::new(&conn, dim)
@@ -240,7 +240,7 @@ mod tests {
 
         let mock_gen = MockGenerator;
         let mock_embed = MockEmbedder { embed_dim: dim };
-        let clusters = cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 3).unwrap();
+        let clusters = cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 3, 0.85).unwrap();
         assert_eq!(clusters, 0);
     }
 
@@ -256,7 +256,7 @@ mod tests {
 
         let mock_gen = MockGenerator;
         let mock_embed = MockEmbedder { embed_dim: dim };
-        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2).unwrap();
+        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
 
         let summaries = SummaryStore::new(&conn, dim)
             .list_by_level(&ConsolidationLevel::Cluster)
@@ -280,12 +280,59 @@ mod tests {
         let mock_embed = MockEmbedder { embed_dim: dim };
 
         // Run twice — should have exactly the same result
-        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2).unwrap();
-        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2).unwrap();
+        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
+        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
 
         let summaries = SummaryStore::new(&conn, dim)
             .list_by_level(&ConsolidationLevel::Cluster)
             .unwrap();
         assert_eq!(summaries.len(), 1); // not 2 — idempotent
+    }
+
+    /// #344: the injected `cluster_threshold` actually drives clustering. Two facts
+    /// at cosine ≈ 0.92 cluster together under a loose threshold (0.85) but split
+    /// into separate singletons under a strict one (0.95) — so a loose run yields a
+    /// 2-fact cluster (1 summary) while a strict run yields none.
+    #[test]
+    fn cluster_threshold_is_honored() {
+        let dim = 4;
+        // a · b = 0.92 (unit vectors) → between 0.85 (loose) and 0.95 (strict).
+        let a = vec![1.0, 0.0, 0.0, 0.0];
+        let b = vec![0.92, 0.3923, 0.0, 0.0];
+
+        // Loose threshold 0.85: the pair is similar enough → one cluster of 2.
+        let loose = open_memory().unwrap();
+        init_schema(&loose).unwrap();
+        insert_fact(&loose, dim, "a", a.clone());
+        insert_fact(&loose, dim, "b", b.clone());
+        let made = cluster_fusion(
+            &loose,
+            &MockGenerator,
+            &MockEmbedder { embed_dim: dim },
+            dim,
+            2,
+            0.85,
+        )
+        .unwrap();
+        assert_eq!(made, 1, "0.92-similar pair clusters under a 0.85 threshold");
+
+        // Strict threshold 0.95: the same pair is NOT similar enough → no cluster.
+        let strict = open_memory().unwrap();
+        init_schema(&strict).unwrap();
+        insert_fact(&strict, dim, "a", a);
+        insert_fact(&strict, dim, "b", b);
+        let made = cluster_fusion(
+            &strict,
+            &MockGenerator,
+            &MockEmbedder { embed_dim: dim },
+            dim,
+            2,
+            0.95,
+        )
+        .unwrap();
+        assert_eq!(
+            made, 0,
+            "the same pair does NOT cluster under a 0.95 threshold"
+        );
     }
 }

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -153,8 +153,14 @@ fn consolidate_with_caps(
         DedupOutcome::Skipped { .. } => (0, Vec::new(), true),
     };
 
-    let clusters_created =
-        cluster_fusion(&tx, generator, embedder, embed_dim, config.min_cluster_size)?;
+    let clusters_created = cluster_fusion(
+        &tx,
+        generator,
+        embedder,
+        embed_dim,
+        config.min_cluster_size,
+        config.cluster_threshold,
+    )?;
     let global_summaries = global_integration(&tx, generator, embedder, embed_dim)?;
 
     // Record the embedding identity on first write (#613, ADR 0015 §2) — but only

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -319,6 +319,7 @@ mod tests {
         let bad = ConsolidationConfig {
             dedup_threshold: 0.90,
             min_cluster_size: 0,
+            ..Default::default()
         };
         let err = consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &bad).unwrap_err();
         assert!(

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -618,10 +618,10 @@ fn consolidate_deduplicates_similar_facts() {
         &make_new_fact("fact alpha copy", vec![0.99, 0.01, 0.0, 0.0]),
     );
 
-    let config = ConsolidationConfig {
-        dedup_threshold: 0.90,
-        min_cluster_size: 10, // high threshold so no clusters form
-    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(0.90)
+        .min_cluster_size(10) // high threshold so no clusters form
+        .build();
     let stats = engine
         .consolidate(&MockGen, &MockEmbedder { dim: DIM }, &config)
         .unwrap();
@@ -643,10 +643,10 @@ fn consolidate_is_idempotent() {
         &make_new_fact("unique B", vec![0.0, 1.0, 0.0, 0.0]),
     );
 
-    let config = ConsolidationConfig {
-        dedup_threshold: 0.92,
-        min_cluster_size: 10,
-    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(0.92)
+        .min_cluster_size(10)
+        .build();
 
     let _stats1 = engine
         .consolidate(&MockGen, &MockEmbedder { dim: DIM }, &config)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -315,7 +315,14 @@ pub trait DreamCycle {
 }
 
 /// Configuration for the consolidation process (Phase 2).
+///
+/// `#[non_exhaustive]` (#344): construct it from outside the crate via
+/// [`ConsolidationConfig::builder`] or [`ConsolidationConfig::default`], not a
+/// struct literal — so adding a future tuning field never breaks downstream call
+/// sites. Defaults are the research-backed values (dedup 0.90, cluster 0.85,
+/// `min_cluster_size` 2).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ConsolidationConfig {
     /// Minimum cosine similarity for two facts to be treated as duplicates.
     ///
@@ -324,25 +331,40 @@ pub struct ConsolidationConfig {
     /// `1.0` deduplicates only exact duplicates (identical embeddings), lower
     /// values fold in progressively looser near-duplicates.
     pub dedup_threshold: f32,
+    /// Cosine-similarity threshold for grouping related facts into a cluster
+    /// (single-linkage). Lower than `dedup_threshold`: clustering is looser than
+    /// dedup. Previously a hard-coded `CLUSTER_SIMILARITY_THRESHOLD` constant (#344).
+    pub cluster_threshold: f32,
     /// Minimum number of facts a similarity group must contain to be summarized
     /// into a cluster. Must be ≥ 2 — a single-fact "cluster" is not a cluster.
     pub min_cluster_size: usize,
 }
 
 impl Default for ConsolidationConfig {
-    /// Canonical defaults: `dedup_threshold = 0.90`, `min_cluster_size = 2`.
+    /// Canonical defaults: `dedup_threshold = 0.90`, `cluster_threshold = 0.85`,
+    /// `min_cluster_size = 2`.
     ///
     /// Hand-written rather than derived: a derived `Default` would yield
     /// `0.0` / `0`, and `min_cluster_size = 0` fails [`validate`](Self::validate).
     fn default() -> Self {
         Self {
             dedup_threshold: 0.90,
+            cluster_threshold: 0.85,
             min_cluster_size: 2,
         }
     }
 }
 
 impl ConsolidationConfig {
+    /// Start building a config from the [defaults](ConsolidationConfig::default).
+    ///
+    /// Preferred construction path now that the struct is `#[non_exhaustive]`;
+    /// only override the fields you care about.
+    #[must_use]
+    pub fn builder() -> ConsolidationConfigBuilder {
+        ConsolidationConfigBuilder(Self::default())
+    }
+
     /// Validate configuration parameters.
     ///
     /// Enforced at the consolidation entry point
@@ -351,9 +373,9 @@ impl ConsolidationConfig {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Conflict` if `dedup_threshold` is not a finite
-    /// value in `[0.0, 1.0]` (it is a cosine-similarity gate), or if
-    /// `min_cluster_size < 2` (a cluster requires at least two members to be
+    /// Returns `MemoryError::Conflict` if `dedup_threshold` or `cluster_threshold`
+    /// is not a finite value in `[0.0, 1.0]` (each is a cosine-similarity gate), or
+    /// if `min_cluster_size < 2` (a cluster requires at least two members to be
     /// fused into a summary; see [`crate::consolidation`]).
     pub fn validate(&self) -> Result<()> {
         use crate::error::{ConflictError, MemoryError};
@@ -363,6 +385,14 @@ impl ConsolidationConfig {
                 format!(
                     "dedup_threshold must be a finite value in [0.0, 1.0], got {}",
                     self.dedup_threshold
+                ),
+            )));
+        }
+        if !self.cluster_threshold.is_finite() || !(0.0..=1.0).contains(&self.cluster_threshold) {
+            return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                format!(
+                    "cluster_threshold must be a finite value in [0.0, 1.0], got {}",
+                    self.cluster_threshold
                 ),
             )));
         }
@@ -376,6 +406,43 @@ impl ConsolidationConfig {
             )));
         }
         Ok(())
+    }
+}
+
+/// Builder for [`ConsolidationConfig`].
+///
+/// Exists because the config is `#[non_exhaustive]` and so cannot be built with a
+/// struct literal (or functional-update) from another crate. New config fields get
+/// a setter here without breaking any existing call site (#344).
+#[derive(Debug, Clone)]
+pub struct ConsolidationConfigBuilder(ConsolidationConfig);
+
+impl ConsolidationConfigBuilder {
+    /// Set the dedup near-duplicate cosine threshold.
+    #[must_use]
+    pub const fn dedup_threshold(mut self, value: f32) -> Self {
+        self.0.dedup_threshold = value;
+        self
+    }
+
+    /// Set the cluster single-linkage cosine threshold.
+    #[must_use]
+    pub const fn cluster_threshold(mut self, value: f32) -> Self {
+        self.0.cluster_threshold = value;
+        self
+    }
+
+    /// Set the minimum cluster size that earns a summary.
+    #[must_use]
+    pub const fn min_cluster_size(mut self, value: usize) -> Self {
+        self.0.min_cluster_size = value;
+        self
+    }
+
+    /// Finalize the configuration.
+    #[must_use]
+    pub const fn build(self) -> ConsolidationConfig {
+        self.0
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -915,6 +915,34 @@ mod tests {
         }
     }
 
+    // --- ConsolidationConfig::validate(): cluster_threshold ∈ [0, 1] (#344) ---
+
+    #[test]
+    fn validate_rejects_cluster_threshold_out_of_range() {
+        for val in [1.01_f32, -0.01_f32] {
+            let c = ConsolidationConfig {
+                cluster_threshold: val,
+                ..Default::default()
+            };
+            let err = c.validate().unwrap_err().to_string();
+            assert!(
+                err.contains("cluster_threshold"),
+                "cluster_threshold={val} should reject; error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_cluster_threshold() {
+        for val in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let c = ConsolidationConfig {
+                cluster_threshold: val,
+                ..Default::default()
+            };
+            assert!(c.validate().is_err(), "{val} should be rejected");
+        }
+    }
+
     // --- ConsolidationConfig::validate(): min_cluster_size >= 2 ---
 
     #[test]

--- a/tests/eval/conformance/fact_lifecycle.rs
+++ b/tests/eval/conformance/fact_lifecycle.rs
@@ -62,10 +62,10 @@ fn dedup_consolidation_expires_one_duplicate() {
     assert!(engine.get_fact(id1).unwrap().t_expired.is_none());
     assert!(engine.get_fact(id2).unwrap().t_expired.is_none());
 
-    let config = ConsolidationConfig {
-        dedup_threshold: 1.0,  // exact match only
-        min_cluster_size: 100, // prevent cluster pass from running
-    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(1.0) // exact match only
+        .min_cluster_size(100) // prevent cluster pass from running
+        .build();
 
     let stats = engine
         .consolidate(&generator, &TestEmbedder, &config)

--- a/tests/eval/quality/consolidation.rs
+++ b/tests/eval/quality/consolidation.rs
@@ -107,10 +107,10 @@ fn dedup_removes_exact_duplicates() {
     assert_eq!(stats_before.facts.active, 10);
 
     let generator = MockSummaryGenerator;
-    let config = ConsolidationConfig {
-        dedup_threshold: 0.92, // standard threshold; exact duplicates have cosine=1.0
-        min_cluster_size: 100, // disable clustering for this test
-    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(0.92) // standard threshold; exact duplicates have cosine=1.0
+        .min_cluster_size(100) // disable clustering for this test
+        .build();
 
     let stats = engine
         .consolidate(&generator, &TestEmbedder, &config)
@@ -150,10 +150,10 @@ fn cluster_fusion_creates_clusters() {
     insert_clusterable(&engine, 4, "project:rust");
 
     let generator = MockSummaryGenerator;
-    let config = ConsolidationConfig {
-        dedup_threshold: 0.95,
-        min_cluster_size: 2,
-    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(0.95)
+        .min_cluster_size(2)
+        .build();
 
     let stats = engine
         .consolidate(&generator, &ClusterableEmbedder, &config)
@@ -177,10 +177,10 @@ fn consolidation_is_idempotent() {
     let _ = insert_exact_duplicate_pairs(&engine);
 
     let generator = MockSummaryGenerator;
-    let config = ConsolidationConfig {
-        dedup_threshold: 0.92,
-        min_cluster_size: 2,
-    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(0.92)
+        .min_cluster_size(2)
+        .build();
 
     // First pass
     let stats1 = engine
@@ -213,10 +213,10 @@ fn cluster_and_global_summary_scoping() {
     insert_clusterable(&engine, 4, scope);
 
     let generator = MockSummaryGenerator;
-    let config = ConsolidationConfig {
-        dedup_threshold: 0.95,
-        min_cluster_size: 2,
-    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(0.95)
+        .min_cluster_size(2)
+        .build();
 
     let stats = engine
         .consolidate(&generator, &ClusterableEmbedder, &config)


### PR DESCRIPTION
## What

Wave 3 of the **#253 consolidation super-qa sweep**. Makes the cluster similarity threshold configurable (it was a hard-coded constant while `dedup_threshold` was configurable — an API asymmetry, #344) and seals `ConsolidationConfig` so future tuning fields won't break callers.

## Changes

- `cluster_threshold: f32` added to `ConsolidationConfig`; `cluster_fusion` takes it as a parameter (the `CLUSTER_SIMILARITY_THRESHOLD` const is removed); `consolidate` threads `config.cluster_threshold`.
- **Sealed config** (locked design decision): `#[non_exhaustive]` + manual `impl Default` (dedup 0.90 / cluster 0.85 / min_cluster_size 2) + a `ConsolidationConfigBuilder`. Non-exhaustive blocks struct-literal/functional-update construction from other crates, so the builder is the construction path — and adding the *next* field won't break any downstream call site. All in-tree sites (tests/example/bench/MCP) migrated to `::builder()`.
- **MCP symmetry**: `memory_consolidate` exposes `cluster_threshold` alongside `dedup_threshold` (schema + range validation + handler), so configurability reaches the agent-facing surface. New validation test added.
- **#495 (low/info)**: the "undocumented non-configurable cluster threshold" item is resolved (now configurable + documented on the field).

## Verification

- Behavior-preserving by default (0.85 unchanged). New `cluster_threshold_is_honored` proves a 0.92-similar pair clusters at 0.85 but not at 0.95.
- `cargo test --workspace --all-features` (root 889) + `clippy --workspace --all-targets --all-features` + `fmt --check` all clean. Builder setters are `const fn`.

Closes #344. Part of #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)