### PR TITLE
refactor(storage): narrow rusqlite from bundled-full to bundled (closes #653)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ cargo deny check                      # supply-chain gate (advisories/licenses/b
 
 The workspace contains 4 crates: `memory-engine` (core), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. The CLI, MCP, and embed crates consume the core's public API — changes to error variants, type definitions, or trait signatures can break them silently if only the root crate is checked.
 
-**Supply-chain gate** — `deny.toml` at the repo root configures [`cargo-deny`](https://embarkstudios.github.io/cargo-deny/) and runs as the `cargo-deny` CI job. It fails on RustSec security advisories (against the full all-features graph) and on disallowed licenses or non-crates.io sources; duplicate transitive versions are surfaced as non-blocking warnings. Install locally with `cargo install cargo-deny --locked`. Note: the MSRV is **Rust 1.88** (raised from 1.85 to take `time` 0.3.47, which patches RUSTSEC-2026-0009).
+**Supply-chain gate** — `deny.toml` at the repo root configures [`cargo-deny`](https://embarkstudios.github.io/cargo-deny/) and runs as the `cargo-deny` CI job. It fails on RustSec security advisories (against the full all-features graph) and on disallowed licenses or non-crates.io sources; duplicate transitive versions are surfaced as non-blocking warnings. Install locally with `cargo install cargo-deny --locked`. Note: the MSRV is **Rust 1.88**, required by the workspace's own use of **let-chains** (a 1.88 language feature). It was originally raised from 1.85 to take `time` 0.3.47 (RUSTSEC-2026-0009); that dependency has since been dropped (rusqlite narrowed to `bundled`), but the let-chain usage keeps the floor at 1.88.
 
 ## Architecture
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 async-trait = "0.1"
-rusqlite = { version = "0.34", features = ["bundled-full"] }
+rusqlite = { version = "0.34", features = ["bundled"] }
 blake3 = "1"
 rmp-serde = "1"
 tempfile = "3"

--- a/memory-engine-cli/Cargo.toml
+++ b/memory-engine-cli/Cargo.toml
@@ -24,7 +24,6 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
-rusqlite = { version = "0.34", features = ["bundled"] }
 tempfile = "3"
 wiremock = "0.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/memory-engine-cli/Cargo.toml
+++ b/memory-engine-cli/Cargo.toml
@@ -19,12 +19,12 @@ serde_json = "1.0"
 anyhow = "1"
 tabled = "0.20"
 chrono = { version = "0.4", features = ["serde"] }
-rusqlite = { version = "0.34", features = ["bundled-full"] }
+rusqlite = { version = "0.34", features = ["bundled"] }
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
-rusqlite = { version = "0.34", features = ["bundled-full"] }
+rusqlite = { version = "0.34", features = ["bundled"] }
 tempfile = "3"
 wiremock = "0.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/memory-engine-mcp/Cargo.toml
+++ b/memory-engine-mcp/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "4", features = ["derive", "env"] }
 toml = "0.8"
 memory-engine-embed = { path = "../memory-engine-embed" }
 reqwest = { version = "0.12", features = ["blocking", "json"] }
-rusqlite = { version = "0.34", features = ["bundled-full"] }
+rusqlite = { version = "0.34", features = ["bundled"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "2"


### PR DESCRIPTION
## What

Narrows the `rusqlite` dependency from `bundled-full` to just `bundled` across all four declarations (root, `memory-engine-cli` deps + dev-deps, `memory-engine-mcp`).

## Why

`bundled-full` (= `bundled` + `modern-full`) pulls in **every** rusqlite type binding and feature. An audit of all `rusqlite::` usage in the codebase found it uses only **core API**:

```
Connection · params · params_from_iter · Row · Result · Error · OpenFlags
OptionalExtension · types::ToSql · types::Type::{Text,Blob,Integer}
```

Zero calls into `functions` / `blob` / `backup` / `hooks` / `load_extension` / `array` / custom vtab. Timestamps are stored as **RFC3339 strings** (`to_rfc3339()`), not via rusqlite's `chrono`/`time` bindings. The JSON1 SQL functions (`json_each`/`json_extract`) used in queries are compiled into the bundled SQLite **C library unconditionally** — they do not need the rusqlite `serde_json` feature. So `bundled-full` was pure over-provisioning.

## Impact

`bundled` still bundles SQLite with **FTS5** (the hybrid-search backbone — confirmed by passing `MATCH`/`bm25()` tests), so nothing functional is lost. The narrower feature set drops **13 transitive crates** from the all-features graph (**355 → 342**):

- `time`, `time-core`, `num-conv` — **removes the RUSTSEC-2026-0009 source at the root**, rather than relying on the MSRV-aware resolver to pull a patched `time`
- `url`, `uuid`, and other unused type-binding deps

### Note on MSRV (corrects this issue's premise)

The issue speculated that removing `time` might let the MSRV drop back toward 1.85. It does **not** — though not for the reason first assumed. No *actually-compiled* dependency requires > 1.85 anymore (the 1.88 `rust_version` `cargo metadata` shows for `darling` is a resolve-graph artifact — `darling` is never built, confirmed via `cargo tree`). The real MSRV driver is the **workspace's own source**: it uses **let-chains** (stabilized in Rust 1.88, introduced by #655's `collapsible_if` fixes — 5 sites in `query.rs`/`conflict.rs`/`hybrid.rs`). So 1.88 stays, and this PR is a pure dependency-surface reduction with no MSRV change.

## Verification

- `cargo tree -i time` → **empty** (dep eliminated)
- `cargo build --workspace` + `--all-features` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace --all-features` ✅ **1266 passed**
- `cargo deny check` ✅ advisories/bans/licenses/sources all ok

Closes #653