### PR TITLE
fix(core): pool read-only guard, in-memory dispatch enum, FD bound (#254 wave1)

### DIFF
--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -194,7 +194,16 @@ impl MemoryEngineBuilder<File> {
         self
     }
 
-    /// Number of read connections in the pool (default 4).
+    /// Number of read connections for a file-backed pool (default 4).
+    ///
+    /// Must be in `[1, 256]`. A value of `0` or one above the cap (256) is
+    /// **rejected at open time** with [`MemoryError::Pool`] — `0` is not a covert
+    /// in-memory request (#340/#356) and each read connection is a real OS file
+    /// descriptor, so an oversized value is refused rather than allowed to
+    /// exhaust the FD table (#415). Ignored for in-memory engines, which serve
+    /// reads through the single shared connection.
+    ///
+    /// [`MemoryError::Pool`]: crate::MemoryError::Pool
     pub const fn read_pool_size(mut self, size: usize) -> Self {
         self.backing.read_pool_size = size;
         self

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -109,7 +109,16 @@ impl EngineConfig {
         }
     }
 
-    /// Set the read connection pool size (default 4).
+    /// Set the read connection pool size for a file-backed engine (default 4).
+    ///
+    /// Must be in `[1, 256]`. A value of `0` or one above the cap (256) is
+    /// **rejected at open time** with [`MemoryError::Pool`] — `0` is not a covert
+    /// in-memory request (#340/#356) and each read connection is a real OS file
+    /// descriptor, so an oversized value is refused rather than allowed to
+    /// exhaust the FD table (#415). Ignored for in-memory engines, which serve
+    /// reads through the single shared connection.
+    ///
+    /// [`MemoryError::Pool`]: crate::MemoryError::Pool
     #[must_use]
     pub const fn with_read_pool_size(mut self, size: usize) -> Self {
         self.read_pool_size = size;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
-use parking_lot::{MutexGuard, RwLock};
+use parking_lot::RwLock;
 use rusqlite::Connection;
 
 use crate::error::{MemoryError, MigrationError, RerankerError, Result};
@@ -574,7 +574,7 @@ impl MemoryEngine {
     /// multiple operations (e.g., DB mutation + cache update).
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    fn write_conn(&self) -> Result<MutexGuard<'_, Connection>> {
+    fn write_conn(&self) -> Result<crate::pool::WriteGuard<'_>> {
         self.pool.try_write()
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -443,8 +443,11 @@ pub enum MemoryError {
 
     /// The connection pool could not hand out or manage a connection.
     ///
-    /// **Terminal — propagate, don't `match`.** Only surfaced under the `async`
-    /// feature (a task-join failure); a single failure mode, so no typed
+    /// **Terminal — propagate, don't `match`.** Surfaced when a read connection
+    /// cannot be acquired within the acquire timeout, when the pool is opened
+    /// with an out-of-range `read_pool_size` (`0` or above the cap), and under
+    /// the `async` feature on a task-join failure. The message identifies the
+    /// concrete cause; callers cannot recover differently per cause, so no typed
     /// sub-enum is warranted (see #560).
     #[error("connection pool error: {0}")]
     Pool(String),

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -943,4 +943,65 @@ mod tests {
         // inline so the significant-Drop guard isn't bound to a local.
         assert!(pool.read().is_ok());
     }
+
+    /// Cross-thread block-then-wake: thread B blocks on an exhausted 1-conn
+    /// pool, the main thread drops the only checked-out connection (firing
+    /// `notify_one`), and B must then **acquire and use** that connection —
+    /// proving the `Condvar` wakeup wakes a genuinely-blocked waiter that then
+    /// succeeds, not merely that the timeout path returns (#473).
+    ///
+    /// The single-threaded `pool_read_acquire_succeeds_when_connection_returned`
+    /// never blocks (take/drop/reacquire on one thread), and the existing
+    /// multithreaded tests prove only the *timeout* path. This is the missing
+    /// case: a real blocked thread woken by a real return.
+    #[test]
+    fn pool_read_blocks_then_wakes_and_succeeds_across_threads() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pool = ConnectionPool::open(&db_path, 4, 1, None).unwrap();
+        // Generous timeout: this test proves the *success-after-wake* path, so
+        // it must never reach the timeout. Default (30s) is ample; keep it.
+
+        // Seed a row so the woken reader can prove its connection is live.
+        {
+            let w = pool.write();
+            crate::store::schema::set_config(&w, "woke", "yes").unwrap();
+        }
+
+        // Hold the only read connection on the main thread: the pool is now
+        // exhausted, so any other reader must block.
+        let held = pool.read().unwrap();
+
+        let (started_tx, started_rx) = mpsc::channel::<()>();
+
+        std::thread::scope(|s| {
+            let reader = s.spawn(|| {
+                // Signal that thread B is about to block, then block on read().
+                started_tx.send(()).unwrap();
+                // This blocks until `held` is dropped on the main thread; on
+                // wake it must acquire the returned connection and read the row.
+                let r = pool
+                    .read()
+                    .expect("woken reader must acquire, not time out");
+                get_config(&r, "woke").unwrap()
+            });
+
+            // Wait until B has reached the point of blocking, then release the
+            // only connection so B's `Condvar` wait is satisfied by a real
+            // return (notify_one), not a spurious wakeup or the timeout.
+            started_rx.recv().unwrap();
+            // Small settle so B is parked in `wait_until` before we notify.
+            std::thread::sleep(Duration::from_millis(50));
+            drop(held);
+
+            let value = reader.join().expect("reader thread panicked");
+            assert_eq!(
+                value,
+                Some("yes".to_string()),
+                "woken reader read the wrong value through its acquired connection"
+            );
+        });
+    }
 }

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -20,6 +20,44 @@ use crate::store::schema::{
 /// to surface a genuine leak.
 const DEFAULT_READ_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Validate a caller-supplied `read_pool_size` for a file-backed pool.
+///
+/// Enforces the lower bound (`>= 1`): a file-backed pool needs at least one
+/// read connection, and `0` is *not* an implicit in-memory request — see
+/// [`BackendMode`] (#340/#356). Returns the validated value so callers can use
+/// it directly.
+///
+/// # Errors
+///
+/// Returns [`MemoryError::Pool`] if `read_pool_size == 0`.
+fn validate_read_pool_size(read_pool_size: usize) -> Result<usize> {
+    if read_pool_size == 0 {
+        return Err(MemoryError::Pool(
+            "read_pool_size must be >= 1 for a file-backed pool; use \
+             ConnectionPool::open_memory for an in-memory database"
+                .to_string(),
+        ));
+    }
+    Ok(read_pool_size)
+}
+
+/// Storage backend a [`ConnectionPool`] is wired to.
+///
+/// This replaces the previous `read_pool_size == 0` sentinel (#356): a zero
+/// read-pool size used to *imply* in-memory mode, which conflated the two
+/// orthogonal facts ("is this in-memory?" vs "how many read connections?") and
+/// let a file-backed `open(.., 0, ..)` silently route every read through the
+/// write connection (#340). The discriminant is now an explicit variant the
+/// read path matches on, so the two modes can never be confused.
+enum BackendMode {
+    /// File-backed: `read_pool_size` pooled read connections (always `>= 1`,
+    /// enforced at construction) plus the exclusive write connection.
+    FileBacked { read_pool_size: usize },
+    /// In-memory: a single shared connection serves both reads and writes
+    /// (reads are serialized through the write `Mutex`).
+    InMemory,
+}
+
 /// A connection pool with N read connections and 1 write connection.
 ///
 /// `SQLite` WAL supports concurrent readers with a single writer.
@@ -33,7 +71,10 @@ pub struct ConnectionPool {
     path: Option<PathBuf>,
     #[allow(dead_code)] // complete pool API — used after #108 engine split
     embed_dim: usize,
-    read_pool_size: usize,
+    /// Which backend this pool drives. The canonical discriminant for the
+    /// in-memory vs file-backed read dispatch (replaces the old
+    /// `read_pool_size == 0` sentinel — see [`BackendMode`]).
+    mode: BackendMode,
     read_only: bool,
     /// Bound on the wait for a read connection in [`Self::read`]. Defaults to
     /// [`DEFAULT_READ_ACQUIRE_TIMEOUT`]; exposed as a field so a future
@@ -64,12 +105,22 @@ impl Drop for ReadGuard<'_> {
     }
 }
 
-/// RAII guard for in-memory mode: wraps write connection `MutexGuard`.
-pub struct WriteAsReadGuard<'a> {
+/// RAII read guard for in-memory mode: a *serialized* read through the shared
+/// write connection's `MutexGuard`.
+///
+/// The name reflects the semantics, not a capability (#357): in-memory mode has
+/// no separate read-only connection, so a "read" simply locks the single
+/// read-write `write_conn`. The wrapped [`Connection`] is therefore fully
+/// writable and carries **no** `PRAGMA query_only = ON` — unlike the file-backed
+/// read connections, which are opened read-only at the `SQLite` level. The guard
+/// is named `SerializedReadGuard` (not the misleading `WriteAsReadGuard`) so
+/// callers do not mistake it for a read-only handle; the read path holds the
+/// write `Mutex`, which is what serializes concurrent in-memory reads.
+pub struct SerializedReadGuard<'a> {
     guard: MutexGuard<'a, Connection>,
 }
 
-impl std::ops::Deref for WriteAsReadGuard<'_> {
+impl std::ops::Deref for SerializedReadGuard<'_> {
     type Target = Connection;
     fn deref(&self) -> &Connection {
         &self.guard
@@ -79,7 +130,9 @@ impl std::ops::Deref for WriteAsReadGuard<'_> {
 /// Enum over read guard types — file-backed (pooled) vs in-memory (write conn).
 pub enum ReadConn<'a> {
     Pooled(ReadGuard<'a>),
-    InMemory(WriteAsReadGuard<'a>),
+    /// In-memory read: the write connection reused under serialization. The
+    /// inner connection is writable and has no `query_only` PRAGMA (#357).
+    InMemory(SerializedReadGuard<'a>),
 }
 
 impl std::ops::Deref for ReadConn<'_> {
@@ -100,6 +153,11 @@ impl ConnectionPool {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::Pool` if `read_pool_size` is `0`: a file-backed
+    /// pool needs at least one read connection, and `0` is *not* a covert
+    /// request for in-memory mode (use [`open_memory`](Self::open_memory) for
+    /// that). Accepting it would yield a file-backed pool that serializes every
+    /// read through the write connection (#340/#356).
     /// Returns `MemoryError::Database` if any connection or schema setup fails.
     /// Returns `MemoryError::Migration` if the schema version cannot be determined
     /// or the stored version is newer than the compiled-in maximum.
@@ -111,6 +169,8 @@ impl ConnectionPool {
         read_pool_size: usize,
         backup_dir: Option<&Path>,
     ) -> Result<Self> {
+        let read_pool_size = validate_read_pool_size(read_pool_size)?;
+
         let path_str = path.to_string_lossy();
         let write_conn = open_connection(&path_str)?;
         init_schema(&write_conn)?;
@@ -130,7 +190,7 @@ impl ConnectionPool {
             read_available: Condvar::new(),
             path: Some(path.to_path_buf()),
             embed_dim,
-            read_pool_size,
+            mode: BackendMode::FileBacked { read_pool_size },
             read_only: false,
             read_acquire_timeout: DEFAULT_READ_ACQUIRE_TIMEOUT,
         })
@@ -151,7 +211,7 @@ impl ConnectionPool {
             read_available: Condvar::new(),
             path: None,
             embed_dim,
-            read_pool_size: 0,
+            mode: BackendMode::InMemory,
             read_only: false,
             read_acquire_timeout: DEFAULT_READ_ACQUIRE_TIMEOUT,
         })
@@ -168,12 +228,17 @@ impl ConnectionPool {
     ///
     /// # Errors
     ///
+    /// Returns `MemoryError::Pool` if `read_pool_size` is `0` (same footgun as
+    /// [`open`](Self::open) — a file-backed pool needs at least one read
+    /// connection; #340/#356).
     /// Returns `MemoryError::Database` if any connection or pragma setup fails.
     /// Returns `MemoryError::Migration` if the file does not exist, the schema
     /// is uninitialized, or the schema needs migration.
     /// Returns `MemoryError::UnsupportedEpoch` if the DB epoch is from the future.
     pub fn open_read_only(path: &Path, embed_dim: usize, read_pool_size: usize) -> Result<Self> {
         use crate::store::schema::validate_schema_version;
+
+        let read_pool_size = validate_read_pool_size(read_pool_size)?;
 
         // Reject nonexistent or non-file paths before SQLite can act
         if !path.is_file() {
@@ -201,7 +266,7 @@ impl ConnectionPool {
             read_available: Condvar::new(),
             path: Some(path.to_path_buf()),
             embed_dim,
-            read_pool_size,
+            mode: BackendMode::FileBacked { read_pool_size },
             read_only: true,
             read_acquire_timeout: DEFAULT_READ_ACQUIRE_TIMEOUT,
         })
@@ -223,11 +288,20 @@ impl ConnectionPool {
     /// within `read_acquire_timeout` — turning a previously-unbounded hang
     /// (e.g. a leaked or deadlocked guard) into an observable failure.
     pub fn read(&self) -> Result<ReadConn<'_>> {
-        if self.read_pool_size == 0 {
-            // In-memory mode: use write connection for reads (serialized)
-            let guard = self.write_conn.lock();
-            return Ok(ReadConn::InMemory(WriteAsReadGuard { guard }));
-        }
+        // Dispatch on the canonical backend discriminant, never on a derived
+        // count (#340/#356). In-memory mode has no pooled read connections, so
+        // a read serializes through the single shared write connection.
+        let read_pool_size = match self.mode {
+            BackendMode::InMemory => {
+                // NOTE: in-memory mode locks the write connection here. The
+                // parking_lot `Mutex` is non-reentrant, so a thread that holds
+                // a `write()` guard MUST NOT call `read()` on the same thread —
+                // doing so self-deadlocks. See `read`/`write` doc comments.
+                let guard = self.write_conn.lock();
+                return Ok(ReadConn::InMemory(SerializedReadGuard { guard }));
+            }
+            BackendMode::FileBacked { read_pool_size } => read_pool_size,
+        };
 
         let mut conns = self.read_conns.lock();
         // Pre-compute an absolute deadline so the total wait is strictly
@@ -248,8 +322,8 @@ impl ConnectionPool {
                 && conns.is_empty()
             {
                 return Err(MemoryError::Pool(format!(
-                    "read pool acquire timed out after {:?} (all {} connections checked out)",
-                    self.read_acquire_timeout, self.read_pool_size
+                    "read pool acquire timed out after {:?} (all {read_pool_size} connections checked out)",
+                    self.read_acquire_timeout
                 )));
             }
         }
@@ -296,10 +370,17 @@ impl ConnectionPool {
 
     /// Number of read connections in the pool. Used by the construction
     /// equivalence harness to prove the builder preserves the old default of 4.
+    ///
+    /// In-memory pools report `0` (they have no pooled read connections — reads
+    /// serialize through the write connection), preserving the observable the
+    /// equivalence snapshots pin.
     #[must_use]
     #[allow(dead_code)] // observed only by the equivalence test harness
     pub(crate) const fn read_pool_size(&self) -> usize {
-        self.read_pool_size
+        match self.mode {
+            BackendMode::InMemory => 0,
+            BackendMode::FileBacked { read_pool_size } => read_pool_size,
+        }
     }
 
     /// Database file path, if file-backed. `None` for in-memory.
@@ -433,6 +514,48 @@ mod tests {
     fn pool_not_read_only_by_default() {
         let pool = ConnectionPool::open_memory(4).unwrap();
         assert!(!pool.is_read_only());
+    }
+
+    /// A file-backed `open()` with `read_pool_size == 0` must be rejected, not
+    /// silently produce a pool that serializes every read through the write
+    /// connection (#340 conflation footgun, #356 sentinel removal). The
+    /// in-memory discriminant is `BackendMode::InMemory`, never a zero read
+    /// pool on a file-backed pool.
+    #[test]
+    fn pool_open_rejects_zero_read_pool_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        // `ConnectionPool` is not `Debug`, so match instead of `unwrap_err()`.
+        assert!(matches!(
+            ConnectionPool::open(&db_path, 4, 0, None),
+            Err(MemoryError::Pool(_))
+        ));
+    }
+
+    /// `open_read_only()` with `read_pool_size == 0` is the same footgun and
+    /// must be rejected identically (#340/#356).
+    #[test]
+    fn pool_open_read_only_rejects_zero_read_pool_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        // Create a valid DB first so the read-only open reaches the size check.
+        let rw = ConnectionPool::open(&db_path, 4, 2, None).unwrap();
+        drop(rw);
+
+        assert!(matches!(
+            ConnectionPool::open_read_only(&db_path, 4, 0),
+            Err(MemoryError::Pool(_))
+        ));
+    }
+
+    /// In-memory pools report `read_pool_size() == 0` (the construction
+    /// equivalence harness pins this); the `BackendMode` enum must preserve that
+    /// observable.
+    #[test]
+    fn pool_in_memory_reports_zero_read_pool_size() {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        assert_eq!(pool.read_pool_size(), 0);
+        assert!(!pool.is_file_backed());
     }
 
     #[test]

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -579,6 +579,13 @@ impl ConnectionPool {
     /// Wrap a freshly-acquired write `MutexGuard` in a [`WriteGuard`], recording
     /// (in debug builds only) that this thread now holds this pool's write lock
     /// so [`read`](Self::read) can detect the in-memory reentrant deadlock.
+    // In release builds the debug-only marking is compiled out, leaving `&self`
+    // unused and the fn const-eligible; the documented (debug-profile) clippy
+    // gate is clean, so allow these only for the release profile.
+    #[cfg_attr(
+        not(debug_assertions),
+        allow(clippy::unused_self, clippy::missing_const_for_fn)
+    )]
     fn make_write_guard<'a>(&self, guard: MutexGuard<'a, Connection>) -> WriteGuard<'a> {
         #[cfg(debug_assertions)]
         {

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -650,6 +650,38 @@ mod tests {
         assert!(matches!(err, MemoryError::ReadOnly));
     }
 
+    /// Companion to [`pool_read_only_write_returns_error`]: `write()`
+    /// **intentionally** bypasses the `read_only` guard that `try_write()`
+    /// enforces. It is infallible — it locks the underlying connection without
+    /// erroring or panicking even on a read-only pool — and is `pub(crate)` so
+    /// only internal code (operating on pools known to be writable) can reach
+    /// it (#416/#472). User-facing writes must go through `try_write()`. This
+    /// test pins that contract so a future change to `write()` (e.g. adding a
+    /// guard, or repurposing it) is a deliberate, reviewed decision rather than
+    /// a silent behavior shift. The underlying `SQLite` connection still refuses
+    /// actual mutations (`SQLITE_OPEN_READ_ONLY`), so the bypass cannot corrupt
+    /// a read-only database — it only changes *which* layer reports the refusal.
+    #[test]
+    fn pool_read_only_write_bypasses_guard_infallibly() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let rw = ConnectionPool::open(&db_path, 4, 2, None).unwrap();
+        drop(rw);
+
+        let pool = ConnectionPool::open_read_only(&db_path, 4, 2).unwrap();
+        assert!(pool.is_read_only());
+
+        // `write()` does NOT check `read_only`: it locks and returns a guard
+        // without error or panic. A read query through it still works (the
+        // connection is open); only a *write* statement would be refused by
+        // SQLite at execution time, which is the point of using `try_write()`
+        // for user-facing operations.
+        let w = pool.write();
+        let v = get_config(&w, "schema_version").unwrap();
+        assert!(v.is_some());
+        drop(w);
+    }
+
     #[test]
     fn pool_open_read_only_nonexistent_file_fails() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -166,10 +166,11 @@ fn assert_not_reentrant(pool_addr: usize) {
     let held = WRITE_HELD.with(|h| h.borrow().contains(&pool_addr));
     assert!(
         !held,
-        "reentrant deadlock: read() called on an in-memory pool while this thread \
-         already holds a guard locking its write connection (a write() guard, or a \
-         prior in-memory read() guard) — read() re-locks the same non-reentrant \
-         Mutex and would hang forever (#278)"
+        "reentrant deadlock: a write-connection lock was requested on a thread that \
+         already holds a guard locking this pool's write connection — i.e. read() (on \
+         an in-memory pool), write(), or try_write() called while already holding a \
+         write() guard or a prior in-memory read() guard. `parking_lot::Mutex` is \
+         non-reentrant, so the second lock would hang forever (#278)"
     );
 }
 
@@ -554,6 +555,8 @@ impl ConnectionPool {
     /// assertion fires). File-backed pools are unaffected (reads come from a
     /// separate pool).
     pub(crate) fn write(&self) -> WriteGuard<'_> {
+        #[cfg(debug_assertions)]
+        assert_not_reentrant(std::ptr::from_ref::<Self>(self) as usize);
         self.make_write_guard(self.write_conn.lock())
     }
 
@@ -568,6 +571,8 @@ impl ConnectionPool {
         if self.read_only {
             return Err(MemoryError::ReadOnly);
         }
+        #[cfg(debug_assertions)]
+        assert_not_reentrant(std::ptr::from_ref::<Self>(self) as usize);
         Ok(self.make_write_guard(self.write_conn.lock()))
     }
 
@@ -896,6 +901,34 @@ mod tests {
         // Same-thread reentrant read while already holding an in-memory read
         // guard: must trip the debug reentrancy guard before blocking forever.
         let _r2 = pool.read();
+    }
+
+    /// `write()` re-locks the same non-reentrant `write_conn`, so a second
+    /// same-thread `write()` while already holding a write guard self-deadlocks
+    /// identically to the read arms. The detector must trip here too — the panic
+    /// guard is at the `write()` entry point, not only `read()` (#278).
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "reentrant")]
+    fn pool_write_while_holding_write_panics_in_debug() {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        let _w1 = pool.write();
+        // Same-thread reentrant write: must trip the debug reentrancy guard
+        // before blocking forever on the non-reentrant Mutex.
+        let _w2 = pool.write();
+    }
+
+    /// `try_write()` shares `write()`'s reentrancy hazard: requesting it while
+    /// already holding a write guard would deadlock on the non-reentrant
+    /// `write_conn`. The debug assertion must fire before the lock attempt (#278).
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "reentrant")]
+    fn pool_try_write_while_holding_write_panics_in_debug() {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        let _w = pool.write();
+        // Same-thread reentrant try_write: tripped before it can hang.
+        let _t = pool.try_write();
     }
 
     /// After an in-memory read guard is dropped, the same thread may read again —

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -20,16 +20,35 @@ use crate::store::schema::{
 /// to surface a genuine leak.
 const DEFAULT_READ_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Upper bound on a file-backed pool's `read_pool_size`.
+///
+/// Each pooled read connection is a real OS file descriptor and an `SQLite`
+/// connection object, so the size flows from caller-supplied config straight
+/// into `Vec::with_capacity` + a connection-open loop. Without a ceiling an
+/// excessive value (e.g. `usize::MAX`, or millions) over-allocates and exhausts
+/// the process FD table before any useful work (#415, CWE-770/789). 256 is far
+/// above any realistic read-concurrency need for an in-process embedded library
+/// (default is 4) yet bounds the worst case. The value is consumer-controlled,
+/// not network-attacker-controlled, which bounds the severity — but enforcing
+/// the invariant at the pool boundary makes it hold regardless of caller.
+const MAX_READ_POOL: usize = 256;
+
 /// Validate a caller-supplied `read_pool_size` for a file-backed pool.
 ///
-/// Enforces the lower bound (`>= 1`): a file-backed pool needs at least one
-/// read connection, and `0` is *not* an implicit in-memory request — see
-/// [`BackendMode`] (#340/#356). Returns the validated value so callers can use
-/// it directly.
+/// Enforces both bounds:
+/// - lower (`>= 1`): a file-backed pool needs at least one read connection, and
+///   `0` is *not* an implicit in-memory request — see [`BackendMode`]
+///   (#340/#356);
+/// - upper (`<= MAX_READ_POOL`): reject (rather than silently clamp) an
+///   excessive value before it can exhaust file descriptors / over-allocate, so
+///   the misconfiguration is surfaced not hidden (#415).
+///
+/// Returns the validated value so callers can use it directly.
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Pool`] if `read_pool_size == 0`.
+/// Returns [`MemoryError::Pool`] if `read_pool_size == 0` or
+/// `read_pool_size > MAX_READ_POOL`.
 fn validate_read_pool_size(read_pool_size: usize) -> Result<usize> {
     if read_pool_size == 0 {
         return Err(MemoryError::Pool(
@@ -37,6 +56,12 @@ fn validate_read_pool_size(read_pool_size: usize) -> Result<usize> {
              ConnectionPool::open_memory for an in-memory database"
                 .to_string(),
         ));
+    }
+    if read_pool_size > MAX_READ_POOL {
+        return Err(MemoryError::Pool(format!(
+            "read_pool_size {read_pool_size} exceeds the maximum of {MAX_READ_POOL}; \
+             each read connection is a real file descriptor"
+        )));
     }
     Ok(read_pool_size)
 }
@@ -640,6 +665,44 @@ mod tests {
         // `ConnectionPool` is not `Debug`, so match instead of `unwrap_err()`.
         assert!(matches!(
             ConnectionPool::open(&db_path, 4, 0, None),
+            Err(MemoryError::Pool(_))
+        ));
+    }
+
+    /// A `read_pool_size` above [`MAX_READ_POOL`] must be rejected, not
+    /// attempted: each connection is a real OS file descriptor, so an
+    /// excessive value would exhaust the FD table / over-allocate before any
+    /// useful work (#415, CWE-770/789). Rejecting (vs silently clamping)
+    /// surfaces the misconfiguration instead of hiding it.
+    #[test]
+    fn pool_open_rejects_oversized_read_pool_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        assert!(matches!(
+            ConnectionPool::open(&db_path, 4, MAX_READ_POOL + 1, None),
+            Err(MemoryError::Pool(_))
+        ));
+    }
+
+    /// `read_pool_size == MAX_READ_POOL` (the boundary) is accepted; only
+    /// strictly-greater values are rejected (#415).
+    #[test]
+    fn pool_open_accepts_read_pool_size_at_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pool = ConnectionPool::open(&db_path, 4, MAX_READ_POOL, None).unwrap();
+        assert_eq!(pool.read_pool_size(), MAX_READ_POOL);
+    }
+
+    /// `open_read_only()` enforces the same upper bound as `open()` (#415).
+    #[test]
+    fn pool_open_read_only_rejects_oversized_read_pool_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let rw = ConnectionPool::open(&db_path, 4, 2, None).unwrap();
+        drop(rw);
+        assert!(matches!(
+            ConnectionPool::open_read_only(&db_path, 4, MAX_READ_POOL + 1),
             Err(MemoryError::Pool(_))
         ));
     }

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -440,7 +440,18 @@ impl ConnectionPool {
         }))
     }
 
