### PR TITLE
refactor(cli): consolidate fact-type converters; cover query filters (#270, #430)

### DIFF
--- a/memory-engine-cli/src/commands/add_fact.rs
+++ b/memory-engine-cli/src/commands/add_fact.rs
@@ -1,30 +1,12 @@
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use clap::ValueEnum;
 use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 
+use crate::commands::types::CliFactType;
 use crate::db::open_engine_writable_with_dim;
 use crate::embedding::PassthroughEmbedder;
 use crate::output::{self, OutputFormat, parse_datetime};
-
-/// Fact type for CLI argument parsing.
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum FactTypeArg {
-    Episodic,
-    Semantic,
-    Procedural,
-}
-
-impl From<FactTypeArg> for FactType {
-    fn from(arg: FactTypeArg) -> Self {
-        match arg {
-            FactTypeArg::Episodic => Self::Episodic,
-            FactTypeArg::Semantic => Self::Semantic,
-            FactTypeArg::Procedural => Self::Procedural,
-        }
-    }
-}
 
 #[derive(clap::Args)]
 pub struct AddFactArgs {
@@ -34,7 +16,7 @@ pub struct AddFactArgs {
 
     /// Fact type
     #[arg(long, value_enum)]
-    fact_type: FactTypeArg,
+    fact_type: CliFactType,
 
     /// Pre-computed embedding as a JSON array of floats (e.g., "[0.1, 0.2, 0.3]")
     #[arg(long)]

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -5,10 +5,11 @@ use std::time::Instant;
 use chrono::{DateTime, Utc};
 use memory_engine::MemoryEngine;
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
+use memory_engine::types::{AddFactOptions, AddFactRequest};
 use serde::{Deserialize, Serialize};
 
 use crate::commands::embedding_args::EmbeddingArgs;
+use crate::commands::types::CliFactType;
 use crate::db::{open_engine_writable, open_engine_writable_with_dim};
 use crate::output::{OutputFormat, print_json};
 
@@ -49,27 +50,9 @@ pub struct BatchIngestArgs {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum JsonlFactType {
-    Episodic,
-    Semantic,
-    Procedural,
-}
-
-impl From<JsonlFactType> for FactType {
-    fn from(jft: JsonlFactType) -> Self {
-        match jft {
-            JsonlFactType::Episodic => Self::Episodic,
-            JsonlFactType::Semantic => Self::Semantic,
-            JsonlFactType::Procedural => Self::Procedural,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
 struct JsonlFact {
     content: String,
-    fact_type: JsonlFactType,
+    fact_type: CliFactType,
     #[serde(default)]
     source_event_id: Option<i64>,
     #[serde(default)]
@@ -432,15 +415,15 @@ mod tests {
     fn jsonl_fact_deserialize_lowercase() {
         let line = r#"{"content":"hello","fact_type":"episodic"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        assert!(matches!(fact.fact_type, JsonlFactType::Episodic));
+        assert!(matches!(fact.fact_type, CliFactType::Episodic));
 
         let line = r#"{"content":"hello","fact_type":"semantic"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        assert!(matches!(fact.fact_type, JsonlFactType::Semantic));
+        assert!(matches!(fact.fact_type, CliFactType::Semantic));
 
         let line = r#"{"content":"hello","fact_type":"procedural"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        assert!(matches!(fact.fact_type, JsonlFactType::Procedural));
+        assert!(matches!(fact.fact_type, CliFactType::Procedural));
     }
 
     #[test]
@@ -468,7 +451,7 @@ mod tests {
         }"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
         assert_eq!(fact.content, "User moved to Istanbul");
-        assert!(matches!(fact.fact_type, JsonlFactType::Episodic));
+        assert!(matches!(fact.fact_type, CliFactType::Episodic));
         assert_eq!(fact.importance, Some(0.7));
         assert!(fact.t_valid.is_some());
         assert!(fact.t_invalid.is_some());
@@ -489,7 +472,7 @@ mod tests {
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
         let req = jsonl_to_request(fact, None);
         assert_eq!(req.content, "test");
-        assert_eq!(req.fact_type, FactType::Semantic);
+        assert_eq!(req.fact_type, memory_engine::types::FactType::Semantic);
         let opts = req.opts.unwrap();
         assert_eq!(opts.importance, Some(0.8));
         assert!(opts.t_valid.is_some());
@@ -499,7 +482,7 @@ mod tests {
     fn validate_importance_out_of_range() {
         let fact = JsonlFact {
             content: "test".into(),
-            fact_type: JsonlFactType::Semantic,
+            fact_type: CliFactType::Semantic,
             source_event_id: None,
             scope: None,
             importance: Some(1.5),
@@ -519,7 +502,7 @@ mod tests {
         let t2 = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let fact = JsonlFact {
             content: "test".into(),
-            fact_type: JsonlFactType::Semantic,
+            fact_type: CliFactType::Semantic,
             source_event_id: None,
             scope: None,
             importance: None,
@@ -537,7 +520,7 @@ mod tests {
     fn validate_valid_fact_passes() {
         let fact = JsonlFact {
             content: "test".into(),
-            fact_type: JsonlFactType::Semantic,
+            fact_type: CliFactType::Semantic,
             source_event_id: None,
             scope: None,
             importance: Some(0.5),

--- a/memory-engine-cli/src/commands/mod.rs
+++ b/memory-engine-cli/src/commands/mod.rs
@@ -14,3 +14,4 @@ pub mod query;
 pub mod record_outcome;
 pub mod schema;
 pub mod stats;
+pub mod types;

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -24,8 +24,8 @@ pub struct QueryArgs {
     #[arg(long)]
     scope: Option<String>,
 
-    /// Filter by fact type
-    #[arg(long, value_enum)]
+    /// Filter by fact type (episodic, semantic, procedural; case-insensitive)
+    #[arg(long, value_enum, ignore_case = true)]
     fact_type: Option<CliFactType>,
 
     /// Minimum importance score

--- a/memory-engine-cli/src/commands/query.rs
+++ b/memory-engine-cli/src/commands/query.rs
@@ -7,6 +7,7 @@ use memory_engine::traits::EmbeddingProvider;
 use tabled::{Table, Tabled};
 
 use crate::commands::embedding_args::EmbeddingArgs;
+use crate::commands::types::CliFactType;
 use crate::db::open_engine;
 use crate::output::{self, OutputFormat, parse_datetime, truncate_str};
 
@@ -23,9 +24,9 @@ pub struct QueryArgs {
     #[arg(long)]
     scope: Option<String>,
 
-    /// Filter by fact type (episodic, semantic, procedural)
-    #[arg(long)]
-    fact_type: Option<String>,
+    /// Filter by fact type
+    #[arg(long, value_enum)]
+    fact_type: Option<CliFactType>,
 
     /// Minimum importance score
     #[arg(long)]
@@ -88,16 +89,8 @@ pub fn run(db: &Path, args: &QueryArgs, format: OutputFormat) -> anyhow::Result<
         query = query.min_importance_score(score);
     }
 
-    if let Some(ft) = &args.fact_type {
-        let fact_type = match ft.to_lowercase().as_str() {
-            "episodic" => memory_engine::FactType::Episodic,
-            "semantic" => memory_engine::FactType::Semantic,
-            "procedural" => memory_engine::FactType::Procedural,
-            other => anyhow::bail!(
-                "unknown fact type: {other} (expected: episodic, semantic, procedural)"
-            ),
-        };
-        query = query.fact_type(fact_type);
+    if let Some(ft) = args.fact_type {
+        query = query.fact_type(ft.into());
     }
 
     if args.pinned_only {

--- a/memory-engine-cli/src/commands/types.rs
+++ b/memory-engine-cli/src/commands/types.rs
@@ -1,0 +1,65 @@
+//! CLI-local fact-type wrapper shared across subcommands.
+//!
+//! `memory_engine::FactType` deliberately exposes no `clap::ValueEnum`,
+//! `serde::Deserialize`, or `FromStr` impl (the core crate has no CLI/serde
+//! concerns), so the CLI needs a thin local wrapper. This is the single source of
+//! truth for it: `add-fact` (clap arg), `query` (clap arg), and `batch-ingest`
+//! (JSONL field) all parse into [`CliFactType`] and convert via `From`.
+
+use memory_engine::types::FactType;
+
+/// Fact type as accepted on the CLI (`--fact-type`) and in JSONL (`fact_type`).
+///
+/// The clap value tokens and the serde field values are both the lower-cased
+/// variant names (`episodic`, `semantic`, `procedural`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliFactType {
+    Episodic,
+    Semantic,
+    Procedural,
+}
+
+impl From<CliFactType> for FactType {
+    fn from(t: CliFactType) -> Self {
+        match t {
+            CliFactType::Episodic => Self::Episodic,
+            CliFactType::Semantic => Self::Semantic,
+            CliFactType::Procedural => Self::Procedural,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_to_engine_fact_type() {
+        assert_eq!(FactType::from(CliFactType::Episodic), FactType::Episodic);
+        assert_eq!(FactType::from(CliFactType::Semantic), FactType::Semantic);
+        assert_eq!(
+            FactType::from(CliFactType::Procedural),
+            FactType::Procedural
+        );
+    }
+
+    #[test]
+    fn deserializes_snake_case() {
+        assert_eq!(
+            serde_json::from_str::<CliFactType>("\"episodic\"").unwrap(),
+            CliFactType::Episodic
+        );
+        assert!(serde_json::from_str::<CliFactType>("\"unknown\"").is_err());
+    }
+
+    #[test]
+    fn clap_value_tokens_are_lowercase() {
+        use clap::ValueEnum;
+        let tokens: Vec<_> = CliFactType::value_variants()
+            .iter()
+            .map(|v| v.to_possible_value().unwrap().get_name().to_owned())
+            .collect();
+        assert_eq!(tokens, ["episodic", "semantic", "procedural"]);
+    }
+}

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -239,6 +239,113 @@ fn query_no_results() {
         .stdout(predicate::str::contains("No results"));
 }
 
+// --- query: filter flags (#430) ---
+
+#[test]
+fn query_filter_fact_type() {
+    let (_dir, db_path) = create_test_db();
+    // "Rust is fast" is Procedural: it passes --fact-type procedural …
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "query",
+            "Rust",
+            "--fact-type",
+            "procedural",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rust"));
+    // … but --fact-type semantic filters it out, leaving no FTS match.
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "query",
+            "Rust",
+            "--fact-type",
+            "semantic",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results"));
+}
+
+#[test]
+fn query_filter_fact_type_unknown_is_rejected() {
+    let (_dir, db_path) = create_test_db();
+    // After #270 the fact type is a clap ValueEnum, so an unknown value is
+    // rejected at parse time rather than via an anyhow bail in the command body.
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "query",
+            "x",
+            "--fact-type",
+            "unknown",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("invalid value").and(predicate::str::contains("procedural")),
+        );
+}
+
+#[test]
+fn query_filter_pinned_only_excludes_unpinned() {
+    let (_dir, db_path) = create_test_db();
+    // The seeded facts are not pinned, so --pinned-only filters them all out.
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "query",
+            "blue sky",
+            "--pinned-only",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results"));
+}
+
+#[test]
+fn query_filter_min_importance_excludes_below_threshold() {
+    let (_dir, db_path) = create_test_db();
+    // Seeded facts use the default importance (0.5), below the 0.99 threshold.
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "query",
+            "blue sky",
+            "--min-importance",
+            "0.99",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results"));
+}
+
+#[test]
+fn query_filter_scope_subtree_excludes_other_scopes() {
+    let (_dir, db_path) = create_test_db();
+    // Seeded facts live at the root scope; a subtree filter excludes them.
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "query",
+            "blue sky",
+            "--scope",
+            "project/sub",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results"));
+}
+
 // --- query: --valid-at temporal filtering ---
 
 /// Create a test database with facts that have explicit `t_valid` / `t_invalid`

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -244,32 +244,31 @@ fn query_no_results() {
 #[test]
 fn query_filter_fact_type() {
     let (_dir, db_path) = create_test_db();
+    let db = db_path.to_str().unwrap();
     // "Rust is fast" is Procedural: it passes --fact-type procedural …
     cli()
-        .args([
-            "--db",
-            db_path.to_str().unwrap(),
-            "query",
-            "Rust",
-            "--fact-type",
-            "procedural",
-        ])
+        .args(["--db", db, "query", "Rust", "--fact-type", "procedural"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Rust"));
     // … but --fact-type semantic filters it out, leaving no FTS match.
     cli()
-        .args([
-            "--db",
-            db_path.to_str().unwrap(),
-            "query",
-            "Rust",
-            "--fact-type",
-            "semantic",
-        ])
+        .args(["--db", db, "query", "Rust", "--fact-type", "semantic"])
         .assert()
         .success()
         .stdout(predicate::str::contains("No results"));
+    // A second variant end-to-end: episodic matches "Memory engines …".
+    cli()
+        .args(["--db", db, "query", "Memory", "--fact-type", "episodic"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Memory engines"));
+    // Case-insensitive (ignore_case preserves the pre-#270 query behavior).
+    cli()
+        .args(["--db", db, "query", "Rust", "--fact-type", "PROCEDURAL"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rust"));
 }
 
 #[test]
@@ -289,22 +288,23 @@ fn query_filter_fact_type_unknown_is_rejected() {
         .assert()
         .failure()
         .stderr(
-            predicate::str::contains("invalid value").and(predicate::str::contains("procedural")),
+            predicate::str::contains("invalid value").and(predicate::str::contains("--fact-type")),
         );
 }
 
 #[test]
 fn query_filter_pinned_only_excludes_unpinned() {
     let (_dir, db_path) = create_test_db();
-    // The seeded facts are not pinned, so --pinned-only filters them all out.
+    let db = db_path.to_str().unwrap();
+    // Baseline: the query returns the fact when the filter is absent …
     cli()
-        .args([
-            "--db",
-            db_path.to_str().unwrap(),
-            "query",
-            "blue sky",
-            "--pinned-only",
-        ])
+        .args(["--db", db, "query", "blue sky"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sky"));
+    // … and the seeded facts are not pinned, so --pinned-only removes it.
+    cli()
+        .args(["--db", db, "query", "blue sky", "--pinned-only"])
         .assert()
         .success()
         .stdout(predicate::str::contains("No results"));
@@ -313,16 +313,15 @@ fn query_filter_pinned_only_excludes_unpinned() {
 #[test]
 fn query_filter_min_importance_excludes_below_threshold() {
     let (_dir, db_path) = create_test_db();
+    let db = db_path.to_str().unwrap();
+    cli()
+        .args(["--db", db, "query", "blue sky"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sky"));
     // Seeded facts use the default importance (0.5), below the 0.99 threshold.
     cli()
-        .args([
-            "--db",
-            db_path.to_str().unwrap(),
-            "query",
-            "blue sky",
-            "--min-importance",
-            "0.99",
-        ])
+        .args(["--db", db, "query", "blue sky", "--min-importance", "0.99"])
         .assert()
         .success()
         .stdout(predicate::str::contains("No results"));
@@ -331,15 +330,42 @@ fn query_filter_min_importance_excludes_below_threshold() {
 #[test]
 fn query_filter_scope_subtree_excludes_other_scopes() {
     let (_dir, db_path) = create_test_db();
+    let db = db_path.to_str().unwrap();
+    cli()
+        .args(["--db", db, "query", "blue sky"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sky"));
     // Seeded facts live at the root scope; a subtree filter excludes them.
+    cli()
+        .args(["--db", db, "query", "blue sky", "--scope", "project/sub"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results"));
+}
+
+#[test]
+fn query_filter_combined_fact_type_and_min_importance() {
+    let (_dir, db_path) = create_test_db();
+    let db = db_path.to_str().unwrap();
+    // --fact-type procedural alone matches "Rust is fast" …
+    cli()
+        .args(["--db", db, "query", "Rust", "--fact-type", "procedural"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rust"));
+    // … adding --min-importance 0.99 removes it, proving the filters AND
+    // together rather than one masking the other.
     cli()
         .args([
             "--db",
-            db_path.to_str().unwrap(),
+            db,
             "query",
-            "blue sky",
-            "--scope",
-            "project/sub",
+            "Rust",
+            "--fact-type",
+            "procedural",
+            "--min-importance",
+            "0.99",
         ])
         .assert()
         .success()


### PR DESCRIPTION
Wave 3 of the #251 area:cli super-qa sweep. Three commits (refactor → tests → review fixes).

## #270 — one `CliFactType`, three converters gone (`refactor`)
The 3 `FactType` variants were mapped in three independent places: `FactTypeArg` (add_fact.rs), `JsonlFactType` (batch_ingest.rs), and a stringly-typed `match ft.to_lowercase()` + `anyhow::bail` (query.rs). Replaced with a single **`CliFactType`** in `commands/types.rs` — `#[derive(clap::ValueEnum, serde::Deserialize)]` + `From<CliFactType> for FactType` — used by both clap args (`add-fact`, `query`) and the JSONL `fact_type` field (`batch-ingest`). One place to add a variant; no stringly-typed path left.

**Behavior parity (verified by review):**
- Valid `--fact-type` values parse identically in any case — query keeps its case-insensitivity via `ignore_case = true` (clap ValueEnum is case-sensitive by default; this preserves the old `to_lowercase()` behavior). add-fact stays case-sensitive exactly as before.
- JSONL `fact_type` is byte-identical (`#[serde(rename_all = "snake_case")]`, same as the deleted `JsonlFactType`).
- **Only intended change:** an *invalid* `query --fact-type` value now fails at clap parse time — `invalid value '…' … [possible values: episodic, semantic, procedural]`, exit code 2 — instead of an `anyhow::bail` (exit 1) in the command body.

## #430 — query filter coverage (`test`)
`--fact-type` / `--scope` / `--min-importance` / `--pinned-only` had zero CLI integration coverage. Added tests with in-test positive baselines (so they can't silently degrade to vacuous "No results" passes), all three fact-type variants exercised (incl. a case-insensitive value), the clap rejection of an unknown value, and a combined `--fact-type + --min-importance` test proving the filters AND together.

## Verification (exact CI commands)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean ✓
- `cargo test --workspace --all-features` — all green ✓
- `cargo deny check` — advisories ok ✓
- `cargo fmt --check` ✓

Closes #270.
Closes #430.