### PR TITLE
fix(core): bound snapshot deserialization + property tests (#254 wave1)

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -830,3 +830,171 @@ impl Drop for MemoryEngine {
         }
     }
 }
+
+/// Property-based coverage for the pure bi-temporal filter helpers (#450).
+///
+/// `passes_temporal_cutoff` and `fact_overlaps_period` encode interval
+/// containment / overlap algebra — exactly the place `<` vs `<=` off-by-one
+/// errors hide and example tests routinely miss. These proptests pin the
+/// helpers to their algebraic spec and to monotonicity laws. Placed at the
+/// end of the file so no non-test items follow a `#[cfg(test)]` module
+/// (`clippy::items_after_test_module`).
+#[cfg(test)]
+mod proptest_temporal {
+    use chrono::{DateTime, Utc};
+    use proptest::prelude::*;
+
+    use super::{fact_overlaps_period, passes_temporal_cutoff};
+    use crate::types::{Fact, FactType};
+
+    /// Build a `Fact` carrying only the valid-time fields the helpers read;
+    /// every other field is an inert placeholder.
+    fn make_fact(t_valid: Option<DateTime<Utc>>, t_invalid: Option<DateTime<Utc>>) -> Fact {
+        Fact {
+            id: 1,
+            content: String::new(),
+            content_hash: String::new(),
+            embedding: vec![],
+            fact_type: FactType::Semantic,
+            t_created: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+            t_expired: None,
+            t_valid,
+            t_invalid,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+            metadata: serde_json::Value::Null,
+            scope_id: 1,
+            is_pinned: false,
+            importance_score: 0.0,
+            surfaced_at: None,
+        }
+    }
+
+    prop_compose! {
+        /// Timestamps as whole seconds in a wide but always-valid range, so
+        /// `from_timestamp` never returns `None`.
+        fn arb_ts()(s in 0i64..=4_000_000_000) -> DateTime<Utc> {
+            DateTime::<Utc>::from_timestamp(s, 0).unwrap()
+        }
+    }
+
+    /// Reference spec for `passes_temporal_cutoff`, written independently of the
+    /// implementation so the proptest is a genuine cross-check, not a tautology.
+    fn spec_passes(
+        t_valid: Option<DateTime<Utc>>,
+        t_invalid: Option<DateTime<Utc>>,
+        cutoff: DateTime<Utc>,
+    ) -> bool {
+        let valid_ok = t_valid.is_none_or(|tv| tv <= cutoff);
+        let invalid_ok = t_invalid.is_none_or(|ti| ti > cutoff);
+        valid_ok && invalid_ok
+    }
+
+    /// Reference spec for `fact_overlaps_period`.
+    fn spec_overlaps(
+        t_valid: Option<DateTime<Utc>>,
+        t_invalid: Option<DateTime<Utc>>,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> bool {
+        t_valid.is_none_or(|tv| tv < end) && t_invalid.is_none_or(|ti| ti > start)
+    }
+
+    proptest! {
+        /// The helper agrees with its independent spec for all inputs (catches
+        /// any `<`/`<=`/`>`/`>=` off-by-one regression).
+        #[test]
+        fn cutoff_matches_spec(
+            t_valid in proptest::option::of(arb_ts()),
+            t_invalid in proptest::option::of(arb_ts()),
+            cutoff in arb_ts(),
+        ) {
+            let fact = make_fact(t_valid, t_invalid);
+            prop_assert_eq!(
+                passes_temporal_cutoff(&fact, cutoff),
+                spec_passes(t_valid, t_invalid, cutoff)
+            );
+        }
+
+        /// With `t_invalid` unbounded, passing is monotone in `cutoff`: once a
+        /// fact is valid at `cutoff` it stays valid at every later instant.
+        #[test]
+        fn cutoff_monotone_when_open_ended(
+            t_valid in proptest::option::of(arb_ts()),
+            cutoff in arb_ts(),
+            delta in 0i64..=1_000_000,
+        ) {
+            let fact = make_fact(t_valid, None);
+            let later = DateTime::<Utc>::from_timestamp(cutoff.timestamp() + delta, 0).unwrap();
+            if passes_temporal_cutoff(&fact, cutoff) {
+                prop_assert!(passes_temporal_cutoff(&fact, later));
+            }
+        }
+
+        /// A fact whose validity starts strictly after `cutoff` never passes.
+        #[test]
+        fn cutoff_rejects_future_t_valid(
+            cutoff in arb_ts(),
+            delta in 1i64..=1_000_000,
+            t_invalid in proptest::option::of(arb_ts()),
+        ) {
+            let t_valid = DateTime::<Utc>::from_timestamp(cutoff.timestamp() + delta, 0).unwrap();
+            let fact = make_fact(Some(t_valid), t_invalid);
+            prop_assert!(!passes_temporal_cutoff(&fact, cutoff));
+        }
+
+        /// The helper agrees with its independent spec for all inputs.
+        #[test]
+        fn overlap_matches_spec(
+            t_valid in proptest::option::of(arb_ts()),
+            t_invalid in proptest::option::of(arb_ts()),
+            a in arb_ts(),
+            b in arb_ts(),
+        ) {
+            // Normalize to a non-empty half-open window [start, end).
+            let (start, end) = if a < b { (a, b) } else { (b, a) };
+            prop_assume!(start < end);
+            let fact = make_fact(t_valid, t_invalid);
+            prop_assert_eq!(
+                fact_overlaps_period(&fact, start, end),
+                spec_overlaps(t_valid, t_invalid, start, end)
+            );
+        }
+
+        /// Overlap is monotone under window widening: if a fact overlaps
+        /// `[start, end)` it overlaps any superset window `[start', end')` with
+        /// `start' <= start` and `end' >= end`.
+        #[test]
+        fn overlap_monotone_under_widening(
+            t_valid in proptest::option::of(arb_ts()),
+            t_invalid in proptest::option::of(arb_ts()),
+            a in arb_ts(),
+            b in arb_ts(),
+            grow_left in 0i64..=1_000_000,
+            grow_right in 0i64..=1_000_000,
+        ) {
+            let (start, end) = if a < b { (a, b) } else { (b, a) };
+            prop_assume!(start < end);
+            let fact = make_fact(t_valid, t_invalid);
+            if fact_overlaps_period(&fact, start, end) {
+                let wider_start =
+                    DateTime::<Utc>::from_timestamp(start.timestamp() - grow_left, 0).unwrap();
+                let wider_end =
+                    DateTime::<Utc>::from_timestamp(end.timestamp() + grow_right, 0).unwrap();
+                prop_assert!(fact_overlaps_period(&fact, wider_start, wider_end));
+            }
+        }
+
+        /// A fact unbounded on both valid-time ends overlaps every non-empty
+        /// window.
+        #[test]
+        fn unbounded_fact_overlaps_everything(a in arb_ts(), b in arb_ts()) {
+            let (start, end) = if a < b { (a, b) } else { (b, a) };
+            prop_assume!(start < end);
+            let fact = make_fact(None, None);
+            prop_assert!(fact_overlaps_period(&fact, start, end));
+        }
+    }
+}

--- a/src/engine/snapshot.rs
+++ b/src/engine/snapshot.rs
@@ -33,22 +33,70 @@ const BLAKE3_LEN: usize = 32;
 
 /// Hard upper bound on the on-disk size of a `.snapshot` sidecar (512 MiB).
 ///
-/// Security guard against allocation denial-of-service (CWE-400/502/789):
-/// `load_from_file` reads the whole file into memory and
-/// `rmp_serde::from_slice` allocates `Vec`s sized by
-/// in-band `MessagePack` array-length prefixes. The blake3 checksum is *unkeyed*
-/// — it is a corruption check, not an authenticity control — so any actor able
-/// to write the sidecar (a local tamper / shared-data-dir threat) can produce a
-/// file that passes the checksum yet declares pathological lengths. Rejecting
-/// before `fs::read` caps the worst case at this many bytes. Tune to the
-/// expected corpus; a real snapshot is dominated by HNSW embeddings.
+/// Bounds the wholesale `fs::read` of an oversized or tampered sidecar
+/// (CWE-400, resource exhaustion via large on-disk file). `load_from_file`
+/// slurps the entire file into a `Vec<u8>` before parsing; rejecting on
+/// `fs::metadata` first caps that read at this many bytes regardless of what
+/// the file claims to contain.
+///
+/// This does **not** defend against in-band `MessagePack` length prefixes:
+/// `rmp_serde` reports the declared `SeqAccess::size_hint`, but serde's `Vec`
+/// deserializer routes every preallocation through `size_hint::cautious`, which
+/// caps `with_capacity` at 1 MiB worth of elements (`MAX_PREALLOC_BYTES`) and
+/// then grows the vector incrementally as real elements are decoded. A small
+/// crafted file therefore cannot force a multi-gigabyte allocation — it simply
+/// errors out of input long before that — so no per-entry-length `DoS` exists for
+/// this guard to mitigate. The complementary integrity defense is the per-entry
+/// embedding-dimension check in `load_from_file` (runs *after* deserialization).
+///
+/// The blake3 checksum is *unkeyed* — a corruption check, not an authenticity
+/// control — so an actor able to write the sidecar (local tamper /
+/// shared-data-dir threat) can still produce a checksum-passing file; the size
+/// cap and the dim check are what bound the blast radius of such a file. Tune to
+/// the expected corpus; a real snapshot is dominated by HNSW embeddings.
 const MAX_SNAPSHOT_BYTES: u64 = 512 * 1024 * 1024;
 
-/// Whether an on-disk size exceeds the [`MAX_SNAPSHOT_BYTES`] cap.
+/// Outcome of the pre-read size gate in [`load_from_file`].
 ///
-/// Boundary is `>` so a file exactly at the cap is still accepted.
-const fn exceeds_size_cap(len: u64) -> bool {
-    len > MAX_SNAPSHOT_BYTES
+/// Separating this from the read makes the short-circuit observable in tests
+/// (a `cap` parameter lets a test prove the over-cap branch fires *before* any
+/// `fs::read`, without materializing a half-gigabyte file).
+#[derive(Debug, PartialEq, Eq)]
+enum SizeGate {
+    /// File is within the cap (or its size is unknown but acceptable); proceed
+    /// to read it.
+    Proceed,
+    /// File exceeds the cap, or its metadata could not be read; abort before
+    /// reading and fall back to a full rebuild.
+    Reject,
+}
+
+/// Decide, from filesystem metadata alone, whether a sidecar is small enough to
+/// read into memory. Rejects over-cap files *before* `fs::read` so a crafted or
+/// tampered large file cannot drive a wholesale slurp into a `Vec<u8>`.
+///
+/// `cap` is a parameter (not the hardcoded const) purely so tests can exercise
+/// the gate against a small real file with a small cap — deleting the size check
+/// here is then an observable test failure, not just a slower path.
+fn size_gate(path: &Path, cap: u64) -> SizeGate {
+    match fs::metadata(path) {
+        Ok(meta) if meta.len() > cap => {
+            tracing::warn!(
+                path = %path.display(),
+                size = meta.len(),
+                cap,
+                "snapshot exceeds size cap, discarding"
+            );
+            SizeGate::Reject
+        }
+        Ok(_) => SizeGate::Proceed,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(path = %path.display(), error = %e, "snapshot metadata failed");
+            }
+            SizeGate::Reject
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -224,28 +272,14 @@ pub fn write_to_file(
 /// mismatch, checksum failure, `embed_dim` mismatch). Never errors — all
 /// failures are logged and treated as "snapshot unavailable".
 pub fn load_from_file(path: &Path, embed_dim: usize) -> Option<(SnapshotHeader, SnapshotPayload)> {
-    // Size guard BEFORE reading the file into memory: a crafted/corrupt sidecar
-    // must not be slurped wholesale, and its in-band length prefixes must not be
-    // allowed to drive an unbounded `Vec` allocation. blake3 is unkeyed and so
-    // is not an authenticity gate (see MAX_SNAPSHOT_BYTES). On metadata failure
-    // (other than NotFound) we discard and fall back to a full rebuild.
-    match fs::metadata(path) {
-        Ok(meta) if exceeds_size_cap(meta.len()) => {
-            tracing::warn!(
-                path = %path.display(),
-                size = meta.len(),
-                cap = MAX_SNAPSHOT_BYTES,
-                "snapshot exceeds size cap, discarding"
-            );
-            return None;
-        }
-        Ok(_) => {}
-        Err(e) => {
-            if e.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!(path = %path.display(), error = %e, "snapshot metadata failed");
-            }
-            return None;
-        }
+    // Size guard BEFORE reading the file into memory: an oversized or tampered
+    // sidecar must not be slurped wholesale into a Vec<u8> (see
+    // MAX_SNAPSHOT_BYTES). This bounds the on-disk read only; in-band length
+    // prefixes are already bounded by serde's cautious preallocation cap. blake3
+    // is unkeyed and so is not an authenticity gate. On metadata failure (other
+    // than NotFound) we discard and fall back to a full rebuild.
+    if size_gate(path, MAX_SNAPSHOT_BYTES) == SizeGate::Reject {
+        return None;
     }
 
     let data = match fs::read(path) {
@@ -558,12 +592,43 @@ mod tests {
     }
 
     #[test]
-    fn oversized_file_returns_none() {
-        // Security (#411): a sidecar larger than MAX_SNAPSHOT_BYTES must be
-        // rejected before `fs::read` so a crafted/corrupt file cannot force a
-        // multi-gigabyte allocation. A sparse file (set_len) reports the
-        // logical size in metadata without consuming disk blocks, so we can
-        // exercise the real cap without writing 512 MiB.
+    fn size_gate_rejects_over_cap_before_read() {
+        // Security (#411): the size gate must REJECT a file larger than the cap
+        // *before* `fs::read`, so a crafted/corrupt file cannot force a
+        // wholesale slurp into memory. This is the load-bearing short-circuit —
+        // and it is what makes deleting the size check an observable failure
+        // (the outcome `None` alone is not, since content checks also reject
+        // garbage; see `oversized_sparse_file_still_returns_none`).
+        //
+        // We use a SMALL real file with a SMALL cap to exercise the exact
+        // over-cap branch with zero large allocations: write a few KiB, set the
+        // cap below it, and assert Reject. A complementary small cap above the
+        // file size yields Proceed, pinning the boundary on a real path.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small.db.snapshot");
+        fs::write(&path, vec![0u8; 4096]).unwrap();
+
+        // File (4096 B) over a 1024 B cap → the gate rejects before any read.
+        assert_eq!(size_gate(&path, 1024), SizeGate::Reject);
+        // File (4096 B) under an 8192 B cap → the gate lets the read proceed.
+        assert_eq!(size_gate(&path, 8192), SizeGate::Proceed);
+        // Missing file → reject (NotFound is silent; still a reject).
+        assert_eq!(
+            size_gate(&dir.path().join("absent.snapshot"), 8192),
+            SizeGate::Reject
+        );
+    }
+
+    #[test]
+    fn oversized_sparse_file_still_returns_none() {
+        // Companion to `size_gate_rejects_over_cap_before_read`: the public
+        // entry point returns None for a file whose metadata exceeds the real
+        // cap. A sparse file (set_len) reports the logical size without
+        // consuming disk blocks, so we exercise the actual MAX_SNAPSHOT_BYTES
+        // without writing 512 MiB. NOTE: this pins only the OUTCOME (None) — the
+        // short-circuit-before-read property is pinned by the `size_gate` unit
+        // test above, because an all-zero file is also rejected on the content
+        // path.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("huge.db.snapshot");
         let f = fs::File::create(&path).unwrap();
@@ -574,22 +639,24 @@ mod tests {
     }
 
     #[test]
-    fn file_at_size_cap_is_not_rejected_for_size() {
-        // A file exactly at the cap passes the size guard (it then fails later
-        // on content, but NOT on the size check). This pins the boundary as
-        // `>` not `>=` so a legitimately large corpus at the limit still loads.
+    fn size_cap_boundary_is_exclusive() {
+        // The cap boundary is `>` not `>=`: a file exactly at the cap passes the
+        // size gate so a legitimately large corpus at the limit still loads,
+        // while one byte over is rejected. Pinned on a real path via `size_gate`
+        // with a SMALL cap — a small file straddles a small cap with zero large
+        // allocations, instead of materializing a half-gigabyte file (a
+        // `set_len` + `load_from_file` would `fs::read` 512 MiB of zeros for zero
+        // extra coverage, risking OOM under cargo's parallel test harness).
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("at_cap.db.snapshot");
-        let f = fs::File::create(&path).unwrap();
-        f.set_len(MAX_SNAPSHOT_BYTES).unwrap();
-        drop(f);
+        let path = dir.path().join("boundary.db.snapshot");
+        let cap: usize = 4096;
+        fs::write(&path, vec![0u8; cap]).unwrap();
+        // Exactly at the cap → proceed (boundary is exclusive).
+        assert_eq!(size_gate(&path, cap as u64), SizeGate::Proceed);
 
-        // The all-zero sparse content is not a valid snapshot, so this returns
-        // None — but via the content path, having passed the size guard. We
-        // assert the size guard itself does not trip at exactly the cap.
-        assert!(!exceeds_size_cap(MAX_SNAPSHOT_BYTES));
-        assert!(exceeds_size_cap(MAX_SNAPSHOT_BYTES + 1));
-        assert!(load_from_file(&path, 128).is_none());
+        // One byte over the cap → reject.
+        fs::write(&path, vec![0u8; cap + 1]).unwrap();
+        assert_eq!(size_gate(&path, cap as u64), SizeGate::Reject);
     }
 
     #[test]

--- a/src/engine/snapshot.rs
+++ b/src/engine/snapshot.rs
@@ -31,6 +31,26 @@ pub const FORMAT_VERSION: u32 = 1;
 /// Size of the blake3 checksum appended to the file.
 const BLAKE3_LEN: usize = 32;
 
+/// Hard upper bound on the on-disk size of a `.snapshot` sidecar (512 MiB).
+///
+/// Security guard against allocation denial-of-service (CWE-400/502/789):
+/// `load_from_file` reads the whole file into memory and
+/// `rmp_serde::from_slice` allocates `Vec`s sized by
+/// in-band `MessagePack` array-length prefixes. The blake3 checksum is *unkeyed*
+/// — it is a corruption check, not an authenticity control — so any actor able
+/// to write the sidecar (a local tamper / shared-data-dir threat) can produce a
+/// file that passes the checksum yet declares pathological lengths. Rejecting
+/// before `fs::read` caps the worst case at this many bytes. Tune to the
+/// expected corpus; a real snapshot is dominated by HNSW embeddings.
+const MAX_SNAPSHOT_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Whether an on-disk size exceeds the [`MAX_SNAPSHOT_BYTES`] cap.
+///
+/// Boundary is `>` so a file exactly at the cap is still accepted.
+const fn exceeds_size_cap(len: u64) -> bool {
+    len > MAX_SNAPSHOT_BYTES
+}
+
 // ---------------------------------------------------------------------------
 // Snapshot types (decoupled from internal representations)
 // ---------------------------------------------------------------------------
@@ -204,6 +224,30 @@ pub fn write_to_file(
 /// mismatch, checksum failure, `embed_dim` mismatch). Never errors — all
 /// failures are logged and treated as "snapshot unavailable".
 pub fn load_from_file(path: &Path, embed_dim: usize) -> Option<(SnapshotHeader, SnapshotPayload)> {
+    // Size guard BEFORE reading the file into memory: a crafted/corrupt sidecar
+    // must not be slurped wholesale, and its in-band length prefixes must not be
+    // allowed to drive an unbounded `Vec` allocation. blake3 is unkeyed and so
+    // is not an authenticity gate (see MAX_SNAPSHOT_BYTES). On metadata failure
+    // (other than NotFound) we discard and fall back to a full rebuild.
+    match fs::metadata(path) {
+        Ok(meta) if exceeds_size_cap(meta.len()) => {
+            tracing::warn!(
+                path = %path.display(),
+                size = meta.len(),
+                cap = MAX_SNAPSHOT_BYTES,
+                "snapshot exceeds size cap, discarding"
+            );
+            return None;
+        }
+        Ok(_) => {}
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(path = %path.display(), error = %e, "snapshot metadata failed");
+            }
+            return None;
+        }
+    }
+
     let data = match fs::read(path) {
         Ok(d) => d,
         Err(e) => {
@@ -278,6 +322,24 @@ pub fn load_from_file(path: &Path, embed_dim: usize) -> Option<(SnapshotHeader, 
             return None;
         }
     };
+
+    // 4. Post-validate per-entry embedding dimensions. The header `embed_dim`
+    //    check above only guards the declared dimension, not the actual vectors
+    //    inside each `HnswEntry`. A corrupt/tampered payload could carry a
+    //    wrong-length embedding that the header still claims is `embed_dim`;
+    //    feeding that into the HNSW rebuild would be a latent dimension bug.
+    if let Some(hnsw) = &payload.hnsw {
+        if let Some(bad) = hnsw.entries.iter().find(|e| e.embedding.len() != embed_dim) {
+            tracing::warn!(
+                path = %path.display(),
+                fact_id = bad.fact_id,
+                entry_dim = bad.embedding.len(),
+                expected = embed_dim,
+                "snapshot HNSW entry embedding dimension mismatch, discarding"
+            );
+            return None;
+        }
+    }
 
     Some((header, payload))
 }
@@ -493,6 +555,116 @@ mod tests {
         assert_eq!(p.graph.edges[0].edge_id, 1);
         assert_eq!(p.scope_tree.nodes.len(), 1);
         assert!(p.hnsw.is_none());
+    }
+
+    #[test]
+    fn oversized_file_returns_none() {
+        // Security (#411): a sidecar larger than MAX_SNAPSHOT_BYTES must be
+        // rejected before `fs::read` so a crafted/corrupt file cannot force a
+        // multi-gigabyte allocation. A sparse file (set_len) reports the
+        // logical size in metadata without consuming disk blocks, so we can
+        // exercise the real cap without writing 512 MiB.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.db.snapshot");
+        let f = fs::File::create(&path).unwrap();
+        f.set_len(MAX_SNAPSHOT_BYTES + 1).unwrap();
+        drop(f);
+
+        assert!(load_from_file(&path, 128).is_none());
+    }
+
+    #[test]
+    fn file_at_size_cap_is_not_rejected_for_size() {
+        // A file exactly at the cap passes the size guard (it then fails later
+        // on content, but NOT on the size check). This pins the boundary as
+        // `>` not `>=` so a legitimately large corpus at the limit still loads.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("at_cap.db.snapshot");
+        let f = fs::File::create(&path).unwrap();
+        f.set_len(MAX_SNAPSHOT_BYTES).unwrap();
+        drop(f);
+
+        // The all-zero sparse content is not a valid snapshot, so this returns
+        // None — but via the content path, having passed the size guard. We
+        // assert the size guard itself does not trip at exactly the cap.
+        assert!(!exceeds_size_cap(MAX_SNAPSHOT_BYTES));
+        assert!(exceeds_size_cap(MAX_SNAPSHOT_BYTES + 1));
+        assert!(load_from_file(&path, 128).is_none());
+    }
+
+    #[test]
+    fn mismatched_entry_embedding_dim_returns_none() {
+        // Security/integrity (#411): the header `embed_dim` check does not
+        // validate per-entry embedding lengths. A payload whose HnswEntry
+        // carries a wrong-dimension vector (corruption or tamper) must be
+        // rejected rather than fed into the index rebuild.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad_dim.db.snapshot");
+
+        let header = SnapshotHeader {
+            format_version: FORMAT_VERSION,
+            fingerprint: DbFingerprint {
+                max_fact_id: 0,
+                active_fact_count: 0,
+                max_edge_id: 0,
+                active_edge_count: 0,
+                max_scope_id: 1,
+                scope_count: 1,
+            },
+            embed_dim: 4,
+            engine_version: "test".into(),
+        };
+        let payload = SnapshotPayload {
+            graph: GraphSnapshot { edges: vec![] },
+            scope_tree: ScopeTreeSnapshot { nodes: vec![] },
+            hnsw: Some(HnswSnapshot {
+                entries: vec![HnswEntry {
+                    fact_id: 1,
+                    // 3 components, but embed_dim is 4 → mismatch.
+                    embedding: vec![0.1, 0.2, 0.3],
+                }],
+            }),
+        };
+
+        write_to_file(&header, &payload, &path).unwrap();
+        assert!(load_from_file(&path, 4).is_none());
+    }
+
+    #[test]
+    fn matching_entry_embedding_dim_loads() {
+        // Counterpart to the mismatch test: a payload whose entry embedding
+        // matches `embed_dim` loads successfully (the validation does not
+        // reject well-formed data).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("good_dim.db.snapshot");
+
+        let header = SnapshotHeader {
+            format_version: FORMAT_VERSION,
+            fingerprint: DbFingerprint {
+                max_fact_id: 0,
+                active_fact_count: 0,
+                max_edge_id: 0,
+                active_edge_count: 0,
+                max_scope_id: 1,
+                scope_count: 1,
+            },
+            embed_dim: 4,
+            engine_version: "test".into(),
+        };
+        let payload = SnapshotPayload {
+            graph: GraphSnapshot { edges: vec![] },
+            scope_tree: ScopeTreeSnapshot { nodes: vec![] },
+            hnsw: Some(HnswSnapshot {
+                entries: vec![HnswEntry {
+                    fact_id: 1,
+                    embedding: vec![0.1, 0.2, 0.3, 0.4],
+                }],
+            }),
+        };
+
+        write_to_file(&header, &payload, &path).unwrap();
+        let (_, p) = load_from_file(&path, 4).expect("matching dim should load");
+        assert_eq!(p.hnsw.unwrap().entries.len(), 1);
     }
 
     #[test]

--- a/src/engine/snapshot.rs
+++ b/src/engine/snapshot.rs
@@ -80,6 +80,16 @@ enum SizeGate {
 /// here is then an observable test failure, not just a slower path.
 fn size_gate(path: &Path, cap: u64) -> SizeGate {
     match fs::metadata(path) {
+        Ok(meta) if !meta.is_file() => {
+            // A directory's `len()` is small and platform-dependent, so it would
+            // otherwise slip past the size check and fail later with a generic
+            // read error. Reject non-regular-files up front with a clear warning.
+            tracing::warn!(
+                path = %path.display(),
+                "snapshot path is not a regular file, discarding"
+            );
+            SizeGate::Reject
+        }
         Ok(meta) if meta.len() > cap => {
             tracing::warn!(
                 path = %path.display(),
@@ -619,6 +629,9 @@ mod tests {
             size_gate(&dir.path().join("absent.snapshot"), 8192),
             SizeGate::Reject
         );
+        // A directory (metadata succeeds, small len) must be rejected as a
+        // non-regular-file before the size check, not slip through to fs::read.
+        assert_eq!(size_gate(dir.path(), 8192), SizeGate::Reject);
     }
 
     #[test]

--- a/src/engine/snapshot.rs
+++ b/src/engine/snapshot.rs
@@ -362,17 +362,19 @@ pub fn load_from_file(path: &Path, embed_dim: usize) -> Option<(SnapshotHeader, 
     //    inside each `HnswEntry`. A corrupt/tampered payload could carry a
     //    wrong-length embedding that the header still claims is `embed_dim`;
     //    feeding that into the HNSW rebuild would be a latent dimension bug.
-    if let Some(hnsw) = &payload.hnsw {
-        if let Some(bad) = hnsw.entries.iter().find(|e| e.embedding.len() != embed_dim) {
-            tracing::warn!(
-                path = %path.display(),
-                fact_id = bad.fact_id,
-                entry_dim = bad.embedding.len(),
-                expected = embed_dim,
-                "snapshot HNSW entry embedding dimension mismatch, discarding"
-            );
-            return None;
-        }
+    if let Some(bad) = payload
+        .hnsw
+        .as_ref()
+        .and_then(|hnsw| hnsw.entries.iter().find(|e| e.embedding.len() != embed_dim))
+    {
+        tracing::warn!(
+            path = %path.display(),
+            fact_id = bad.fact_id,
+            entry_dim = bad.embedding.len(),
+            expected = embed_dim,
+            "snapshot HNSW entry embedding dimension mismatch, discarding"
+        );
+        return None;
     }
 
     Some((header, payload))

--- a/src/engine/snapshot.rs
+++ b/src/engine/snapshot.rs
@@ -687,4 +687,189 @@ mod tests {
         let full: SnapshotPayload = rmp_serde::from_slice(&bytes).unwrap();
         assert!(full.hnsw.is_none());
     }
+
+    // -----------------------------------------------------------------------
+    // Property-based coverage (#451)
+    //
+    // The example tests above exercise the happy path and each individual
+    // reject branch. These proptests stress the `write_to_file` →
+    // `load_from_file` pipeline (two MessagePack serializations + a u32 LE
+    // header length + a blake3 integrity check) over arbitrary field values —
+    // including i64 boundaries (MIN/MAX) and random collection counts — and
+    // assert the integrity-protected region rejects any single-byte mutation.
+    // -----------------------------------------------------------------------
+    mod proptest_roundtrip {
+        // Bit-exact equality is the whole point of a serde roundtrip test: a
+        // faithfully written then loaded `f32`/`f64` must be identical. We
+        // exclude NaN in the strategies, so `==` is well-defined here.
+        #![allow(clippy::float_cmp)]
+
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Embedding dimensions kept small to keep generated payloads cheap;
+        /// the dimension is the only field both serialized into the header and
+        /// cross-checked against each `HnswEntry`, so it is the interesting one.
+        const DIM_RANGE: std::ops::RangeInclusive<usize> = 1..=8;
+
+        prop_compose! {
+            fn arb_fingerprint()(
+                max_fact_id in any::<i64>(),
+                active_fact_count in any::<i64>(),
+                max_edge_id in any::<i64>(),
+                active_edge_count in any::<i64>(),
+                max_scope_id in any::<i64>(),
+                scope_count in any::<i64>(),
+            ) -> DbFingerprint {
+                DbFingerprint {
+                    max_fact_id,
+                    active_fact_count,
+                    max_edge_id,
+                    active_edge_count,
+                    max_scope_id,
+                    scope_count,
+                }
+            }
+        }
+
+        prop_compose! {
+            fn arb_edge()(
+                edge_id in any::<i64>(),
+                source in any::<i64>(),
+                target in any::<i64>(),
+                relation_type in ".*",
+                weight in proptest::num::f64::NORMAL | proptest::num::f64::ZERO,
+            ) -> GraphEdgeSnapshot {
+                GraphEdgeSnapshot { edge_id, source, target, relation_type, weight }
+            }
+        }
+
+        prop_compose! {
+            fn arb_node()(
+                id in any::<i64>(),
+                parent_id in proptest::option::of(any::<i64>()),
+                label in ".*",
+                depth in any::<i64>(),
+            ) -> ScopeNode {
+                ScopeNode { id, parent_id, label, depth }
+            }
+        }
+
+        prop_compose! {
+            fn arb_entry(dim: usize)(
+                fact_id in any::<i64>(),
+                embedding in prop::collection::vec(
+                    proptest::num::f32::NORMAL | proptest::num::f32::ZERO,
+                    dim..=dim,
+                ),
+            ) -> HnswEntry {
+                HnswEntry { fact_id, embedding }
+            }
+        }
+
+        prop_compose! {
+            /// Generate a self-consistent `(header, payload)` pair: the header's
+            /// `embed_dim` and every HNSW entry's embedding length agree, so a
+            /// faithful roundtrip is expected to succeed.
+            fn arb_snapshot()(
+                dim in DIM_RANGE,
+            )(
+                dim in Just(dim),
+                fingerprint in arb_fingerprint(),
+                engine_version in ".*",
+                edges in prop::collection::vec(arb_edge(), 0..6),
+                nodes in prop::collection::vec(arb_node(), 0..6),
+                hnsw in proptest::option::of(
+                    prop::collection::vec(arb_entry(dim), 0..6),
+                ),
+            ) -> (SnapshotHeader, SnapshotPayload, usize) {
+                let header = SnapshotHeader {
+                    format_version: FORMAT_VERSION,
+                    fingerprint,
+                    embed_dim: dim,
+                    engine_version,
+                };
+                let payload = SnapshotPayload {
+                    graph: GraphSnapshot { edges },
+                    scope_tree: ScopeTreeSnapshot { nodes },
+                    hnsw: hnsw.map(|entries| HnswSnapshot { entries }),
+                };
+                (header, payload, dim)
+            }
+        }
+
+        proptest! {
+            /// A faithfully written snapshot roundtrips to identical data for
+            /// arbitrary field values (including i64::MIN/MAX and random counts).
+            #[test]
+            fn write_load_roundtrip((header, payload, dim) in arb_snapshot()) {
+                let dir = tempfile::tempdir().unwrap();
+                let path = dir.path().join("rt.db.snapshot");
+
+                write_to_file(&header, &payload, &path).unwrap();
+                let (h, p) = load_from_file(&path, dim)
+                    .expect("faithful roundtrip must load");
+
+                prop_assert_eq!(h.format_version, header.format_version);
+                prop_assert_eq!(h.embed_dim, header.embed_dim);
+                prop_assert_eq!(h.fingerprint, header.fingerprint);
+                prop_assert_eq!(&h.engine_version, &header.engine_version);
+
+                prop_assert_eq!(p.graph.edges.len(), payload.graph.edges.len());
+                for (a, b) in p.graph.edges.iter().zip(payload.graph.edges.iter()) {
+                    prop_assert_eq!(a.edge_id, b.edge_id);
+                    prop_assert_eq!(a.source, b.source);
+                    prop_assert_eq!(a.target, b.target);
+                    prop_assert_eq!(&a.relation_type, &b.relation_type);
+                    prop_assert_eq!(a.weight, b.weight);
+                }
+
+                prop_assert_eq!(p.scope_tree.nodes, payload.scope_tree.nodes);
+
+                match (&p.hnsw, &payload.hnsw) {
+                    (Some(got), Some(want)) => {
+                        prop_assert_eq!(got.entries.len(), want.entries.len());
+                        for (a, b) in got.entries.iter().zip(want.entries.iter()) {
+                            prop_assert_eq!(a.fact_id, b.fact_id);
+                            prop_assert_eq!(&a.embedding, &b.embedding);
+                        }
+                    }
+                    (None, None) => {}
+                    _ => prop_assert!(false, "hnsw presence mismatch"),
+                }
+            }
+
+            /// Any single-byte mutation inside the blake3-covered region
+            /// (payload bytes + the trailing 32-byte checksum) must be rejected.
+            /// The header region is intentionally NOT integrity-protected
+            /// (the format hashes the payload only), so it is excluded here.
+            #[test]
+            fn bit_flip_in_protected_region_rejected(
+                (header, payload, dim) in arb_snapshot(),
+                flip_bit in 0u8..8,
+                pos in any::<usize>(),
+            ) {
+                let dir = tempfile::tempdir().unwrap();
+                let path = dir.path().join("flip.db.snapshot");
+                write_to_file(&header, &payload, &path).unwrap();
+
+                let mut bytes = fs::read(&path).unwrap();
+                let header_len =
+                    u32::from_le_bytes(bytes[..4].try_into().unwrap()) as usize;
+                let protected_start = 4 + header_len; // first payload byte
+                let protected_len = bytes.len() - protected_start;
+                prop_assume!(protected_len > 0);
+
+                // Map `pos` into the protected region [protected_start, len).
+                let offset = protected_start + (pos % protected_len);
+                bytes[offset] ^= 1u8 << flip_bit;
+                fs::write(&path, &bytes).unwrap();
+
+                prop_assert!(
+                    load_from_file(&path, dim).is_none(),
+                    "single-byte mutation in the payload/checksum region must reject"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 1). Subsystem-cohesive PR closing 3 findings.

## Findings closed

- **#411** [security/medium] — Unbounded MessagePack deserialization of .snapshot sidecar (allocation DoS)
- **#451** [test/low] — Snapshot serde roundtrip lacks property-based + bit-flip proptest
- **#450** [test/low] — Temporal helpers passes_temporal_cutoff / fact_overlaps_period lack property-based tests

## Review (internal diverse-lens subagents — no external models)

3 clean-slate adversarial reviewers (correctness / security & soundness / api-surface & test-quality): **0 blocker, 3 major** found.

All blocker/major **addressed** in fix commits (3):
- Finding 1 (major, correctness): Rewrote the MAX_SNAPSHOT_BYTES doc-comment and the load_from_file inline comment in /home/mroynard/dev/memory-engine/.worktrees/sweep-254-snapshot/src/engine/snapshot.rs. Removed the false claim that rmp_serde pre-allocates Vecs from untrusted in-band MessagePack leng
- Finding 2 (major, correctness): file_at_size_cap_is_not_rejected_for_size (renamed size_cap_boundary_is_exclusive) no longer creates a 512 MiB sparse file or calls load_from_file (which would fs::read 512 MiB of zeros into a Vec<u8>, risking OOM under cargo's parallel harness). The exclusive (> not 
- Finding 3 (major, api-surface & test-quality): Extracted the pre-read metadata/size check from load_from_file into a private testable seam size_gate(path, cap) -> SizeGate (Proceed/Reject). New unit test size_gate_rejects_over_cap_before_read exercises the exact over-cap branch with a 4 KiB file and

## Gate
`cargo build/test/clippy --workspace` + `cargo fmt --check` — green (rebased on current main).

Fixes #411, fixes #451, fixes #450