-    /// Lock the write connection.
+    /// Lock the write connection **unconditionally**, bypassing the
+    /// `read_only` guard.
+    ///
+    /// `pub(crate)` by design (#416): on a read-only pool this hands out the
+    /// `write_conn` with no `read_only` check, so a write attempt would surface
+    /// a raw `SQLite` error instead of the typed [`MemoryError::ReadOnly`].
+    /// Restricting visibility keeps that footgun off the public API — external
+    /// callers must go through [`try_write`](Self::try_write) (or the engine's
+    /// `write_conn` helper), which enforces the guard. Internal callers use this
+    /// only on pools known to be writable (restore/init paths). A read-only pool
+    /// additionally sets `query_only`/`SQLITE_OPEN_READ_ONLY`, so this is
+    /// defense-in-depth, not a live vulnerability.
     ///
     /// # In-memory reentrancy hazard (#278)
     ///
@@ -450,7 +461,7 @@ impl ConnectionPool {
     /// self-deadlocks (in release it hangs forever; in debug a reentrancy
     /// assertion fires). File-backed pools are unaffected (reads come from a
     /// separate pool).
-    pub fn write(&self) -> WriteGuard<'_> {
+    pub(crate) fn write(&self) -> WriteGuard<'_> {
         self.make_write_guard(self.write_conn.lock())
     }
 

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -83,6 +83,64 @@ pub struct ConnectionPool {
     read_acquire_timeout: Duration,
 }
 
