### PR TITLE
refactor(temporal): scope path invertibility + validation symmetry + docs/tests (#254 wave1)

### DIFF
--- a/src/scope/mod.rs
+++ b/src/scope/mod.rs
@@ -3,3 +3,37 @@
 pub mod tree;
 
 pub use tree::ScopeTree;
+
+/// Maximum byte length of a single scope-path segment (label).
+pub const MAX_SEGMENT_LEN: usize = 256;
+
+/// Validate the *structural* rules a single scope-path segment must satisfy:
+/// non-empty, no embedded `/`, and at most [`MAX_SEGMENT_LEN`] bytes.
+///
+/// This is the single source of truth shared by the two scope APIs that must
+/// agree on what a valid segment is:
+/// - [`crate::store::ScopeStore::ensure_path`] (write path) — wraps the failure
+///   reason in [`crate::error::ConflictError::ScopeLabel`].
+/// - [`ScopeTree::resolve_path`] (read path) — maps any failure to `None`.
+///
+/// The "no surrounding whitespace" rule is intentionally *not* enforced here: it
+/// is a write-path-only constraint applied by `ScopeStore::validate_label`, so
+/// that the read path can keep its defensive trim (a segment with incidental
+/// whitespace can never match a stored — already-trimmed — label anyway). See
+/// [`ScopeTree::resolve_path`] for the trim semantics.
+///
+/// # Errors
+///
+/// Returns a static reason string when `segment` violates a structural rule.
+pub fn validate_segment(segment: &str) -> std::result::Result<(), &'static str> {
+    if segment.is_empty() {
+        return Err("scope label must not be empty");
+    }
+    if segment.contains('/') {
+        return Err("scope label must not contain '/'");
+    }
+    if segment.len() > MAX_SEGMENT_LEN {
+        return Err("scope label must be at most 256 bytes");
+    }
+    Ok(())
+}

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -68,6 +68,15 @@ impl ScopeTree {
     /// For any other input, segments are separated by `/`. Returns `None` if any
     /// segment does not exist in the cached tree, or if the path contains an
     /// empty *inner* segment (e.g. a leading/trailing `/` or `//`).
+    ///
+    /// **Whitespace:** each segment is trimmed of ASCII whitespace before lookup,
+    /// so `resolve_path(" user:michael")` matches the stored label `user:michael`.
+    /// This diverges from [`crate::store::ScopeStore::ensure_path`], which
+    /// *rejects* a label with surrounding whitespace (`MemoryError::Conflict`).
+    /// The asymmetry is intentional and safe: because `ensure_path` guarantees no
+    /// stored label ever carries surrounding whitespace, the trim here can only
+    /// recover the un-padded label — it is defensive, not permissive. Use
+    /// `ensure_path` when you need the input itself validated rather than coerced.
     pub fn resolve_path(&self, path: &str) -> Option<i64> {
         // Root synonyms: the canonical "/" rendered by `path_for_id`, and "" as
         // the conceptual root. Handled up front so the per-segment loop never

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -60,10 +60,13 @@ impl ScopeTree {
 
     /// Resolve a path string to a `scope_id` (read-only, no creation).
     ///
-    /// The empty string `""` and `"/"` both resolve to the root scope. `"/"` is
-    /// the canonical string [`ScopeTree::path_for_id`] renders for the root, so
+    /// The canonical root string `"/"` (the one [`ScopeTree::path_for_id`]
+    /// renders for the root) resolves to the root scope, so
     /// `resolve_path(path_for_id(root))` round-trips rather than returning
-    /// `None` (the representation is invertible).
+    /// `None` (the representation is invertible). The empty string `""` is
+    /// **not** a root synonym — it resolves to `None`, agreeing with the write
+    /// path ([`crate::store::ScopeStore::ensure_path`] rejects `""`) and keeping
+    /// an empty/defaulted scope query from silently meaning "the entire store".
     ///
     /// For any other input, segments are separated by `/`. Returns `None` if any
     /// segment does not exist in the cached tree, or if the path contains an
@@ -78,10 +81,16 @@ impl ScopeTree {
     /// recover the un-padded label — it is defensive, not permissive. Use
     /// `ensure_path` when you need the input itself validated rather than coerced.
     pub fn resolve_path(&self, path: &str) -> Option<i64> {
-        // Root synonyms: the canonical "/" rendered by `path_for_id`, and "" as
-        // the conceptual root. Handled up front so the per-segment loop never
-        // sees the empty inner segment they would otherwise split into.
-        if path.is_empty() || path == "/" {
+        // Root synonym: the canonical "/" rendered by `path_for_id`. Handled up
+        // front so the per-segment loop never sees the two empty segments "/"
+        // would otherwise split into. The empty string "" is deliberately *not*
+        // a root synonym: it stays unresolvable (`None`), matching the write
+        // path where `ScopeStore::ensure_path("")` errors. Resolving "" to root
+        // would make an empty/defaulted scope query mean "the entire store"
+        // (subtree(root) = all facts) — a fail-open hole for a scope-isolation
+        // primitive. `path_for_id` never emits "", so only "/" is needed for the
+        // representation to round-trip.
+        if path == "/" {
             return Some(Self::ROOT_ID);
         }
         let mut current = Self::ROOT_ID; // start at root
@@ -207,8 +216,9 @@ impl ScopeTree {
     /// Returns `"/"` for the root scope. Non-root example: `"user:michael/project:demo"`.
     /// Returns `None` if the ID is not in the tree.
     ///
-    /// **Note:** The root path `"/"` is display-only — it is not a valid input to
-    /// [`ScopeTree::resolve_path`].
+    /// **Note:** The root path `"/"` is accepted by
+    /// [`ScopeTree::resolve_path`] as a root synonym, so the representation
+    /// round-trips: `resolve_path(path_for_id(root)) == Some(root_id())`.
     #[must_use]
     pub fn path_for_id(&self, scope_id: i64) -> Option<String> {
         if !self.nodes.contains_key(&scope_id) {
@@ -418,12 +428,14 @@ mod tests {
     fn resolve_path_root_synonyms() {
         // The root path produced by `path_for_id` ("/") must round-trip back
         // through `resolve_path` (#360 — eliminate the non-invertible
-        // representation). The empty string is also accepted as a root synonym,
-        // matching how `ScopeStore::ensure_path` treats the conceptual root.
+        // representation). The empty string is deliberately NOT a root synonym:
+        // it stays unresolvable, agreeing with the write path
+        // (`ScopeStore::ensure_path("")` errors) and avoiding the fail-open
+        // "empty scope query == the entire store" footgun.
         let tree = setup_tree();
         let root = ScopeTree::root_id();
         assert_eq!(tree.resolve_path("/"), Some(root));
-        assert_eq!(tree.resolve_path(""), Some(root));
+        assert_eq!(tree.resolve_path(""), None);
     }
 
     #[test]
@@ -445,6 +457,31 @@ mod tests {
         assert!(tree.resolve_path("user:michael//project:demo").is_none());
         assert!(tree.resolve_path("/user:michael").is_none());
         assert!(tree.resolve_path("user:michael/").is_none());
+    }
+
+    #[test]
+    fn resolve_query_empty_string_is_no_match_not_everything() {
+        // Guards the dangerous direction at the query boundary: an empty scope
+        // string must NOT resolve to root. If it did, `Subtree("")`/`Inherited("")`
+        // would expand to `subtree(root)` = every scope_id in the store, turning
+        // an empty/defaulted scope query into an unscoped scan over all facts —
+        // a fail-open hole for a scope-isolation primitive. All four variants
+        // must report `None` ("scope doesn't exist → no results"), the same as
+        // any other non-existent path.
+        let tree = setup_tree();
+        assert_eq!(tree.resolve_query(&ScopeQuery::Exact(String::new())), None);
+        assert_eq!(
+            tree.resolve_query(&ScopeQuery::Subtree(String::new())),
+            None
+        );
+        assert_eq!(
+            tree.resolve_query(&ScopeQuery::Ancestors(String::new())),
+            None
+        );
+        assert_eq!(
+            tree.resolve_query(&ScopeQuery::Inherited(String::new())),
+            None
+        );
     }
 
     #[test]

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -344,6 +344,56 @@ mod tests {
     }
 
     #[test]
+    fn resolve_query_ancestors() {
+        // `resolve_query` must dispatch `Ancestors` to `ancestors()` (not e.g.
+        // `subtree`). For demo the chain is demo -> user:michael -> root. (#322)
+        let tree = setup_tree();
+        let demo_id = tree.resolve_path("user:michael/project:demo").unwrap();
+        let ids = tree
+            .resolve_query(&ScopeQuery::Ancestors("user:michael/project:demo".into()))
+            .unwrap();
+        // Identical to the primitive — proves the arm routed to `ancestors`.
+        assert_eq!(ids, tree.ancestors(demo_id));
+        assert_eq!(ids.len(), 3);
+        assert_eq!(ids[0], demo_id);
+        assert_eq!(*ids.last().unwrap(), ScopeTree::root_id());
+    }
+
+    #[test]
+    fn resolve_query_inherited() {
+        // `resolve_query` must dispatch `Inherited` to `inherited()`. For
+        // user:michael that is ancestors [user, root] + descendants [demo,
+        // other], deduped to 4 unique ids. (#322)
+        let tree = setup_tree();
+        let user_id = tree.resolve_path("user:michael").unwrap();
+        let ids = tree
+            .resolve_query(&ScopeQuery::Inherited("user:michael".into()))
+            .unwrap();
+        // Identical to the primitive — proves the arm routed to `inherited`.
+        assert_eq!(ids, tree.inherited(user_id));
+        let mut unique = ids.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), 4, "expected user + root + demo + other");
+        assert!(ids.contains(&ScopeTree::root_id()));
+    }
+
+    #[test]
+    fn resolve_query_missing_path_returns_none() {
+        // Every arm short-circuits to None when the path does not resolve, so a
+        // nonexistent scope yields no ids regardless of query kind.
+        let tree = setup_tree();
+        for q in [
+            ScopeQuery::Exact("user:ghost".into()),
+            ScopeQuery::Subtree("user:ghost".into()),
+            ScopeQuery::Ancestors("user:ghost".into()),
+            ScopeQuery::Inherited("user:ghost".into()),
+        ] {
+            assert!(tree.resolve_query(&q).is_none(), "{q:?} should be None");
+        }
+    }
+
+    #[test]
     fn insert_idempotent() {
         let mut tree = setup_tree();
         let node_count_before = tree.nodes.len();

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -416,6 +416,57 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_roundtrip_preserves_tree() {
+        // `from_snapshot(to_snapshot())` is the crash-recovery path
+        // (engine/mod.rs builds the in-memory tree from a serialized snapshot on
+        // resume). Assert it reconstructs the tree faithfully: a future
+        // `ScopeNode` field left unwired in `from_snapshot` (or a dropped node)
+        // would silently lose scope hierarchy on restore, and this test catches
+        // it. (#323)
+        let tree = setup_tree(); // root -> user:michael -> {project:demo, project:other}
+        let rebuilt = ScopeTree::from_snapshot(&tree.to_snapshot());
+
+        // Same node set.
+        assert_eq!(rebuilt.node_count(), tree.node_count());
+
+        // Path resolution still works on the rebuilt tree.
+        let id = rebuilt
+            .resolve_path("user:michael/project:demo")
+            .expect("path must resolve in the rebuilt tree");
+        assert_eq!(id, tree.resolve_path("user:michael/project:demo").unwrap());
+
+        // Ancestor chain preserved: demo -> user:michael -> root.
+        let ancestors = rebuilt.ancestors(id);
+        assert_eq!(ancestors.len(), 3);
+        assert_eq!(*ancestors.last().unwrap(), ScopeTree::root_id());
+        assert_eq!(ancestors[0], id);
+
+        // path_for_id roundtrip preserved for every node, including siblings.
+        assert_eq!(
+            rebuilt.path_for_id(id).as_deref(),
+            Some("user:michael/project:demo")
+        );
+        let other_id = rebuilt.resolve_path("user:michael/project:other").unwrap();
+        assert_eq!(
+            rebuilt.path_for_id(other_id).as_deref(),
+            Some("user:michael/project:other")
+        );
+
+        // children maps agree node-for-node (the structural index, not just the
+        // node set): every parent resolves to the same descendant set.
+        for &node_id in &[
+            ScopeTree::root_id(),
+            tree.resolve_path("user:michael").unwrap(),
+        ] {
+            let mut a = rebuilt.subtree(node_id);
+            let mut b = tree.subtree(node_id);
+            a.sort_unstable();
+            b.sort_unstable();
+            assert_eq!(a, b, "subtree of {node_id} must survive the roundtrip");
+        }
+    }
+
+    #[test]
     fn inherited_non_leaf_dedups_self_once() {
         let tree = setup_tree();
         // user:michael is a NON-leaf: its subtree has 3 nodes (itself + 2

--- a/src/scope/tree.rs
+++ b/src/scope/tree.rs
@@ -59,12 +59,30 @@ impl ScopeTree {
     }
 
     /// Resolve a path string to a `scope_id` (read-only, no creation).
-    /// Returns `None` if any segment is missing.
+    ///
+    /// The empty string `""` and `"/"` both resolve to the root scope. `"/"` is
+    /// the canonical string [`ScopeTree::path_for_id`] renders for the root, so
+    /// `resolve_path(path_for_id(root))` round-trips rather than returning
+    /// `None` (the representation is invertible).
+    ///
+    /// For any other input, segments are separated by `/`. Returns `None` if any
+    /// segment does not exist in the cached tree, or if the path contains an
+    /// empty *inner* segment (e.g. a leading/trailing `/` or `//`).
     pub fn resolve_path(&self, path: &str) -> Option<i64> {
+        // Root synonyms: the canonical "/" rendered by `path_for_id`, and "" as
+        // the conceptual root. Handled up front so the per-segment loop never
+        // sees the empty inner segment they would otherwise split into.
+        if path.is_empty() || path == "/" {
+            return Some(Self::ROOT_ID);
+        }
         let mut current = Self::ROOT_ID; // start at root
         for segment in path.split('/') {
             let segment = segment.trim();
-            if segment.is_empty() {
+            // Shared structural validation (non-empty, no '/', <= 256 bytes) —
+            // the single source of truth in `crate::scope::validate_segment`,
+            // also used by `ScopeStore::ensure_path` on the write path. Any
+            // failure is indistinguishable from "not found" here, so map to None.
+            if super::validate_segment(segment).is_err() {
                 return None;
             }
             let child_ids = self.children.get(&current)?;
@@ -330,11 +348,44 @@ mod tests {
     #[test]
     fn path_for_id_root_returns_slash() {
         let tree = setup_tree();
-        // Root scope is the display-only "/" path (tree.rs:151-153).
+        // Root scope renders as the canonical "/" path.
         assert_eq!(
             tree.path_for_id(ScopeTree::root_id()),
             Some("/".to_string())
         );
+    }
+
+    #[test]
+    fn resolve_path_root_synonyms() {
+        // The root path produced by `path_for_id` ("/") must round-trip back
+        // through `resolve_path` (#360 — eliminate the non-invertible
+        // representation). The empty string is also accepted as a root synonym,
+        // matching how `ScopeStore::ensure_path` treats the conceptual root.
+        let tree = setup_tree();
+        let root = ScopeTree::root_id();
+        assert_eq!(tree.resolve_path("/"), Some(root));
+        assert_eq!(tree.resolve_path(""), Some(root));
+    }
+
+    #[test]
+    fn path_for_id_root_roundtrips_through_resolve_path() {
+        // The whole point of #360: `resolve_path(path_for_id(root))` resolves
+        // back to root rather than silently returning `None`.
+        let tree = setup_tree();
+        let root = ScopeTree::root_id();
+        let rendered = tree.path_for_id(root).expect("root has a path");
+        assert_eq!(tree.resolve_path(&rendered), Some(root));
+    }
+
+    #[test]
+    fn resolve_path_still_rejects_empty_inner_segment() {
+        // A leading/trailing "/" or "//" still yields an empty *inner* segment
+        // and must remain unresolvable — accepting the root synonym must not
+        // make malformed multi-segment paths resolve.
+        let tree = setup_tree();
+        assert!(tree.resolve_path("user:michael//project:demo").is_none());
+        assert!(tree.resolve_path("/user:michael").is_none());
+        assert!(tree.resolve_path("user:michael/").is_none());
     }
 
     #[test]

--- a/src/store/scopes.rs
+++ b/src/store/scopes.rs
@@ -58,6 +58,15 @@ impl<'a> ScopeStore<'a> {
     }
 
     /// Insert a scope under a parent. Returns the created node.
+    ///
+    /// **Does not validate the label.** Unlike [`Self::ensure_path`], this
+    /// low-level method inserts `label` verbatim — callers are responsible for
+    /// ensuring it is non-empty, contains no `/`, has no leading/trailing
+    /// whitespace, and is at most [`crate::scope::MAX_SEGMENT_LEN`] bytes (the
+    /// rules enforced by [`crate::scope::validate_segment`]). Storing a malformed
+    /// label here can break round-tripping through
+    /// [`crate::scope::ScopeTree::resolve_path`]. Prefer [`Self::ensure_path`]
+    /// for a validated, idempotent alternative.
     pub fn insert(&self, parent_id: i64, label: &str, depth: i64) -> Result<ScopeNode> {
         self.conn.execute(
             "INSERT INTO scopes (parent_id, label, depth) VALUES (?1, ?2, ?3)",

--- a/src/store/scopes.rs
+++ b/src/store/scopes.rs
@@ -72,24 +72,17 @@ impl<'a> ScopeStore<'a> {
         })
     }
 
-    /// Validate a scope label segment.
+    /// Validate a scope label segment (write path).
+    ///
+    /// Applies the shared structural rules from [`crate::scope::validate_segment`]
+    /// (non-empty, no `/`, at most 256 bytes) on the trimmed label, plus the
+    /// write-path-only rule that the label must have no leading/trailing
+    /// whitespace — so that stored labels always round-trip through
+    /// [`crate::scope::ScopeTree::resolve_path`].
     fn validate_label(label: &str) -> Result<()> {
         let trimmed = label.trim();
-        if trimmed.is_empty() {
-            return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
-                "scope label must not be empty".into(),
-            )));
-        }
-        if trimmed.contains('/') {
-            return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
-                "scope label must not contain '/'".into(),
-            )));
-        }
-        if trimmed.len() > 256 {
-            return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
-                "scope label must be at most 256 bytes".into(),
-            )));
-        }
+        crate::scope::validate_segment(trimmed)
+            .map_err(|reason| MemoryError::Conflict(ConflictError::ScopeLabel(reason.into())))?;
         if trimmed != label {
             return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
                 "scope label must not have leading/trailing whitespace".into(),

--- a/tests/eval/conformance/scope_isolation.rs
+++ b/tests/eval/conformance/scope_isolation.rs
@@ -141,6 +141,112 @@ fn unscoped_query_returns_all_facts() {
 }
 
 #[test]
+fn scope_ancestors_returns_self_and_parent_facts_not_sibling() {
+    // End-to-end coverage for MemoryQuery::scope_ancestors → ScopeQuery::Ancestors
+    // → ScopeTree::resolve_query dispatch (#322). Ancestors of a leaf are the
+    // leaf itself plus every parent up to root, so a fact at the parent scope
+    // must surface while a sibling-subtree fact must not.
+    let engine = eval_engine();
+
+    engine
+        .ensure_scope_path("user:alice")
+        .expect("ensure alice scope");
+
+    let parent_id = add_scoped_fact(
+        &engine,
+        "Alice parent-scope config",
+        FactType::Semantic,
+        "user:alice",
+    );
+    let child_id = add_scoped_fact(
+        &engine,
+        "Alice child deployment plan",
+        FactType::Semantic,
+        "user:alice/project:x",
+    );
+    let _sibling_id = add_scoped_fact(
+        &engine,
+        "Bob unrelated note",
+        FactType::Semantic,
+        "user:bob",
+    );
+
+    let response = engine
+        .execute_query(&MemoryQuery::new().scope_ancestors("user:alice/project:x"))
+        .expect("query failed");
+
+    let ids: Vec<i64> = response.results.iter().map(|r| r.fact.id).collect();
+    assert!(
+        ids.contains(&child_id),
+        "the queried scope's own fact must appear in an ancestors query"
+    );
+    assert!(
+        ids.contains(&parent_id),
+        "the parent scope's fact must appear in an ancestors query"
+    );
+    assert!(
+        !ids.iter().any(|id| {
+            let f = engine.get_fact(*id).unwrap();
+            f.content.contains("Bob")
+        }),
+        "a sibling-branch fact must NOT appear in an ancestors query; got {ids:?}"
+    );
+}
+
+#[test]
+fn scope_inherited_includes_ancestors_and_descendants_not_unrelated() {
+    // End-to-end coverage for MemoryQuery::scope_inherited → ScopeQuery::Inherited
+    // → ScopeTree::resolve_query dispatch (#322). Inherited context is ancestors
+    // PLUS the subtree of the queried scope, so both a parent fact and a child
+    // fact surface while an unrelated branch does not.
+    let engine = eval_engine();
+
+    engine
+        .ensure_scope_path("user:alice")
+        .expect("ensure alice scope");
+
+    let parent_id = add_scoped_fact(
+        &engine,
+        "Alice parent-scope config",
+        FactType::Semantic,
+        "user:alice",
+    );
+    let child_id = add_scoped_fact(
+        &engine,
+        "Alice child env settings",
+        FactType::Semantic,
+        "user:alice/project:x",
+    );
+    let _other_id = add_scoped_fact(
+        &engine,
+        "Bob unrelated fact",
+        FactType::Semantic,
+        "user:bob",
+    );
+
+    let response = engine
+        .execute_query(&MemoryQuery::new().scope_inherited("user:alice"))
+        .expect("query failed");
+
+    let ids: Vec<i64> = response.results.iter().map(|r| r.fact.id).collect();
+    assert!(
+        ids.contains(&parent_id),
+        "the queried scope's own fact must appear in an inherited query"
+    );
+    assert!(
+        ids.contains(&child_id),
+        "a descendant fact must appear in an inherited query"
+    );
+    assert!(
+        !ids.iter().any(|id| {
+            let f = engine.get_fact(*id).unwrap();
+            f.content.contains("Bob")
+        }),
+        "an unrelated-branch fact must NOT appear in an inherited query; got {ids:?}"
+    );
+}
+
+#[test]
 fn scope_exact_does_not_include_parent_facts() {
     let engine = eval_engine();
 

--- a/tests/eval/conformance/scope_isolation.rs
+++ b/tests/eval/conformance/scope_isolation.rs
@@ -247,6 +247,57 @@ fn scope_inherited_includes_ancestors_and_descendants_not_unrelated() {
 }
 
 #[test]
+fn empty_scope_string_returns_no_facts_not_everything() {
+    // Caller-level regression for the empty-string fail-open (#360 follow-up).
+    // An empty scope-query string must be treated as a non-existent scope ("no
+    // results"), NOT silently resolved to root. If `resolve_path("")` returned
+    // root, `scope_exact("")` would surface the root scope's facts and, worse,
+    // `scope_subtree("")` would expand to subtree(root) = EVERY fact across
+    // EVERY context — leaking all facts through a blank/defaulted scope field.
+    // This guards the boundary that actually flips (engine/query.rs), which the
+    // tree-level unit tests don't exercise end-to-end.
+    let engine = eval_engine();
+
+    add_scoped_fact(&engine, "Alice fact", FactType::Semantic, "project:alpha");
+    add_scoped_fact(&engine, "Bob fact", FactType::Semantic, "project:beta");
+
+    let exact = engine
+        .execute_query(&MemoryQuery::new().scope_exact(""))
+        .expect("query failed");
+    assert!(
+        exact.results.is_empty(),
+        "empty scope_exact must return zero results, not root facts; got {:?}",
+        exact.results.iter().map(|r| r.fact.id).collect::<Vec<_>>()
+    );
+
+    let subtree = engine
+        .execute_query(&MemoryQuery::new().scope_subtree(""))
+        .expect("query failed");
+    assert!(
+        subtree.results.is_empty(),
+        "empty scope_subtree must NOT leak the whole store (subtree(root)); got {:?}",
+        subtree
+            .results
+            .iter()
+            .map(|r| r.fact.id)
+            .collect::<Vec<_>>()
+    );
+
+    let inherited = engine
+        .execute_query(&MemoryQuery::new().scope_inherited(""))
+        .expect("query failed");
+    assert!(
+        inherited.results.is_empty(),
+        "empty scope_inherited must NOT leak the whole store; got {:?}",
+        inherited
+            .results
+            .iter()
+            .map(|r| r.fact.id)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn scope_exact_does_not_include_parent_facts() {
     let engine = eval_engine();
 


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 1). Subsystem-cohesive PR closing 6 findings.

## Findings closed

- **#322** [test/medium] — ScopeQuery::Ancestors and ::Inherited dispatch via resolve_query has no test
- **#323** [test/medium] — ScopeTree::to_snapshot/from_snapshot has no roundtrip test
- **#360** [refactor/medium] — path_for_id(root) returns "/" which resolve_path cannot parse back (non-invertible)
- **#361** [refactor/medium] — resolve_path silently returns None for inputs validate_label would reject (validation asymmetry)
- **#383** [docs/medium] — resolve_path silently trims segments — undocumented, diverges from ensure_path
- **#384** [docs/medium] — ScopeStore::insert bypasses validate_label — no doc warning

## Review (internal diverse-lens subagents — no external models)

3 clean-slate adversarial reviewers (correctness / security & soundness / api-surface & test-quality): **0 blocker, 3 major** found.

All blocker/major **addressed** in fix commits (4):
- MAJOR (tree.rs:84-86, correctness) — fail-open on empty path: dropped the `path.is_empty()` arm in resolve_path; only `path == "/"` (the canonical render of root by path_for_id) is now a root synonym. `resolve_path("")` returns None again (as on main), restoring fail-closed handling for load_context
- MAJOR (tree.rs:210-211, security & soundness) — self-contradicting doc: updated path_for_id's doc note. Replaced 'The root path "/" is display-only — it is not a valid input to resolve_path' with a note stating "/" is accepted as a root synonym and `resolve_path(path_for_id(root)) == Some(root_id())
- MAJOR (tree.rs:80-86, api-surface & test-quality) — behavior change with no caller-level test + false-premise justification: chose the safer feature-level option (empty scope string = 'no match', NOT 'entire tree'), which also fixes the false rationale (ensure_path("") errors at scopes.rs:110-114, s
- Supporting doc edits: resolve_path doc (tree.rs:63-66) and inline comment (tree.rs:81-83) rewritten to state ""->None and explain why, agreeing with the write path.

## Gate
`cargo build/test/clippy --workspace` + `cargo fmt --check` — green (rebased on current main).

Fixes #322, fixes #323, fixes #360, fixes #361, fixes #383, fixes #384