### PR TITLE
refactor(consolidation): summarize via SummarizableContent, not pseudo-Fact structs

### DIFF
--- a/benches/lifecycle_bench.rs
+++ b/benches/lifecycle_bench.rs
@@ -28,9 +28,9 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::traits::{
-    ConsolidationConfig, EmbeddingProvider, ForgetPolicy, SummaryGenerator,
+    ConsolidationConfig, EmbeddingProvider, ForgetPolicy, SummarizableContent, SummaryGenerator,
 };
-use memory_engine::types::{AddFactOptions, AddFactRequest, Fact, FactType};
+use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 
 const DIM: usize = 128;
 
@@ -67,12 +67,8 @@ impl EmbeddingProvider for ConstEmbedder {
 struct ConcatSummaryGenerator;
 
 impl SummaryGenerator for ConcatSummaryGenerator {
-    fn summarize(&self, facts: &[Fact]) -> memory_engine::error::Result<String> {
-        let summary: String = facts
-            .iter()
-            .map(|f| f.content.as_str())
-            .collect::<Vec<_>>()
-            .join("; ");
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> memory_engine::error::Result<String> {
+        let summary: String = items.iter().map(|i| i.text).collect::<Vec<_>>().join("; ");
         Ok(summary)
     }
 }

--- a/docs/advanced/extensibility.md
+++ b/docs/advanced/extensibility.md
@@ -56,11 +56,11 @@ Called during consolidation (cluster fusion and global integration) to produce t
 
 ```rust
 pub trait SummaryGenerator {
-    fn summarize(&self, facts: &[Fact]) -> Result<String>;
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String>;
 }
 ```
 
-The `summarize` method receives a slice of related facts (a cluster or the set of cluster summaries) and returns a textual summary. Embedding of that summary is **not** the generator's job: the `EmbeddingProvider` passed alongside the generator into `consolidate()` embeds it, so summaries share the fact vector space. (A redundant `SummaryGenerator::embed` was removed; it merely duplicated `EmbeddingProvider::embed`.)
+The `summarize` method receives a slice of [`SummarizableContent`] — a minimal borrowed view of each item's `text` and that text's `embedding` — covering both consolidation passes (a cluster of facts, or the set of cluster summaries) without fabricating throwaway `Fact` structs (#273). A plain text summarizer reads only `item.text`; `item.embedding` is there for embedding-aware merging. Embedding of the produced summary is **not** the generator's job: the `EmbeddingProvider` passed alongside the generator into `consolidate()` embeds it, so summaries share the fact/summary vector space. (A redundant `SummaryGenerator::embed` was removed; it merely duplicated `EmbeddingProvider::embed`.)
 
 Implementation example:
 
@@ -71,10 +71,10 @@ struct LlmSummarizer {
 }
 
 impl SummaryGenerator for LlmSummarizer {
-    fn summarize(&self, facts: &[Fact]) -> Result<String> {
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String> {
         let prompt = format!(
-            "Summarize these facts concisely:\n{}",
-            facts.iter().map(|f| f.content.as_str()).collect::<Vec<_>>().join("\n")
+            "Summarize these concisely:\n{}",
+            items.iter().map(|i| i.text).collect::<Vec<_>>().join("\n")
         );
         // Call LLM API...
         Ok(summary)

--- a/examples/custom_traits.rs
+++ b/examples/custom_traits.rs
@@ -9,7 +9,7 @@ use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
 use memory_engine::traits::{
     ConflictArbiter, ConsolidationConfig, CrudDecision, EmbeddingProvider, ForgetPolicy,
-    SummaryGenerator,
+    SummarizableContent, SummaryGenerator,
 };
 use memory_engine::types::{AddFactRequest, Fact, FactType, NewFact};
 
@@ -43,13 +43,9 @@ impl EmbeddingProvider for SimpleEmbedder {
 struct ConcatSummarizer;
 
 impl SummaryGenerator for ConcatSummarizer {
-    fn summarize(&self, facts: &[Fact]) -> Result<String, MemoryError> {
-        // Toy: concatenate fact contents. Replace with LLM call in production.
-        let summary = facts
-            .iter()
-            .map(|f| f.content.as_str())
-            .collect::<Vec<_>>()
-            .join("; ");
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String, MemoryError> {
+        // Toy: concatenate the item texts. Replace with LLM call in production.
+        let summary = items.iter().map(|i| i.text).collect::<Vec<_>>().join("; ");
         Ok(format!("Summary: {summary}"))
     }
     // No `embed`: summaries are embedded by the EmbeddingProvider passed into

--- a/memory-engine-mcp/src/summary.rs
+++ b/memory-engine-mcp/src/summary.rs
@@ -1,6 +1,5 @@
 use memory_engine::error::MemoryError;
-use memory_engine::traits::SummaryGenerator;
-use memory_engine::types::Fact;
+use memory_engine::traits::{SummarizableContent, SummaryGenerator};
 
 /// Default system prompt for memory consolidation summarization.
 ///
@@ -52,11 +51,11 @@ impl HttpSummaryGenerator {
 }
 
 impl SummaryGenerator for HttpSummaryGenerator {
-    fn summarize(&self, facts: &[Fact]) -> Result<String, MemoryError> {
-        let user_content = facts
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String, MemoryError> {
+        let user_content = items
             .iter()
             .enumerate()
-            .map(|(i, f)| format!("{}. {}", i + 1, f.content))
+            .map(|(i, item)| format!("{}. {}", i + 1, item.text))
             .collect::<Vec<_>>()
             .join("\n");
 

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -4,7 +4,7 @@ use crate::error::Result;
 use crate::search::vector::cosine_similarity;
 use crate::store::facts::FactStore;
 use crate::store::summaries::SummaryStore;
-use crate::traits::{EmbeddingProvider, SummaryGenerator};
+use crate::traits::{EmbeddingProvider, SummarizableContent, SummaryGenerator};
 use crate::types::{ConsolidationLevel, Fact, NewSummary};
 
 /// Cluster fusion pass.
@@ -70,8 +70,15 @@ pub fn cluster_fusion(
             .collect();
         let source_ids: Vec<i64> = cluster_facts.iter().map(|f| f.id).collect();
 
+        let items: Vec<SummarizableContent<'_>> = cluster_facts
+            .iter()
+            .map(|f| SummarizableContent {
+                text: &f.content,
+                embedding: &f.embedding,
+            })
+            .collect();
         let (summary_text, summary_embedding) =
-            super::summarize_and_embed(generator, embedder, &cluster_facts, embed_dim)?;
+            super::summarize_and_embed(generator, embedder, &items, embed_dim)?;
 
         // Determine scope_id from majority vote of source facts.
         // Deterministic tie-break: lowest scope_id wins on equal counts.
@@ -154,12 +161,8 @@ mod tests {
     struct MockGenerator;
 
     impl SummaryGenerator for MockGenerator {
-        fn summarize(&self, facts: &[Fact]) -> Result<String> {
-            Ok(facts
-                .iter()
-                .map(|f| f.content.as_str())
-                .collect::<Vec<_>>()
-                .join(" + "))
+        fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String> {
+            Ok(items.iter().map(|i| i.text).collect::<Vec<_>>().join(" + "))
         }
     }
 

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -72,10 +72,7 @@ pub fn cluster_fusion(
 
         let items: Vec<SummarizableContent<'_>> = cluster_facts
             .iter()
-            .map(|f| SummarizableContent {
-                text: &f.content,
-                embedding: &f.embedding,
-            })
+            .map(|f| SummarizableContent::new(&f.content, &f.embedding))
             .collect();
         let (summary_text, summary_embedding) =
             super::summarize_and_embed(generator, embedder, &items, embed_dim)?;

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -39,10 +39,7 @@ pub fn global_integration(
     // embedding, with no throwaway `Fact` structs and no clones (#273, #495).
     let items: Vec<SummarizableContent<'_>> = cluster_summaries
         .iter()
-        .map(|s| SummarizableContent {
-            text: &s.content,
-            embedding: &s.embedding,
-        })
+        .map(|s| SummarizableContent::new(&s.content, &s.embedding))
         .collect();
 
     let (global_text, global_embedding) =

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -2,8 +2,8 @@ use rusqlite::Connection;
 
 use crate::error::Result;
 use crate::store::summaries::SummaryStore;
-use crate::traits::{EmbeddingProvider, SummaryGenerator};
-use crate::types::{ConsolidationLevel, Fact, NewSummary};
+use crate::traits::{EmbeddingProvider, SummarizableContent, SummaryGenerator};
+use crate::types::{ConsolidationLevel, NewSummary};
 
 /// Global integration pass.
 ///
@@ -35,33 +35,18 @@ pub fn global_integration(
         return Ok(0);
     }
 
-    // Convert summaries to Fact-like structs for the SummaryGenerator trait
-    let pseudo_facts: Vec<Fact> = cluster_summaries
+    // Summarize the cluster summaries directly — borrow each summary's text and
+    // embedding, with no throwaway `Fact` structs and no clones (#273, #495).
+    let items: Vec<SummarizableContent<'_>> = cluster_summaries
         .iter()
-        .map(|s| Fact {
-            id: s.id,
-            content: s.content.clone(),
-            content_hash: String::new(),
-            embedding: s.embedding.clone(),
-            fact_type: crate::types::FactType::Semantic,
-            t_created: s.created_at,
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
-            scope_id: s.scope_id,
-            importance: 1.0,
-            access_count: 0,
-            last_accessed: s.created_at,
-            metadata: serde_json::json!({}),
-            is_pinned: false,
-            importance_score: Fact::UNSCORED_IMPORTANCE,
-            surfaced_at: None,
+        .map(|s| SummarizableContent {
+            text: &s.content,
+            embedding: &s.embedding,
         })
         .collect();
 
     let (global_text, global_embedding) =
-        super::summarize_and_embed(generator, embedder, &pseudo_facts, embed_dim)?;
+        super::summarize_and_embed(generator, embedder, &items, embed_dim)?;
 
     // Collect all source fact ids from all cluster summaries.
     // Pre-size to avoid repeated reallocations: flat_map has no upper-bound hint.
@@ -100,12 +85,8 @@ mod tests {
     struct MockGenerator;
 
     impl SummaryGenerator for MockGenerator {
-        fn summarize(&self, facts: &[Fact]) -> Result<String> {
-            Ok(facts
-                .iter()
-                .map(|f| f.content.as_str())
-                .collect::<Vec<_>>()
-                .join(" | "))
+        fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String> {
+            Ok(items.iter().map(|i| i.text).collect::<Vec<_>>().join(" | "))
         }
     }
 

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -15,8 +15,10 @@ use rusqlite::Connection;
 
 use crate::error::Result;
 use crate::store::schema::{get_config, set_config};
-use crate::traits::{ConsolidationConfig, ConsolidationStats, EmbeddingProvider, SummaryGenerator};
-use crate::types::Fact;
+use crate::traits::{
+    ConsolidationConfig, ConsolidationStats, EmbeddingProvider, SummarizableContent,
+    SummaryGenerator,
+};
 
 /// Safety cap for the O(N·M) [`local_dedup`] pass. Beyond this many active facts
 /// the pass is **skipped and the consolidation watermark is NOT advanced**, so the
@@ -35,7 +37,7 @@ const MAX_FACTS_FOR_DEDUP: usize = 50_000;
 /// separately so the policies cannot drift silently (#345).
 const MAX_FACTS_FOR_CLUSTERING: usize = 50_000;
 
-/// Summarize a slice of facts and embed the resulting summary text, validating
+/// Summarize a slice of items and embed the resulting summary text, validating
 /// the embedding dimension. Shared by cluster fusion and global integration so
 /// the summarize → embed → dimension-check sequence cannot diverge (issue #116:
 /// embedding now flows through the injected `EmbeddingProvider`).
@@ -47,10 +49,10 @@ const MAX_FACTS_FOR_CLUSTERING: usize = 50_000;
 pub fn summarize_and_embed(
     generator: &dyn SummaryGenerator,
     embedder: &dyn EmbeddingProvider,
-    facts: &[Fact],
+    items: &[SummarizableContent<'_>],
     embed_dim: usize,
 ) -> Result<(String, Vec<f32>)> {
-    let text = generator.summarize(facts)?;
+    let text = generator.summarize(items)?;
     let embedding = embedder.embed(&text)?;
     if embedding.len() != embed_dim {
         return Err(crate::error::MemoryError::EmbeddingDimension {
@@ -210,12 +212,8 @@ mod tests {
     struct MockGenerator;
 
     impl SummaryGenerator for MockGenerator {
-        fn summarize(&self, facts: &[Fact]) -> Result<String> {
-            Ok(facts
-                .iter()
-                .map(|f| f.content.as_str())
-                .collect::<Vec<_>>()
-                .join(" + "))
+        fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String> {
+            Ok(items.iter().map(|i| i.text).collect::<Vec<_>>().join(" + "))
         }
     }
 
@@ -224,7 +222,7 @@ mod tests {
     struct FailingGenerator;
 
     impl SummaryGenerator for FailingGenerator {
-        fn summarize(&self, _facts: &[Fact]) -> Result<String> {
+        fn summarize(&self, _items: &[SummarizableContent<'_>]) -> Result<String> {
             Err(crate::error::MemoryError::Internal("summarize boom".into()))
         }
     }

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -4,7 +4,7 @@ use crate::search::hybrid::{SearchMode, SearchQuery};
 use crate::search::query::MemoryQuery;
 use crate::traits::{
     ConflictArbiter, ConsolidationConfig, CrudDecision, EmbeddingProvider, ForgetPolicy,
-    PersistenceClassifier, SummaryGenerator,
+    PersistenceClassifier, SummarizableContent, SummaryGenerator,
 };
 use crate::types::{
     AddFactOptions, AddFactRequest, EmbeddingFingerprint, EventType, Fact, FactType, NewEvent,
@@ -29,12 +29,8 @@ impl EmbeddingProvider for MockEmbedder {
 
 struct MockGen;
 impl SummaryGenerator for MockGen {
-    fn summarize(&self, facts: &[Fact]) -> Result<String> {
-        Ok(facts
-            .iter()
-            .map(|f| f.content.as_str())
-            .collect::<Vec<_>>()
-            .join("; "))
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String> {
+        Ok(items.iter().map(|i| i.text).collect::<Vec<_>>().join("; "))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub use store::schema::CURRENT_SCHEMA_VERSION;
 pub use traits::{
     ConflictArbiter, ConflictResolution, ConsolidationConfig, ConsolidationStats, CrudDecision,
     DeltaProposer, DreamCycle, EmbeddingProvider, ForgetPolicy, InsightStream,
-    PersistenceClassifier, PruneStats, Reranker, SummaryGenerator,
+    PersistenceClassifier, PruneStats, Reranker, SummarizableContent, SummaryGenerator,
 };
 pub use types::*;
 
@@ -157,6 +157,10 @@ mod tests {
         fn _accepts_delta_proposer(_: &dyn crate::DeltaProposer) {}
         // storage port umbrella (bounded traits stay at `crate::storage::*`)
         fn _accepts_storage_backend(_: &dyn crate::StorageBackend) {}
+
+        // `SummaryGenerator`'s parameter type must be reachable from the same
+        // crate-root namespace as the trait it appears in (#273).
+        fn _uses_summarizable_content(_: crate::SummarizableContent<'_>) {}
 
         // trait types
         let _ = std::mem::size_of::<crate::CrudDecision>();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -96,21 +96,23 @@ pub trait EmbeddingProvider: Send + Sync {
 
 // --- Phase 2 placeholder traits and types ---
 
-/// Trait for generating summaries from fact clusters (Phase 2).
+/// Trait for generating a textual summary from a set of related items (Phase 2).
 ///
-/// Used by consolidation to merge related facts into higher-level summaries.
+/// Used by consolidation: the cluster-fusion pass summarizes related *facts*, and
+/// the global-integration pass summarizes the resulting *cluster summaries* — both
+/// feed [`SummaryGenerator::summarize`] a slice of [`SummarizableContent`].
 ///
 /// Summaries are embedded by the [`EmbeddingProvider`] passed alongside the
 /// generator into [`consolidate`](crate::engine::MemoryEngine::consolidate), so
-/// summary text shares the same vector space as the facts it summarizes. The
-/// generator only produces text — it never embeds (issue #116: embedding lived
-/// here as a duplicate of [`EmbeddingProvider::embed`]).
+/// summary text shares the fact/summary vector space. The generator only produces
+/// text — it never embeds (issue #116: embedding lived here as a duplicate of
+/// [`EmbeddingProvider::embed`]).
 ///
 /// Requires `Send + Sync`: summary generators are shared across the engine's
 /// worker threads alongside the other consumer providers.
 pub trait SummaryGenerator: Send + Sync {
     /// Generate a textual summary from a slice of items, each carrying its text
-    /// and the embedding of that text.
+    /// and that text's embedding.
     ///
     /// # Errors
     ///
@@ -118,21 +120,34 @@ pub trait SummaryGenerator: Send + Sync {
     fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String>;
 }
 
-/// A minimal, borrowed view of something to summarize: its text and the
-/// embedding of that text in the fact vector space.
+/// A minimal, borrowed view of something to summarize: its `text` and that text's
+/// `embedding` in the shared fact/summary vector space.
 ///
-/// Both the cluster-fusion pass (summarizing facts) and the global-integration
-/// pass (summarizing cluster summaries) feed [`SummaryGenerator::summarize`]
-/// through this type, so neither has to fabricate throwaway `Fact` structs with
-/// phantom field values just to satisfy the trait (#273). It is `Copy` — two
-/// shared references — and borrows its inputs, so no content or embedding is
-/// cloned to build it.
+/// Both consolidation passes feed [`SummaryGenerator::summarize`] through this type
+/// — the cluster pass over facts, the global pass over cluster summaries — so
+/// neither fabricates throwaway `Fact` structs with phantom field values just to
+/// satisfy the trait (#273). It is `Copy` (two shared references) and borrows its
+/// inputs, so building it clones nothing.
+///
+/// `embedding` is provided for summarizers that want embedding-aware merging
+/// (ordering, centroid weighting, dedup hints); a plain text summarizer ignores
+/// it. `#[non_exhaustive]`: build it via [`SummarizableContent::new`] so a future
+/// field (e.g. scope or metadata for richer prompting) won't break callers.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct SummarizableContent<'a> {
     /// The text to summarize.
     pub text: &'a str,
-    /// The embedding of `text`, in the same vector space as the facts.
+    /// The embedding of `text`, in the shared fact/summary vector space.
     pub embedding: &'a [f32],
+}
+
+impl<'a> SummarizableContent<'a> {
+    /// Create a summarizable view from borrowed text and its embedding.
+    #[must_use]
+    pub const fn new(text: &'a str, embedding: &'a [f32]) -> Self {
+        Self { text, embedding }
+    }
 }
 
 /// Trait for proposing how to consolidate a window of facts (#554).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -109,12 +109,30 @@ pub trait EmbeddingProvider: Send + Sync {
 /// Requires `Send + Sync`: summary generators are shared across the engine's
 /// worker threads alongside the other consumer providers.
 pub trait SummaryGenerator: Send + Sync {
-    /// Generate a textual summary from a slice of facts.
+    /// Generate a textual summary from a slice of items, each carrying its text
+    /// and the embedding of that text.
     ///
     /// # Errors
     ///
     /// Returns an error if summarization fails.
-    fn summarize(&self, facts: &[Fact]) -> Result<String>;
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String>;
+}
+
+/// A minimal, borrowed view of something to summarize: its text and the
+/// embedding of that text in the fact vector space.
+///
+/// Both the cluster-fusion pass (summarizing facts) and the global-integration
+/// pass (summarizing cluster summaries) feed [`SummaryGenerator::summarize`]
+/// through this type, so neither has to fabricate throwaway `Fact` structs with
+/// phantom field values just to satisfy the trait (#273). It is `Copy` — two
+/// shared references — and borrows its inputs, so no content or embedding is
+/// cloned to build it.
+#[derive(Debug, Clone, Copy)]
+pub struct SummarizableContent<'a> {
+    /// The text to summarize.
+    pub text: &'a str,
+    /// The embedding of `text`, in the same vector space as the facts.
+    pub embedding: &'a [f32],
 }
 
 /// Trait for proposing how to consolidate a window of facts (#554).
@@ -994,7 +1012,10 @@ mod tests {
     fn summary_generator_is_object_safe() {
         struct Dummy;
         impl SummaryGenerator for Dummy {
-            fn summarize(&self, _facts: &[Fact]) -> crate::error::Result<String> {
+            fn summarize(
+                &self,
+                _items: &[SummarizableContent<'_>],
+            ) -> crate::error::Result<String> {
                 Ok(String::new())
             }
         }

--- a/tests/eval/helpers.rs
+++ b/tests/eval/helpers.rs
@@ -9,7 +9,7 @@ use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
 use memory_engine::traits::{
     ConflictArbiter, CrudDecision, EmbeddingProvider, ForgetPolicy, PersistenceClassifier,
-    SummaryGenerator,
+    SummarizableContent, SummaryGenerator,
 };
 use memory_engine::types::{AddFactOptions, AddFactRequest, Fact, FactType};
 
@@ -61,12 +61,8 @@ impl EmbeddingProvider for TestEmbedder {
 pub struct MockSummaryGenerator;
 
 impl SummaryGenerator for MockSummaryGenerator {
-    fn summarize(&self, facts: &[Fact]) -> Result<String> {
-        Ok(facts
-            .iter()
-            .map(|f| f.content.as_str())
-            .collect::<Vec<_>>()
-            .join("; "))
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String> {
+        Ok(items.iter().map(|i| i.text).collect::<Vec<_>>().join("; "))
     }
 }
 


### PR DESCRIPTION
## What

Wave 4 of the **#253 consolidation super-qa sweep**. Removes the leaky pseudo-`Fact` abstraction in the summarization path (#273) and the associated clones (#495).

## The problem (#273)

`global_integration` fabricated a full `Fact` per cluster summary — hard-coding ~20 fields (`content_hash`, `importance`, bi-temporal timestamps, pinning, `metadata`) to phantom values — solely to satisfy `SummaryGenerator::summarize(&[Fact])`. `Fact` is not `#[non_exhaustive]`, so a new required field silently compiled this site with a wrong value (it had already grown `importance_score` + `surfaced_at`).

## The fix (locked decision D2)

- Introduce `SummarizableContent<'a> { text: &str, embedding: &[f32] }` — a minimal, borrowed, `Copy` view.
- Change the trait to `summarize(&[SummarizableContent<'_>])`.
- `cluster_fusion` maps its facts to borrowed views; `global_integration` borrows each summary's text + embedding directly — **deleting the pseudo-`Fact` construction and the per-summary clones** (#495 perf item).

## Blast radius

All 10 in-tree `SummaryGenerator` impls updated (real `HttpSummaryGenerator` in mcp, the public example, the bench, 7 test doubles). No external implementors → the breaking trait change is contained. Single call site (`summarize_and_embed`) + one trait method = the whole surface.

## Verification

- `cargo test --workspace --all-features`: 35 binaries pass. `clippy --workspace --all-targets --all-features -- -D warnings` + `fmt` + `cargo deny` clean.

Closes #273. Part of #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)