+// Debug-only, per-thread set of pool addresses on which *this* thread currently
+// holds the write guard. Used to detect the in-memory reentrant deadlock (#278)
+// without false positives: the marker is keyed by pool identity AND is
+// thread-local, so legitimate cross-thread write/read contention never trips it,
+// and a write guard on one pool does not implicate reads on another. Compiled
+// out entirely in release builds.
+#[cfg(debug_assertions)]
+thread_local! {
+    static WRITE_HELD: std::cell::RefCell<std::collections::HashSet<usize>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// RAII guard for the write connection.
+///
+/// Wraps the underlying `MutexGuard` and `Deref`s to [`Connection`]
+/// transparently, so callers use it exactly like the raw guard. In debug builds
+/// it additionally records that the current thread holds this pool's write lock
+/// (and clears that record on drop) so [`ConnectionPool::read`] can assert
+/// against the in-memory reentrant deadlock (#278). In release builds it is a
+/// zero-overhead newtype around the `MutexGuard`.
+pub struct WriteGuard<'a> {
+    guard: MutexGuard<'a, Connection>,
+    /// Pool identity, used only by the debug reentrancy detector.
+    #[cfg(debug_assertions)]
+    pool_addr: usize,
+}
+
+impl std::ops::Deref for WriteGuard<'_> {
+    type Target = Connection;
+    fn deref(&self) -> &Connection {
+        &self.guard
+    }
+}
+
+impl std::ops::DerefMut for WriteGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Connection {
+        &mut self.guard
+    }
+}
+
+impl std::fmt::Debug for WriteGuard<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Delegate to the inner `Connection` so `Result<WriteGuard, _>` keeps
+        // the `Debug` bound the previous `MutexGuard<Connection>` return type
+        // satisfied (e.g. `.unwrap_err()` in tests).
+        f.debug_tuple("WriteGuard").field(&*self.guard).finish()
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for WriteGuard<'_> {
+    fn drop(&mut self) {
+        WRITE_HELD.with(|held| {
+            held.borrow_mut().remove(&self.pool_addr);
+        });
+    }
+}
+
 /// RAII guard that returns a read connection to the pool on drop.
 pub struct ReadGuard<'a> {
     conn: Option<Connection>,
