### PR TITLE
fix(core): cleanup orphan .pak on archive failure + push candidate selection into SQL (#254 wave1)

### DIFF
--- a/src/archive/pak.rs
+++ b/src/archive/pak.rs
@@ -28,28 +28,40 @@ pub fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
             ))
         })?;
 
-    let mut hasher = blake3::Hasher::new();
-    let hashing_writer = HashingWriter {
-        inner: file,
-        hasher: &mut hasher,
-    };
-    let mut encoder = zstd::Encoder::new(hashing_writer, 3)
-        .map_err(|e| ArchiveError::Codec(format!("failed to create zstd encoder: {e}")))?;
-    serde_json::to_writer(&mut encoder, pak)?;
-    encoder
-        .finish()
-        .map_err(|e| ArchiveError::Codec(format!("failed to finalize zstd stream: {e}")))?;
+    // The temp file now exists. Any failure while serializing/compressing or
+    // renaming must remove it, or a failed archive leaves an orphan `.pak.tmp`
+    // on disk (CWE-459) — the temp-file analogue of the committed-`.pak` orphan
+    // the caller guards against. Run the fallible work in a closure and clean up
+    // on `Err`.
+    let write_result: Result<String> = (|| {
+        let mut hasher = blake3::Hasher::new();
+        let hashing_writer = HashingWriter {
+            inner: file,
+            hasher: &mut hasher,
+        };
+        let mut encoder = zstd::Encoder::new(hashing_writer, 3)
+            .map_err(|e| ArchiveError::Codec(format!("failed to create zstd encoder: {e}")))?;
+        serde_json::to_writer(&mut encoder, pak)?;
+        encoder
+            .finish()
+            .map_err(|e| ArchiveError::Codec(format!("failed to finalize zstd stream: {e}")))?;
 
-    let hash = hasher.finalize().to_hex().to_string();
+        let hash = hasher.finalize().to_hex().to_string();
 
-    fs::rename(&tmp_path, path).map_err(|e| {
-        ArchiveError::Io(format!(
-            "failed to rename {} -> {}: {e}",
-            tmp_path.display(),
-            path.display()
-        ))
-    })?;
-    Ok(hash)
+        fs::rename(&tmp_path, path).map_err(|e| {
+            ArchiveError::Io(format!(
+                "failed to rename {} -> {}: {e}",
+                tmp_path.display(),
+                path.display()
+            ))
+        })?;
+        Ok(hash)
+    })();
+
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    write_result
 }
 
 /// Read and decompress a `.pak` file. Caps at 4 GiB decompressed.

--- a/src/engine/archive.rs
+++ b/src/engine/archive.rs
@@ -4,7 +4,6 @@
 //! records a manifest row, hard-deletes from `SQLite`, and prunes the
 //! in-memory graph — all in a crash-safe sequence.
 
-use std::collections::HashSet;
 use std::path::PathBuf;
 
 use chrono::Utc;
