### PR TITLE
feat(cli): wire query to embed_query + shared embedding identity/asymmetry config

### DIFF
--- a/docs/reference/cli-inspector.md
+++ b/docs/reference/cli-inspector.md
@@ -59,16 +59,21 @@ memory-engine-cli explain 42
 
 Shows why a fact is in its current state: active/expired/pinned/due, scope path, importance breakdown (base vs composite), access count, source event ID, and graph context (degree, component size, neighbor IDs).
 
-#### `query <text>` — Full-Text Search
+#### `query <text>` — Full-Text + (optional) Vector Search
 
 ```bash
+# FTS-only (no embedder configured)
 memory-engine-cli query "database migration"
 memory-engine-cli query "auth" --scope "project/backend" --limit 5
-memory-engine-cli query "pattern" --fact-type semantic --min-importance 0.5
-memory-engine-cli query "critical" --pinned-only
+
+# Hybrid FTS + vector: pass an embedder and the query text is embedded via embed_query
+memory-engine-cli query "how does auth work" \
+  --embed-url http://localhost:8080/v1/embeddings \
+  --embed-model Qwen/Qwen3-Embedding-0.6B --embed-provider tei \
+  --query-instruction "Instruct: Given a search query, retrieve relevant memory facts.\nQuery: "
 ```
 