@@ -282,6 +340,16 @@ impl ConnectionPool {
     /// The happy path (a connection available immediately) returns without
     /// waiting and never errors.
     ///
+    /// # In-memory reentrancy hazard (#278)
+    ///
+    /// In in-memory mode this locks the **same** `Mutex` as
+    /// [`write`](Self::write)/[`try_write`](Self::try_write). The
+    /// `parking_lot::Mutex` is non-reentrant, so calling `read()` on the same
+    /// thread that already holds a write guard self-deadlocks (a release-build
+    /// hang; a debug-build reentrancy panic). Always drop the write guard before
+    /// reading on an in-memory pool. File-backed pools are immune (reads use a
+    /// separate connection pool).
+    ///
     /// # Errors
     ///
     /// Returns [`MemoryError::Pool`] if no read connection becomes available
@@ -293,10 +361,23 @@ impl ConnectionPool {
         // a read serializes through the single shared write connection.
         let read_pool_size = match self.mode {
             BackendMode::InMemory => {
-                // NOTE: in-memory mode locks the write connection here. The
-                // parking_lot `Mutex` is non-reentrant, so a thread that holds
+                // In-memory mode locks the write connection here. The
+                // `parking_lot::Mutex` is non-reentrant, so a thread that holds
                 // a `write()` guard MUST NOT call `read()` on the same thread —
-                // doing so self-deadlocks. See `read`/`write` doc comments.
+                // doing so self-deadlocks (#278). Catch the violation at dev
+                // time with a per-pool, per-thread marker before the blocking
+                // `lock()` would hang forever; compiled out in release.
+                #[cfg(debug_assertions)]
+                {
+                    let pool_addr = std::ptr::from_ref::<Self>(self) as usize;
+                    let held = WRITE_HELD.with(|h| h.borrow().contains(&pool_addr));
+                    assert!(
+                        !held,
+                        "reentrant deadlock: read() called on an in-memory pool while this \
+                         thread holds its write() guard — read() locks the same non-reentrant \
+                         Mutex (#278)"
+                    );
+                }
                 let guard = self.write_conn.lock();
                 return Ok(ReadConn::InMemory(SerializedReadGuard { guard }));
             }
@@ -335,18 +416,49 @@ impl ConnectionPool {
     }
 
     /// Lock the write connection.
-    pub fn write(&self) -> MutexGuard<'_, Connection> {
-        self.write_conn.lock()
+    ///
+    /// # In-memory reentrancy hazard (#278)
+    ///
+    /// In in-memory mode [`read`](Self::read) locks this same connection. The
+    /// `parking_lot::Mutex` is **non-reentrant**, so a thread that holds the
+    /// guard returned here MUST NOT call `read()` on the same thread — doing so
+    /// self-deadlocks (in release it hangs forever; in debug a reentrancy
+    /// assertion fires). File-backed pools are unaffected (reads come from a
+    /// separate pool).
+    pub fn write(&self) -> WriteGuard<'_> {
+        self.make_write_guard(self.write_conn.lock())
     }
 
     /// Attempt to lock the write connection.
     ///
     /// Returns `MemoryError::ReadOnly` if the pool was opened read-only.
-    pub fn try_write(&self) -> Result<MutexGuard<'_, Connection>> {
+    ///
+    /// The same in-memory reentrancy hazard as [`write`](Self::write) applies:
+    /// never call [`read`](Self::read) on the same thread while holding the
+    /// returned guard on an in-memory pool.
+    pub fn try_write(&self) -> Result<WriteGuard<'_>> {
         if self.read_only {
             return Err(MemoryError::ReadOnly);
         }
-        Ok(self.write_conn.lock())
+        Ok(self.make_write_guard(self.write_conn.lock()))
+    }
+
+    /// Wrap a freshly-acquired write `MutexGuard` in a [`WriteGuard`], recording
+    /// (in debug builds only) that this thread now holds this pool's write lock
+    /// so [`read`](Self::read) can detect the in-memory reentrant deadlock.
+    fn make_write_guard<'a>(&self, guard: MutexGuard<'a, Connection>) -> WriteGuard<'a> {
+        #[cfg(debug_assertions)]
+        {
+            let pool_addr = std::ptr::from_ref::<Self>(self) as usize;
+            WRITE_HELD.with(|held| {
+                held.borrow_mut().insert(pool_addr);
+            });
+            WriteGuard { guard, pool_addr }
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            WriteGuard { guard }
+        }
     }
 
     /// Whether this pool was opened in read-only mode.