@@ -160,24 +159,18 @@ impl MemoryEngine {
     // --- Private helpers ---
 
     /// Select expired, non-pinned facts and their internal edges.
+    ///
+    /// Both predicates are pushed into SQL — `FactStore::list_archive_candidates`
+    /// and `EdgeStore::list_internal_by_facts` — so a large database never
+    /// materializes every fact (with its embedding BLOB) and every edge just to
+    /// discard the rows that don't qualify.
     fn select_archive_candidates(&self, policy: &ArchivePolicy) -> Result<(Vec<Fact>, Vec<Edge>)> {
         let conn = self.pool.read()?;
-        let all_facts = FactStore::new(&conn, self.embed_dim).list_all()?;
-        let candidate_facts: Vec<_> = all_facts
-            .into_iter()
-            .filter(|f| !f.is_pinned && f.t_expired.is_some_and(|te| te < policy.expired_before))
-            .collect();
+        let candidate_facts =
+            FactStore::new(&conn, self.embed_dim).list_archive_candidates(policy.expired_before)?;
 
-        let candidate_ids: HashSet<i64> = candidate_facts.iter().map(|f| f.id).collect();
-
-        let all_edges = EdgeStore::new(&conn).list_all()?;
-        let candidate_edges: Vec<_> = all_edges
-            .into_iter()
-            .filter(|e| {
-                candidate_ids.contains(&e.source_fact_id)
-                    && candidate_ids.contains(&e.target_fact_id)
-            })
-            .collect();
+        let candidate_ids: Vec<i64> = candidate_facts.iter().map(|f| f.id).collect();
+        let candidate_edges = EdgeStore::new(&conn).list_internal_by_facts(&candidate_ids)?;
 
         drop(conn);
         Ok((candidate_facts, candidate_edges))

--- a/src/engine/archive.rs
+++ b/src/engine/archive.rs
@@ -73,6 +73,11 @@ impl MemoryEngine {
             .to_string_lossy()
             .to_string();
 
+        // The `.pak` is already on disk. If the commit (manifest insert +
+        // hard-delete tx) fails, the file would be an orphan with no manifest
+        // row — a permanent disk leak that `verify_archives()` could never
+        // reconcile (CWE-459). Remove it on error, mirroring the cleanup the
+        // restore path uses for its half-written DB file.
         self.commit_archive(
             &pak_filename,
             &candidate_facts,
@@ -80,7 +85,10 @@ impl MemoryEngine {
             &fact_ids,
             pak_size_bytes,
             &blake3_hash,
-        )?;
+        )
+        .inspect_err(|_| {
+            let _ = std::fs::remove_file(&pak_path);
+        })?;
 
         // Update in-memory graph
         {
@@ -344,5 +352,94 @@ impl MemoryEngine {
             ))
         })?;
         Ok(parent.join("archives"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    use crate::types::{FactType, NewFact};
+
+    const DIM: usize = 8;
+
+    fn make_expired_fact(content: &str, expired_at: chrono::DateTime<Utc>) -> NewFact {
+        NewFact {
+            content: content.into(),
+            content_hash: String::new(),
+            embedding: vec![0.1_f32; DIM],
+            fact_type: FactType::Episodic,
+            t_created: Utc::now() - Duration::days(2),
+            t_expired: Some(expired_at),
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+            scope_id: 1,
+            is_pinned: false,
+        }
+    }
+
+    /// #265: a failure inside `commit_archive` (here: the manifest INSERT fails
+    /// because the table was dropped) must NOT leave an orphan `.pak` file behind.
+    /// The `.pak` is written before the commit transaction; without on-error
+    /// cleanup it would be a permanent disk leak with no manifest row (CWE-459).
+    #[test]
+    fn archive_cleans_up_pak_when_commit_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = MemoryEngine::builder(DIM)
+            .path(dir.path().join("orphan.db"))
+            .build()
+            .unwrap();
+
+        // Insert expired, non-pinned facts directly via the store so they qualify
+        // as archive candidates.
+        let expired_at = Utc::now() - Duration::hours(1);
+        {
+            let conn = engine.write_conn().unwrap();
+            let store = FactStore::new(&conn, DIM);
+            for i in 0..20 {
+                store
+                    .insert(&make_expired_fact(&format!("orphan fact {i}"), expired_at))
+                    .unwrap();
+            }
+            // Force `commit_archive` to fail: drop the manifest table so its INSERT
+            // errors out *after* the `.pak` has already been written to disk.
+            conn.execute_batch("DROP TABLE archive_manifest;").unwrap();
+        }
+
+        let policy = ArchivePolicy {
+            expired_before: Utc::now() + Duration::hours(1),
+            min_facts: 1,
+        };
+
+        let result = engine.archive(&policy);
+        assert!(
+            result.is_err(),
+            "archive must propagate the commit failure, got {result:?}"
+        );
+
+        // The archive directory must contain no orphan `.pak` file.
+        let archive_dir = dir.path().join("archives");
+        let orphans: Vec<_> = std::fs::read_dir(&archive_dir)
+            .map(|rd| {
+                rd.filter_map(std::result::Result::ok)
+                    .filter(|e| {
+                        e.path()
+                            .extension()
+                            .is_some_and(|ext| ext.eq_ignore_ascii_case("pak"))
+                    })
+                    .map(|e| e.path())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            orphans.is_empty(),
+            "commit_archive failure left orphan .pak file(s): {orphans:?}"
+        );
     }
 }

--- a/src/engine/archive.rs
+++ b/src/engine/archive.rs
@@ -206,8 +206,14 @@ impl MemoryEngine {
         let pak_path = archive_dir.join(&pak_filename);
 
         let blake3_hash = write_pak_and_hash(pak, &pak_path)?;
+        // `write_pak_and_hash` has now renamed the `.pak` into place, so it
+        // physically exists. Any failure from here on must remove it, or it
+        // becomes an orphan with no manifest row (CWE-459) — the same guarantee
+        // `commit_archive`'s cleanup gives for the downstream commit step. The
+        // stat below is the only such fallible step before this fn returns.
         let pak_size_bytes = std::fs::metadata(&pak_path)
             .map_err(|e| {
+                let _ = std::fs::remove_file(&pak_path);
                 ArchiveError::Io(format!(
                     "failed to stat pak file {}: {e}",
                     pak_path.display()

--- a/src/store/edges.rs
+++ b/src/store/edges.rs
@@ -265,6 +265,39 @@ impl<'a> EdgeStore<'a> {
         Ok(edges)
     }
 
+    /// List edges (including expired) where BOTH endpoints are in the given
+    /// fact ID set, ordered by id ascending.
+    ///
+    /// This is the read counterpart of [`Self::hard_delete_by_facts`] — it
+    /// selects exactly the set of edges that archival will remove, pushing the
+    /// "both endpoints internal" predicate into SQL so the engine never loads
+    /// every edge just to discard the ones that straddle the live/archived
+    /// boundary. Equivalent to the prior Rust-side filter
+    /// `candidate_ids.contains(&e.source_fact_id) && candidate_ids.contains(&e.target_fact_id)`
+    /// over `list_all()`.
+    ///
+    /// Returns an empty `Vec` for an empty `fact_ids` slice (no query issued).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn list_internal_by_facts(&self, fact_ids: &[i64]) -> Result<Vec<Edge>> {
+        if fact_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let ids_json = serde_json::to_string(fact_ids)?;
+        let mut stmt = self.conn.prepare(
+            "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id
+             FROM edges
+             WHERE source_fact_id IN (SELECT value FROM json_each(?1))
+               AND target_fact_id IN (SELECT value FROM json_each(?1))
+             ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map(params![ids_json], row_to_edge)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
     /// Hard-delete edges where BOTH endpoints are in the given fact ID set.
     ///
     /// Used after successful archival to remove edges whose facts have been
@@ -437,6 +470,87 @@ mod tests {
         let active = store.list_active().unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].relation_type, "d");
+    }
+
+    // --- list_internal_by_facts tests ---
+
+    #[test]
+    fn list_internal_by_facts_matches_rust_both_endpoints_filter() {
+        // Equivalence guard for the SQL-pushdown refactor (#349): the new
+        // `list_internal_by_facts` must return exactly the edges the prior
+        // archive-side Rust filter did — `candidate_ids.contains(&e.source) &&
+        // candidate_ids.contains(&e.target)` over `list_all()` — i.e. both
+        // endpoints inside the candidate set.
+        //
+        // facts: 1, 2, 3. Edge f1→f2 is internal to {1,2}; f2→f3 straddles
+        // the live/archived boundary (f3 not in set) and must be excluded.
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+
+        let internal = store.insert(&make_edge(1, 2, "internal")).unwrap();
+        store.insert(&make_edge(2, 3, "cross_boundary")).unwrap();
+
+        // Reference: the prior Rust-side semantics over the full edge list.
+        let set: std::collections::HashSet<i64> = [1, 2].into_iter().collect();
+        let expected: Vec<i64> = store
+            .list_all()
+            .unwrap()
+            .into_iter()
+            .filter(|e| set.contains(&e.source_fact_id) && set.contains(&e.target_fact_id))
+            .map(|e| e.id)
+            .collect();
+
+        let got: Vec<i64> = store
+            .list_internal_by_facts(&[1, 2])
+            .unwrap()
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
+
+        assert_eq!(
+            got, expected,
+            "SQL pushdown must match the prior Rust filter"
+        );
+        assert_eq!(got, vec![internal], "only the fully-internal edge");
+    }
+
+    #[test]
+    fn list_internal_by_facts_includes_expired_edges() {
+        // Archival removes edges whose BOTH facts are archived regardless of the
+        // edge's own t_expired (the prior code filtered `list_all()`, which
+        // returns expired edges too — unlike `list_active`). This guards against
+        // a regression that would orphan an expired edge whose endpoints are gone.
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+
+        let active = store.insert(&make_edge(1, 2, "active")).unwrap();
+        let expired = store.insert(&make_edge(2, 1, "expired")).unwrap();
+        store.expire(expired, Utc::now()).unwrap();
+
+        let got: Vec<i64> = store
+            .list_internal_by_facts(&[1, 2])
+            .unwrap()
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
+
+        assert_eq!(
+            got,
+            vec![active, expired],
+            "both active and expired internal edges, id-ascending"
+        );
+    }
+
+    #[test]
+    fn list_internal_by_facts_empty_slice_is_noop() {
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        store.insert(&make_edge(1, 2, "a")).unwrap();
+
+        assert!(
+            store.list_internal_by_facts(&[]).unwrap().is_empty(),
+            "empty fact-id set selects no edges (no query issued)"
+        );
     }
 
     // --- hard_delete_by_facts tests ---

--- a/src/store/edges.rs
+++ b/src/store/edges.rs
@@ -289,11 +289,14 @@ impl<'a> EdgeStore<'a> {
             return Ok(Vec::new());
         }
         let ids_json = serde_json::to_string(fact_ids)?;
+        // Parse the JSON id array exactly once via a CTE, then reuse it for both
+        // endpoint predicates (vs. evaluating json_each(?1) twice).
         let mut stmt = self.conn.prepare(
-            "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id
+            "WITH ids(value) AS (SELECT value FROM json_each(?1))
+             SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id
              FROM edges
-             WHERE source_fact_id IN (SELECT value FROM json_each(?1))
-               AND target_fact_id IN (SELECT value FROM json_each(?1))
+             WHERE source_fact_id IN (SELECT value FROM ids)
+               AND target_fact_id IN (SELECT value FROM ids)
              ORDER BY id ASC",
         )?;
         let rows = stmt.query_map(params![ids_json], row_to_edge)?;

--- a/src/store/edges.rs
+++ b/src/store/edges.rs
@@ -280,7 +280,10 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Database` on SQL failure, or
+    /// `MemoryError::Serialization` if the `fact_ids` slice cannot be serialized
+    /// to the JSON array bound into the query (infallible in practice for
+    /// `&[i64]`).
     pub fn list_internal_by_facts(&self, fact_ids: &[i64]) -> Result<Vec<Edge>> {
         if fact_ids.is_empty() {
             return Ok(Vec::new());

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1151,6 +1151,14 @@ impl<'a> FactStore<'a> {
     /// [`insert_or_reinforce`](Self::insert_or_reinforce) relies on for its
     /// `min`/`max` over `t_created`).
     ///
+    /// **Precondition:** this equivalence holds *iff* `t_expired` is stored as
+    /// the rfc3339 form of a UTC instant (`…+00:00`) — the only form any
+    /// production write path produces. A non-UTC offset or a space-separated
+    /// `datetime('now')` value would break both lexicographic ordering here and
+    /// the rfc3339 parse on the [`list_all`](Self::list_all) read path, so no
+    /// path is robust to it; the SQL filter assumes the same storage invariant
+    /// the rest of the store upholds.
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on SQL failure.

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -1134,6 +1134,40 @@ impl<'a> FactStore<'a> {
         let deleted = self.conn.execute(&sql, params.as_slice())?;
         Ok(deleted)
     }
+
+    /// List archive candidates: non-pinned facts whose system-time validity has
+    /// expired before `expired_before` (`t_expired IS NOT NULL AND t_expired <
+    /// expired_before`), ordered by id ascending.
+    ///
+    /// This pushes the archive selection predicate into SQL so the engine never
+    /// materializes every fact (and every embedding BLOB) just to discard the
+    /// ones that don't qualify. Equivalent to the prior Rust-side filter
+    /// `!f.is_pinned && f.t_expired.is_some_and(|te| te < expired_before)` over
+    /// `list_all()`.
+    ///
+    /// The `t_expired < ?` comparison is a string comparison on the stored
+    /// rfc3339 timestamps; this is correct because `DateTime::to_rfc3339()` emits
+    /// a lexicographically-ordered encoding (the same invariant
+    /// [`insert_or_reinforce`](Self::insert_or_reinforce) relies on for its
+    /// `min`/`max` over `t_created`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn list_archive_candidates(&self, expired_before: DateTime<Utc>) -> Result<Vec<Fact>> {
+        let cutoff = expired_before.to_rfc3339();
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {FACT_COLUMNS} FROM facts
+             WHERE is_pinned = 0
+               AND t_expired IS NOT NULL
+               AND t_expired < ?1
+             ORDER BY id ASC"
+        ))?;
+        let dim = self.embed_dim;
+        let rows = stmt.query_map(params![cutoff], |row| row_to_fact(row, dim))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
 }
 
 fn row_to_fact(row: &rusqlite::Row<'_>, embed_dim: usize) -> rusqlite::Result<Fact> {
@@ -1348,6 +1382,51 @@ mod tests {
             store.merge_metadata(id, &serde_json::json!("not-an-object")),
             Err(MemoryError::Internal(_))
         ));
+    }
+
+    #[test]
+    fn list_archive_candidates_matches_pinned_and_expiry_predicate() {
+        // Equivalence guard for the SQL-pushdown refactor (#349): the new
+        // `list_archive_candidates` must select exactly the rows the prior
+        // Rust filter did — `!is_pinned && t_expired.is_some_and(|te| te < cutoff)`.
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let cutoff = Utc::now();
+
+        // Helper: insert a fact with explicit t_expired and is_pinned values
+        // (both are persisted verbatim by insert()).
+        let insert_expired =
+            |content: &str, embed: f32, expired: Option<DateTime<Utc>>, pinned: bool| {
+                let mut f = make_fact(content, vec![embed; DIM]);
+                f.t_expired = expired;
+                f.is_pinned = pinned;
+                store.insert(&f).unwrap()
+            };
+
+        // (1) expired before cutoff, not pinned → INCLUDED
+        let qualifies = insert_expired("qualifies", 0.1, Some(cutoff - TimeDelta::hours(1)), false);
+        // (2) active (t_expired NULL) → EXCLUDED
+        let _active = insert_expired("active", 0.2, None, false);
+        // (3) expired AFTER cutoff → EXCLUDED
+        let _too_recent =
+            insert_expired("too recent", 0.3, Some(cutoff + TimeDelta::hours(1)), false);
+        // (4) expired before cutoff but PINNED → EXCLUDED
+        let _pinned = insert_expired("pinned", 0.4, Some(cutoff - TimeDelta::hours(1)), true);
+        // (5) a second qualifying fact (higher id) to assert id-ascending order
+        let qualifies2 = insert_expired(
+            "qualifies two",
+            0.5,
+            Some(cutoff - TimeDelta::minutes(30)),
+            false,
+        );
+
+        let candidates = store.list_archive_candidates(cutoff).unwrap();
+        let ids: Vec<i64> = candidates.iter().map(|f| f.id).collect();
+        assert_eq!(
+            ids,
+            vec![qualifies, qualifies2],
+            "only non-pinned facts expired strictly before the cutoff, id-ascending"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 1). Subsystem-cohesive PR closing 2 findings.

## Findings closed

- **#265** [bug/high] — Orphaned `.pak` file when `commit_archive` fails mid-archive
- **#349** [refactor/medium] — `select_archive_candidates()` materialised all facts+edges then filtered in Rust → pushed into SQL

## Review (internal diverse-lens subagents — no external models)

3 clean-slate adversarial reviewers (correctness / security & soundness / api-surface & test-quality): **0 blocker, 0 major**. Addressed the actionable minors/nits:
- **#265 cleanup coverage**: the orphan-removal guard now covers the post-rename `stat` failure inside `write_pak_to_disk` (not only `commit_archive`), closing the full leak window (CWE-459).
- **`# Errors` doc**: `EdgeStore::list_internal_by_facts` now documents `MemoryError::Serialization`.
- **`t_expired` precondition**: documented the UTC-rfc3339 storage invariant the lexicographic SQL comparison relies on.
- 4 new equivalence tests (facts + edges SQL-vs-Rust candidate parity, incl. straddling-edge exclusion and deliberate expired-edge inclusion).

## Gate

`cargo build/test/clippy --workspace` + `cargo fmt --check` — green (rebased on current main; #629 storage-traits did not conflict).

Fixes #265, fixes #349