-FTS5-based text search. No embeddings required (the CLI has no `EmbeddingProvider`). Filters: `--scope`, `--limit`, `--fact-type` (episodic/semantic/procedural), `--min-importance`, `--pinned-only`.
+FTS5 text search by default. **When `--embed-url` + `--embed-model` are supplied (#619), the query text is embedded via `embed_query`** (applying an asymmetric model's query-instruction prefix) for hybrid FTS + vector retrieval; with no embedder it stays FTS-only. The embedder flags are shared with `batch-ingest` / `bootstrap` / `consolidate` (`--embed-provider`, `--embed-api-key`, `--query-instruction`, `--mrl-dim`, `--native-dim`, `--embed-timeout`) and the declared `--embed-provider` must match the store's recorded identity (#614). Filters: `--scope`, `--limit`, `--fact-type` (episodic/semantic/procedural), `--min-importance`, `--pinned-only`.
 
 #### `export -o <path>` — Export State
 
@@ -215,6 +220,6 @@ The `open_engine()` function sets `backup_dir` adjacent to the database as a saf
 
 ### Known Limitations
 
-- **No vector search in `query`**: The `query` subcommand doesn't use a `EmbeddingProvider`, so only FTS5 text matching works. Vector/hybrid search requires the MCP server. (The `batch-ingest` command does use embeddings for ingestion, but `query` remains text-only.)
+- **`query` is FTS-only without an embedder**: with no `--embed-url`/`--embed-model` the `query` subcommand does FTS5 text matching only. Supplying the embedder flags (#619) enables hybrid FTS + vector search via `embed_query`.
 - **`dump --limit` pushes SQL LIMIT**: `list_active_facts(Some(n))` adds a `LIMIT` clause to avoid materializing the full corpus.
 - **Import schema version**: Export/import roundtrip fails due to schema v6 vs restore v5 mismatch. Tracked in #80.

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -6,9 +6,9 @@ use chrono::{DateTime, Utc};
 use memory_engine::MemoryEngine;
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
-use memory_engine_embed::HttpEmbeddingProvider;
 use serde::{Deserialize, Serialize};
 
+use crate::commands::embedding_args::EmbeddingArgs;
 use crate::db::{open_engine_writable, open_engine_writable_with_dim};
 use crate::output::{OutputFormat, print_json};
 
@@ -22,25 +22,14 @@ pub struct BatchIngestArgs {
     #[arg(long)]
     file: PathBuf,
 
-    /// OpenAI-compatible embedding endpoint URL (e.g. `http://localhost:11434/v1/embeddings`)
-    #[arg(long, env = "MEMORY_ENGINE_EMBED_URL")]
-    embed_url: String,
-
-    /// Embedding model name
-    #[arg(long, env = "MEMORY_ENGINE_EMBED_MODEL")]
-    embed_model: String,
-
-    /// Bearer API key for the embedding endpoint
-    #[arg(long, env = "MEMORY_ENGINE_EMBED_API_KEY")]
-    embed_api_key: Option<String>,
+    /// Embedding provider config (shared with query/bootstrap; #619). `--embed-url` +
+    /// `--embed-model` are required here. Documents are embedded via `embed_batch`.
+    #[command(flatten)]
+    embed: EmbeddingArgs,
 
     /// Facts per transaction batch (default: 100)
     #[arg(long, default_value = "100")]
     batch_size: usize,
-
-    /// HTTP timeout in seconds for embedding calls
-    #[arg(long, default_value = "30")]
-    embed_timeout: u64,
 
     /// Create a new database (requires --embed-dim)
     #[arg(long)]
@@ -399,16 +388,8 @@ pub fn run(db: &Path, args: &BatchIngestArgs, format: OutputFormat) -> anyhow::R
         open_engine_writable(db)?
     };
 
-    // Build embedding provider
-    let embedder = HttpEmbeddingProvider::new(
-        args.embed_url.clone(),
-        args.embed_model.clone(),
-        "ollama".to_string(), // TODO(#618): provider should come from config/CLI
-        args.embed_api_key.clone(),
-        engine.embed_dim(),
-        args.embed_timeout,
-    )
-    .map_err(|e| anyhow::anyhow!("failed to create embedding provider: {e}"))?;
+    // Build embedding provider (shared config — provider/MRL identity per #619).
+    let embedder = args.embed.build_required(engine.embed_dim())?;
 
     // Open input — bind stdin before locking to extend lifetime
     let stdin = std::io::stdin();

--- a/memory-engine-cli/src/commands/bootstrap.rs
+++ b/memory-engine-cli/src/commands/bootstrap.rs
@@ -16,8 +16,8 @@ use memory_engine::bootstrap::{
     BootstrapConfig, BootstrapReport, KeywordExtractor, load_secret_denylist,
 };
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine_embed::HttpEmbeddingProvider;
 
+use crate::commands::embedding_args::EmbeddingArgs;
 use crate::db::{open_engine_writable, open_engine_writable_with_dim};
 use crate::output::{OutputFormat, print_json};
 
@@ -35,21 +35,10 @@ pub struct BootstrapArgs {
     #[arg(long)]
     memory_dir: Option<PathBuf>,
 
-    /// OpenAI-compatible embedding endpoint URL (e.g. `http://localhost:11434/v1/embeddings`)
-    #[arg(long, env = "MEMORY_ENGINE_EMBED_URL")]
-    embed_url: String,
-
-    /// Embedding model name
-    #[arg(long, env = "MEMORY_ENGINE_EMBED_MODEL")]
-    embed_model: String,
-
-    /// Bearer API key for the embedding endpoint
-    #[arg(long, env = "MEMORY_ENGINE_EMBED_API_KEY")]
-    embed_api_key: Option<String>,
-
-    /// HTTP timeout in seconds for embedding calls
-    #[arg(long, default_value = "30")]
-    embed_timeout: u64,
+    /// Embedding provider config (shared with query/batch-ingest; #619). `--embed-url` +
+    /// `--embed-model` are required here. Documents are embedded via `embed` / `embed_batch`.
+    #[command(flatten)]
+    embed: EmbeddingArgs,
 
     /// Default scope path for all imported facts
     #[arg(long)]
@@ -190,16 +179,8 @@ pub fn run(db: &Path, args: &BootstrapArgs, format: OutputFormat) -> anyhow::Res
         open_engine_writable(db)?
     };
 
-    // Embedding provider (Ollama / any OpenAI-compatible endpoint).
-    let embedder = HttpEmbeddingProvider::new(
-        args.embed_url.clone(),
-        args.embed_model.clone(),
-        "ollama".to_string(), // TODO(#618): provider should come from config/CLI
-        args.embed_api_key.clone(),
-        engine.embed_dim(),
-        args.embed_timeout,
-    )
-    .map_err(|e| anyhow::anyhow!("failed to create embedding provider: {e}"))?;
+    // Embedding provider (shared config — provider/MRL identity per #619).
+    let embedder = args.embed.build_required(engine.embed_dim())?;
 
     // Author-seeded denylist (#51). Loud about how many literals loaded so an
     // unset env var (→ signatures-only) is never silently mistaken for "active".

--- a/memory-engine-cli/src/commands/consolidate.rs
+++ b/memory-engine-cli/src/commands/consolidate.rs
@@ -21,7 +21,7 @@ use memory_engine::{
 use memory_engine_embed::HttpDeltaProposer;
 
 use crate::commands::embedding_args::EmbeddingArgs;
-use crate::db::{open_engine_writable, peek_embed_dim_from_db};
+use crate::db::open_engine_writable;
 use crate::output::OutputFormat;
 
 /// Upper bound on #209 drain retries. `consolidate` is a manual force-consolidate, so a
@@ -106,7 +106,9 @@ pub fn run(db: &Path, args: &ConsolidateArgs, format: OutputFormat) -> anyhow::R
         BackendArg::Llm => {
             let llm_url = require(args.llm_url.as_ref(), "--llm-url")?;
             let llm_model = require(args.llm_model.as_ref(), "--llm-model")?;
-            let dim = peek_embed_dim_from_db(db)?;
+            // The engine is already open in scope — use its dim rather than reopening
+            // the DB to re-read the config (per review).
+            let dim = engine.embed_dim();
 
             let proposer = HttpDeltaProposer::new(
                 llm_url.to_owned(),

--- a/memory-engine-cli/src/commands/consolidate.rs
+++ b/memory-engine-cli/src/commands/consolidate.rs
@@ -18,8 +18,9 @@ use clap::ValueEnum;
 use memory_engine::{
     CycleOutcome, DefaultDreamCycle, DreamCycle, LlmDreamCycle, MemoryEngine, SkipReason,
 };
-use memory_engine_embed::{HttpDeltaProposer, HttpEmbeddingProvider};
+use memory_engine_embed::HttpDeltaProposer;
 
+use crate::commands::embedding_args::EmbeddingArgs;
 use crate::db::{open_engine_writable, peek_embed_dim_from_db};
 use crate::output::OutputFormat;
 
@@ -68,16 +69,14 @@ pub struct ConsolidateArgs {
     #[arg(long)]
     llm_model: Option<String>,
 
-    /// Embedding endpoint URL — the LLM backend embeds its own summaries
-    /// (required for `--backend llm`).
-    #[arg(long)]
-    embed_url: Option<String>,
+    /// Embedding provider config — the LLM backend embeds its own summaries via this
+    /// (shared with query/ingest; #619). `--embed-url` + `--embed-model` are required for
+    /// `--backend llm`. Summaries are documents → embedded with `embed`, not `embed_query`.
+    #[command(flatten)]
+    embed: EmbeddingArgs,
 
-    /// Embedding model name (required for `--backend llm`).
-    #[arg(long)]
-    embed_model: Option<String>,
-
-    /// HTTP timeout (seconds) for the LLM and embedding calls.
+    /// HTTP timeout (seconds) for the LLM `/api/generate` calls (the embedder uses
+    /// `--embed-timeout`).
     #[arg(long, default_value_t = 120)]
     timeout_secs: u64,
 }
@@ -107,8 +106,6 @@ pub fn run(db: &Path, args: &ConsolidateArgs, format: OutputFormat) -> anyhow::R
         BackendArg::Llm => {
             let llm_url = require(args.llm_url.as_ref(), "--llm-url")?;
             let llm_model = require(args.llm_model.as_ref(), "--llm-model")?;
-            let embed_url = require(args.embed_url.as_ref(), "--embed-url")?;
-            let embed_model = require(args.embed_model.as_ref(), "--embed-model")?;
             let dim = peek_embed_dim_from_db(db)?;
 
             let proposer = HttpDeltaProposer::new(
@@ -117,14 +114,9 @@ pub fn run(db: &Path, args: &ConsolidateArgs, format: OutputFormat) -> anyhow::R
                 None,
                 args.timeout_secs,
             )?;
-            let embedder = HttpEmbeddingProvider::new(
-                embed_url.to_owned(),
-                embed_model.to_owned(),
-                "ollama".to_owned(), // TODO(#618): provider should come from config/CLI
-                None,
-                dim,
-                args.timeout_secs,
-            )?;
+            // Summary embedder: shared config (provider/MRL identity per #619). Required
+            // for the LLM backend — errors if --embed-url/--embed-model are absent.
+            let embedder = args.embed.build_required(dim)?;
             let cycle = LlmDreamCycle::new(&proposer, &embedder);
             let result = run_with_drain(&engine, &cycle);
             (result, Some(proposer.stats()))

--- a/memory-engine-cli/src/commands/embedding_args.rs
+++ b/memory-engine-cli/src/commands/embedding_args.rs
@@ -104,7 +104,16 @@ impl EmbeddingArgs {
         model: &str,
         engine_dim: usize,
     ) -> anyhow::Result<HttpEmbeddingProvider> {
-        // Always honour an explicit --native-dim (default: the engine dim) so a stray
+        // MRL truncates a NATIVE-length response down to the stored dim, so the native
+        // dim must be declared explicitly: defaulting it to the (truncated) engine dim
+        // would make the provider validate the raw response against the wrong length and
+        // reject every real embedding. Require --native-dim whenever --mrl-dim is set.
+        anyhow::ensure!(
+            self.mrl_dim.is_none() || self.native_dim.is_some(),
+            "--native-dim is required with --mrl-dim: it is the native dimension the model \
+             returns before truncation (the engine stores the truncated --mrl-dim)"
+        );
+        // Otherwise honour an explicit --native-dim (default: the engine dim) so a stray
         // --native-dim without --mrl-dim surfaces as a mismatch below rather than being
         // silently ignored.
         let native_dim = self.native_dim.unwrap_or(engine_dim);
@@ -201,6 +210,22 @@ mod tests {
         let mut a = args(Some(URL), Some("m"));
         a.native_dim = Some(16); // != engine_dim 8, and no --mrl-dim
         assert!(a.build_optional(8).is_err());
+    }
+
+    #[test]
+    fn mrl_dim_requires_native_dim() {
+        // Without --native-dim, the provider would validate the raw native-length
+        // response against the truncated engine dim and reject every embedding — so
+        // --mrl-dim must be accompanied by --native-dim (fails at build time).
+        let mut a = args(Some(URL), Some("m"));
+        a.mrl_dim = Some(8); // == engine_dim, but native_dim omitted
+        // `.err()` avoids unwrap_err's Debug bound on the Ok type (HttpEmbeddingProvider
+        // deliberately has no Debug — it holds an api_key).
+        let err = a.build_optional(8).err().expect("must error").to_string();
+        assert!(
+            err.contains("--native-dim is required"),
+            "expected a --native-dim requirement error, got: {err}"
+        );
     }
 
     #[test]

--- a/memory-engine-cli/src/commands/embedding_args.rs
+++ b/memory-engine-cli/src/commands/embedding_args.rs
@@ -1,0 +1,215 @@
+//! Shared embedding-provider CLI configuration (#619, §Design.6).
+//!
+//! Every command that builds an [`HttpEmbeddingProvider`] (query, batch-ingest,
+//! bootstrap, consolidate) flattens [`EmbeddingArgs`] so the identity/asymmetry config
+//! keys match the MCP server's `[embedding]` section: `provider` (feeds the
+//! [`EmbeddingFingerprint`] that #614 enforces — replaces the old hardcoded `"ollama"`),
+//! `query_instruction` (asymmetric query prefix), and `mrl_dim` (Matryoshka truncation).
+//! Centralizing construction here keeps the native-vs-stored dimension handling — the
+//! same model as the MCP `build_embedder` — in one place.
+
+use anyhow::Context;
+use memory_engine_embed::HttpEmbeddingProvider;
+
+/// Embedding-provider configuration shared across CLI commands.
+///
+/// `embed_url` + `embed_model` are optional at the clap layer (a query with neither is
+/// FTS-only); commands that require an embedder call [`build_required`](Self::build_required),
+/// which errors clearly when they are absent.
+#[derive(clap::Args, Clone, Debug)]
+pub struct EmbeddingArgs {
+    /// OpenAI-compatible embedding endpoint URL (e.g. `http://localhost:11434/v1/embeddings`).
+    #[arg(long, env = "MEMORY_ENGINE_EMBED_URL")]
+    pub embed_url: Option<String>,
+
+    /// Embedding model name / slug (e.g. `Qwen/Qwen3-Embedding-0.6B`).
+    #[arg(long, env = "MEMORY_ENGINE_EMBED_MODEL")]
+    pub embed_model: Option<String>,
+
+    /// Serving backend — operator-declared, feeds the embedding fingerprint (#614).
+    /// e.g. `ollama`, `tei`, `openai`. Defaults to `ollama` for back-compat.
+    #[arg(long, env = "MEMORY_ENGINE_EMBED_PROVIDER", default_value = "ollama")]
+    pub embed_provider: String,
+
+    /// Bearer API key for the embedding endpoint.
+    #[arg(long, env = "MEMORY_ENGINE_EMBED_API_KEY")]
+    pub embed_api_key: Option<String>,
+
+    /// Native model dimension before MRL truncation. Required only with `--mrl-dim`
+    /// (then the provider validates raw responses against this while the engine stores
+    /// the truncated `--mrl-dim`). Named distinctly from `--embed-dim` (the engine's
+    /// stored dimension on `--create`) to avoid confusion.
+    #[arg(long)]
+    pub native_dim: Option<usize>,
+
+    /// Query-only instruction prefix for asymmetric models (e.g. Qwen). Applied by the
+    /// query path's `embed_query`; document embedding is never prefixed.
+    #[arg(long)]
+    pub query_instruction: Option<String>,
+
+    /// Matryoshka (MRL) truncation target. Must equal the engine `embed_dim` (the engine
+    /// stores post-truncation vectors); `--embed-dimensions` gives the native length.
+    #[arg(long)]
+    pub mrl_dim: Option<usize>,
+
+    /// HTTP timeout in seconds for embedding calls.
+    #[arg(long, default_value = "30")]
+    pub embed_timeout: u64,
+}
+
+impl EmbeddingArgs {
+    /// Build the provider when configured, returning `None` when **both** `embed_url`
+    /// and `embed_model` are absent (e.g. an FTS-only query). A partial configuration
+    /// (one present, one missing) is an error.
+    ///
+    /// `engine_dim` is the engine's stored dimension; see [`build_inner`](Self::build_inner)
+    /// for how it relates to the native dimension under MRL.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on a partial configuration or any provider construction failure.
+    pub fn build_optional(
+        &self,
+        engine_dim: usize,
+    ) -> anyhow::Result<Option<HttpEmbeddingProvider>> {
+        match (self.embed_url.as_deref(), self.embed_model.as_deref()) {
+            (None, None) => Ok(None),
+            (Some(url), Some(model)) => Ok(Some(self.build_inner(url, model, engine_dim)?)),
+            _ => anyhow::bail!("--embed-url and --embed-model must be provided together"),
+        }
+    }
+
+    /// Build the provider, erroring if `embed_url` / `embed_model` are not set. For
+    /// commands that always embed (batch-ingest, bootstrap).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the embedder is not configured or construction fails.
+    pub fn build_required(&self, engine_dim: usize) -> anyhow::Result<HttpEmbeddingProvider> {
+        self.build_optional(engine_dim)?
+            .context("--embed-url and --embed-model are required for this command")
+    }
+
+    /// Construct the provider, wiring `provider`, `query_instruction`, and `mrl_dim`.
+    ///
+    /// The provider's `expected_dim` is the **native** dimension it validates raw
+    /// responses against: with MRL it is `--native-dim` (falling back to the engine
+    /// dim) and the engine stores the truncated `--mrl-dim`; without MRL native == stored
+    /// == `engine_dim`. `--mrl-dim` MUST equal `engine_dim` (the engine stores the
+    /// post-truncation vector), and without MRL `--native-dim` must too — surfaced
+    /// at build time, mirroring the MCP `build_embedder`.
+    fn build_inner(
+        &self,
+        url: &str,
+        model: &str,
+        engine_dim: usize,
+    ) -> anyhow::Result<HttpEmbeddingProvider> {
+        // Always honour an explicit --native-dim (default: the engine dim) so a stray
+        // --native-dim without --mrl-dim surfaces as a mismatch below rather than being
+        // silently ignored.
+        let native_dim = self.native_dim.unwrap_or(engine_dim);
+        let mut provider = HttpEmbeddingProvider::new(
+            url.to_owned(),
+            model.to_owned(),
+            self.embed_provider.clone(),
+            self.embed_api_key.clone(),
+            native_dim,
+            self.embed_timeout,
+        )
+        .map_err(|e| anyhow::anyhow!("failed to create embedding provider: {e}"))?;
+
+        if let Some(instruction) = &self.query_instruction {
+            provider = provider.with_query_instruction(instruction.clone());
+        }
+        if let Some(target) = self.mrl_dim {
+            anyhow::ensure!(
+                target == engine_dim,
+                "--mrl-dim ({target}) must equal the engine embed_dim ({engine_dim}): \
+                 the engine stores post-truncation vectors"
+            );
+            provider = provider
+                .with_mrl_dim(target)
+                .map_err(|e| anyhow::anyhow!("invalid --mrl-dim: {e}"))?;
+        } else {
+            anyhow::ensure!(
+                native_dim == engine_dim,
+                "--native-dim ({native_dim}) must equal the engine embed_dim \
+                 ({engine_dim}) when --mrl-dim is unset"
+            );
+        }
+        Ok(provider)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use memory_engine::EmbeddingFingerprint;
+    use memory_engine::traits::EmbeddingProvider;
+
+    /// An `EmbeddingArgs` with the given url/model and otherwise minimal config.
+    fn args(url: Option<&str>, model: Option<&str>) -> EmbeddingArgs {
+        EmbeddingArgs {
+            embed_url: url.map(String::from),
+            embed_model: model.map(String::from),
+            embed_provider: "tei".into(),
+            embed_api_key: None,
+            native_dim: None,
+            query_instruction: None,
+            mrl_dim: None,
+            embed_timeout: 5,
+        }
+    }
+
+    const URL: &str = "http://127.0.0.1:0/v1/embeddings";
+
+    #[test]
+    fn build_optional_none_when_both_absent() {
+        assert!(args(None, None).build_optional(8).unwrap().is_none());
+    }
+
+    #[test]
+    fn build_optional_partial_config_errors() {
+        assert!(args(Some(URL), None).build_optional(8).is_err());
+        assert!(args(None, Some("m")).build_optional(8).is_err());
+    }
+
+    #[test]
+    fn build_required_errors_when_absent() {
+        assert!(args(None, None).build_required(8).is_err());
+    }
+
+    #[test]
+    fn build_reports_declared_identity() {
+        let provider = args(Some(URL), Some("m")).build_required(8).unwrap();
+        assert_eq!(
+            provider.fingerprint(),
+            EmbeddingFingerprint::new("m", "tei", 8)
+        );
+    }
+
+    #[test]
+    fn mrl_dim_must_equal_engine_dim() {
+        let mut a = args(Some(URL), Some("m"));
+        a.native_dim = Some(16);
+        a.mrl_dim = Some(4); // != engine_dim 8
+        assert!(a.build_optional(8).is_err());
+    }
+
+    #[test]
+    fn native_dim_must_equal_engine_dim_without_mrl() {
+        let mut a = args(Some(URL), Some("m"));
+        a.native_dim = Some(16); // != engine_dim 8, and no --mrl-dim
+        assert!(a.build_optional(8).is_err());
+    }
+
+    #[test]
+    fn valid_mrl_config_reports_matryoshka_fingerprint() {
+        let mut a = args(Some(URL), Some("m"));
+        a.native_dim = Some(16);
+        a.mrl_dim = Some(8); // == engine_dim (stored), native 16
+        let fp = a.build_optional(8).unwrap().unwrap().fingerprint();
+        assert_eq!(fp.dim, 8, "stored dim is the truncated mrl_dim");
+        assert_eq!(fp.matryoshka_base_dim, Some(16), "native dim recorded");
+    }
+}

--- a/memory-engine-cli/src/commands/mod.rs
+++ b/memory-engine-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod batch_ingest;
 pub mod bootstrap;
 pub mod consolidate;
 pub mod dump;
+pub mod embedding_args;
 pub mod explain;
 pub mod export;
 pub mod import;

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -3,8 +3,10 @@ use std::path::Path;
 use chrono::{DateTime, Utc};
 use memory_engine::MemoryQuery;
 use memory_engine::search::hybrid::MatchType;
+use memory_engine::traits::EmbeddingProvider;
 use tabled::{Table, Tabled};
 
+use crate::commands::embedding_args::EmbeddingArgs;
 use crate::db::open_engine;
 use crate::output::{self, OutputFormat, parse_datetime, truncate_str};
 
@@ -38,6 +40,12 @@ pub struct QueryArgs {
     /// `t_valid` <= dt AND (`t_invalid` IS NULL OR `t_invalid` > dt).
     #[arg(long, value_parser = parse_datetime)]
     valid_at: Option<DateTime<Utc>>,
+
+    /// Embedding provider config. When `--embed-url` + `--embed-model` are set, the
+    /// query text is embedded via `embed_query` (asymmetric prefix applied) for
+    /// hybrid FTS + vector search; otherwise the query is FTS-only.
+    #[command(flatten)]
+    embed: EmbeddingArgs,
 }
 
 #[derive(Tabled)]
@@ -98,6 +106,16 @@ pub fn run(db: &Path, args: &QueryArgs, format: OutputFormat) -> anyhow::Result<
 
     if let Some(dt) = args.valid_at {
         query = query.valid_at(dt);
+    }
+
+    // When an embedder is configured, embed the query text via embed_query (so an
+    // asymmetric model applies its query instruction prefix) for hybrid FTS + vector
+    // search. With no embedder configured the query stays FTS-only (#619, §Design.6).
+    if let Some(provider) = args.embed.build_optional(engine.embed_dim())? {
+        let embedding = provider
+            .embed_query(&args.text)
+            .map_err(|e| anyhow::anyhow!("query embedding failed: {e}"))?;
+        query = query.embedding(embedding);
     }
 
     let response = engine.execute_query(&query)?;


### PR DESCRIPTION
## What

§Design.6 of the embedding-identity spec, **CLI side** — the sibling of #618's MCP wiring.

- **New shared `EmbeddingArgs`** ([commands/embedding_args.rs](memory-engine-cli/src/commands/embedding_args.rs)) flattened into **query, batch-ingest, bootstrap, consolidate**. Carries the MCP-parity config keys: `provider` (feeds the #614 fingerprint — **replaces the hardcoded `"ollama"` `TODO(#618)`** in all three write commands), `query_instruction`, `mrl_dim`, `native_dim`. `build_embedder` centralizes the native-vs-stored dimension model (mirrors the MCP `build_embedder`: `mrl_dim` must equal the engine dim; `native_dim` too when MRL is off — validated at build time).
- **`query`**: gains the embedder flags. With `--embed-url` + `--embed-model`, the query text is embedded via `embed_query` (asymmetric prefix applied) for hybrid FTS + vector; with no embedder it stays **FTS-only** (mode inferred from embedder presence — zero behavior change when absent).
- **`batch-ingest` / `bootstrap` / `consolidate`**: keep `embed` / `embed_batch` (documents) but build via the shared `EmbeddingArgs`.

## Why CLI-wide (not query-only)

The hardcoded `provider="ollama"` + missing `mrl_dim` in the write commands **broke CLI↔MCP interop** on TEI/Qwen/MRL stores once #614 enforcement landed: a CLI `batch-ingest` stamping `"ollama"` is *rejected* against a store the MCP stamped `tei`, and MRL stores need document vectors truncated to the stored dim. So "same config keys as MCP" (§Design.6) is required, not cosmetic. (Confirmed scope with maintainer.)

## Tests

`EmbeddingArgs::build_*`: none/partial/required, dim validation (`mrl_dim`/`native_dim` must equal engine dim), MRL matryoshka fingerprint. A unit test caught a silent-ignore (a stray `--native-dim` without `--mrl-dim`) → now errors.

## Verification

- `cargo test --workspace` ✅ 1257 passed
- `cargo clippy --workspace --all-targets` ✅ clean
- `cargo fmt --check` ✅ exit 0

Docs: cli-inspector.md query hybrid section + resolved the "no vector search in query" known-limitation.

Wave 1 of epic #610.

Fixes #619