@@ -556,6 +668,51 @@ mod tests {
         let pool = ConnectionPool::open_memory(4).unwrap();
         assert_eq!(pool.read_pool_size(), 0);
         assert!(!pool.is_file_backed());
+    }
+
+    /// In in-memory mode, `read()` locks the (non-reentrant) write `Mutex`, so
+    /// holding a `write()` guard and calling `read()` on the same thread would
+    /// self-deadlock. A debug-only assertion turns that latent hang into an
+    /// immediate, observable panic at dev time (#278). The guard is per-pool and
+    /// per-thread, so legitimate cross-thread contention does not trip it.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "reentrant")]
+    fn pool_in_memory_read_while_holding_write_panics_in_debug() {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        let _w = pool.write();
+        // Same-thread reentrant read: must trip the debug reentrancy guard
+        // before it can block forever on the non-reentrant Mutex.
+        let _r = pool.read();
+    }
+
+    /// A held write guard on one pool must NOT make a same-thread read on a
+    /// *different* in-memory pool panic — the reentrancy detector is scoped per
+    /// pool, not per thread (#278). Guards soundness against false positives.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn pool_in_memory_read_other_pool_while_holding_write_is_ok() {
+        let pool_a = ConnectionPool::open_memory(4).unwrap();
+        let pool_b = ConnectionPool::open_memory(4).unwrap();
+        let _wa = pool_a.write();
+        // Reading pool_b while holding pool_a's write guard is safe. Assert
+        // inline so the significant-Drop `Ok` guard isn't bound to a local.
+        assert!(pool_b.read().is_ok());
+    }
+
+    /// After the write guard is dropped, the same thread may read the in-memory
+    /// pool again — the per-thread/per-pool marker is cleared on guard drop, so
+    /// the detector does not leave a stale "held" state (#278).
+    #[cfg(debug_assertions)]
+    #[test]
+    fn pool_in_memory_read_after_write_dropped_is_ok() {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        {
+            let _w = pool.write();
+        }
+        // Assert inline so the significant-Drop `Ok` guard isn't bound to a
+        // local (matches the other read-acquire tests in this module).
+        assert!(pool.read().is_ok());
     }
 
     #[test]

--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -106,18 +106,71 @@ pub struct ConnectionPool {
     /// `EngineConfig::read_acquire_timeout` can be wired in without touching
     /// the acquire path.
     read_acquire_timeout: Duration,
+    /// Test-only deterministic synchronization hook for the block-then-wake
+    /// path. Invoked inside [`Self::read`] while the `read_conns` `Mutex` is held
+    /// and found empty, immediately *before* `wait_until` atomically releases the
+    /// lock and parks. Because the lock is still held when this fires, any other
+    /// thread that subsequently tries to lock `read_conns` (e.g. to return a
+    /// connection) cannot proceed until this thread has parked — turning the
+    /// "is the waiter parked yet?" race into a deterministic lock handoff. `None`
+    /// (and zero-cost) outside tests.
+    #[cfg(test)]
+    on_acquire_park: Option<Box<dyn Fn() + Send + Sync>>,
 }
 
 // Debug-only, per-thread set of pool addresses on which *this* thread currently
-// holds the write guard. Used to detect the in-memory reentrant deadlock (#278)
-// without false positives: the marker is keyed by pool identity AND is
-// thread-local, so legitimate cross-thread write/read contention never trips it,
-// and a write guard on one pool does not implicate reads on another. Compiled
-// out entirely in release builds.
+// holds the in-memory write `Mutex` (via a `write()`/`try_write()` guard OR an
+// in-memory `read()` guard — both lock the *same* non-reentrant `write_conn`).
+// Used to detect the in-memory reentrant deadlock (#278) without false
+// positives: the marker is keyed by pool identity AND is thread-local, so
+// legitimate cross-thread write/read contention never trips it, and a guard on
+// one pool does not implicate reads on another. Compiled out entirely in release
+// builds.
+//
+// A `HashSet` cannot represent the same pool held *twice* by one thread, but
+// that can never happen for in-memory pools: holding any guard that locks
+// `write_conn` and acquiring a second guard on the same pool/thread would
+// deadlock on the non-reentrant `Mutex` — exactly the violation the marker
+// catches *before* the second lock. So at most one live marker per pool is
+// possible, and a plain set is sufficient (insert is idempotent, drop removes).
 #[cfg(debug_assertions)]
 thread_local! {
     static WRITE_HELD: std::cell::RefCell<std::collections::HashSet<usize>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// Insert this pool's address into the per-thread `WRITE_HELD` marker (debug
+/// only). Both [`WriteGuard`] and the in-memory [`SerializedReadGuard`] register
+/// here because both hold the single non-reentrant `write_conn` `Mutex`.
+#[cfg(debug_assertions)]
+fn mark_write_held(pool_addr: usize) {
+    WRITE_HELD.with(|held| {
+        held.borrow_mut().insert(pool_addr);
+    });
+}
+
+/// Remove this pool's address from the per-thread `WRITE_HELD` marker (debug
+/// only), called from the `Drop` of whichever guard holds `write_conn`.
+#[cfg(debug_assertions)]
+fn unmark_write_held(pool_addr: usize) {
+    WRITE_HELD.with(|held| {
+        held.borrow_mut().remove(&pool_addr);
+    });
+}
+
+/// Assert (debug only) that this thread does not already hold a guard locking
+/// `write_conn` for the given in-memory pool, before a path that would lock it
+/// again and self-deadlock on the non-reentrant `Mutex` (#278).
+#[cfg(debug_assertions)]
+fn assert_not_reentrant(pool_addr: usize) {
+    let held = WRITE_HELD.with(|h| h.borrow().contains(&pool_addr));
+    assert!(
+        !held,
+        "reentrant deadlock: read() called on an in-memory pool while this thread \
+         already holds a guard locking its write connection (a write() guard, or a \
+         prior in-memory read() guard) — read() re-locks the same non-reentrant \
+         Mutex and would hang forever (#278)"
+    );
 }
 
 /// RAII guard for the write connection.
@@ -160,9 +213,7 @@ impl std::fmt::Debug for WriteGuard<'_> {
 #[cfg(debug_assertions)]
 impl Drop for WriteGuard<'_> {
     fn drop(&mut self) {
-        WRITE_HELD.with(|held| {
-            held.borrow_mut().remove(&self.pool_addr);
-        });
+        unmark_write_held(self.pool_addr);
     }
 }
 
@@ -201,12 +252,25 @@ impl Drop for ReadGuard<'_> {
 /// write `Mutex`, which is what serializes concurrent in-memory reads.
 pub struct SerializedReadGuard<'a> {
     guard: MutexGuard<'a, Connection>,
+    /// Pool identity, used only by the debug reentrancy detector. An in-memory
+    /// read holds the same `write_conn` `Mutex` as a write guard, so it registers
+    /// in `WRITE_HELD` too — making the #278 assertion cover read-then-read, not
+    /// just write-then-read.
+    #[cfg(debug_assertions)]
+    pool_addr: usize,
 }
 
 impl std::ops::Deref for SerializedReadGuard<'_> {
     type Target = Connection;
     fn deref(&self) -> &Connection {
         &self.guard
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for SerializedReadGuard<'_> {
+    fn drop(&mut self) {
+        unmark_write_held(self.pool_addr);
     }
 }
 
@@ -241,6 +305,10 @@ impl ConnectionPool {
     /// request for in-memory mode (use [`open_memory`](Self::open_memory) for
     /// that). Accepting it would yield a file-backed pool that serializes every
     /// read through the write connection (#340/#356).
+    /// Returns `MemoryError::Pool` if `read_pool_size` exceeds `MAX_READ_POOL`
+    /// (256): each read connection is a real OS file descriptor, so an excessive
+    /// value is rejected (not clamped) before it can exhaust the FD table /
+    /// over-allocate (#415, CWE-770/789).
     /// Returns `MemoryError::Database` if any connection or schema setup fails.
     /// Returns `MemoryError::Migration` if the schema version cannot be determined
     /// or the stored version is newer than the compiled-in maximum.
@@ -276,6 +344,8 @@ impl ConnectionPool {
             mode: BackendMode::FileBacked { read_pool_size },
             read_only: false,
             read_acquire_timeout: DEFAULT_READ_ACQUIRE_TIMEOUT,
+            #[cfg(test)]
+            on_acquire_park: None,
         })
     }
 
@@ -297,6 +367,8 @@ impl ConnectionPool {
             mode: BackendMode::InMemory,
             read_only: false,
             read_acquire_timeout: DEFAULT_READ_ACQUIRE_TIMEOUT,
+            #[cfg(test)]
+            on_acquire_park: None,
         })
     }
 
@@ -313,7 +385,9 @@ impl ConnectionPool {
     ///
     /// Returns `MemoryError::Pool` if `read_pool_size` is `0` (same footgun as
     /// [`open`](Self::open) — a file-backed pool needs at least one read
-    /// connection; #340/#356).
+    /// connection; #340/#356), or if it exceeds `MAX_READ_POOL` (256): each read
+    /// connection is a real OS file descriptor, so an oversized value is rejected
+    /// rather than allowed to exhaust the FD table (#415, CWE-770/789).
     /// Returns `MemoryError::Database` if any connection or pragma setup fails.
     /// Returns `MemoryError::Migration` if the file does not exist, the schema
     /// is uninitialized, or the schema needs migration.
@@ -352,6 +426,8 @@ impl ConnectionPool {
             mode: BackendMode::FileBacked { read_pool_size },
             read_only: true,
             read_acquire_timeout: DEFAULT_READ_ACQUIRE_TIMEOUT,
+            #[cfg(test)]
+            on_acquire_park: None,
         })
     }
 
@@ -368,12 +444,16 @@ impl ConnectionPool {
     /// # In-memory reentrancy hazard (#278)
     ///
     /// In in-memory mode this locks the **same** `Mutex` as
-    /// [`write`](Self::write)/[`try_write`](Self::try_write). The
-    /// `parking_lot::Mutex` is non-reentrant, so calling `read()` on the same
-    /// thread that already holds a write guard self-deadlocks (a release-build
-    /// hang; a debug-build reentrancy panic). Always drop the write guard before
-    /// reading on an in-memory pool. File-backed pools are immune (reads use a
-    /// separate connection pool).
+    /// [`write`](Self::write)/[`try_write`](Self::try_write) — and as a *prior*
+    /// in-memory `read()`, since an in-memory read guard
+    /// ([`SerializedReadGuard`]) holds that very `write_conn` lock. The
+    /// `parking_lot::Mutex` is non-reentrant, so calling `read()` on a thread
+    /// that already holds **any** guard locking `write_conn` (a write guard OR an
+    /// earlier in-memory read guard) self-deadlocks (a release-build hang; a
+    /// debug-build reentrancy panic). Drop every such guard before reading again
+    /// on an in-memory pool. File-backed pools are immune — reads use a separate
+    /// connection pool, so neither read-then-read nor write-then-read contends on
+    /// one lock.
     ///
     /// # Errors
     ///
@@ -388,23 +468,28 @@ impl ConnectionPool {
             BackendMode::InMemory => {
                 // In-memory mode locks the write connection here. The
                 // `parking_lot::Mutex` is non-reentrant, so a thread that holds
-                // a `write()` guard MUST NOT call `read()` on the same thread —
-                // doing so self-deadlocks (#278). Catch the violation at dev
+                // ANY guard locking `write_conn` — a `write()`/`try_write()`
+                // guard OR a prior in-memory `read()` guard — MUST NOT call
+                // `read()` again on the same thread: doing so re-locks the same
+                // Mutex and self-deadlocks (#278). Catch the violation at dev
                 // time with a per-pool, per-thread marker before the blocking
                 // `lock()` would hang forever; compiled out in release.
+                //
+                // The in-memory read guard registers in the SAME marker as the
+                // write guard (insert below; removed in its `Drop`), so the
+                // assertion covers read-then-read as well as write-then-read.
                 #[cfg(debug_assertions)]
-                {
-                    let pool_addr = std::ptr::from_ref::<Self>(self) as usize;
-                    let held = WRITE_HELD.with(|h| h.borrow().contains(&pool_addr));
-                    assert!(
-                        !held,
-                        "reentrant deadlock: read() called on an in-memory pool while this \
-                         thread holds its write() guard — read() locks the same non-reentrant \
-                         Mutex (#278)"
-                    );
-                }
+                let pool_addr = std::ptr::from_ref::<Self>(self) as usize;
+                #[cfg(debug_assertions)]
+                assert_not_reentrant(pool_addr);
                 let guard = self.write_conn.lock();
-                return Ok(ReadConn::InMemory(SerializedReadGuard { guard }));
+                #[cfg(debug_assertions)]
+                mark_write_held(pool_addr);
+                return Ok(ReadConn::InMemory(SerializedReadGuard {
+                    guard,
+                    #[cfg(debug_assertions)]
+                    pool_addr,
+                }));
             }
             BackendMode::FileBacked { read_pool_size } => read_pool_size,
         };
@@ -418,6 +503,13 @@ impl ConnectionPool {
         // ceiling across all iterations.
         let deadline = Instant::now() + self.read_acquire_timeout;
         while conns.is_empty() {
+            // Test-only: signal "about to park" while still holding `conns`, so a
+            // returning thread's `read_conns.lock()` blocks until `wait_until`
+            // (below) releases the lock — a deterministic park handoff, no sleep.
+            #[cfg(test)]
+            if let Some(hook) = self.on_acquire_park.as_ref() {
+                hook();
+            }
             // `wait_until` returns once notified, or when `deadline` passes.
             // `timed_out()` distinguishes the two; re-check `is_empty()` to
             // guard against spurious wakeups (notified but raced).
@@ -486,9 +578,7 @@ impl ConnectionPool {
         #[cfg(debug_assertions)]
         {
             let pool_addr = std::ptr::from_ref::<Self>(self) as usize;
-            WRITE_HELD.with(|held| {
-                held.borrow_mut().insert(pool_addr);
-            });
+            mark_write_held(pool_addr);
             WriteGuard { guard, pool_addr }
         }
         #[cfg(not(debug_assertions))]
@@ -792,6 +882,49 @@ mod tests {
         let _r = pool.read();
     }
 
+    /// The reentrancy detector must also catch the **read-then-read** arm: an
+    /// in-memory `read()` guard holds the same non-reentrant `write_conn` lock as
+    /// a write guard, so a second same-thread `read()` self-deadlocks identically
+    /// (#278). Holding a [`SerializedReadGuard`] and calling `read()` again must
+    /// trip the debug assertion before it can hang.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "reentrant")]
+    fn pool_in_memory_read_while_holding_read_panics_in_debug() {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        let _r1 = pool.read().unwrap();
+        // Same-thread reentrant read while already holding an in-memory read
+        // guard: must trip the debug reentrancy guard before blocking forever.
+        let _r2 = pool.read();
+    }
+
+    /// After an in-memory read guard is dropped, the same thread may read again —
+    /// the `SerializedReadGuard` `Drop` clears the per-thread/per-pool marker, so
+    /// the detector leaves no stale "held" state for the read path either (#278).
+    #[cfg(debug_assertions)]
+    #[test]
+    fn pool_in_memory_read_after_read_dropped_is_ok() {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        {
+            let _r = pool.read().unwrap();
+        }
+        // Assert inline so the significant-Drop `Ok` guard isn't bound to a
+        // local (matches the other read-acquire tests in this module).
+        assert!(pool.read().is_ok());
+    }
+
+    /// A held in-memory read guard on one pool must NOT make a same-thread read
+    /// on a *different* in-memory pool panic — the read-path marker is scoped per
+    /// pool, not per thread, exactly like the write-path one (#278).
+    #[cfg(debug_assertions)]
+    #[test]
+    fn pool_in_memory_read_other_pool_while_holding_read_is_ok() {
+        let pool_a = ConnectionPool::open_memory(4).unwrap();
+        let pool_b = ConnectionPool::open_memory(4).unwrap();
+        let _ra = pool_a.read().unwrap();
+        assert!(pool_b.read().is_ok());
+    }
+
     /// A held write guard on one pool must NOT make a same-thread read on a
     /// *different* in-memory pool panic — the reentrancy detector is scoped per
     /// pool, not per thread (#278). Guards soundness against false positives.
@@ -954,15 +1087,40 @@ mod tests {
     /// never blocks (take/drop/reacquire on one thread), and the existing
     /// multithreaded tests prove only the *timeout* path. This is the missing
     /// case: a real blocked thread woken by a real return.
+    ///
+    /// **Determinism** (no sleep/timing heuristic): the park is synchronized via
+    /// the `on_acquire_park` hook, which fires inside `read()` *while the
+    /// `read_conns` `Mutex` is still held*, immediately before `wait_until`
+    /// atomically releases it and parks. The main thread waits for that hook to
+    /// run, then calls `drop(held)` — whose `read_conns.lock()` **cannot** acquire
+    /// the lock until B has parked and released it. So the connection is returned
+    /// (and `notify_one` fired) only after B is genuinely blocked on the
+    /// `Condvar`. The old version relied on `sleep(50ms)` to *guess* B had
+    /// parked; if the scheduler delayed B past the window, `drop(held)` returned
+    /// the connection before B's first `is_empty()` check and B never blocked —
+    /// the notify-wake path went unexercised yet the test still passed. This
+    /// version proves the wake path or hangs (timeout-bounded), never green-
+    /// without-proof.
     #[test]
     fn pool_read_blocks_then_wakes_and_succeeds_across_threads() {
-        use std::sync::mpsc;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
 
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.db");
-        let pool = ConnectionPool::open(&db_path, 4, 1, None).unwrap();
+        let mut pool = ConnectionPool::open(&db_path, 4, 1, None).unwrap();
         // Generous timeout: this test proves the *success-after-wake* path, so
         // it must never reach the timeout. Default (30s) is ample; keep it.
+
+        // Deterministic park signal: flipped by the acquire-park hook while B
+        // still holds `read_conns`, just before `wait_until` releases it.
+        let b_parking = Arc::new(AtomicBool::new(false));
+        {
+            let flag = Arc::clone(&b_parking);
+            pool.on_acquire_park = Some(Box::new(move || {
+                flag.store(true, Ordering::SeqCst);
+            }));
+        }
 
         // Seed a row so the woken reader can prove its connection is live.
         {
@@ -974,26 +1132,28 @@ mod tests {
         // exhausted, so any other reader must block.
         let held = pool.read().unwrap();
 
-        let (started_tx, started_rx) = mpsc::channel::<()>();
-
         std::thread::scope(|s| {
             let reader = s.spawn(|| {
-                // Signal that thread B is about to block, then block on read().
-                started_tx.send(()).unwrap();
-                // This blocks until `held` is dropped on the main thread; on
-                // wake it must acquire the returned connection and read the row.
+                // Blocks until `held` is dropped on the main thread; on wake it
+                // must acquire the returned connection and read the seeded row.
                 let r = pool
                     .read()
                     .expect("woken reader must acquire, not time out");
                 get_config(&r, "woke").unwrap()
             });
 
-            // Wait until B has reached the point of blocking, then release the
-            // only connection so B's `Condvar` wait is satisfied by a real
-            // return (notify_one), not a spurious wakeup or the timeout.
-            started_rx.recv().unwrap();
-            // Small settle so B is parked in `wait_until` before we notify.
-            std::thread::sleep(Duration::from_millis(50));
+            // Spin until B has locked `read_conns`, found it empty, and run the
+            // park hook (still holding the lock). After this, B is committed to
+            // `wait_until`; the lock handoff below makes the park-before-notify
+            // ordering deterministic — no sleep needed.
+            while !b_parking.load(Ordering::SeqCst) {
+                std::hint::spin_loop();
+            }
+
+            // `drop(held)` returns the connection: `read_conns.lock()` inside the
+            // drop blocks until B's `wait_until` releases the lock by parking, so
+            // the push + `notify_one` land only once B is genuinely parked on the
+            // `Condvar`. This wakes a real blocked waiter (not the timeout path).
             drop(held);
 
             let value = reader.join().expect("reader thread panicked");

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -4,4 +4,4 @@
 
 mod connection_pool;
 
-pub use connection_pool::ConnectionPool;
+pub use connection_pool::{ConnectionPool, WriteGuard};


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 1). Subsystem-cohesive PR closing 8 findings.

## Findings closed

- **#278** [refactor/high] — In-memory read() locks write_conn — reentrant deadlock if write guard held
- **#340** [bug/medium] — read() dispatches on read_pool_size==0 instead of path.is_none(), conflating in-memory with zero-sized file-backed pool
- **#356** [refactor/medium] — read_pool_size==0 used as implicit in-memory sentinel; open() doesn't reject 0 for file-backed
- **#357** [refactor/medium] — WriteAsReadGuard name implies read-only but exposes fully-writable Connection, no query_only
- **#415** [security/medium] — Unbounded read_pool_size leads to FD exhaustion / large allocation
- **#416** [bug/medium] — pub write() bypasses the read-only guard enforced by try_write()
- **#472** [test/low] — write() on a read-only pool is untested and bypasses the read_only guard
- **#473** [test/low] — Cross-thread Condvar block-then-wake (pool exhaustion) still untested

## Review (internal diverse-lens subagents — no external models)

3 clean-slate adversarial reviewers (correctness / security & soundness / api-surface & test-quality): **0 blocker, 4 major** found.

All blocker/major **addressed** in fix commits (4):
- Finding 1 (major, correctness — in-memory read-then-read deadlock not caught): Confirmed valid. read() returns a SerializedReadGuard holding the write_conn MutexGuard, and a second read() re-locks the non-reentrant write_conn, but WRITE_HELD was populated only by make_write_guard() (write path). Fix
- Finding 2 (major, api-surface — incomplete # Errors on open()/open_read_only()): Confirmed valid. validate_read_pool_size returns MemoryError::Pool for both ==0 AND >MAX_READ_POOL (256, #415), but the per-function # Errors documented only the ==0 case. Added a sentence to both open() and open_read_o
- Finding 3 (major, api-surface — public setter doc/behavior mismatch): Confirmed valid. MemoryEngineBuilder::read_pool_size and EngineConfig::with_read_pool_size are pub and documented only 'Number of read connections in the pool (default 4)' while 0 or >256 now fails at open time with MemoryError::P
- Finding 4 (major, test-quality — non-deterministic block-then-wake test): Confirmed valid. The test used started_rx.recv() + sleep(50ms) to guess thread B had parked in wait_until before drop(held); a scheduler delay past the window let drop(held) return the connection before B's first is_empty() ch

## Gate
`cargo build/test/clippy --workspace` + `cargo fmt --check` — green (rebased on current main).

Fixes #278, fixes #340, fixes #356, fixes #357, fixes #415, fixes #416, fixes #472, fixes #473