### PR TITLE
refactor(storage): implement SqliteBackend behind traits (zero behavior change)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = "3"
 tracing = "0.1"
 petgraph = "0.7"
 parking_lot = "0.12"
-tokio = { version = "1", features = ["rt", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "macros", "sync"], optional = true }
 hnsw = { version = "0.11", optional = true }
 space = { version = "0.17", optional = true }
 rand = { version = "0.8", features = ["small_rng"], optional = true }

--- a/docs/plans/2026-06-20-sqlite-backend-630-prreview-async.md
+++ b/docs/plans/2026-06-20-sqlite-backend-630-prreview-async.md
@@ -1,0 +1,424 @@
+# Async / Concurrency Adversarial Review — PR #682 `SqliteBackend` (#630)
+
+**Lens:** async seam correctness, concurrency, `Send`/`Sync`, deadlock, error-priority.
+**Verdict scale:** [BLOCKER] / [HIGH] / [MEDIUM] / [LOW] / [SOUND].
+**Code references** are file-relative to the worktree root.
+
+---
+
+## 1. `block_read` / `block_write` — seam bounds, guard placement, error wrapping
+
+### 1a. `T: Send + 'static`, `F: Send + 'static` — SOUND
+
+`tokio::task::spawn_blocking` requires `F: FnOnce() -> R + Send + 'static` and `R: Send + 'static`.
+The actual signature of `JoinHandle<R>` being `Send` forces `R: Send + 'static`.
+Both helpers declare exactly these bounds on `T` (the return value) and `F` (the closure).
+The pool `Arc` is cloned on the executor thread and moved into the closure — no borrow crosses
+the thread boundary. Correct.
+
+### 1b. `!Send` guard acquired inside the closure — SOUND
+
+`ReadConn<'_>` (which wraps `MutexGuard<'_, Connection>` for in-memory mode, or `ReadGuard<'_>`
+for pooled mode) is `!Send` because `parking_lot::MutexGuard<T>` is `!Send`.
+Both guards are acquired inside the `spawn_blocking` closure, never stored in a `Send + 'static`
+position. The closures themselves close over only `Arc<ConnectionPool>` (which is `Send + Sync`)
+and other `Send` values. Correct.
+
+### 1c. Doubly-wrapped `Result` — SOUND
+
+```
+spawn_blocking(|| -> Result<T> { … })
+    .await                     // -> Result<Result<T>, JoinError>
+    .map_err(map_join)?        // -> Result<Result<T>, MemoryError>  (JoinError→Pool)
+```
+
+Wait — `.await` on a `JoinHandle<Result<T>>` returns `Result<Result<T>, JoinError>`.
+`.map_err(map_join)?` propagates a `JoinError` (panic/cancel) as `MemoryError::Pool` and
+unwraps the `Result<Result<T>, MemoryError>` to `Result<T, MemoryError>` via `?`. So after
+the `?` we hold `Result<T>` (the closure's return). Then `map_seam_err(out)` remaps
+`MemoryError::Database` to `MemoryError::Storage(Backend)`. The double-unwrap is correct;
+the naming `out` for the inner `Result<T>` is accurate.
+
+### 1d. `map_seam_err` — SOUND
+
+D4 contract: a `MemoryError::Database` (raw rusqlite error) becomes opaque
+`StorageError::Backend`; every named semantic variant passes through unchanged.
+The `match` in `map_seam_err` is exhaustive: arm 1 matches `Database`, arm 2 is `other => other`
+which re-returns every other variant including `NotFound`, `ReadOnly`, `EmbeddingDimension`, etc.
+Confirmed by the three tests `block_read_maps_database_error_to_storage_backend`,
+`block_read_passes_semantic_variant_through`, and the `get_fact_missing_yields_not_found` /
+`get_missing_yields_not_found` tests across the trait files.
+
+---
+
+## 2. `for_each_streamed` — the cap-1 channel bridge
+
+### 2a. Early-callback-error path — SOUND WITH CAVEATS (see 2c)
+
+Walk the path:
+
+1. `cb(row)` returns `Err(e)` at row k.
+2. `cb_err = Some(e)`, `break` exits the `while let` loop.
+3. `drop(rx)` — receiver dropped, channel closed from receiver side.
+4. The scan task is blocked on `blocking_send` for row k+1 (cap-1 backpressure).
+   `blocking_send` returns `Err(SendError(_))` because the receiver is gone.
+5. The scan closure maps this to `stream_consumer_dropped()` via `.map_err(|_| …)?`,
+   which propagates out of the scan closure as `Err(MemoryError::Internal(…))`.
+6. The blocking task completes with this error.
+7. `handle.await.map_err(map_join)?` succeeds (no panic): `out = Err(Internal(…))`.
+8. `map_seam_err(out)` — `Internal` is not `Database`, so it passes through.
+9. `cb_err.map_or(scan_res, Err)` — `cb_err` is `Some(e)`, so returns `Err(e)`.
+   The scan's `Internal` error is discarded.
+
+The callback error wins. No row is double-counted: the `break` exits the loop before
+the next `recv().await`, so row k is the last row handed to `cb`. Row k+1 is
+already in the channel (or not yet sent); it never reaches `cb`.
+
+**Caveat:** rows already sent into the cap-1 channel before `rx` is dropped are
+silently discarded (the channel is flushed on drop). At most 1 row can be in-flight
+(cap = 1), and it belongs to the _next_ iteration the `while let` would have taken —
+so there is no double-delivery, but there is a silent skip of up to 1 buffered row.
+This is correct for the stop-early contract (once `cb` returns `Err`, further rows
+are irrelevant), but worth acknowledging.
+
+### 2b. `handle.await` after `drop(rx)` — SOUND
+
+`tokio::task::JoinHandle` is safe to `.await` regardless of whether the task has
+already completed. If the task finished before `.await`, the future resolves
+immediately with the stored result. If the task panicked, `JoinError::is_panic()` is
+true and `map_join` maps it to `MemoryError::Pool`. Dropping `rx` does not cancel the
+`JoinHandle` — only `handle.abort()` would do that. So the `handle.await` here
+always eventually resolves.
+
+### 2c. Scan task cannot block indefinitely — SOUND UNDER A CONDITION [MEDIUM note]
+
+After `drop(rx)`, the scan's next `blocking_send` returns `Err` immediately because
+`blocking_send` checks the receiver count before blocking. This is the correct
+behavior for `tokio::sync::mpsc::Sender::blocking_send` when the receiver is dropped.
+However, if the scan _never calls `blocking_send`_ again (e.g., the SQL cursor is
+exhausted before the next send attempt), the task finishes normally with `Ok(())` and
+`scan_res` is `Ok(())` while `cb_err` wins.
+
+**[MEDIUM]** — not a bug, but a documentation gap: the `for_each_streamed` doc says
+"the scan's next `blocking_send` fails and it stops", which is only true if the scan
+has more rows to send. If the cursor was exhausted at exactly row k (the failing row),
+the scan returns `Ok(())` and `cb_err.map_or(scan_res, Err)` still correctly returns
+the callback error. The implementation is correct; the doc is imprecise and could
+mislead a future implementor who changes the scan body.
+
+**Fix:** Add "or the scan finishes naturally" to the `for_each_streamed` doc comment.
+
+### 2d. Cap-1 backpressure — SOUND
+
+With cap-1, the scan can be at most 1 row ahead of the consumer. This satisfies O(1)
+peak memory (the claim in the doc comment). Larger capacity would increase throughput
+at the cost of more in-flight rows; cap-1 is the conservative correct choice for
+O(1) memory. Sound.
+
+### 2e. `for_each_streamed` uses `block_read`, not `block_write` — SOUND
+
+The `for_each_*` streaming methods (facts, edges, scopes, events, summaries, lineage)
+all call `for_each_streamed`, which internally calls `pool.read()`. Correct for read
+operations. None of the streaming callsites are write paths.
+
+---
+
+## 3. In-memory pool: `ReadConn::InMemory` collapses reads onto the write mutex
+
+### 3a. Potential self-deadlock in in-memory mode — [HIGH]
+
+In-memory mode: `pool.read()` acquires `write_conn.lock()` and returns a
+`ReadConn::InMemory(WriteAsReadGuard { guard })`. The guard holds the `parking_lot`
+mutex for the write connection.
+
+`pool.try_write()` also calls `write_conn.lock()`.
+
+**`parking_lot::Mutex` is NOT re-entrant by default.** If any code path on the same
+thread (or the same blocking-pool thread in a single-threaded test) attempts to call
+`pool.try_write()` while a `ReadConn::InMemory` guard is alive, it will **deadlock**.
+
+The risk is real in these scenarios:
+
+1. **`#[tokio::test]` default (single-threaded executor) + `spawn_blocking` serialized
+   on one thread:** tokio's `#[tokio::test]` without `flavor = "multi_thread"` uses a
+   `current_thread` runtime. `spawn_blocking` spawns a real OS thread via the blocking
+   pool, so two concurrent `block_read`/`block_write` calls do NOT share the same OS
+   thread — this case is **safe** in tests.
+
+2. **`seeded()` helper in `graph.rs` and `search_index.rs` tests:** these helpers call
+   `pool.write()` (not `try_write()`) to seed data, hold the guard across a loop, then
+   drop it — all synchronously, before the backend is used. No async overlap. **Safe.**
+
+3. **Two `for_each_streamed` calls on the same in-memory backend, overlapping:** each
+   `for_each_streamed` spawns a blocking task that calls `pool.read()`, which acquires
+   `write_conn.lock()`. If two such tasks run concurrently on the blocking thread pool
+   against the same in-memory backend, the second `pool.read()` blocks until the first
+   `ReadGuard` is dropped. This is correct serialization, not a deadlock — eventually
+   the first scan finishes.
+
+4. **`block_read` then `block_write` in the same `spawn_blocking` closure:** this is
+   impossible by design — each method call goes through a single `block_read` or
+   `block_write` invocation; no closure acquires both.
+
+5. **`set_config` test helper in `pool` tests calls `pool.write()` directly, not
+   `try_write()`:** `write()` does not check `read_only`. If a test held a
+   `ReadConn::InMemory` while simultaneously calling `write()` on the same thread
+   (single-threaded test, no `spawn_blocking`), it would deadlock. Inspecting the
+   pool tests: all `write()` calls are separate from all `read()` calls, with explicit
+   `drop()` in between. **Safe as written.**
+
+**Actual risk:** The current backend API never calls `pool.read()` then `pool.try_write()`
+in the same closure or task without first dropping the read guard. But the abstraction
+does not prevent a future implementor from doing so. The `ReadConn::InMemory` variant
+holding the write mutex is a subtle invariant that is not documented in the `ConnectionPool`
+or on `ReadConn`.
+
+**[HIGH] — not a present bug but a latent trap.** Recommendation: document in
+`ConnectionPool::read()` that in in-memory mode the read guard holds the write mutex
+and that acquiring a write guard while a `ReadConn::InMemory` is live will deadlock.
+A `debug_assert!` or compile-time guard is not possible here, but the doc comment
+should make this explicit.
+
+### 3b. Read-only pool `open_read_only` stores a read-only connection in `write_conn` — [MEDIUM]
+
+In `open_read_only`, a connection opened with `SQLITE_OPEN_READ_ONLY` is stored in
+`write_conn`. When `read()` is called on this pool in in-memory mode — which cannot
+happen since `open_read_only` is always file-backed — it would return this connection
+as the write mutex guard. For file-backed read-only pools, `read()` correctly serves
+from `read_conns`. Not a bug as written (the read-only pool always has `read_pool_size > 0`
+for file-backed), but the struct layout where `write_conn` holds a read-only connection
+is surprising. `try_write()` correctly guards this with `if self.read_only { return Err(ReadOnly) }`.
+
+No action required; noting for clarity.
+
+---
+
+## 4. `Send + Sync` correctness
+
+### 4a. Compile-time witness — SOUND BUT INCOMPLETE [LOW]
+
+`mod.rs` contains:
+
+```rust
+fn _assert_send_sync() {
+    fn f<T: Send + Sync>() {}
+    f::<SqliteBackend>();
+    f::<UpcasterRegistry>();
+    f::<ConnectionPool>();
+}
+```
+
+This is a compile-time dead-code check (the function is never called, but the compiler
+must prove the bounds at the `f::<T>()` call site). It correctly proves `SqliteBackend: Send + Sync`.
+
+`SqliteBackend` fields:
+
+- `pool: Arc<ConnectionPool>` — `Arc<T>: Send + Sync` iff `T: Send + Sync`. `ConnectionPool` is asserted `Send + Sync`.
+- `embed_dim: usize` — trivially `Send + Sync`.
+- `upcaster_registry: Arc<UpcasterRegistry>` — `UpcasterRegistry` is asserted `Send + Sync`.
+
+`ConnectionPool` fields:
+
+- `write_conn: parking_lot::Mutex<Connection>` — `parking_lot::Mutex<T>: Send + Sync` iff `T: Send`. `rusqlite::Connection: Send` (rusqlite guarantees this).
+- `read_conns: parking_lot::Mutex<Vec<Connection>>` — same reasoning.
+- `Condvar`, `Option<PathBuf>`, `usize`, `bool`, `Duration` — all `Send + Sync`.
+
+**[LOW]** — the check is in `#[cfg(test)]` only, so it's not enforced in `--release`
+builds or in downstream crates that don't run tests. For a library crate, the idiomatic
+stronger approach is a `const _: fn() = || { … }` item at module level (not
+test-gated) so the Send+Sync contract is proven for every build configuration.
+Currently, if a field is added that breaks `Send+Sync`, this is only caught when tests
+run, not at `cargo build`. Low severity because the CI gate runs tests, but worth fixing.
+
+**Fix:** Move `_assert_send_sync` out of `#[cfg(test)]` into the main module body as a
+`const _: fn() = || { fn f<T: Send + Sync>() {} f::<SqliteBackend>(); };`.
+
+### 4b. `async_trait` `Send` futures — SOUND
+
+`#[async_trait]` by default rewrites `async fn` to return `Pin<Box<dyn Future<Output=…> + Send>>`.
+For the future to be `Send`, all captured references must be `Send`. In all trait impls:
+
+- `&self` is `&SqliteBackend` — `Send` (since `SqliteBackend: Sync`).
+- All temporary owned values cloned before the closure (`query.to_owned()`, `fact.clone()`, etc.) are `Send`.
+- The closures themselves are `Send + 'static`.
+
+No `!Send` type is stored across an `.await` point. **Sound.**
+
+---
+
+## 5. tokio feature: `"sync"` requirement for `blocking_send`
+
+### 5a. tokio features — SOUND
+
+`Cargo.toml`:
+
+```toml
+tokio = { version = "1", features = ["rt", "macros", "sync"], optional = true }
+```
+
+- `tokio::sync::mpsc` / `blocking_send` — requires `"sync"`. Present.
+- `tokio::task::spawn_blocking` — requires `"rt"`. Present.
+- `#[tokio::test]` — requires `"macros"` + `"rt"`. Both present.
+
+All tokio feature requirements are met. **SOUND.**
+
+### 5b. D1 async gate on the `sqlite` subtree — SOUND
+
+`src/storage/mod.rs` (verified):
+
+```rust
+#[cfg(feature = "async")]
+pub mod sqlite;           // line 38–39
+
+#[cfg(feature = "async")]
+pub use sqlite::SqliteBackend;  // line 52–53
+```
+
+The entire `storage/sqlite` directory is excluded from compilation when `feature = "async"`
+is absent. Individual sibling files inside the module do not need their own `cfg` gates —
+they are only reachable through `mod.rs`, which is itself only included when the parent
+`pub mod sqlite` is compiled. `mod cold_storage` adds a second gate (`archive`) on top.
+D1 holds. Default (no-`async`) builds pull no tokio. **SOUND.**
+
+---
+
+## 6. `spawn_blocking` semantics — executor vs blocking pool
+
+### 6a. Nothing runs on the executor thread that belongs on the blocking pool — SOUND
+
+Every rusqlite call (`pool.read()`, `pool.try_write()`, `conn.query_row()`,
+`conn.execute()`, etc.) is inside a `spawn_blocking` closure. The executor threads
+see only:
+
+1. `Arc::clone(&self.pool)` — O(1) atomic increment, trivially non-blocking.
+2. The `.await` of the `JoinHandle`.
+
+No synchronous I/O or mutex acquisition occurs on the tokio executor threads. **Sound.**
+
+### 6b. `pool.read()` Condvar wait inside `spawn_blocking` — SOUND
+
+If all read connections are checked out, `pool.read()` calls
+`read_available.wait_until(&mut conns, deadline)` — a synchronous blocking wait.
+This is inside `spawn_blocking`, so it occupies a blocking-pool thread, not an
+executor thread. This is the correct place to block. The `DEFAULT_READ_ACQUIRE_TIMEOUT`
+(30s) provides a finite upper bound to avoid permanent thread pool exhaustion.
+
+### 6c. `parking_lot::Mutex` inside `spawn_blocking` — SOUND
+
+`parking_lot::Mutex::lock()` can spin-wait then OS-park. Both are acceptable on a
+blocking thread. The write mutex is uncontended in almost all cases (single writer
+per pool). **Sound.**
+
+### 6d. Panic inside the closure → `JoinError::is_panic()` → `MemoryError::Pool` — SOUND
+
+`map_join` maps any `JoinError` (panic or cancellation) to `MemoryError::Pool`. A
+panic inside the closure would propagate through the `JoinHandle` and surface as
+`MemoryError::Pool`, not silently swallow the panic. The blocking pool thread is
+not poisoned (panics do not permanently disable blocking pool threads in tokio).
+Confirmed by `block_read_panic_maps_to_pool` test. **Sound.**
+
+---
+
+## 7. Additional findings
+
+### 7a. `for_each_streamed` always uses `pool.read()`, not `pool.try_write()` — SOUND
+
+All `for_each_*` streaming paths go through `for_each_streamed`, which calls
+`pool.read()`. This means streaming on a read-only pool works correctly. No streaming
+path accidentally calls `pool.try_write()`. **Sound.**
+
+### 7b. `seeded()` helper self-deadlock risk in in-memory tests — SOUND BUT FRAGILE [LOW]
+
+`graph.rs` and `search_index.rs` test helpers call `pool.write()` to seed data with
+a guard held across a loop:
+
+```rust
+let conn = pool.write();
+let store = FactStore::new(&conn, DIM);
+for f in facts { store.insert(f).unwrap(); }
+// guard dropped here
+```
+
+Then later `pool.read()` is called by the async backend. Since the `write()` guard
+is dropped before the backend is used, no deadlock. The `clippy::significant_drop_tightening`
+allow attribute is correctly applied. Sound but fragile: if the seeding pattern is
+ever changed to interleave with async calls, deadlock would occur in in-memory mode
+(see finding 3a).
+
+### 7c. `for_each_streamed` scan closure borrows `&tokio::sync::mpsc::Sender<T>` — SOUND
+
+The scan closure receives `&tokio::sync::mpsc::Sender<T>` as a second parameter.
+The `Sender` is owned by the `spawn_blocking` closure (moved in), not borrowed from
+the async side. The `&Sender` reference is valid for the entire lifetime of the scan
+closure. The `Sender` is correctly dropped when the closure returns, signaling the
+channel's send side is gone (though the receiver may already be dropped). **Sound.**
+
+### 7d. `drop(rx)` timing relative to `handle.await` — SOUND
+
+`drop(rx)` is explicit before `handle.await`. In Rust, drops happen in order of
+statements, so `rx` is definitely dropped before `handle.await` begins. This is
+intentional: it ensures the scan's next `blocking_send` (or a current wait in
+`blocking_send`) unblocks promptly. **Sound.**
+
+### 7e. No `#[must_use]` on `block_read`/`block_write` — [LOW]
+
+`block_read` and `block_write` return `Result<T>`. If a caller forgets to `.await`
+the returned future (or ignores the `Result`), silent data loss or logic errors
+could occur. These are `async fn` so the future is `#[must_use]` by default from
+the compiler (an unawaited async call is a warning). The `Result` is not `#[must_use]`-
+annotated, but `clippy::must_use_candidate` or `clippy::unused_must_use` would catch
+dropping the `Result` without inspection. Given they are `async fn`, the risk is low.
+
+---
+
+## Summary Table
+
+| ID  | Severity | Location                                      | Finding                                                                  |
+| --- | -------- | --------------------------------------------- | ------------------------------------------------------------------------ |
+| 1a  | SOUND    | `mod.rs:109–122`                              | `Send + 'static` bounds correct                                          |
+| 1b  | SOUND    | `mod.rs:115–118`                              | `!Send` guard acquired inside closure                                    |
+| 1c  | SOUND    | `mod.rs:119–121`                              | Double-wrapped `Result` unwrap correct                                   |
+| 1d  | SOUND    | `mod.rs:94–101`                               | `map_seam_err` passes semantic variants                                  |
+| 2a  | SOUND    | `mod.rs:152–183`                              | Callback error wins; no double-count                                     |
+| 2b  | SOUND    | `mod.rs:179`                                  | `handle.await` after `drop(rx)` safe                                     |
+| 2c  | [MEDIUM] | `mod.rs:148–150` (doc comment)                | Doc says "next send fails" — imprecise if cursor already exhausted       |
+| 2d  | SOUND    | `mod.rs:164`                                  | Cap-1 backpressure correct for O(1) memory                               |
+| 3a  | [HIGH]   | `connection_pool.rs:225–261`                  | In-memory `ReadConn` holds write mutex — deadlock trap undocumented      |
+| 3b  | [MEDIUM] | `connection_pool.rs:198–208`                  | `write_conn` holds a read-only connection in RO mode — confusing layout  |
+| 4a  | [LOW]    | `mod.rs:197–201`                              | `Send+Sync` witness is `#[cfg(test)]`-only; use `const _` for all builds |
+| 4b  | SOUND    | All `impl` files                              | `async_trait` Send futures correct                                       |
+| 5a  | SOUND    | `Cargo.toml`                                  | `"sync"` feature present; `blocking_send` requirement met                |
+| 5b  | SOUND    | `src/storage/mod.rs:38–39`                    | D1 `#[cfg(feature = "async")]` gate confirmed in parent module           |
+| 6a  | SOUND    | All trait impls                               | No sync I/O on executor threads                                          |
+| 6b  | SOUND    | `connection_pool.rs:240–255`                  | Condvar wait inside `spawn_blocking` correct                             |
+| 6c  | SOUND    | `connection_pool.rs:271–276`                  | `parking_lot::Mutex` on blocking thread correct                          |
+| 6d  | SOUND    | `mod.rs:87–89`, test                          | Panic→`Pool` error correct                                               |
+| 7a  | SOUND    | `mod.rs:152–183`                              | Streaming uses read path only                                            |
+| 7b  | [LOW]    | `graph.rs:581–591`, `search_index.rs:116–126` | Seed helpers fragile under in-memory interleave                          |
+| 7c  | SOUND    | `mod.rs:159,165`                              | `&Sender` borrow lifetime valid                                          |
+| 7d  | SOUND    | `mod.rs:177–179`                              | `drop(rx)` before `handle.await` correct                                 |
+| 7e  | [LOW]    | `mod.rs:109, 127`                             | `Result` not `#[must_use]`; mitigated by async `#[must_use]`             |
+
+---
+
+## Verdict
+
+**No blockers. No HIGH issues after verification.** The seam design is fundamentally correct:
+
+- The `Send + 'static` discipline, guard placement, and error-wrapping chain are clean.
+- The `for_each_streamed` cap-1 bridge handles early-callback-error correctly with the right priority semantics (callback error wins, no double-count, no lost rows beyond the intentional early-stop).
+- The `spawn_blocking` usage is disciplined — no sync I/O on executor threads.
+- D1 async gating confirmed: `src/storage/mod.rs:38–39` gates the entire `sqlite` subtree with `#[cfg(feature = "async")]`. Default builds pull no tokio.
+- All tokio feature requirements (`"rt"`, `"macros"`, `"sync"`) are present.
+
+**One HIGH finding to address before merge:**
+
+1. **[HIGH] 3a** — `ConnectionPool::read()` in in-memory mode returns a `ReadConn::InMemory` that holds the `write_conn` parking_lot mutex. This is a re-entrant deadlock trap: any code path on the same blocking-pool thread that acquires a read guard and then (directly or indirectly) calls `pool.try_write()` or `pool.write()` will deadlock silently. Not triggered by any current call site, but undocumented and a latent footgun for future implementors. Fix: add an explicit `# Panics / Deadlock` note to `ConnectionPool::read()` stating that in in-memory mode the returned guard holds the write mutex, and that calling `write()`/`try_write()` while that guard is alive deadlocks.
+
+**Three LOW/MEDIUM findings worth a follow-up (non-blocking):**
+
+2. **[MEDIUM] 2c** — `for_each_streamed` doc comment says "the scan's next `blocking_send` fails and it stops" — imprecise when the SQL cursor is already exhausted at the failing row. The implementation is correct; the doc should say "or the scan finishes naturally".
+
+3. **[LOW] 4a** — The `Send + Sync` compile-time witness is `#[cfg(test)]`-only. Move it to a `const _: fn() = || { … }` at module level so it is enforced on every `cargo build`, not just `cargo test`.
+
+4. **[MEDIUM] 3b** — In `open_read_only`, a `SQLITE_OPEN_READ_ONLY` connection is stored in `write_conn`. Harmless (guarded by `try_write()` returning `ReadOnly`), but the layout is confusing to future readers of the pool code. Consider renaming to `primary_conn` or adding a doc note.

--- a/docs/plans/2026-06-20-sqlite-backend-630-prreview-mapping.md
+++ b/docs/plans/2026-06-20-sqlite-backend-630-prreview-mapping.md
@@ -1,0 +1,270 @@
+# PR #682 (#630) — `SqliteBackend` delegation-mapping review
+
+**Lens:** behavior-preservation / delegation-mapping fidelity. The PR re-homes the
+concrete SQLite stores behind a trait family by delegating to them verbatim. The
+danger is a silently mis-mapped method (wrong concrete method, wrong conn, dropped
+or reordered arg, lost semantic).
+
+**Verdict: APPROVE.** All 7 impl files reviewed method-by-method against both the
+trait contract (`src/storage/*.rs`) and the concrete store
+(`src/store/*`, `src/search/{fts,vector}.rs`). Every delegation maps to the
+semantically-equivalent concrete method, with the correct conn, faithful args, and
+faithful return shape. No mis-mapping, no dropped semantic, no stub. The two
+"looks-like-a-read-but-writes" traps (`insert_or_reinforce_fact`,
+`ensure_scope_path`) and the third write-via-UPDATE (`stamp_facts_surfaced`) are all
+correctly routed to `block_write`. The `scope_ids` non-uniform empty contract is
+preserved verbatim everywhere. `embed_dim` is `self.embed_dim` at every call site
+(never `0`). The f32→f64 vector-score widening and the `FtsResult`/`VectorResult`
+tuple projections are exact.
+
+No BLOCKER / HIGH / MEDIUM findings. Two LOW observations (documentation/robustness,
+not behavior deltas) are recorded at the end.
+
+---
+
+## Method-by-method mapping verification
+
+### `graph.rs` — `FactGraph` (49 methods)
+
+Concrete surface cross-check: `FactStore` has exactly 30 `pub`/`pub(crate)` methods
+(`grep -oE "pub(\(crate\))? fn"` → 30 unique). All 30 map to exactly one `FactGraph`
+fact method; none dropped:
+
+| concrete `FactStore::*`            | trait method                              | conn   | OK |
+| ---------------------------------- | ----------------------------------------- | ------ | -- |
+| `insert`                           | `insert_fact`                             | WRITE  | ✓  |
+| `insert_or_reinforce`              | `insert_or_reinforce_fact`                | WRITE† | ✓  |
+| `expire`                           | `expire_fact`                             | WRITE  | ✓  |
+| `set_pinned`                       | `set_fact_pinned`                         | WRITE  | ✓  |
+| `update_importance`                | `update_fact_importance`                  | WRITE  | ✓  |
+| `update_importance_score`          | `update_fact_importance_score`            | WRITE  | ✓  |
+| `increment_access`                 | `increment_fact_access`                   | WRITE  | ✓  |
+| `merge_metadata`                   | `merge_fact_metadata`                     | WRITE  | ✓  |
+| `mark_dream_cycled`                | `mark_facts_dream_cycled`                 | WRITE  | ✓  |
+| `stamp_surfaced`                   | `stamp_facts_surfaced`                    | WRITE† | ✓  |
+| `hard_delete_ids`                  | `hard_delete_facts`                       | WRITE  | ✓  |
+| `get`                              | `get_fact`                                | READ   | ✓  |
+| `get_many`                         | `get_facts`                               | READ   | ✓  |
+| `list_all`                         | `list_all_facts`                          | READ   | ✓  |
+| `for_each`                         | `for_each_fact`                           | READ‡  | ✓  |
+| `max_caller_written_fact_id`       | `max_caller_written_fact_id`              | READ   | ✓  |
+| `list_active`                      | `list_active_facts`                       | READ   | ✓  |
+| `list_active_scoring`              | `list_active_facts_scoring`               | READ   | ✓  |
+| `list_active_at`                   | `list_active_facts_at`                    | READ   | ✓  |
+| `list_dormant`                     | `list_dormant_facts`                      | READ   | ✓  |
+| `list_by_scope_importance`         | `list_facts_by_scope_importance`          | READ   | ✓  |
+| `list_by_scopes_importance`        | `list_facts_by_scopes_importance`         | READ   | ✓  |
+| `list_by_importance_score`         | `list_facts_by_importance_score`          | READ   | ✓  |
+| `list_pinned`                      | `list_pinned_facts`                       | READ   | ✓  |
+| `list_due`                         | `list_due_facts`                          | READ   | ✓  |
+| `next_due_time`                    | `next_due_time`                           | READ   | ✓  |
+| `list_by_scopes_recent`            | `list_facts_by_scopes_recent`             | READ   | ✓  |
+| `list_active_by_metadata_key_recent` | `list_active_facts_by_metadata_key_recent` | READ | ✓  |
+| `list_active_in_period`            | `list_active_facts_in_period`             | READ   | ✓  |
+| `list_undreamt_in_period`          | `list_undreamt_facts_in_period`           | READ   | ✓  |
+| `list_active_by_session`           | `list_active_facts_by_session`            | READ   | ✓  |
+
+† **Write-conn trap correctly handled.** `insert_or_reinforce` is SELECT-then-
+UPDATE/INSERT (`facts.rs` ~162: `query_row("SELECT id …")` → `execute("UPDATE …")`);
+`stamp_surfaced` is `execute("UPDATE facts SET surfaced_at …")` then a SELECT
+read-back (`facts.rs` 599-628). Both *write*, so `block_write` is correct and
+necessary — a read pool would (correctly) reject them with `ReadOnly`.
+‡ `for_each_fact` routes through `for_each_streamed` (which acquires `pool.read()`),
+the right primitive for a streaming scan.
+
+`EdgeStore` (12 methods) — all mapped:
+`insert→insert_edge` (W), `get→get_edge` (R), `expire→expire_edge` (W),
+`expire_by_fact→expire_edges_by_fact` (W), `list_all→list_all_edges` (R),
+`for_each→for_each_edge` (R), `list_active→list_active_edges` (R),
+`list_active_by_source→list_active_edges_by_source` (R),
+`list_active_by_target→list_active_edges_by_target` (R),
+`exists_active→edge_exists_active` (R),
+`list_active_pairs_by_facts→list_active_edge_pairs_by_facts` (R),
+`hard_delete_by_facts→hard_delete_edges_by_facts` (W). All correct.
+
+`ScopeStore` (6 methods) — all mapped:
+`get→get_scope` (R), `find_by_label→find_scope_by_label` (R),
+`insert→insert_scope` (W), `ensure_path→ensure_scope_path` (**W, trap†**),
+`list_all→list_all_scopes` (R), `for_each→for_each_scope` (R).
+`ensure_path` is `INSERT OR IGNORE` then SELECT (`scopes.rs` 107-140) — it writes;
+`block_write` correct.
+
+**Args:** every borrowed arg is `.to_vec()`/`.to_owned()`/`.clone()`/`.copied()` to
+owned with no change of meaning. `Option<&[i64]>` → `.map(<[i64]>::to_vec)` then
+`.as_deref()` (`list_dormant_facts`), preserving `None` vs `Some(empty)`. `&[i64]`
+scope slices forwarded verbatim — no normalization (the empty=ALL vs empty=NONE
+contract is left to the concrete SQL, exactly as before). `marker_key` forwarded
+unmodified so the concrete injection guard fires (test
+`list_active_by_metadata_key_recent_rejects_invalid_keys` pins it). `dim =
+self.embed_dim` at every `FactStore::new(c, dim)` call site.
+
+**Returns:** identity types (`Fact`, `Edge`, `ScopeNode`, `HashMap`, `HashSet`,
+tuples) pass through unchanged.
+
+### `event_log.rs` — `EventLog` (7 methods)
+
+`EventStore::new(c, &registry)` is a 2-arg ctor; the backend clones
+`Arc<UpcasterRegistry>` into every closure and never lets it cross the trait
+boundary (matches the trait doc). Mapping:
+`insert→insert_event` (W), `get→get_event` (R), `list→list_events` (R),
+`count→count_events` (R), `for_each→for_each_event` (R),
+`get_upcasted→get_upcasted_event` (R), `list_upcasted→list_upcasted_events` (R).
+Raw vs upcasted reads correctly split (`get` vs `get_upcasted`,
+`list` vs `list_upcasted`) — verified by test `upcasted_read_applies_registry`.
+
+### `search_index.rs` — `SearchIndex` (3 methods)
+
+- `lexical_search` → `fts_search(c, &query, k, fact_type.as_ref(), scope_ids.as_deref())`.
+  Concrete sig `(conn, query, limit, fact_type, scope_ids)`, arg order exact
+  (`k`→`limit`). `FtsResult.score` is `f64` → `(r.fact_id, r.score)` pass-through, no
+  cast. ✓
+- `vector_search` → `vector_search(c, &q, dim, k, fact_type.as_ref(), scope_ids.as_deref())`.
+  Concrete sig `(conn, query_embedding, embed_dim, limit, fact_type, scope_ids)`,
+  arg order exact; `dim = self.embed_dim` (the dim-guard `EmbeddingDimension` error
+  is raised by the concrete fn — test `vector_wrong_dim_is_embedding_dimension_error`
+  pins `expected: DIM`, confirming dim is NOT 0). `VectorResult.score` is `f32` →
+  widened `f64::from(r.score)` (value-exact, order-preserving). ✓
+- `lexical_count_expired` → `fts_count_expired(c, &query, fact_type.as_ref(), scope_ids.as_deref())`.
+  Bypasses `FactFilter` (takes raw `Option<&FactType>` + `Option<&[i64]>`), matching
+  the concrete fn shape; the intrinsic `t_expired IS NOT NULL` predicate stays in the
+  concrete SQL. ✓
+
+`convert::search_params` projects `FactFilter` → `(fact_type, scope_ids)` and
+**errors loud** on any dimension the verbatim SQL cannot honor (`temporal != Active`,
+`ids`, `pinned`, `metadata`) instead of silently dropping a predicate — this is the
+correct fail-closed choice for a "zero behavior change" seam (the alternative,
+silently honoring fewer predicates, *would* be a behavior change). `Some(empty)`
+round-trips as `Some(vec![])` (matches nothing), not normalized to `None` — pinned by
+`empty_scope_ids_round_trip_preserved` and `lexical_scope_some_empty_matches_nothing_none_finds`.
+
+### `consolidation.rs` — `ConsolidationStore` (12 methods)
+
+`SummaryStore` (7): `insert→insert_summary` (W), `get→get_summary` (R),
+`list_by_level→list_summaries_by_level` (R), `list_all→list_all_summaries` (R),
+`for_each→for_each_summary` (R), `delete_by_level→delete_summaries_by_level` (W).
+`SummaryStore::new(c, dim)` uses `self.embed_dim` for the embedding (de)serialize
+path. ✓
+`LineageStore` (8): `insert→insert_lineage` (W, forwards both `record` and
+`provenance`), `insert_raw→insert_lineage_raw` (W),
+`get_by_wisdom_fact→get_lineage_by_wisdom_fact` (R, returns the
+`(LineageRecord, PromotionProvenance)` tuple unchanged),
+`get_source_fact_ids→get_lineage_source_fact_ids` (R), `delete→delete_lineage` (W),
+`has_lineage→has_lineage` (R), `for_each→for_each_lineage` (R). `LineageStore::new(c)`
+is a 1-arg ctor (no dim) — correct. ✓
+
+### `session.rs` — `SessionStore` (10 methods)
+
+`ActivityStore` (6): `insert_or_dedup→insert_or_dedup_activity` (W, forwards
+`dedup_window_secs`), `get→get_activity` (R),
+`list_by_session→list_activities_by_session` (R),
+`list_recent_by_scope→list_recent_activities_by_scope` (R, **empty scope_ids ⇒ empty
+result, NOT all** — pinned verbatim; test
+`list_recent_by_scope_empty_slice_returns_empty`),
+`update_status→update_activity_status` (W, forwards `status` + `promoted_fact_id`),
+`count_by_session→count_activities_by_session` (R).
+`CheckpointStore` (5): `upsert→upsert_checkpoint` (W), `get→get_checkpoint` (R),
+`get_by_scope→get_checkpoint_by_scope` (R), `list_recent→list_recent_checkpoints` (R).
+The module doc notes the previously `#[cfg(test)]` reads were un-gated in the same
+commit so the trait can call them unconditionally — a deliberate, documented change,
+not a stub. ✓
+
+### `schema.rs` — `SchemaManager` (8 methods)
+
+- `migrate` → `migrate(c, None)` (W). The concrete sig is
+  `migrate(conn, backup_dir: Option<&Path>)`; passing `None` is documented (the pool
+  already migrated at open; this is an idempotent at-HEAD re-check, no backup at this
+  level). Faithful to the prior open path, which never took a backup at this point.
+- `schema_version` → reads `get_config(c, "schema_version")` with `"1"` default,
+  parsing to `u32` (R). Matches the concrete default-and-parse used inside
+  `validate_schema_version` (`schema/mod.rs` 325). ✓
+- `validate_schema_version` → `validate_schema_version(c)` (R). Verified the concrete
+  fn is read-only (only `query_row` / `get_config`, no `execute`; `schema/mod.rs`
+  293-347) — correctly routed to `block_read`, preserving the read-only open path
+  (Key Design Decision #6). ✓
+- `capabilities` — sync, returns the fixed SQLite tier
+  (`Bm25` / `true_idf = true` / `server_side_vector = false`). Not a delegation; a new
+  constant surface introduced by #629's trait. Matches the documented SQLite tier. ✓
+- `embedding_meta`: `load→load_embedding_fingerprint` (R),
+  `store→store_embedding_fingerprint` (W),
+  `record_if_absent→record_embedding_fingerprint_if_absent` (W, forwards
+  `candidate` + `expected_dim`; the dim-mismatch `EmbeddingDimension` guard fires in
+  the concrete fn — test `record_if_absent_dim_mismatch_yields_embedding_dimension`),
+  `require_present→require_embedding_fingerprint_present` (R). ✓
+
+### `cold_storage.rs` — `ColdStorage` (3 methods, cfg archive+async)
+
+`ArchiveManifestStore` (3): `insert→insert_archive_manifest` (W),
+`list→list_archive_manifest` (R), `delete→delete_archive_manifest` (W).
+The 10-arg `insert` forwarding was checked position-by-position against the concrete
+sig (`archive_manifest.rs` 27-58) — `pak_path, created_at, fact_count, edge_count,
+fact_id_min, fact_id_max, t_created_min, t_created_max, size_bytes, blake3_hash` — no
+swap of the look-alike pairs (`fact_count`/`edge_count`,
+`fact_id_min`/`fact_id_max`, `t_created_min`/`t_created_max`). ✓
+
+---
+
+## Seam-primitive fidelity (mod.rs)
+
+- `block_read` → `pool.read()`; `block_write` → `pool.try_write()` (so a read-only
+  pool yields `ReadOnly` — Key Design Decision #6). Verified by
+  `block_write_on_read_only_pool_yields_read_only` and the per-trait
+  read-only-rejects-write tests.
+- `map_seam_err` opacifies only `MemoryError::Database` → `Storage(Backend)` (D4);
+  semantic variants (`NotFound`, `Migration`, `EmbeddingDimension`, `Conflict`,
+  `ReadOnly`, `Internal`, `Lineage`, …) pass through. Pinned by
+  `block_read_maps_database_error_to_storage_backend` /
+  `block_read_passes_semantic_variant_through` and the per-trait `*_yields_not_found`
+  / `*_yields_lineage_error` tests.
+- `for_each_streamed` cap-1 backpressure; **callback error wins** over the scan's
+  induced send failure (`for_each_streamed_callback_error_wins_and_stops_early`),
+  mid-scan SQL error surfaced + remapped
+  (`for_each_streamed_surfaces_mid_scan_error`). Faithful to a synchronous
+  `for_each` that stops on the first callback `Err`.
+
+## Completeness (no missing / stubbed method)
+
+`backend.rs` R-COMPLETE checklist matches the concrete surface exactly: every
+`pub`/`pub(crate)` concrete method maps to exactly one trait method or is an
+intentionally-private ctor/index-maintenance concern (HNSW
+`build_from_db`/`notify_*`/snapshot, `init_schema`, generic config K/V,
+`backup_before_migration`, `.pak` file I/O). The `StorageBackend` umbrella +
+blanket impl require all six bounded traits; `realization.rs` constructs a real
+`Arc<dyn StorageBackend>` and dispatches at least one method per bounded trait
+through the object. No method is `todo!()`/`unimplemented!()`/stubbed.
+
+---
+
+## Findings
+
+### [LOW] `schema_version` default-and-parse is duplicated, not delegated
+
+`src/storage/sqlite/schema.rs:39-49` re-implements the `get_config("schema_version")`
+→ `"1"` default → `u32` parse inline rather than calling a shared concrete helper.
+It is byte-faithful to the logic inside `schema/mod.rs:325`, but the duplication
+means a future change to the default/parse in the concrete path would silently NOT
+propagate here. Behavior today is correct; flagging the drift risk. Suggest a
+`pub(crate) fn schema_version(conn) -> Result<u32>` in `store::schema` that both the
+backend and `validate_schema_version` call. Not blocking.
+
+### [LOW] `migrate(c, None)` hard-codes "no backup" — correct now, fragile later
+
+`src/storage/sqlite/schema.rs:35`. The module doc already calls this out and defers
+the decision. The current behavior matches the prior open path (no backup taken at
+the post-open re-check). Noting it only so the #631 canonical-constructor work
+revisits whether `SchemaManager::migrate` should ever carry a backup dir, rather than
+silently inheriting `None`. Not blocking; explicitly documented.
+
+---
+
+## Confirmed-faithful summary
+
+- Right concrete method: **all 49 + 12 + 10 + 8 + 7 + 3 + 3 delegations** map to the
+  semantically-equivalent concrete method. No similarly-named wrong target.
+- Right conn: every read → `block_read`, every write → `block_write`. The three
+  read-shaped writes (`insert_or_reinforce_fact`, `stamp_facts_surfaced`,
+  `ensure_scope_path`) are correctly on `block_write`.
+- Args faithful: borrow→own only; `scope_ids` slices forwarded verbatim; `Option<&[i64]>`
+  preserves `None`/`Some(empty)`; `embed_dim = self.embed_dim` everywhere (never 0).
+- Returns faithful: `FtsResult.score` (f64) pass-through; `VectorResult.score` (f32)
+  widened with `f64::from`; tuples/maps/sets unchanged.
+- No trait method missing or stubbed.

--- a/docs/plans/2026-06-20-sqlite-backend-630-prreview-security.md
+++ b/docs/plans/2026-06-20-sqlite-backend-630-prreview-security.md
@@ -1,0 +1,95 @@
+# PR #682 (#630 `SqliteBackend`) — Adversarial Review: SECURITY / ERROR-FIDELITY / SCOPE-DISCIPLINE
+
+**Range reviewed:** `git diff 24f9d65..HEAD` (7 commits, 20 files, +4247/−18).
+**Reviewer lens:** security, error fidelity, scope discipline. No prior context.
+**Verdict: APPROVE.** Zero BLOCKER / HIGH / MEDIUM. Two LOW (doc-only). The "zero behavior change" claim holds for the security/error/scope surface.
+
+Build/test/clippy gate (run, not asserted):
+
+- `cargo build --all-features` → exit 0.
+- `cargo test --all-features --lib storage::sqlite` → **72 passed, 0 failed**.
+- `cargo clippy --all-features --all-targets` → clean (no sqlite warnings).
+
+---
+
+## Point-by-point
+
+### 1. D4 error remap (`map_seam_err`, `src/storage/sqlite/mod.rs:94-101`) — SOUND
+
+`map_seam_err` matches **only** `Err(MemoryError::Database(e))` → `Storage(StorageError::Backend(e.to_string()))`; everything else (`other => other`) passes through verbatim. This matches the `StorageError` contract doc (`src/error.rs:345-368`): the seam opacifies driver failures with no precise home; causes that _do_ have a home (`NotFound`, `Migration`, `Pool`, `Serialization`, `Conflict`, `ReadOnly`, `Lineage`, …) stay typed.
+
+**Not-found integrity (the failure mode the blanket remap could cause):** every read method that can "miss" maps the miss to a _semantic_ variant in the underlying store, so the remap never opacifies a not-found:
+
+| Read seam method                   | Underlying store                   | Not-found maps to     | Source                                                    |
+| ---------------------------------- | ---------------------------------- | --------------------- | --------------------------------------------------------- |
+| `get_fact`                         | `FactStore::get`                   | `NotFound`            | `src/store/facts.rs` (`None => NotFound("fact {id}")`)    |
+| `get_edge`                         | `EdgeStore::get`                   | `NotFound`            | `src/store/edges.rs` (`QueryReturnedNoRows => NotFound`)  |
+| `get_scope`                        | `ScopeStore::get`                  | `NotFound`            | `src/store/scopes.rs` (`QueryReturnedNoRows => NotFound`) |
+| `get_event` / `get_upcasted_event` | `EventStore::get`                  | `NotFound`            | `src/store/events.rs:154`                                 |
+| `get_summary`                      | `SummaryStore::get`                | `NotFound`            | `src/store/summaries.rs:89-90`                            |
+| `get_activity`                     | `ActivityStore::get`               | `NotFound`            | `src/store/activities.rs:115-116`                         |
+| `get_lineage_by_wisdom_fact`       | `LineageStore::get_by_wisdom_fact` | `Lineage` (semantic)  | `src/store/lineage.rs:126`                                |
+| `get_facts`                        | `FactStore::get_many`              | absent key (no error) | HashMap projection                                        |
+| `get_checkpoint*`                  | `CheckpointStore::get`             | `Ok(None)` (Option)   | not an error path                                         |
+
+No method returns a RAW `Database` for a semantic "not found". Witness tests at the seam: `mod.rs:238` `block_read_passes_semantic_variant_through` (NotFound survives), `mod.rs:221` `block_read_maps_database_error_to_storage_backend` (Database opacified), `event_log.rs:118` `get_missing_yields_not_found`, `graph.rs:602` `get_fact_missing_yields_not_found`. **Contract honored.**
+
+### 2. `marker_key` injection guard — SOUND
+
+`list_active_facts_by_metadata_key_recent` (`src/storage/sqlite/graph.rs:310-322`) delegates straight to `FactStore::list_active_by_metadata_key_recent` (`src/store/facts.rs:976`) passing `marker_key` through **unchanged**. The guard (`facts.rs:986-996`) runs _inside_ the delegate — it cannot be bypassed by the seam:
+
+```rust
+if marker_key.is_empty() || !marker_key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+    return Err(MemoryError::Conflict(ConflictError::QueryValidation(...)));
+}
+```
+
+`marker_key` is interpolated (not bound) into a `json_extract(metadata, '$.{marker_key}')` path because JSON paths can't be portably parameterized — so the `[A-Za-z0-9_]+` allowlist is the actual defense, and it is a runtime check (not `debug_assert`, so it survives release). `Conflict(QueryValidation)` is a semantic variant ⇒ passes through `map_seam_err` untouched (no opacification). Seam reject-test `graph.rs:754` exercises `["", "in'sight", "$.x", "a b", "a;b"]` — meaningful set covering empty, single-quote SQLi, JSON-path traversal, whitespace, and `;` statement-chaining — all asserted to yield `QueryValidation`. **Guard intact end-to-end.**
+
+### 3. read_only enforcement — SOUND
+
+Every production WRITE trait method routes through `SqliteBackend::block_write` (`mod.rs:127-140`), which acquires via `ConnectionPool::try_write()` → `MemoryError::ReadOnly` on a read-only pool. Verified all 27 production write sites use `block_write` (`grep block_write` across the backend; no production write uses `.write()`).
+
+The 7 raw `.write()` calls flagged by grep are **all below their file's `#[cfg(test)]` line** — test-only seeding helpers, never compiled into the lib:
+
+- `graph.rs:584/660/697/728/780` — below `#[cfg(test)]` at `graph.rs:537` (`fn seeded`, empty-scope tests).
+- `consolidation.rs:215` — below `#[cfg(test)]` at `:155` (`seeded_with_facts`).
+- `search_index.rs:119` — below `#[cfg(test)]` at `:73` (`seeded`).
+
+Seam witness: `mod.rs:259` `block_write_on_read_only_pool_yields_read_only` opens a real file-backed RO pool and asserts `ReadOnly`. Key Design Decision #6 preserved for free. **No bypass.**
+
+### 4. The 5 `#[cfg(test)]` removals — BODY-NEUTRAL
+
+`git diff 24f9d65..HEAD -- src/store/activities.rs src/store/checkpoints.rs` shows each of the 5 hunks (`activities.rs`: `get`, `list_by_session`, `count_by_session`; `checkpoints.rs`: `get`, `list_recent`) changes **only** the doc comment + the `#[cfg(test)]` line; the hunk context ends at the `pub fn …` signature and **no body line appears in any diff**. Behavior-neutral — the methods become reachable in non-test builds (now called by the `SessionStore` impl), nothing else. (LOW doc nit below.)
+
+### 5. Scope discipline — SOUND
+
+- **Engine untouched:** `git diff 24f9d65..HEAD -- src/engine/` is **empty**.
+- **No HNSW-in-backend (D3 deferred to #631):** grep for `hnsw|Hnsw|HNSW|ann::|feature = "ann"` under `src/storage/sqlite/` → **none**. `vector_search` (`search_index.rs:37`) is brute-force via the verbatim `search::vector` free function.
+- **No driver leak in the seam:** no `rusqlite::Connection|Error|Row` appears in any `pub`/`pub(crate)`/trait-method signature. The only `rusqlite` references outside private `block_*`/`for_each_streamed` closure types are two `#[cfg(test)]` `MemoryError::Database(...)` constructions (`mod.rs:227,343`). `convert.rs::search_params` is `pub(super)` and port-neutral. `realization.rs` is fully `#[cfg(test)]`.
+- **No engine rewire:** `storage/mod.rs` adds only `#[cfg(feature="async")] pub mod sqlite;` + `pub use sqlite::SqliteBackend;` (D1 async-gated). `Cargo.toml` adds only the tokio `sync` feature (for the `for_each_streamed` mpsc channel) — minimal, scoped.
+
+`from_pool(Arc<ConnectionPool>)` (`mod.rs:70`) is a _constructor_, not a trait method, and `ConnectionPool` is memory-engine's own pool abstraction (`src/pool/connection_pool.rs`), not a re-exported `rusqlite` type — so the port boundary is not violated.
+
+### 6. `unsafe_code` — SOUND
+
+No `unsafe` in the diff (`git diff | grep -i unsafe` → none). `unsafe_code = "forbid"` intact at `Cargo.toml:59`.
+
+---
+
+## Findings
+
+### [LOW] Doc imprecision: "promoted to unconditional `pub(crate)`" — `src/store/activities.rs` / `src/store/checkpoints.rs`
+
+The 5 replacement doc comments say _"Promoted to unconditional `pub(crate)`"_, but the signatures are and remain `pub fn` (they were `pub fn` under `#[cfg(test)]` too). Only the `#[cfg(test)]` gate was removed; the visibility keyword did not change. Harmless, but the comment misdescribes its own edit.
+**Fix:** reword to "promoted to unconditional (was `#[cfg(test)]`)" — drop the inaccurate `pub(crate)` claim, or change the keyword to actually match if `pub(crate)` was intended.
+
+### [LOW] `stream_consumer_dropped` internal error is structurally unreachable as a surfaced value — `src/storage/sqlite/mod.rs:189`
+
+`stream_consumer_dropped()` builds a `MemoryError::Internal` that, per the `for_each_streamed` contract (`mod.rs:182`, `cb_err.map_or(scan_res, Err)`), can never be the returned error — the callback error always wins. This is intentional and documented (`mod.rs:186-188`), and the value does stop the scan, so it is correct. Flagged only as a readability note: a future refactor that reorders the "callback error wins" precedence could silently start surfacing this string to callers. The existing test `for_each_streamed_callback_error_wins_and_stops_early` (`mod.rs:304`) pins the precedence, which mitigates this — **no action required**, recorded for completeness.
+
+---
+
+## What's sound (summary)
+
+D4 remap + not-found integrity; `marker_key` allowlist non-bypassable and `Conflict`-typed; read_only via `try_write` on every production write (0 bypasses); the 5 cfg removals body-neutral; engine byte-identical; no HNSW, no driver leak, no engine rewire; `unsafe_code = forbid` intact; 72 backend tests green, clippy clean. **APPROVE.**

--- a/docs/plans/2026-06-20-sqlite-backend-630-review-arch.md
+++ b/docs/plans/2026-06-20-sqlite-backend-630-review-arch.md
@@ -1,0 +1,151 @@
+# Architecture / Scope / API-Seam Review — Plan #630 `SqliteBackend`
+
+> Reviewer: clean-slate, architecture/scope/seam lens, adversarial.
+> Plan under review: `docs/plans/2026-06-20-sqlite-backend-630.md`.
+> Verdict: **APPROVE with fixes.** The seam is drawn in the right place, delegation is the correct call, and #630 stays in its lane. No BLOCKERs. A handful of HIGH/MEDIUM points sharpen claims that are currently overstated or under-specified, plus one genuine seam-leakage gap in the verification gate.
+
+---
+
+## Summary table
+
+| #   | Severity | Area                    | One line                                                                                                                                                                                                                                                                                                                              |
+| --- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | HIGH     | #631 set-up (oversell)  | "Four-fields-to-one swap" understates #631 — the engine reads `pool`/`graph`/`hnsw` directly in dozens of non-storage call sites; #630 cannot make #631 mechanical and should stop claiming it.                                                                                                                                       |
+| F2  | HIGH     | Seam leakage (gate gap) | The grep gate (`§7`) forbids `rusqlite`/`Connection` in `pub` signatures, but every `block_*`/`for_each_streamed`/`scan` bound names `rusqlite::Connection`. Those are private, but the gate as written has no allowlist mechanism beyond prose — specify the exact grep so it does not false-positive and get silently weakened.     |
+| F3  | MEDIUM   | Delegation two-layer    | Plan does not acknowledge the real downside of delegation: the parity oracle and the SUT share the same SQL, so H1/H2 parity tests are partly tautological (identity by construction). Name it and state what they actually catch (the _wrapper_, not the SQL).                                                                       |
+| F4  | MEDIUM   | D4 error mapping        | `map_seam_err` only remaps `MemoryError::Database`. Verified correct against `error.rs:393-395`, but the FTS path never yields `Database` (it swallows to `Ok(empty)`), so the "forced raw SQL fail ⇒ `Storage(Backend)`" D4 witness (T1) must come from a _non-FTS_ method — call that out or the witness is vacuous.                |
+| F5  | MEDIUM   | Scope creep (T9)        | T9 (`Arc<dyn StorageBackend>` realization) is correctly in #630's lane, not gold-plating — but its framing as "the value-level upgrade of #629's vtable test" is right only if it does NOT pull forward the #632 conformance battery. The plan says this; keep T9 to one call-per-trait smoke, no semantic assertions.                |
+| F6  | MEDIUM   | ColdStorage gating      | `#[cfg(all(async, archive))]` on the impl is correct, but the plan never states the load-bearing reason it is _safe_: `ColdStorage` is not a `StorageBackend` supertrait bound, so gating the impl out cannot change the umbrella's vtable. Make the invariant explicit so a future contributor does not "promote" it into the bound. |
+| F7  | LOW      | D3 HNSW ownership       | Owning HNSW in #630 is the right call (defensible), but the decision rationale conflates "where it lives" with "when it is built"; D3 should note that `notify_*` hooks are _new_ call sites with no existing oracle — H9 is the only net-new-behavior test and deserves that label.                                                  |
+| F8  | LOW      | Collateral §9           | §9 item 3 ("note on #631 issue") is the one collateral that is NOT a separate issue — it is a comment on a sibling issue. That is fine per the one-concern rule, but the plan should not list it alongside "separate issues" without distinguishing it.                                                                               |
+
+---
+
+## What checks out (confirmed against source)
+
+These claims I verified against the tree and they hold — calling them out so the author knows they are load-bearing-and-correct, not unexamined:
+
+- **Engine holds the pool by value** (`engine/mod.rs:157` → `pub(crate) pool: ConnectionPool`), and the four sibling fields the struct absorbs all exist: `pool`, `embed_dim` (`:158`), `upcaster_registry` (`:167`), `hnsw_strategy` (`:163-164`, `#[cfg(feature="ann")]`). The plan's `SqliteBackend` field list (plan §2, lines 57-63) is an accurate mirror. The `Arc<ConnectionPool>` change (owned handle for `'static` closures) is justified — `spawn_blocking` needs `'static`, and the pool is not `Clone`.
+- **`try_write` returns `MemoryError::ReadOnly` on a read-only pool** (`connection_pool.rs:271-273`) — so D-decision "`try_write` not `write` preserves DD#6 for free" (plan §3, line 119) is real. `write()` (`:264`) bypasses the guard; the plan correctly mandates `try_write` for every write method.
+- **`pool.read()` returns `Result<ReadConn>` yielding `MemoryError::Pool` on timeout** (`:225,250`), never `Database`. So `map_seam_err`'s pass-through of `Pool` (plan §3, line 84-88) is correct: a pool-acquire failure stays `Pool`, only raw driver `Database` becomes `Storage(Backend)`.
+- **FTS5 malformed-query swallow** is real and per-call: `fts_search` catches at `query_map` and returns `Ok(vec![])` (`fts.rs:65-71`); `fts_count_expired` mirrors it (`fts.rs:90` doc + body). So "malformed ⇒ empty / Ok(0)" (plan H1) is preserved purely by delegation. **But see F4** — this means the FTS path cannot be the D4 `Database→Storage(Backend)` witness.
+- **`Some(&[]) = matches-nothing` scope quirk** is preserved by passing the slice straight to `serialize_scope_ids` (`search/mod.rs:32-39`): `Some(&[])` → `Some("[]")` → `scope_id IN (json_each('[]'))` matches nothing; `None` → `None` → filter skipped. The plan's convert.rs claim (plan §3, line 142) is exact. ✅
+- **`lexical_count_expired` already drops `FactFilter`** in the #629 trait (`search_index.rs:59-64` takes `(query, fact_type, scope_ids)`), matching `fts_count_expired`'s free-fn shape (`fts.rs:95-100`). So H1's "count_expired not taking a filter" is a non-issue at the trait level — the trait was already shaped right in #629. The plan inherits this correctly.
+- **`StorageError::Backend(String)` is the designed opaque sink** (`error.rs:361-368`), and `MemoryError::Database(#[from] rusqlite::Error)` is explicitly reserved for "SQLite-internal use" (`error.rs:355`). D4's remap target is exactly right.
+- **`vector_search` returns `EmbeddingDimension` on wrong-length input** (`vector.rs:76-81`), matching the #629 `SearchIndex::vector_search` doc contract (`search_index.rs:40-44`). H1's "wrong-dim ⇒ EmbeddingDimension" is preserved by delegation. ✅
+- **`ColdStorage` is a separate `Option<Arc<dyn ColdStorage>>`, NOT a supertrait bound** (`cold_storage.rs:4-9`, `backend.rs:49-51`). The umbrella (`backend.rs:52-55`) is genuinely feature-invariant. The plan's `#[cfg(all(async,archive))]` treatment is structurally sound — **see F6** for the missing rationale.
+- **#629 explicitly defers the full-value realization to #630** (`backend.rs:86-90`: "constructing a full `Arc<dyn StorageBackend>` value … is #630's `SqliteBackend`"). So T9 is in-scope by #629's own design, not gold-plating. ✅
+
+---
+
+## Findings (detail)
+
+### F1 — [HIGH] "Four-fields-to-one swap" oversells #631; #630 cannot make #631 mechanical
+
+**Plan:** §2 line 54 ("so #631 is a four-fields-to-one swap"); §1 D-table and H5 reinforce a "mechanical #631" framing.
+
+**Problem.** The engine does not access persistence _only_ through the four named fields as opaque handles. The `MemoryEngine` struct (`engine/mod.rs:156-168`) also holds `graph: RwLock<MemoryGraph>`, `scope_tree: RwLock<ScopeTree>`, `vector_strategy: Box<dyn VectorSearchStrategy>`, and `hnsw_strategy` — and the engine's sub-modules (`ingest`, `query`, `consolidation`, `forgetting`, `inspect`, …, 20+ modules listed at `engine/mod.rs:21-40`) call `self.pool.read()` / `self.pool.try_write()` directly and compose multi-store transactions over a single `&Connection` (the H5 hazard, which the plan _does_ acknowledge separately). Swapping four fields to one `Arc<dyn StorageBackend>` does not rewire those call sites — every `self.pool.write()` + inline `FactStore::new(&conn).insert(...)` becomes `self.backend.insert_fact(...).await`, across the whole engine, and the transaction-composing ones (`add_fact`, `consolidate`) cannot be swapped at all without a seam-level transaction primitive (correctly flagged as collateral §9 item 3).
+
+This is not a #630 defect — #630 is right to _not_ touch the engine. The defect is the **claim**: #630 sets up the _field_ for #631 but does not make #631 mechanical, and asserting it does will mislead the #631 planner into under-scoping.
+
+**Fix.** Soften §2 line 54 to: "#631 replaces the four fields with one `Arc<dyn SqliteBackend-as-StorageBackend>` **handle**; the call-site rewrite (every `self.pool.*` + inline-store call → an `await` on the handle) and the multi-store-transaction reshaping (§9 item 3) are #631's substantive work — #630 only makes the handle constructible." Keep H5's `git diff --stat src/engine/` empty-gate; it is the right guard.
+
+---
+
+### F2 — [HIGH] The seam-leakage grep gate has no teeth as written
+
+**Plan:** §7 pass-criteria ("no `rusqlite`/`Connection` symbol in any `pub` signature under `storage/` … except inside the private `block_*` helper bounds (grep check)").
+
+**Problem.** The design _does_ confine `rusqlite::Connection` correctly: it appears only in the `where F: FnOnce(&rusqlite::Connection) -> Result<T>` bounds of the private `block_read`/`block_write`/`for_each_streamed`/`scan` items (plan §3 lines 94, 105, 129). None of those are `pub`. **But** the verification is specified as prose ("grep check") with a prose exception ("except inside the private `block_*` helper bounds"). A literal `grep -r 'rusqlite\|Connection' src/storage/sqlite/` will hit those private bounds and either (a) trip a naive reviewer into thinking the seam leaks, or (b) get "fixed" by loosening the grep to the point it stops catching a _real_ `pub fn foo(&self, c: &Connection)` regression. The gate's value is entirely in its precision, and the plan does not pin the precise command.
+
+**Fix.** Replace the prose with the exact gate, e.g.:
+
+```bash
+# A pub trait-method or pub fn must never name a driver type.
+# Allowed: rusqlite in private `fn block_*` / `scan` closure bounds only.
+! grep -rnE '^\s*(pub(\([^)]*\))?\s+)?async\s+fn .*\b(rusqlite|Connection)\b' src/storage/sqlite/
+grep -rn 'rusqlite::Connection' src/storage/sqlite/ | grep -vE 'fn (block_read|block_write|for_each_streamed)|where|FnOnce'  # expect: empty
+```
+
+State that the second grep returning non-empty is a hard fail. Without a pinned command the "confinement to private helpers" claim is unverifiable and will rot exactly the way `storage/mod.rs:8` warns seams rot.
+
+---
+
+### F3 — [MEDIUM] Delegation's real downside (tautological parity) is unacknowledged
+
+**Plan:** §1 "Why delegation, not absorption" (lines 15); §4 hazard register; §10 testing ("identity holds because the SQL is reused").
+
+**Assessment of the architectural call:** delegation is **correct** for the epic. #634's `PgBackend` reuses zero SQLite SQL (spec §7 line 339-341: "shared-SQL approach would have been wrong"), so inlining the SQL into `impl FactGraph for SqliteBackend` would only have to be undone, and would fork the SQL away from the existing fast in-process unit tests that exercise `src/store/*` directly. The two-layer structure (`storage/sqlite/graph.rs` adapter → `store/facts.rs` SQL) is the right shape and #634 mirrors it cleanly as `storage/postgres/graph.rs`. No change to the decision.
+
+**The unacknowledged downside:** because the parity oracle (`FactStore::m`) and the system-under-test (`SqliteBackend::m` → `FactStore::m`) call the **same** SQL, the H1/H2 parity tests assert `f(x) == f(x)` — they are identity-by-construction for everything _below_ the wrapper. They genuinely catch wrapper-layer drift (a `convert.rs` mis-projection, a wrong conn selection, a `block_read` vs `block_write` swap, a forgotten `.await`, a `map_seam_err` mistake), which is the real risk surface. But the plan's framing ("per-dimension parity vs `fts_search`", H1) reads as if it proves the SQL correct, which it cannot — the SQL is the same object. A green parity suite where the wrapper is a perfect pass-through is _expected_, not _informative_, for the SQL.
+
+**Fix.** Add one sentence to §4 / §10: "Parity tests are identity-by-construction below the wrapper (same SQL on both sides); their job is to catch **wrapper** defects — conn-selection, projection, async-bridge, error-remap — not to (re)validate the delegated SQL, which the existing `store/*` unit tests own." This reframes what 'green' means and stops H1 from over-claiming.
+
+---
+
+### F4 — [MEDIUM] The D4 witness (T1) cannot come from the FTS path
+
+**Plan:** T1 ("forced raw SQL fail ⇒ `Storage(Backend)` (D4 witness)"); H4 ("forced raw SQL fail ⇒ `Storage(Backend)`").
+
+**Problem.** `map_seam_err` remaps only `MemoryError::Database` (plan §3 line 85). Verified: that variant is `Database(#[from] rusqlite::Error)` (`error.rs:393-395`). But the two FTS methods **never produce `Database`** — they catch the rusqlite error and return `Ok(vec![])` / `Ok(0)` (`fts.rs:65-71`). So you cannot witness D4 by forcing an FTS failure; it will silently succeed-empty. The witness must force a `Database` from a method that _propagates_ it — e.g. `vector_search` (propagates via `?` at `vector.rs:91,97`), or a `FactStore` write against a corrupted/locked DB, or `get_fact` on a malformed row. T1 implements only `EventLog::{insert_event, get_event, for_each_event}` — so the T1 D4 witness must be an `EventLog` method whose body can surface a real `rusqlite::Error` (a `get_event` on a row that fails column extraction, or an `insert_event` against a constraint violation), not a query-swallow path.
+
+**Fix.** In T1, name the concrete D4 witness method and the forced failure (e.g. "force `insert_event` to hit a UNIQUE/constraint `rusqlite::Error` ⇒ assert `MemoryError::Storage(StorageError::Backend(_))`"). Add a note that FTS-swallow methods are _not_ valid D4 witnesses (they prove the empty-result contract instead).
+
+---
+
+### F5 — [MEDIUM] T9 is in-scope, but guard its blast radius
+
+**Plan:** T9 ("`Arc<dyn StorageBackend>` realization proof … one method per bounded trait through it").
+
+**Assessment.** Correctly in #630's lane — #629 explicitly deferred the full-value vtable realization here (`backend.rs:86-90`). It is **not** gold-plating: it is the minimal closure of #629's deliberately-partial callability test (which only proved a 3-method `Dummy SearchIndex` through `&dyn`, `backend.rs:97-139`). Building a real `Arc<dyn StorageBackend>` from `SqliteBackend` and dispatching one method per bounded trait through it is the value-level proof that the blanket impl (`backend.rs:60-63`) actually closes over a real type.
+
+**The risk:** the line between "one smoke call per trait through the `dyn`" (T9, in scope) and "assert the semantics of each call" (#632 conformance, out of scope) is thin, and the testing section's appetite for parity tables could leak the #632 battery into T9. The plan says the right thing (T9 = "drive one method per bounded trait", #632 = the conformance suite) — but it is one editing pass away from over-building.
+
+**Fix.** Add an explicit non-goal to T9: "T9 asserts _dispatchability_ (the call returns `Ok`/the right variant through `&dyn`), NOT semantic parity — semantic parity per method already lives in T1-T8's per-trait tests; the _cross-backend_ battery is #632. T9 is ~7 calls, no fixtures beyond an empty DB."
+
+---
+
+### F6 — [MEDIUM] ColdStorage gating is correct but the safety invariant is unstated
+
+**Plan:** §2 layout (`cold_storage.rs #[cfg(all(feature="async", feature="archive"))]`); T7; §1 D-table omits a ColdStorage decision.
+
+**Assessment.** The gating is structurally right. `ColdStorage` is held by the engine as a separate `Option<Arc<dyn ColdStorage>>` and is explicitly **not** a `StorageBackend` supertrait bound (`cold_storage.rs:4-9`; `backend.rs:49-51`). Therefore cfg-gating the `impl ColdStorage for SqliteBackend` in or out **cannot** change the `StorageBackend` vtable — the umbrella stays feature-invariant (`backend.rs:52-55` has no `ColdStorage` in the bound list). The `all(async, archive)` conjunction is correct because the impl needs _both_ `spawn_blocking` (async) _and_ the archive types.
+
+**The gap.** The plan treats this as obvious, but it is exactly the kind of invariant a future contributor breaks by "tidying up" — adding `+ ColdStorage` to the umbrella bound under `#[cfg(archive)]`, which would make `Arc<dyn StorageBackend>`'s type feature-dependent and silently break #631/#634's single-handle assumption. The plan's own module doc (`storage/mod.rs:18-20`, `backend.rs:49-51`) calls this out for the _trait_; the #630 plan should restate it for the _impl_.
+
+**Fix.** Add to T7 / §8 module-rustdoc bullet: "`impl ColdStorage` is gated `all(async, archive)` and lives off the `StorageBackend` supertrait set _by design_ — the umbrella vtable MUST stay feature-invariant (`backend.rs:49-51`). Never fold `ColdStorage` into the umbrella bound." This is a one-line invariant that prevents a whole class of #634 breakage.
+
+---
+
+### F7 — [LOW] D3 conflates HNSW _placement_ with HNSW _maintenance_, hiding the one net-new-behavior surface
+
+**Plan:** §1 D3; T8; H9.
+
+**Assessment.** Owning HNSW in `SqliteBackend` (vs deferring to #631) is **defensible and probably right**: the index-maintenance hooks (`notify_insert`/`notify_expire`) fire from the _write_ methods, which live in the backend after #630; deferring would split write-and-index across the seam and reintroduce an O(N) brute-force regression #631 could not fix without reopening the seam (plan's D3 rationale). #629 already declared these hooks impl-private (`backend.rs:21-23`: "HNSW index-maintenance hooks … stay impl-private — SQLite-ann internals, not a port contract"). So #630 owning them is consistent with the established seam.
+
+**The subtlety the plan buries.** Everything else in #630 is a _pure pass-through_ with an identity oracle (F3). The HNSW `notify_*` wiring is the **one place #630 introduces genuinely new call sequencing** — the write methods must call `notify_insert`/`notify_expire` in the right order, and there is no existing engine call site doing exactly this (today the engine maintains `hnsw_strategy` itself, `engine/mod.rs:163-164`). So H9 ("brute≡HNSW recall; insert/expire reflected") is not a parity-with-an-oracle test like the others — it is the genuine _new-behavior_ test, and the highest-value one in the whole plan. The plan ranks it H9 (near-bottom) and labels it "perf cliff", underselling it.
+
+**Fix.** Re-label H9 as "HNSW maintenance — the one net-new write-path behavior in #630 (no pre-existing oracle)" and note T8 carries the only correctness risk not covered by identity-parity. Consider moving T8 earlier or at least flagging it as not-mechanical. (Severity LOW because the plan _does_ test it; the issue is mis-prioritization, not omission.)
+
+---
+
+### F8 — [LOW] §9 collateral list mixes a sibling-issue comment in with separate issues
+
+**Plan:** §9 ("Collateral / follow-ups (separate issues …)"); item 3 is "note on the #631 issue"; item 4 is "already tracked, #652-style".
+
+**Assessment.** The repo convention (CLAUDE.md "Collateral issues": one logical concern per issue, separate `type:*`+`area:*`, linked via `addSubIssue`) is satisfied by items 1 and 2 (genuine new separate issues: `type:docs`/`area:storage` and `type:enhancement`/`area:retrieval` — both correctly labeled). Item 3 is NOT a new issue — it is a comment on the existing #631 — and item 4 is a pointer to existing #652. Listing them under a header that says "separate issues" is mildly inconsistent: a reader checking the one-concern rule will expect four `gh issue create` calls and find two.
+
+**Fix.** Re-title §9 "Collateral / follow-ups" and tag each: items 1-2 `[NEW ISSUE]`, item 3 `[COMMENT on #631]`, item 4 `[EXISTING #652 — link only]`. No behavior change; just truth-in-labeling so T12 ("Collateral issues filed") does not over- or under-create.
+
+---
+
+## Scope verdict (explicit answers to the brief)
+
+- **Seam leakage (Q1):** No `pub` signature leaks `rusqlite`/`Connection`. Confinement to private `block_*`/`scan` bounds is achievable as designed and verified against the #629 trait surface (no driver types in `graph.rs`/`search_index.rs`/`cold_storage.rs`). `SqliteBackend` itself being `pub` is **correct** — #631 and #632 must name the type to construct it; the _trait methods_ are the seam, not the struct. The only weakness is the **gate's precision (F2)**, not the design.
+- **Delegation vs absorption (Q2):** Delegation is the right architectural call for the epic (#634 reuses zero SQLite SQL). The two-layer structure is justified and #634-symmetric. The one unacknowledged downside is **tautological parity (F3)** — a framing fix, not a design fix.
+- **Scope creep / under-scope (Q3):** No task reaches into #631/#632/#634 territory. T9 is in-scope (not gold-plating) per #629's explicit deferral; guard its blast radius (F5). D3 HNSW-ownership is correctly #630's job (F7).
+- **#631 set-up (Q4):** The plan **oversells** "#631 mechanical" (F1). #630 makes the handle _constructible_; the call-site rewrite and transaction reshaping are #631's real work. The H5 empty-diff gate is the correct #630-side guard.
+- **ColdStorage gating (Q5):** Correct; `all(async, archive)` and off-the-umbrella-bound is right. Make the feature-invariance invariant explicit (F6).
+- **Structural completeness + feasibility (Q6):** Documentation (§8), Verification (§7), Testing (§10) all present. Task ordering is feasible — no task depends on a later one (seam core T1 before all impls; HNSW T8 after the write methods it hooks; T9 after the traits it realizes; docs/PR last). Collateral handling is convention-consistent modulo the labeling nit (F8).
+
+**Bottom line:** the seam is in the right place and #630 stays in its lane. Land it after fixing F1 (claim), F2 (gate), F4 (witness) — the three that would otherwise let a real regression or a misleading hand-off through. F3/F5/F6 are framing/invariant hardening; F7/F8 are polish.

--- a/docs/plans/2026-06-20-sqlite-backend-630-review-async.md
+++ b/docs/plans/2026-06-20-sqlite-backend-630-review-async.md
@@ -1,0 +1,280 @@
+# Async / Runtime-Correctness Review — #630 `SqliteBackend`
+
+> Lens: compile-level and runtime-level traps in the proposed async seam only.
+> Verdict per finding: [BLOCKER] / [HIGH] / [MEDIUM] / [LOW].
+> Plan citations reference `docs/plans/2026-06-20-sqlite-backend-630.md`.
+> Code citations reference the files as read for this review.
+
+---
+
+## 1. `block_read` / `block_write` helper bounds
+
+**Plan §3 signatures:**
+
+```rust
+async fn block_read<T, F>(&self, f: F) -> Result<T>
+where T: Send + 'static, F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static
+```
+
+### 1a. The `T: Send + 'static` + `F: Send + 'static` bounds are necessary and sufficient — SOUND
+
+`tokio::task::spawn_blocking` requires the closure to be `FnOnce() -> R + Send + 'static`, and the return type `R` has no explicit bound (it is moved back through the `JoinHandle` on the current thread, not across a thread boundary at the type-system level). However, tokio's `spawn_blocking` internally requires `R: Send` since Rust 1.x because the `JoinHandle<R>` must be `Send` for the `.await` to work on any executor thread. Concretely:
+
+```
+pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
+where F: FnOnce() -> R + Send + 'static, R: Send + 'static
+```
+
+Both `T: Send + 'static` and `F: FnOnce(...) -> Result<T> + Send + 'static` are required. The plan states exactly these bounds. **Sound.**
+
+### 1b. The `!Send` guard acquired **inside** the closure — SOUND
+
+`ReadConn<'_>` borrows `&ConnectionPool`, which makes it `!Send` (a lifetime-carrying reference to a non-`Send` pool field). `MutexGuard<'_, Connection>` from `parking_lot` is also `!Send`. Both are acquired inside the closure, so they never cross an `await` point, and the closure itself is `FnOnce() -> Result<T>` — the guard's lifetime is entirely within the blocking thread's stack frame. The compiler sees no `!Send` type in the closure's captured environment (only `Arc<ConnectionPool>` which is `Send`). **Sound.**
+
+### 1c. The doubly-wrapped `Result` and `map_err` / `map_seam_err` composition — SOUND WITH ONE NUANCE
+
+`spawn_blocking(...).await` returns `Result<Result<T>, JoinError>`. The plan's shape is:
+
+```rust
+let out: Result<T> = spawn_blocking(...).await  // Result<Result<T>, JoinError>
+    .map_err(map_join)?;                        // after ?:  Result<T>
+map_seam_err(out)                              // Result<T>
+```
+
+The `?` after `.map_err(map_join)` unwraps the outer `JoinError` layer, leaving `out: Result<T>` (the inner `Result`). `map_seam_err` then remaps `Database → Storage(Backend)` on the inner `Result`. This is correct — `map_seam_err` sees exactly the `Result<T>` produced by `f`. **Sound.**
+
+The nuance: `map_seam_err` and `map_join` are free functions, not methods on `SqliteBackend`, so they must be visible from within the `impl` block. The plan shows them as module-level free functions — fine as long as they are `pub(super)` or live in the same module as the `impl`. Not a blocker, but confirm visibility during implementation.
+
+---
+
+## 2. `#[async_trait]` object-safety
+
+### 2a. `StorageBackend` stays `dyn`-safe — SOUND
+
+The blanket impl at `backend.rs:60-63` and the object-safety assertions at `backend.rs:72-79` already compile today (A1 is merged). The plan adds only **inherent** methods on the concrete `SqliteBackend` struct (`block_read`, `block_write`, `for_each_streamed`), not new trait methods. Inherent methods on a concrete type cannot break object-safety of a trait. No generic methods are added to any of the six bounded-context traits. **No E0038 risk from #630's additions.**
+
+### 2b. `#[async_trait]` `Self: Sync` hidden bound — SOUND
+
+`async_trait` desugars `async fn foo(&self) -> T` to a boxed future `Box<dyn Future<Output=T> + Send + '_>`. For the boxed future to be `Send`, the `Self` type must be `Send + Sync` (because `&self` is captured). The `SqliteBackend` struct fields are:
+
+- `pool: Arc<ConnectionPool>` — `Arc<T>: Send + Sync` iff `T: Send + Sync`. `ConnectionPool` contains `Mutex<Connection>` and `Condvar` (from `parking_lot`). `parking_lot::Mutex<T>: Send + Sync` iff `T: Send`. `rusqlite::Connection` is `Send` (verified: rusqlite marks `Connection: Send`). So `Arc<ConnectionPool>: Send + Sync`. ✓
+- `embed_dim: usize` — trivially `Send + Sync`. ✓
+- `upcaster_registry: UpcasterRegistry` — assumed `Send + Sync` (it is a registry of upcast functions, not verified here, but the engine already holds one and passes it through blocking tasks in the existing code). Flag if `UpcasterRegistry` is not `Sync`.
+- `#[cfg(feature = "ann")] hnsw: Option<Arc<parking_lot::RwLock<HnswStrategy>>>` — `Arc<RwLock<T>>: Send + Sync` iff `T: Send + Sync`. Needs verification that `HnswStrategy: Send + Sync`.
+
+[MEDIUM] **Unverified `Send + Sync` on `UpcasterRegistry` and `HnswStrategy`**: the plan assumes these are `Send + Sync` because the existing engine holds them, but the existing engine does **not** place them behind `async_trait` futures. If either type is `!Sync`, the compiler will reject `impl FactGraph for SqliteBackend` with a future-`Send` error that looks like an `async_trait` puzzle, not a struct-field error. Verify before T1; add `static_assertions::assert_impl_all!(UpcasterRegistry: Send + Sync)` and `assert_impl_all!(HnswStrategy: Send + Sync)` in the `SqliteBackend` module under `#[cfg(test)]`.
+
+---
+
+## 3. `for_each_streamed` — deadlock, backpressure, early-exit, and `handle.await` correctness
+
+Plan §3 (D2):
+
+```rust
+async fn for_each_streamed<T, S>(&self, scan: S, cb: &mut (dyn FnMut(T) -> Result<()> + Send))
+    -> Result<()>
+where T: Send + 'static,
+      S: FnOnce(&rusqlite::Connection, &std::sync::mpsc::SyncSender<T>) -> Result<()>
+           + Send + 'static
+{
+    let pool = Arc::clone(&self.pool);
+    let (tx, rx) = std::sync::mpsc::sync_channel::<T>(1);
+    let handle = tokio::task::spawn_blocking(move || { let conn = pool.read()?; scan(&conn, &tx) });
+    while let Ok(row) = rx.recv() { cb(row)?; }
+    map_seam_err(handle.await.map_err(map_join)?)
+}
+```
+
+### 3a. Cap-1 channel backpressure — SOUND
+
+A `sync_channel(1)` means the blocking producer can at most have 1 row queued (plus whatever is in `send` if that send blocks). The consumer drains synchronously (`rx.recv()` blocks until a row arrives). Because the consumer and producer run on separate threads (blocking pool thread vs async task), this is a producer–consumer ping-pong that never exceeds 2 rows in flight (1 buffered + 1 being processed by the callback). Peak memory O(1) per scan is correct.
+
+### 3b. Early-exit on callback error — SOUND
+
+When `cb(row)?` returns `Err`, the `?` propagates out of `for_each_streamed`. `rx` is dropped. The producer's next `tx.send(next_row)` will return `Err(SendError(...))` because the receiver is gone. The `scan` closure should propagate this as an error (or ignore it). However:
+
+**The plan's scan closures must handle `SendError` gracefully.** If a scan closure does:
+
+```rust
+|conn, tx| { for row in query { tx.send(row).map_err(|_| MemoryError::Internal(...))? } }
+```
+
+then the `SendError` on early-exit will cause `scan` to return an `Err`, which propagates through `handle.await`. This is fine — `map_seam_err` will remap it. But if the caller's early-exit `Err` and the `SendError`-induced scan `Err` are both live, which one surfaces?
+
+The sequence:
+
+1. `cb(row)?` returns `Err(E_cb)` and exits the `while` loop.
+2. `rx` is dropped.
+3. `handle.await` resumes the blocking task, which returns `Err(E_send)` (from the next `tx.send`).
+4. `map_seam_err(handle.await.map_err(map_join)?)` returns `Err(E_send)`, **discarding** `E_cb`.
+
+[HIGH] **The callback's early-exit error `E_cb` is silently discarded.** The plan states "early callback Err drops rx → scan's send errs → stops" but does not address the fact that the error surfaced to the caller is `E_send` (a `SendError` from the blocking task), not `E_cb` (the semantic error from the callback). The caller can't distinguish "scan had a SQL error" from "callback said stop" from the returned error. The fix: capture the callback error before the loop exits and use it if the scan result is an artificial `SendError`:
+
+```rust
+let mut cb_err: Option<MemoryError> = None;
+while let Ok(row) = rx.recv() {
+    if let Err(e) = cb(row) {
+        cb_err = Some(e);
+        break;  // drop rx on next iteration (or explicitly drop rx below)
+    }
+}
+drop(rx);  // ensure producer unblocks
+// Drain handle result; prefer cb_err if the scan error is merely SendError
+let scan_result = map_seam_err(handle.await.map_err(map_join)?);
+if let Some(e) = cb_err { return Err(e); }
+scan_result
+```
+
+Without this fix, test H6 (streaming early-error + correct error propagation) cannot pass as specified, because the error the test asserts is `E_cb` but the function returns `E_send`.
+
+### 3c. `handle.await` after the drain loop — potential hang on consumer panic
+
+If the `async fn for_each_streamed` itself panics (not the blocking task) before `handle.await` is reached, the `JoinHandle` is dropped. `tokio::task::spawn_blocking` returns a detached task on `JoinHandle` drop — the blocking thread keeps running until `scan` blocks on `tx.send` (which will `SendError` immediately since `rx` was dropped by the panic). This is safe: the blocking task will finish soon. No hang.
+
+If `cb` panics (rather than returning `Err`), the panic propagates out of the async function. Same analysis: handle dropped, blocking task unblocks on next send, finishes. No hang.
+
+**`handle.await` correctness**: after `rx.recv()` returns `Err` (meaning `tx` was dropped because `scan` completed or panicked), the blocking task has already finished. `handle.await` on an already-completed `JoinHandle` returns immediately. **Sound.**
+
+### 3d. The `&mut (dyn FnMut(T) -> Result<()> + Send)` callback and the async drain loop — SOUND
+
+The callback is invoked synchronously inside the `while let Ok(row) = rx.recv()` loop, which is `await`-free. `rx.recv()` is a synchronous call; the loop itself is not `async`. However, the function `for_each_streamed` is `async`, so its entire body is a future. The `rx.recv()` call will block the async executor thread.
+
+[BLOCKER] **`rx.recv()` is a synchronous blocking call inside an `async fn` — this blocks the tokio executor thread.** `while let Ok(row) = rx.recv()` is equivalent to a `std::thread::park` on the executor thread. Under `tokio::test` (which uses a single-threaded runtime by default), this is a guaranteed deadlock if `spawn_blocking` exhausts the blocking thread pool — but more critically, `rx.recv()` unconditionally parks the current executor thread (not a `spawn_blocking` worker) until a row arrives from the blocking thread. Even on a multi-thread runtime, parking an executor thread degrades throughput and, on a 1-thread runtime, deadlocks if the blocking pool is also at capacity.
+
+The correct fix is to use `tokio::sync::mpsc` (async channel) instead of `std::sync::mpsc`, and `.await` on the receiver:
+
+```rust
+let (tx, mut rx) = tokio::sync::mpsc::channel::<T>(1);
+// producer sends via tx (must be adapted — tokio channel's send is async)
+```
+
+But the producer runs in `spawn_blocking`, so it cannot `.await`. The clean solution is `tokio::sync::mpsc::channel` with `tx.blocking_send(row)` in the `spawn_blocking` closure, and `rx.recv().await` in the async drain loop:
+
+```rust
+let (tx, mut rx) = tokio::sync::mpsc::channel::<T>(1);
+let handle = tokio::task::spawn_blocking(move || {
+    let conn = pool.read()?;
+    scan(&conn, &tx)  // scan uses tx.blocking_send(row)
+});
+while let Some(row) = rx.recv().await { cb(row)?; }
+drop(rx);
+map_seam_err(handle.await.map_err(map_join)?)
+```
+
+This requires changing the `scan` closure signature to accept `&tokio::sync::mpsc::Sender<T>` instead of `&std::sync::mpsc::SyncSender<T>`, and the blocking side calls `tx.blocking_send(row).ok()?` (or maps the error). The `tokio::sync::mpsc::Sender<T>` is `Send + 'static` when `T: Send`, so the closure bound remains satisfiable.
+
+Alternatively, use `tokio::task::block_in_place` around `rx.recv()`, but that requires `rt-multi-thread` which is not in the production feature set (only in `[dev-dependencies]`).
+
+The `std::sync::mpsc` approach is not suitable here. **This is a BLOCKER.**
+
+### 3e. `#[tokio::test]` default flavor for parity tests — compound with 3d
+
+The plan (§10) specifies `#[cfg(feature="async")] #[tokio::test]` for parity tests. `#[tokio::test]` defaults to the `current_thread` (single-thread) flavor. With `rx.recv()` blocking an executor thread as described in 3d, a single-thread runtime will deadlock: the executor thread is parked waiting for the blocking task to send, but the blocking task cannot run because... actually `spawn_blocking` uses a dedicated thread pool separate from the executor thread pool. So on a single-thread runtime:
+
+- Executor thread parks on `rx.recv()`.
+- `spawn_blocking` task runs on a separate blocking thread.
+- Blocking thread sends a row.
+- Executor thread unblocks, processes one row, loops back, parks again.
+
+This is technically not a deadlock on `current_thread` because `spawn_blocking` threads are independent of executor threads. However, it is still **incorrect async practice** — parking an executor thread is prohibited. On a saturated blocking pool (which is bounded at 512 threads by default in tokio), this creates backpressure that could deadlock in production.
+
+[HIGH] **The parity tests should use `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`** regardless: the streaming tests need the blocking task and the drain loop to run concurrently, and the single-thread flavor serializes them through cooperative yielding — it works only because `rx.recv()` happens to unpark when `spawn_blocking` sends. With the async-channel fix from 3d, `rx.recv().await` yields properly and `#[tokio::test]` (single-thread) works correctly. So this item is secondary to the BLOCKER in 3d.
+
+---
+
+## 4. tokio feature surface — `spawn_blocking` vs `rt` vs `rt-multi-thread`
+
+**Cargo.toml production dependency (line 29):** `tokio = { version = "1", features = ["rt", "macros"], optional = true }`
+
+**`spawn_blocking` feature requirement:** `tokio::task::spawn_blocking` is gated on `tokio/rt` only — it does not require `rt-multi-thread`. Confirmed from tokio's documented feature matrix: `spawn_blocking` ships with the basic `rt` feature because it uses a separate blocking thread pool, not the `rt-multi-thread` scheduler.
+
+**`#[tokio::test]` default flavor:** uses `current_thread` runtime, which only requires `tokio/rt`. This is available in `[dev-dependencies]` where tokio is pulled with `rt-multi-thread` + `macros` (line 37). The `current_thread` runtime provided by `tokio/rt` is sufficient for `#[tokio::test]`.
+
+**Verdict on tokio features:** [LOW] The production feature `async = ["dep:tokio"]` enables `tokio` with `["rt", "macros"]`. This is sufficient for `spawn_blocking` and `#[tokio::test]`. The dev-dependency pulls `rt-multi-thread` for the existing `async_engine.rs` concurrency tests. No gap here for the basic `block_read`/`block_write` pattern.
+
+However, as noted in 3d, the `std::sync::mpsc::recv()` call inside the async drain loop can park an executor thread. If the fix (3d) uses `tx.blocking_send`, the `tokio::sync::mpsc` channel is also available under `tokio/rt` — no new feature dependency.
+
+---
+
+## 5. `map_seam_err` / `map_join` placement and D4 interaction with `?` inside closures
+
+### 5a. Error mapping at the seam boundary — SOUND
+
+The closures passed to `block_read`/`block_write` call the sync store functions which emit `MemoryError::Database(rusqlite::Error)` via `#[from]`. The `?` inside the closure propagates those as `Result<T>` (i.e., `Err(MemoryError::Database(...))`). `spawn_blocking` returns `Ok(Err(MemoryError::Database(...)))`. After `.map_err(map_join)?`, `out` is `Err(MemoryError::Database(...))`. `map_seam_err(out)` then remaps it to `Err(MemoryError::Storage(StorageError::Backend(...)))`. **Correct and atomic for the common case.**
+
+### 5b. Semantic variants pass through `map_seam_err` unchanged — SOUND
+
+The `map_seam_err` match arm:
+
+```rust
+Err(MemoryError::Database(e)) => Err(MemoryError::Storage(StorageError::Backend(e.to_string()))),
+other => other,
+```
+
+Any non-`Database` variant (`NotFound`, `ReadOnly`, `Internal`, `EmbeddingDimension`, `Migration`, etc.) passes through unchanged. This correctly implements D4. **Sound.**
+
+### 5c. `map_seam_err` applied to a `SendError`-caused scan failure (compound with 3b)
+
+As identified in 3b: on early callback exit, the scan closure's `tx.send(row)` returns `Err(SendError(...))`. The scan closure maps this to some `MemoryError` variant. If mapped to `MemoryError::Internal` (a semantic variant), it passes through `map_seam_err` unchanged. If mapped to `MemoryError::Database`, it gets remapped to `Storage(Backend)`. Either way, the wrong error (scan's `SendError` instead of callback's `E_cb`) is surfaced. This is the same issue as 3b — listed there as [HIGH].
+
+---
+
+## 6. `Send` holes in `async_trait` boxed futures and the `for_each_*` callbacks
+
+### 6a. `+ Send` on `async_trait` futures — SOUND
+
+`async_trait` in the `proc-macro` sense generates, for each `async fn foo(&self, ...) -> T`, a method returning `Pin<Box<dyn Future<Output=T> + Send + '_>>`. For this to typecheck, all captured references in the async body must be `Send`. The callbacks passed to `for_each_*` are `&mut (dyn FnMut(T) -> Result<()> + Send)` — explicitly `Send`. The pool `Arc<ConnectionPool>` is `Send + Sync`. The channel types (`std::sync::mpsc::SyncSender<T>` or `tokio::sync::mpsc::Sender<T>`) are `Send` when `T: Send`. All rows `T: Send + 'static` by the helper's bound. **No `Send` hole here.**
+
+### 6b. The `&mut dyn FnMut` callback is not `Sync`
+
+`&mut (dyn FnMut(T) -> Result<()> + Send)` is a mutable reference to a non-`Sync` trait object. In the drain loop (inside `for_each_streamed`), the callback is called from the async context only — never from the blocking task. The blocking task only touches `tx` (the sender). So there is no concurrent access to `cb`. **No `Sync` requirement on `cb`, no hole.**
+
+### 6c. Rows `T: Send + 'static` — sufficient
+
+The rows travel across thread boundaries via the channel (blocking thread → async context). `T: Send` is required for channel transport; `T: 'static` is required by `spawn_blocking`. Both bounds are on the helper. All concrete row types (`Fact`, `Edge`, `ScopeNode`, `Event`, etc.) from `crate::types` are `'static` (no borrowed fields) and `Send` (no `Rc`, no raw pointers). **Sound.**
+
+---
+
+## 7. Additional findings not in the scrutiny list
+
+### 7a. `pool.read()` inside `spawn_blocking` can block for up to 30 seconds — [MEDIUM]
+
+`ConnectionPool::read()` uses a `Condvar::wait_until` with `DEFAULT_READ_ACQUIRE_TIMEOUT = 30s` (`connection_pool.rs:21`). If all read connections are checked out, `pool.read()` blocks the blocking thread for up to 30 seconds before returning `MemoryError::Pool`. Under a `spawn_blocking` task, this occupies a thread in tokio's blocking pool. This is acceptable behavior (blocking threads are meant to block), but the 30s timeout means a streaming scan can appear hung for 30s before failing. Document in `block_read`'s rustdoc.
+
+### 7b. `block_write` uses `try_write` which calls `parking_lot::Mutex::lock()` — potential priority inversion — [LOW]
+
+`try_write` at `connection_pool.rs:271-276` calls `self.write_conn.lock()` (unconditional lock, despite the name). If two concurrent `block_write` calls are in-flight, the second blocking task will park on the `parking_lot::Mutex::lock()` for the write connection, occupying a second blocking thread while waiting. This is fine — that is the intended serialization mechanism. However, if many concurrent write calls are made, the blocking pool can saturate. This is a pre-existing design constraint, not introduced by #630. **Informational.**
+
+### 7c. In-memory pool: `block_read` and `block_write` both lock `write_conn` — [MEDIUM]
+
+For in-memory pools, `pool.read()` returns `ReadConn::InMemory(WriteAsReadGuard { guard: self.write_conn.lock() })` (`connection_pool.rs:226-230`). This means `block_read` and `block_write` both contend on the same `write_conn` mutex. A concurrent `block_read` and `block_write` will serialize correctly. However, the H8 parity test (file-backed concurrent-read routing) is specified for file-backed pools only — in-memory tests will not catch a mis-route (which is documented in the plan). This is already acknowledged. Confirmed sound for the plan's intent.
+
+### 7d. `UpcasterRegistry` across `spawn_blocking` — [MEDIUM]
+
+The plan mentions `SqliteBackend` holds `upcaster_registry: UpcasterRegistry`. The blocking closures for `get_upcasted_event` / `list_upcasted_events` will need to call into the registry. If the registry is referenced from the closure, it must be `Send` (captured by `Arc<SqliteBackend>` or by cloning). Verify: the closures likely call `self.upcaster_registry.upcast(event)` but `self` is not captured by the closure — `pool` is. The registry must be cloned into each closure, or accessed via `Arc`. Cloning a registry on each call is expensive if it contains many upcast functions. The plan says the registry is a field of `SqliteBackend`, so consider wrapping it in `Arc<UpcasterRegistry>` to make clone cheap.
+
+---
+
+## Summary table
+
+| #   | Severity    | Finding                                                                                                                                                                                                                                                                              | Plan ref               |
+| --- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| 3d  | **BLOCKER** | `rx.recv()` (sync) inside `async fn` blocks the executor thread. Use `tokio::sync::mpsc` + `rx.recv().await` + `tx.blocking_send()` instead.                                                                                                                                         | §3 D2                  |
+| 3b  | **HIGH**    | On callback early-exit, `E_cb` is discarded; `E_send` (SendError from scan) is returned instead. Capture `cb_err` and prefer it over the artificial scan error.                                                                                                                      | §3 D2, H6              |
+| 2b  | **MEDIUM**  | `UpcasterRegistry` and `HnswStrategy` must be `Send + Sync` for the `async_trait` futures to be `Send`. Not verified. Add `static_assertions` in `#[cfg(test)]`.                                                                                                                     | §2 struct              |
+| 7c  | **MEDIUM**  | In-memory pool: `block_read` and `block_write` both lock `write_conn`; concurrent streaming scans will serialize. Not a correctness bug but kills read concurrency on in-memory instances. Document.                                                                                 | §3, pool               |
+| 7d  | **MEDIUM**  | `UpcasterRegistry` cloned per closure call if it is a plain struct field. Wrap in `Arc<>` for cheap cross-`spawn_blocking` sharing.                                                                                                                                                  | §2 struct              |
+| 3e  | **HIGH**    | Parity tests must use `#[tokio::test(flavor = "multi_thread")]` (or fix 3d first). Single-thread runtime + sync `recv()` in executor is technically non-deadlocking with `spawn_blocking` but violates async contract; with the async-channel fix, `current_thread` works correctly. | §10                    |
+| 4   | **LOW**     | `spawn_blocking` requires only `tokio/rt` — the production feature set is sufficient. No gap.                                                                                                                                                                                        | §7                     |
+| 5   | **LOW**     | `map_seam_err`/`map_join` visibility must be confirmed (`pub(super)` or same module). Not a blocking issue; will surface as a compile error if wrong.                                                                                                                                | §3                     |
+| 7b  | **LOW**     | `try_write` (`parking_lot::Mutex::lock`) can saturate the blocking pool under high write concurrency. Pre-existing design constraint; document.                                                                                                                                      | connection_pool.rs:271 |
+
+---
+
+## Required actions before T1
+
+1. **Fix D2 channel type** (BLOCKER): replace `std::sync::mpsc::sync_channel` with `tokio::sync::mpsc::channel(1)`, `tx.blocking_send(row)` in the scan closure, `rx.recv().await` in the drain loop.
+2. **Fix early-exit error priority** (HIGH): capture `cb_err`, drain `rx`, await handle, return `cb_err` if set and the scan error is an artifact.
+3. **Verify `UpcasterRegistry: Send + Sync` and `HnswStrategy: Send + Sync`** (MEDIUM): add compile-time assertions in the sqlite module's `#[cfg(test)]` block.
+4. **Wrap `UpcasterRegistry` in `Arc`** (MEDIUM) if it is not already.
+5. **Update test annotations** (HIGH consequence of fix 1): after fixing to async channel, `#[tokio::test]` single-thread flavor is correct — no `multi_thread` override needed. But confirm with T1's no-hang test.

--- a/docs/plans/2026-06-20-sqlite-backend-630-review-refactor.md
+++ b/docs/plans/2026-06-20-sqlite-backend-630-review-refactor.md
@@ -1,0 +1,369 @@
+# Clean-slate review — #630 `SqliteBackend` plan, REFACTOR-SAFETY / BEHAVIOR-PRESERVATION lens
+
+Reviewer: clean-slate, no prior context. Target plan: `docs/plans/2026-06-20-sqlite-backend-630.md`.
+Verification basis: the real code in this checkout (file:line citations below).
+
+The plan's whole safety claim is **zero behavior change**, and the structural trap it
+correctly names is real: the engine is **not** rewired in #630, so **no existing test
+exercises `SqliteBackend`**. A green suite proves nothing unless the new parity tests
+_independently_ pin behavior. My job was to find a way drift slips past those parity
+tests. I found one BLOCKER (HNSW build/dispatch policy lives in the engine, not the
+backend, and the differential proof is structurally blind to it), plus several HIGH/MEDIUM
+gaps. Most of the plan's load-bearing claims (D4, the empty-slice quirk, marker_key,
+NotFound, the f32→f64 widening direction, ReadOnly preservation) **check out against the
+code** — I confirm those explicitly so the author isn't second-guessing the parts that are
+right.
+
+---
+
+## Findings
+
+### [BLOCKER] B1 — HNSW build + dispatch policy lives in the **engine** (`search_config`), not the backend; D3/H9 cannot see the divergence
+
+**Plan:** §1 D3 ("`SqliteBackend` **owns** its `HnswStrategy` … built `from_db` at
+construction … `vector_search` dispatches HNSW-vs-brute"); struct §2 lines 57–66; H9 §4
+("Brute≡HNSW recall on exact-small corpus; insert/expire reflected"); T8 §5.
+
+**Reality:**
+
+- The engine builds HNSW **conditionally on `search_config`** — `engine/mod.rs:264-272`:
+  HNSW is constructed **only** when `search_config` is `Some` **and**
+  `ann_threshold < usize::MAX`. The default config is `None` (`engine/mod.rs:105`), so a
+  default engine — even with `--features ann` compiled in — **never builds HNSW at all**.
+- The engine dispatches HNSW vs brute via `should_use_hnsw()` (`engine/mod.rs:370-378`),
+  gated on `hnsw.active_count() >= search_config.ann_threshold` (default fallback
+  `usize::MAX` ⇒ **never** when no config). `active_vector_strategy()`
+  (`engine/query.rs:17-27`) consults that gate per query.
+
+The plan's `SqliteBackend` struct (lines 57–63) holds `hnsw: Option<…>` but carries **no
+`search_config`/`ann_threshold`**. So the backend, as designed, will (a) build HNSW
+unconditionally at construction and (b) dispatch to HNSW whenever the index is populated —
+**both diverge from the engine's config-gated policy.** When #631 rewires the engine onto
+this backend, a deployment that today runs pure brute-force (no `search_config`) silently
+flips to approximate HNSW search → a recall change. That is precisely the "zero behavior
+change" violation #630 exists to prevent, relocated into #631 where the seam is closed and
+it cannot be fixed without re-opening it (the very argument the plan uses _for_ doing HNSW
+in #630).
+
+**Why H9 is blind to it:** H9 asserts brute ≡ HNSW recall _on an exact-small corpus_. On a
+tiny corpus the two strategies return identical results **by construction**, regardless of
+_when_ HNSW is built or _at what threshold_ it dispatches. The proof targets recall
+equivalence; the drift is in the **build/dispatch policy**, which recall-equivalence
+testing cannot observe. This is the cleanest "green test that proves nothing" hole in the
+plan — and it sits on the one hazard (H9) the plan flags as a "perf cliff," masking that it
+is also a **correctness/behavior** divergence.
+
+**Fix (concrete):**
+
+1. Carry the policy into the backend: add `search_config: Option<SearchConfig>` (or at
+   minimum `ann_threshold: usize`) to `SqliteBackend`, and replicate **both** the
+   build-condition (`cfg.ann_threshold < usize::MAX`) and the dispatch gate
+   (`active_count() >= ann_threshold`, with the `None ⇒ usize::MAX ⇒ never` fallback)
+   verbatim from `engine/mod.rs:264-272` + `engine/mod.rs:370-378`. The constructor
+   (`with_hnsw`) must build HNSW **only** under the same condition the engine uses, not
+   "always at construction."
+2. Add a parity test that pins the **dispatch boundary**, not just recall: construct the
+   backend with `ann_threshold` set just above and just below `active_count()`, and assert
+   the _same dispatch decision_ (HNSW vs brute) the engine's `should_use_hnsw()` makes —
+   e.g. by asserting backend `vector_search` ≡ `BruteForce::search` when below threshold,
+   and ≡ the HNSW strategy when at/above. Include the `search_config = None ⇒ never HNSW`
+   case explicitly.
+3. If the author prefers to keep the policy engine-side (defer the gate to #631), then D3's
+   "backend **owns** HNSW" framing is wrong and must be restated: the backend exposes
+   `vector_search` brute-only (or a strategy injected by #631), and the §1 D3 rationale
+   ("deferring relocates an O(log N)→O(N) regression into #631 it could not fix") collapses
+   — because the _gate_ is what #631 must port anyway. Pick one; the current plan straddles
+   both and the straddle is the bug.
+
+---
+
+### [HIGH] H-a — `SqliteBackend` struct omits `vector_strategy` / `search_config`; the "four-fields-to-one swap" (§2) is actually six-plus fields, and the omission is what hides B1
+
+**Plan:** §2 "`SqliteBackend` absorbs the four SQLite-private fields the engine holds as
+siblings today (`pool`, `embed_dim`, `upcaster_registry`, `hnsw`), so #631 is a
+four-fields-to-one swap."
+
+**Reality:** the engine struct (`engine/mod.rs:157-167`) holds `pool`, `embed_dim`,
+`graph: RwLock<MemoryGraph>`, `scope_tree: RwLock<ScopeTree>`,
+`vector_strategy: Box<dyn VectorSearchStrategy>` (the brute-force fallback),
+`reranker`, `hnsw_strategy`, **`search_config: Option<SearchConfig>`**, and
+`upcaster_registry`. The "four SQLite-private fields" the plan lists drops both
+`vector_strategy` and `search_config` — yet `vector_strategy` (`BruteForce`) is the
+non-HNSW arm of dispatch and `search_config` is the gate (B1). `graph`/`scope_tree`/
+`reranker` legitimately stay engine-side (they are caches / consumer traits), so the plan
+is right to exclude _those_ — but it must not exclude `vector_strategy` and `search_config`,
+which are intrinsic to the search seam it is moving.
+
+**Fix:** restate §2 to list the _actual_ set the backend must own for the seam
+(`pool`, `embed_dim`, `upcaster_registry`, `hnsw`, `vector_strategy` or its equivalent,
+`search_config`), and explicitly note which engine fields stay (graph/scope_tree/reranker)
+and why. This is the same root cause as B1 surfaced at the design-altitude.
+
+---
+
+### [HIGH] H-b — Collateral #1 (§9) misdescribes the real doc-drift, and the _trait-level_ error menu actually understates the returned variant
+
+**Plan:** §9 collateral #1: "the rustdoc implies `EmbeddingDimension` for
+`require_embedding_fingerprint_present`, but the concrete (and #630 impl) returns
+`Internal` — reconcile." H4 (§4) lists "`require_*_present` fresh ⇒ `Internal`."
+
+**Reality:**
+
+- The concrete `embedding_meta::require_present` returns `MemoryError::Internal`
+  (`store/embedding_meta.rs:128-137`), and its **own** rustdoc correctly says
+  `MemoryError::Internal` (`embedding_meta.rs:126-127`). So the claim "the rustdoc implies
+  `EmbeddingDimension`" is **not** true of the concrete function's doc.
+- The drift is at the **trait** layer: `SchemaManager::require_embedding_fingerprint_present`
+  (`storage/schema.rs:53-54`) documents it only as "the open-time identity guard" and the
+  trait-level `# Errors` menu (`storage/schema.rs:22-27`) lists `Storage` / `Migration` /
+  `EmbeddingDimension` — but **not** `Internal`, which is exactly what the concrete path
+  returns. So a backend author reading the trait doc would not expect `Internal`, and H4's
+  parity assertion (`Internal`) would _contradict_ the trait's documented error set.
+
+**Why it matters for behavior preservation:** H4 is the error-fidelity hazard. If the plan
+asserts `Internal` in tests (correct vs the concrete) while the trait doc forbids it, the
+seam's documented contract and its tested behavior disagree — a latent #632-conformance
+landmine and a real chance someone "fixes" the test to match the doc and silently changes
+the variant. The method name in H4/T6 is also wrong (`require_*_present` →
+`require_embedding_fingerprint_present` / underlying `require_present`).
+
+**Fix:** Rewrite collateral #1 to target the _trait_ doc: `storage/schema.rs:22-27` +
+`:53-54` must add `MemoryError::Internal` to the documented error set for
+`require_embedding_fingerprint_present` (it is the un-stamped-store guard, #614 landmine).
+Keep H4 asserting `Internal` (it is correct vs the concrete) but cite the concrete source
+of truth (`embedding_meta.rs:128`).
+
+---
+
+### [HIGH] H-c — D2 streaming early-exit "at most one extra row" caveat is under-tested, and the `for_each_streamed` error-surfacing order can swallow a mid-scan SQL error behind a callback error
+
+**Plan:** §3 D2 code + caveat ("on early callback `Err`, the blocking scan produces at most
+one extra row before its next `send` fails — acceptable"); H6 catch ("callback `Err` at row
+`k` ⇒ same `Err`, exactly `k` rows seen").
+
+**Reality / risk:** the sketch (lines 125–135) does:
+
+```
+while let Ok(row) = rx.recv() { cb(row)?; }   // returns callback Err immediately
+map_seam_err(handle.await...)                 // only reached if the loop ended Ok
+```
+
+On a callback `Err` at row `k`, the function returns the **callback** error via `?` and
+**never awaits the join handle** — so a _mid-scan SQL error_ that the blocking scan would
+have produced is dropped. Conversely, if the scan errors first, the `send` fails, the loop
+ends `Ok` (recv sees a closed channel), and the join handle surfaces the SQL error — good.
+The two error sources race, and the plan's H6 catch only pins the callback-error case
+("exactly `k` rows seen"). It does **not** pin which error wins when _both_ a callback error
+and a scan SQL error occur, nor does it assert the callback-error path is value-identical to
+the free-fn's `for_each_*` early-exit (the free fns are synchronous and surface the callback
+error directly — there is no join handle to abandon). For a "zero behavior change" claim
+this is a real semantic the differential proof must pin, not hand-wave.
+
+**Fix:** Make H6/T1 assert (a) callback `Err` at row `k` ⇒ that exact `Err`, `k` rows seen
+(already planned); (b) a forced **mid-scan SQL error with no callback error** ⇒ surfaced as
+`Storage(Backend)` (the join-await path); (c) explicitly document that a callback error
+takes precedence over a concurrent scan error (callback error wins, scan error dropped) and
+confirm that matches the synchronous free-fn semantics (it does — the free fn would also
+return the callback error first and never continue the scan). Add the "no hang on early
+exit" assertion (drop `rx`, scan's `send` must error and the `spawn_blocking` task must
+terminate) — the plan mentions it in T1 prose but it is not in the H6 catch column.
+
+---
+
+### [MEDIUM] M-a — vector-search tie ordering is **non-deterministic** (unstable sort); a naive value-and-order parity test can false-green or flake
+
+**Plan:** H1 catch "Per-dimension parity vs `fts_search`/`vector_search` (value **and**
+order)"; §10 "assert results **identical** to the … oracle on a shared fixture (identity
+holds because the SQL is reused)."
+
+**Reality:** `vector_search` (`search/vector.rs:122-135`) uses
+`select_nth_unstable_by` + `sort_by` with `partial_cmp(...).unwrap_or(Ordering::Equal)`.
+For **tied scores** the relative order is **not stable / not deterministic** (unstable
+sort, ties compare `Equal`). So "order-identical to the free fn on a shared fixture" is only
+well-defined when scores are strictly distinct. A fixture with tied cosine scores (trivial
+to hit: two identical embeddings, or the all-`0.1` vectors the existing tests use) can make
+the backend and the oracle disagree on tie order across runs — either a flaky parity test,
+or (if both happen to agree on one run) a false green that masks a _real_ future reordering.
+
+**Fix:** Either (a) build the H1 vector fixture with strictly-distinct scores so order is
+total and parity is meaningful, or (b) compare as **sets** for ties and assert order only on
+the strictly-ordered prefix, and document that tie order is an unspecified detail the seam
+does not promise. Note: this is _not_ the f32→f64 issue (that one is fine — see C-2); it is
+orthogonal and the plan currently conflates "order" into one H1 bullet.
+
+---
+
+### [MEDIUM] M-b — in-memory pool **collapses reads onto the write mutex**; D2's "never blocks the executor" and H8's routing claim need the in-memory caveat stated
+
+**Plan:** §3 "Guard acquired inside the closure"; D2 "never blocks the executor"; H8 "**File-backed**
+concurrent-read routing test (in-memory collapses both conns and would mask a mis-route)."
+
+**Reality:** `ConnectionPool::read()` in in-memory mode (`read_pool_size == 0`) acquires the
+**write** connection's `Mutex` (`pool/connection_pool.rs:225-230`,
+`ReadConn::InMemory(WriteAsReadGuard)`). The plan correctly identifies this for H8 (good —
+that claim checks out). But two consequences are unstated: (1) a long-running
+`for_each_streamed` scan in in-memory mode holds the _write_ mutex for the whole stream, so
+a concurrent `block_write` on the same backend serializes behind it — the cap-1 backpressure
+means the stream can be slow (bounded by the async drainer / callback), extending the
+write-lock hold. This is _not_ a deadlock but it is a contention behavior the "never blocks
+the executor" line glosses. (2) The H8 test is correctly scoped to file-backed — confirm it,
+but also assert the in-memory path _works_ (doesn't deadlock) under a read-during-write
+pattern, since that is the default test harness mode.
+
+**Fix:** Add one sentence to the D2 rustdoc/§3: "in in-memory mode `pool.read()` takes the
+write mutex, so a streamed scan and a concurrent write serialize (no deadlock; bounded by
+the cap-1 drain)." Keep H8 file-backed but add an in-memory no-deadlock smoke assertion.
+
+---
+
+### [MEDIUM] M-c — `schema_version()` String→u32 parse failure returns **`Migration`**, not the variant H10/T6 implies; pin it
+
+**Plan:** T6 "`schema_version` (String→u32 parse)"; H10 catch "`string→u32` parse."
+
+**Reality:** the underlying read parses the config string and on failure returns
+`MigrationError::Incompatible` → `MemoryError::Migration` (`store/schema/mod.rs:204-206`,
+mirrored at `:325-327` for the validate path). The trait `schema_version()` returns
+`Result<u32>` (`storage/schema.rs:33`). So a corrupt `schema_version` value surfaces as
+`Migration`, and — per D4 — `Migration` is a semantic variant that **passes through**
+unchanged (not remapped to `Storage(Backend)`). The plan's H10 "`string→u32` parse" bullet
+doesn't say which variant it asserts. For error fidelity (the spirit of H4) it should pin
+**`Migration`**, and confirm `map_seam_err` does **not** opacify it (it won't — only
+`Database` is remapped; see C-1).
+
+**Fix:** H10/T6: assert a corrupt `schema_version` config value ⇒ `MemoryError::Migration`
+(passes through the seam), citing `store/schema/mod.rs:204`.
+
+---
+
+### [LOW] L-a — Documentation/Testing/Verification sections are present and substantive — minor structural nit only
+
+**Confirmed present:** §7 Verification (the full feature-matrix build/test/clippy/fmt + the
+`git diff --stat src/engine/` H5 gate + the "no `rusqlite`/`Connection` in `pub`
+signatures" grep), §8 Documentation (module rustdoc, crate-layout, CLAUDE.md status, ADR
+N/A with rationale, Sphinx N/A with rationale), §10 Testing (positive differential proof,
+error-variant fidelity, file-backed routing, feature-matrix, e2e/bench N/A with rationale).
+This is a structurally complete plan — no missing section. **Nit:** §6 is "(reserved)" and
+empty; either fill or delete to avoid a reader hunting for content. The N/A justifications
+are concrete, not hand-wavy (ADR N/A correctly notes the seam ADR is a separate spec
+deliverable; bench N/A correctly defers to memarch-bench).
+
+---
+
+### [LOW] L-b — circularity of the differential proof is real but _partially_ acknowledged; tighten the wording
+
+**Plan:** §10 "assert results **identical** to the concrete-store/free-fn oracle on a shared
+fixture (identity holds **because the SQL is reused**)."
+
+**Assessment:** the plan is honest that identity holds _because the same SQL runs on both
+sides_ — which is exactly the circularity: a bug in the shared SQL passes on both sides. The
+plan does **not** fully spell out the residual risk or its mitigation. The residual risk is:
+the differential proof catches **wrapper/adapter** bugs (wrong conn selection, dropped
+filter dimension, wrong error remap, broken streaming, f32→f64 mistakes, scope-slice
+inversion) — i.e. everything the _adapter_ adds — but is **blind to** any bug already in the
+delegated SQL/free-fn (those are pre-existing and out of #630's scope) **and** blind to any
+divergence in _policy the adapter must re-implement rather than delegate_ (HNSW build/
+dispatch — B1 — is the prime example: there is no shared code to make both sides agree, so
+"identity because SQL is reused" does not hold there). T2 partially mitigates by adding "a
+hand-built SQL oracle for the asserted-absent dimensions," which is the right instinct.
+
+**Fix:** Add one explicit paragraph to §4 or §10: "The differential proof is sound for
+delegated behavior (the adapter and oracle share SQL) but **provides no coverage where the
+adapter re-implements rather than delegates** — HNSW build/dispatch policy (B1) and any
+fail-loud projection in `convert.rs`. Those require an **independent** oracle (the engine's
+own `should_use_hnsw`/build condition for HNSW; a hand-built SQL/expected-set for
+`convert.rs`), not a self-comparison." This makes the one genuine hole (B1) visible in the
+proof strategy itself.
+
+---
+
+## Claims that CHECK OUT (confirmed against code — no change needed)
+
+- **C-1 / D4 error mapping is correct.** `StorageError` doc (`error.rs:345-368`) explicitly
+  states driver errors map to an opaque `String` at the seam and "the existing `Database`
+  variant stays for `SQLite`-internal use" — so the seam **must** remap `Database` →
+  `Storage(Backend)` and pass semantic variants through. The plan's `map_seam_err`
+  (lines 83–89) matches **only** `MemoryError::Database(e)` and remaps it; every other
+  variant (`NotFound`, `Migration`, `EmbeddingDimension`, `Conflict`, `ReadOnly`,
+  `Internal`, `UnsupportedEpoch`, `Pool`, `Serialization`) flows through untouched. This is
+  exactly what #629 intends. **No "should-be-NotFound raw Database" leak found:** I checked
+  the high-risk methods — `FactStore::get(missing)` returns `NotFound` (`store/facts.rs:228`,
+  not a raw `Database`); the importance/access mutators return `NotFound` on zero rows
+  affected (`facts.rs:409/425/442/714/732`); `marker_key` returns
+  `Conflict(QueryValidation)` (`facts.rs:991-995`). None of these would be wrongly opacified
+  by the blanket `Database` remap, because none of them emit a raw `Database` for a semantic
+  condition. The D4 remap is safe as written. (The single-point enforcement in `map_seam_err`
+  is the right call — it makes per-method omission impossible.)
+
+- **C-2 / f32→f64 widening is order-safe and value-exact.** `SearchIndex` returns
+  `Vec<(i64, f64)>` (`storage/search_index.rs:38/50`); the concrete `VectorResult.score` is
+  `f32` (`search/vector.rs:13`). The engine's own single-channel path already widens with
+  `f64::from(r.score)` (`search/hybrid.rs:196`), which is value-exact (every f32 → f64
+  losslessly) and monotonic, so widening cannot reorder. The backend doing the same widening
+  is correct. RRF (`hybrid.rs:117`) fuses by **rank only**, so even if scores differed the
+  fusion would be invariant — but they don't. The plan's H1 "f32→f64 order" catch targets
+  the right thing and will pass. (The _separate_ tie-ordering issue is M-a.)
+
+- **C-3 / the non-uniform `scope_ids` empty-slice contract is preserved by passthrough.**
+  `fts_search`/`vector_search`/`fts_count_expired` take `scope_ids: Option<&[i64]>` and
+  honor `Some(&[]) ⇒ matches-nothing` vs `None ⇒ filter disabled` — verified by the existing
+  tests `fts_search_empty_scope_slice_matches_nothing` (`fts.rs:301-317`) and
+  `vector_search_empty_scope_slice_matches_nothing` (`vector.rs:331-353`), and the SQL
+  `(?3 IS NULL OR scope_id IN (json_each(?3)))`. `FactFilter.scope_ids: Option<Vec<i64>>`
+  uses the **same** `Some(empty)=matches-nothing` convention (`storage/filter.rs:23-27`,
+  explicitly "A backend MUST NOT normalize `Some(empty)` to no-filter"). So `convert.rs`
+  projecting `filter.scope_ids.as_deref()` into the free fns is faithful, and
+  `serialize_scope_ids` (`search/mod.rs:32`) maps `None→None`, `Some(&[])→Some("[]")`
+  correctly. The plan's §3 convert.rs claim ("preserved by passing the slice straight
+  through to `serialize_scope_ids`") is correct. **Note the trap the plan navigates well:**
+  the `FactGraph` `&[i64]` methods use the _opposite_ convention (empty = ALL for 7 of them,
+  per `storage/graph.rs:30-47`), so the H2 parametric table (empty-slice meaning per method)
+  is genuinely necessary and correctly scoped. Confirmed the doc at `graph.rs:30-47` lists
+  the 7 empty=ALL, 3 empty=NONE, 1 `Option` split exactly as H2 says.
+
+- **C-4 / `marker_key` guard.** `list_active_by_metadata_key_recent` rejects a
+  non-`[A-Za-z0-9_]+`/empty key with `Conflict(QueryValidation)` in **all** build profiles
+  (`store/facts.rs:986-996`), and the key is interpolated (not bound) into the JSON path —
+  so H3's reject-set + happy-path parity is the right test and the variant assertion is
+  correct.
+
+- **C-5 / ReadOnly preservation via `try_write`.** `ConnectionPool::try_write()` returns
+  `MemoryError::ReadOnly` on a read-only pool (`pool/connection_pool.rs:271-274`), and
+  `block_write` (plan lines 104–112) uses `try_write()?`, so DD#6 is preserved for free on
+  every write method. H7's "each mutator ⇒ `ReadOnly`" is correct. The pool API the plan
+  assumes (`read() -> Result<ReadConn>`, `try_write() -> Result<MutexGuard>`) exists exactly
+  as used.
+
+- **C-6 / engine stays untouchable & default build is runtime-free.** `MemoryEngine { pool:
+ConnectionPool }` by value (`engine/mod.rs:157`); `default = []` (no async/ann) in
+  `Cargo.toml`, so gating `storage::sqlite` behind `#[cfg(feature = "async")]` (D1) genuinely
+  compiles it out of the default build — zero tokio, confirmed. The concrete stores are
+  `&Connection`-scoped and transient (`FactStore<'a> { conn: &'a Connection }`,
+  `store/facts.rs:11-12`), which validates the delegation-not-absorption rationale (§1)
+  and the "engine untouched" achievability: nothing in the additive `storage/sqlite/*`
+  subtree forces an `src/engine/` edit, because the stores it delegates to are constructed
+  per-call from a borrowed connection — **except** the HNSW policy (B1), which is the one
+  place the backend cannot stay engine-independent without copying `search_config` logic.
+  `archive_manifest.list()` orders `BY created_at` ascending = oldest-first (T7 claim
+  correct, `store/archive_manifest.rs:65-70`). `migrate` returns `UnsupportedEpoch` for a
+  future epoch (`store/schema/mod.rs:215-219`), validating the H10 epoch assertion.
+
+---
+
+## Bottom line
+
+The plan is **strong** on the parts most likely to leak — D4 error remapping, the
+non-uniform scope-slice contract, marker_key, NotFound, f32→f64, ReadOnly — all verified
+correct against the code, and its differential-proof instinct (ship parity tests in the
+same commit; fail-loud `convert.rs`; file-backed for routing) is right. The **one structural
+hole** is HNSW (B1/H-a): the build-and-dispatch _policy_ lives in the engine's
+`search_config`, the backend struct omits it, and the H9 recall test is constitutionally
+blind to the divergence — so #630 can ship green while planting a recall-behavior change for
+#631 to detonate. Fix B1 (carry `search_config` + replicate the gate, and pin the dispatch
+_boundary_ not just recall) and the "zero behavior change" claim becomes defensible. H-b
+(trait-doc error menu omits `Internal`) and M-c (pin `Migration` on schema-version parse)
+are cheap error-fidelity tightenings. H-c (streaming error-precedence) and M-a (tie-order
+nondeterminism) are real but bounded. The Documentation/Testing/Verification scaffolding is
+complete and concrete.
+
+**Severity tally:** 1 BLOCKER (B1), 3 HIGH (H-a, H-b, H-c), 3 MEDIUM (M-a, M-b, M-c),
+2 LOW (L-a, L-b). 6 load-bearing claims confirmed correct (C-1…C-6).

--- a/docs/plans/2026-06-20-sqlite-backend-630-subagent-review.md
+++ b/docs/plans/2026-06-20-sqlite-backend-630-subagent-review.md
@@ -1,0 +1,57 @@
+# Review — #630 plan — diverse-lens internal subagent panel
+
+**Review roster (per user override of super-plan Step 3/4):** three clean-slate internal subagents, one per lens, replacing external Codex/agy AND the unavailable `advisor()`. Each read the plan + the real code from disk with no conversation context.
+
+- Async / runtime-correctness lens → `2026-06-20-sqlite-backend-630-review-async.md`
+- Refactor-safety / behavior-preservation lens → `2026-06-20-sqlite-backend-630-review-refactor.md`
+- Architecture / scope / API-seam lens → `2026-06-20-sqlite-backend-630-review-arch.md`
+
+## Findings (consolidated, by severity)
+
+### BLOCKER
+
+- **B-async — `std::sync::mpsc::recv()` inside an `async fn` parks a tokio executor thread** (D2 bridge). Drain side must be `tokio::sync::mpsc::channel(1)` + `rx.recv().await`; scan closure must use `tx.blocking_send(row)`. Requires adding `"sync"` to tokio's `async`-feature list in `Cargo.toml`.
+- **B1-refactor — HNSW build/dispatch _policy_ lives in the engine** (`search_config` Some + `ann_threshold < usize::MAX` build gate, `active_count() >= ann_threshold` dispatch gate, `engine/mod.rs:264-272,370-378`). D3 (own HNSW in the backend) requires replicating that policy; H9's small-corpus recall test cannot exercise the threshold. Reshapes D3 — escalated to user.
+
+### HIGH
+
+- **H-async early-exit precedence** — on callback `Err`, dropping `rx` makes the scan's next `send` fail; the sketch would return the scan's `SendError`-derived error and discard the real callback error. Capture `cb_err`, `drop(rx)`, return `cb_err` preferentially. H6 test must pin this.
+- **H-b-refactor — collateral #1 mis-states the doc drift** — the concrete `require_present` rustdoc _does_ say `Internal` (`embedding_meta.rs:126-137`); the real drift is the **trait** `SchemaManager` error menu (`storage/schema.rs:22-27`) listing `EmbeddingDimension` but omitting `Internal`.
+- **F1-arch — "#631 is a four-fields-to-one swap" oversells** — the engine reads `pool`/`graph`/`hnsw` across 20+ sub-modules and composes multi-store transactions. #630 makes the handle _constructible_, not #631 _mechanical_.
+- **F2-arch — seam-leakage gate has no teeth** — pin the exact grep command instead of prose.
+- **F4-arch — D4 witness can't use the FTS path** — `fts_search`/`fts_count_expired` swallow errors to `Ok(empty)`; the "raw SQL fail ⇒ `Storage(Backend)`" witness must use a propagating method (e.g. `insert_event` constraint violation).
+
+### MEDIUM
+
+- **M-async-1** — assert `UpcasterRegistry: Send + Sync` and `HnswStrategy: Send + Sync` (the `async_trait` futures are `Send`); add `static_assertions` in T1.
+- **M-async-2** — `Arc`-wrap `UpcasterRegistry` (cloned into closures).
+- **M-a-refactor** — vector tie-ordering is non-deterministic (`select_nth_unstable_by`, `vector.rs:122-135`); parity on tied scores can flake → use distinct scores or set-compare ties.
+- **M-b-refactor** — in-memory pool collapses reads onto the write mutex; D2's "never blocks executor" needs that caveat.
+- **M-c-refactor** — `schema_version()` parse failure returns `Migration` (`schema/mod.rs:204`); pin in H10.
+- **F3-arch** — parity is identity-by-construction below the wrapper (oracle and SUT share the SQL); reframe the tests as catching _wrapper_ drift, not SQL correctness.
+- **F5-arch** — cap T9 at one dispatch-call per trait (semantic parity is #632).
+- **F6-arch** — state the invariant: never fold `ColdStorage` into the `StorageBackend` supertrait bound (keeps the umbrella vtable feature-invariant).
+
+### LOW
+
+- **F7-arch** — re-rank H9 (HNSW notify is the only net-new write logic) — moot if D3 defers.
+- **F8-arch** — §9 mislabels: items 3 (note on #631) and 4 (existing #652) are not new issues.
+- Remove the empty reserved §6.
+
+### Confirmed correct (no change needed)
+
+D4 remap safe (only `Database` matched; no semantic condition emits raw `Database`); `f32→f64` value-exact + order-safe; `Some(&[])`=matches-nothing round-trips through `convert.rs`; `marker_key` guard, `ReadOnly`-via-`try_write`, engine-untouchable, default-build-runtime-free, archive oldest-first, epoch gate; `ColdStorage` `cfg(all(async,archive))` off the umbrella is correct; T9 is in-scope (not gold-plating); delegation-not-absorption is the right epic call.
+
+## Resolution
+
+- **B-async** → ADOPTED. D2 rewritten to `tokio::sync::mpsc` (`blocking_send`/`recv().await`); `Cargo.toml` `async` feature gains `"sync"`.
+- **B1-refactor (D3)** → ESCALATED TO USER as a feature-altitude decision (own HNSW now + replicate policy, vs defer brute-force-only to #631). Plan finalized per the user's choice; H9 + T8 + struct fields adjusted accordingly.
+- **H-async early-exit / H-c** → ADOPTED. `for_each_streamed` returns `cb_err` preferentially; H6 test pins both callback-error and mid-scan-SQL-error precedence.
+- **H-b-refactor** → ADOPTED. Collateral #1 reworded to target the trait error-menu omission of `Internal`.
+- **F1-arch** → ADOPTED. §2 reworded: #630 makes the handle constructible; #631 is non-trivial (20+ call sites + transactions).
+- **F2-arch** → ADOPTED. Pinned grep added to §7.
+- **F4-arch** → ADOPTED. D4 witness uses a propagating write method, not an FTS swallow.
+- **M-async-1/2, M-a/b/c-refactor, F3/F5/F6/F7/F8-arch, empty §6** → ADOPTED into the relevant plan sections.
+- All "confirmed correct" items → no change.
+
+No findings were dismissed. The one substantive disagreement among the drafts (D4) was resolved against primary source (`error.rs:345-368`) and independently confirmed by the refactor lens.

--- a/docs/plans/2026-06-20-sqlite-backend-630.md
+++ b/docs/plans/2026-06-20-sqlite-backend-630.md
@@ -1,0 +1,238 @@
+# Implementation Plan — #630 `SqliteBackend` behind the storage traits
+
+> `refactor(storage): implement SqliteBackend behind traits (zero behavior change)`
+> Epic **#628** · depends on **#629** (A1, MERGED `24f9d65`) · feeds **#631** (engine rewire), **#632** (conformance suite), **#634** (PgBackend).
+> Spec: `docs/superpowers/specs/2026-06-19-pluggable-storage-backend-design.md` §4 (module layout) + §7 (backend impls).
+
+Synthesized from three max-effort lens drafts (`docs/plans/2026-06-20-sqlite-backend-630-drafts/`: architecture / risk / mvp) and reviewed by a three-lens internal subagent panel (`*-review-async.md`, `*-review-refactor.md`, `*-review-arch.md`; consolidated in `*-subagent-review.md`). All BLOCKER/HIGH findings are folded in below; D3 was decided by the user (defer).
+
+---
+
+## 1. BLUF — what #630 is, and the four decisions
+
+**What:** Add `SqliteBackend`, a concrete implementation of the six #629 bounded-context traits (`FactGraph`, `EventLog`, `SearchIndex`, `ConsolidationStore`, `SessionStore`, `SchemaManager`) plus `ColdStorage` (feature `archive`). It **delegates** to the existing `src/store/*` structs and `src/search/*` free functions — reusing their SQL **verbatim** — wrapping each sync `rusqlite` call in `spawn_blocking`. The crate's `MemoryEngine` is **not** touched (that is #631); `SqliteBackend` is added purely additively and proven by new parity tests.
+
+**Why delegation, not absorption:** the concrete stores are `&Connection`-scoped and are the SQL's single source of truth, shared by today's fast in-process unit tests. `SqliteBackend` is an _adapter_ that re-homes the borrow→own and sync→async concerns. #634's `PgBackend` reuses zero SQLite bodies, so absorbing the SQL would only have to be undone. (Retiring `src/store/` once Postgres parity exists is a separate, deliberate future call — explicitly out of scope.)
+
+**Decisions:**
+
+| #   | Fork                      | Decision                                                                                                                                                                                                                                                                                                                                                                        | Anchored by                                                         |
+| --- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| D1  | async gating              | **Gate the whole `storage::sqlite` subtree behind `#[cfg(feature = "async")]`.** `spawn_blocking` needs tokio; default builds stay runtime-free.                                                                                                                                                                                                                                | `backend.rs:84-94` names #630's impl as `async`-gated.              |
+| D2  | `for_each_*` streaming    | **`tokio::sync::mpsc::channel(1)` bridge**: the `spawn_blocking` scan `blocking_send`s rows; the async side `recv().await`s and invokes the non-`'static` callback. O(1) peak memory, mid-stream early-exit error propagation, never parks an executor thread. (Reject `std::sync::mpsc` — its blocking `recv` parks the executor; reject collect-to-Vec; reject inline-block.) | streaming contract `graph.rs:82-85`; async-lens BLOCKER             |
+| D3  | ANN/HNSW                  | **Defer to #631.** `SqliteBackend::vector_search` is the verbatim **brute-force** free function. HNSW + its engine-owned build/dispatch policy (`search_config`, `ann_threshold`) move into the backend during the #631 rewire, as one coherent step. The backend is unused until #631, so there is no interim regression; tracked as a #631 task, not a silent gap.            | user decision; B1 (policy lives in `engine/mod.rs:264-272,370-378`) |
+| D4  | error mapping at the seam | **Map `MemoryError::Database(rusqlite::Error)` → `Storage(StorageError::Backend(e.to_string()))` at the seam; pass semantic variants through unchanged.** The concrete stores keep emitting `Database` internally; the trait boundary must not leak a driver type.                                                                                                              | `error.rs:345-368` (driver errors → opaque `String` at the seam)    |
+
+**Scope OUT:** rewire the engine (#631); cross-backend conformance battery (#632); `PgBackend` / new `backend-*` features (#633/#634); HNSW-in-backend (deferred to #631 per D3). The engine path stays byte-identical (`git diff --stat src/engine/` empty for production code).
+
+---
+
+## 2. Module layout (additive — no engine edits)
+
+```
+src/storage/
+  mod.rs              (exists) — ADD `#[cfg(feature = "async")] pub mod sqlite;`
+  backend.rs filter.rs capabilities.rs cold_storage.rs
+  graph.rs event_log.rs search_index.rs consolidation.rs session.rs schema.rs   (exist — UNCHANGED contracts)
+  sqlite/             NEW — one file per bounded trait, mirroring the contract 1:1
+    mod.rs            SqliteBackend struct + ctors + delegation core
+                      (block_read / block_write / for_each_streamed / map_join / map_seam_err)
+    convert.rs        FactFilter → (Option<FactType>, Option<Vec<i64>>) projection + fail-loud assertions
+    graph.rs          impl FactGraph         (delegates store/facts, edges, scopes)
+    event_log.rs      impl EventLog          (delegates store/events + UpcasterRegistry)
+    search_index.rs   impl SearchIndex       (delegates search/fts, vector — brute force)
+    consolidation.rs  impl ConsolidationStore (delegates store/summaries, lineage)
+    session.rs        impl SessionStore      (delegates store/activities, checkpoints)
+    schema.rs         impl SchemaManager     (delegates store/schema + embedding_meta)
+    cold_storage.rs   #[cfg(all(feature="async", feature="archive"))] impl ColdStorage (delegates store/archive_manifest)
+```
+
+One file per trait so a reviewer diffs `storage/sqlite/graph.rs` against `storage/graph.rs` side by side, and #634 mirrors it as `storage/postgres/graph.rs`. `mod.rs` is the only file that knows the struct internals.
+
+### The ownership struct (`storage/sqlite/mod.rs`)
+
+`SqliteBackend` absorbs the SQLite-private fields the engine holds as siblings today, so #631's construction site is simple. It stores the pool as `Arc<ConnectionPool>` (the `'static` `spawn_blocking` closures need an owned handle) even though the engine holds it by value today (`MemoryEngine { pool: ConnectionPool }`, `engine/mod.rs:157`). `UpcasterRegistry` is `Arc`-wrapped (cloned into every `EventLog` closure).
+
+```rust
+pub struct SqliteBackend {
+    pool: Arc<ConnectionPool>,
+    embed_dim: usize,
+    upcaster_registry: Arc<UpcasterRegistry>,
+}
+```
+
+> **D3 note:** no `hnsw` / `search_config` fields. `vector_search` is brute-force; HNSW ownership + policy is a #631 move (the engine still owns its `hnsw_strategy` and dispatch threshold until then). This keeps #630's struct free of `ann`-gated state and avoids duplicating engine query-policy.
+
+`Send + Sync` is required (the `async_trait` futures are `Send`, `&self` is captured). T1 adds `static_assertions::assert_impl_all!(SqliteBackend: Send, Sync)` and `assert_impl_all!(UpcasterRegistry: Send, Sync)` so a non-`Sync` field is a loud, early failure.
+
+Constructors: `from_pool(Arc<ConnectionPool>, embed_dim, Arc<UpcasterRegistry>)` (the path #631 uses) + thin `open`/`open_memory`/`open_read_only` wrappers the parity tests use.
+
+---
+
+## 3. The delegation seam (the DRY core, `storage/sqlite/mod.rs`)
+
+Five private items carry the entire borrow→own + sync→async + error-mapping transition. Trait methods are ~3 lines each.
+
+```rust
+#[cfg(feature = "async")]
+fn map_join(e: tokio::task::JoinError) -> MemoryError {              // panic/cancel → Pool
+    MemoryError::Pool(format!("task join error: {e}"))              // matches async_engine::join_err
+}
+
+/// D4: confine `rusqlite` below the seam. Raw driver failures → opaque Storage(Backend);
+/// semantic variants (NotFound, Migration, EmbeddingDimension, Conflict, ReadOnly, Internal, …)
+/// pass through — they have a precise home (verified: no method emits raw `Database` for a
+/// semantic condition — get→NotFound, marker→Conflict, fingerprint-absent→Internal).
+fn map_seam_err<T>(r: Result<T>) -> Result<T> {
+    match r {
+        Err(MemoryError::Database(e)) =>
+            Err(MemoryError::Storage(StorageError::Backend(e.to_string()))),
+        other => other,
+    }
+}
+
+impl SqliteBackend {
+    #[cfg(feature = "async")]
+    async fn block_read<T, F>(&self, f: F) -> Result<T>
+    where T: Send + 'static, F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static {
+        let pool = Arc::clone(&self.pool);
+        let out = tokio::task::spawn_blocking(move || {
+            let conn = pool.read()?;        // ReadConn derefs to &Connection; !Send → acquired inside
+            f(&conn)
+        }).await.map_err(map_join)?;
+        map_seam_err(out)
+    }
+
+    #[cfg(feature = "async")]
+    async fn block_write<T, F>(&self, f: F) -> Result<T>
+    where T: Send + 'static, F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static {
+        let pool = Arc::clone(&self.pool);
+        let out = tokio::task::spawn_blocking(move || {
+            let conn = pool.try_write()?;   // MutexGuard; errs ReadOnly on a read-only pool (preserves DD#6)
+            f(&conn)
+        }).await.map_err(map_join)?;
+        map_seam_err(out)
+    }
+}
+```
+
+Load-bearing design points:
+
+- **Guard acquired inside the closure** — `ReadConn`/`MutexGuard` are `!Send`; acquiring outside would not compile and would serialize the executor.
+- **`try_write`, not `write`** — preserves Key Design Decision #6 (read-only → `MemoryError::ReadOnly`) for free, on every write method (H7).
+- **`map_seam_err` at one point** — D4 enforced once for every delegated call; impossible to forget per-method.
+- **`Send + 'static`** is always satisfiable (every trait arg is owned/`Copy` or cloned-to-owned); the `for_each_*` callback is the sole exception (D2).
+
+### D2 — `for_each_streamed` (the one intricate method; async-lens BLOCKER fix folded in)
+
+```rust
+#[cfg(feature = "async")]
+async fn for_each_streamed<T, S>(&self, scan: S, cb: &mut (dyn FnMut(T) -> Result<()> + Send)) -> Result<()>
+where T: Send + 'static,
+      S: FnOnce(&rusqlite::Connection, &tokio::sync::mpsc::Sender<T>) -> Result<()> + Send + 'static {
+    let pool = Arc::clone(&self.pool);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<T>(1);   // cap-1 backpressure ⇒ O(1) peak
+    let handle = tokio::task::spawn_blocking(move || { let conn = pool.read()?; scan(&conn, &tx) });
+    // Drain on the async side; invoke the borrowing callback here. Capture an early
+    // callback error and PREFER it over the scan's resulting send failure.
+    let mut cb_err: Option<MemoryError> = None;
+    while let Some(row) = rx.recv().await {
+        if let Err(e) = cb(row) { cb_err = Some(e); break; }
+    }
+    drop(rx);                                               // unblocks/aborts the scan's next blocking_send
+    let scan_res = map_seam_err(handle.await.map_err(map_join)?);
+    match cb_err { Some(e) => Err(e), None => scan_res }    // callback error wins; else surface scan SQL error
+}
+```
+
+Scan closures use `tx.blocking_send(row)` (legal on the blocking thread). Requires tokio feature `"sync"` (added to the `async` feature in `Cargo.toml`). Caveat documented in code: in-memory pools collapse reads onto the write mutex (`connection_pool.rs:225-230`), so for an in-memory store the scan briefly holds the write lock — acceptable (dump/export path), noted for completeness.
+
+### convert.rs — the `FactFilter` projection (fail loud)
+
+`SearchIndex` takes a rich `FactFilter`; the verbatim `fts_search`/`vector_search` honor only `(fact_type, scope_ids)` and hard-code `t_expired IS NULL` (Active). `convert::search_params(filter)` projects onto what the SQL accepts and **errors loud** (`MemoryError::Internal`) if `temporal != Active`, or `ids`/`pinned`/`metadata` are set — rather than silently dropping a predicate. The engine query path never sets those on a search filter; honoring them would be _new behavior_ #630 must not introduce. The `scope_ids: Some(empty) = matches-nothing` quirk is preserved by passing the slice straight to the unchanged `serialize_scope_ids`. (Collateral: full FactFilter→SQLite-search translation tracked separately.)
+
+---
+
+## 4. Hazard register → the differential proof
+
+"Zero behavior change," but the engine is not rewired ⇒ **no existing test exercises `SqliteBackend`**; the danger is a _green_ suite that proves nothing. Each impl ships its parity assertions in the **same commit**. Note (review F3): because the backend delegates to the same SQL the oracle calls, parity is identity-by-construction _below_ the wrapper — these tests catch **wrapper drift** (wrong conn, lost error, bad projection, broken streaming), not SQL correctness (that is the stores' own unit tests + #632). Ranked, retire top-down:
+
+| Id  | Hazard                                                                                                                                               | Catch (the assertion that fails on drift)                                                                                                                                                                                                                                                                                               |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| H1  | Search-seam drift: `FactFilter`→SQL infidelity, empty-scope inversion, `f32→f64` order, malformed-query swallow, `count_expired` not taking a filter | Per-dimension parity vs `fts_search`/`vector_search`/`fts_count_expired` (value + order; **distinct scores** to avoid `select_nth_unstable_by` tie flake, or set-compare ties); `Some(&[])`⇒empty vs `None`⇒found; `"\"unbalanced`⇒`Ok(empty)`; wrong-dim⇒`EmbeddingDimension`                                                          |
+| H2  | Non-uniform `scope_ids` empty-slice on 11 `FactGraph` methods (empty=ALL×7, =NONE×3, `Option`×1)                                                     | Parametric table: `backend.m(&[]) == FactStore::m(&[])` for all 11 on a 2-scope fixture                                                                                                                                                                                                                                                 |
+| H3  | `marker_key` injection guard (security)                                                                                                              | Reject-set `["", "in'sight", "$.x", "a b", "a;b"]` ⇒ `Conflict(QueryValidation)`; happy-path parity                                                                                                                                                                                                                                     |
+| H4  | Error-variant fidelity (D4)                                                                                                                          | Exact-variant matrix: **propagating** write fail (e.g. `insert_event` constraint violation, NOT an FTS swallow) ⇒ `Storage(Backend)`; `get_fact(missing)`⇒`NotFound`; `require_*_present` fresh ⇒ `Internal`; `record_*_if_absent` dim-mismatch ⇒ `EmbeddingDimension`; read-only write ⇒ `ReadOnly`; future-epoch ⇒ `UnsupportedEpoch` |
+| H5  | Transaction-boundary collapse (latent for #631)                                                                                                      | #630 leaves engine untouched ⇒ `git diff --stat src/engine/` empty for prod code; doc note that single-op trait methods are independent writes; #631 hazard filed as collateral                                                                                                                                                         |
+| H6  | `spawn_blocking` `'static`: streaming + arg cloning                                                                                                  | Streaming test asserts BOTH precedences: callback `Err` at row _k_ ⇒ that exact `Err` + exactly _k_ rows seen; and a mid-scan SQL error (no callback error) ⇒ `Storage(Backend)`. Clone-to-owned is value-identical (no interior mutability)                                                                                            |
+| H7  | `read_only` enforcement preserved                                                                                                                    | Read-only backend: each representative mutator ⇒ `ReadOnly`; reads still succeed                                                                                                                                                                                                                                                        |
+| H8  | Read-vs-write conn selection per method                                                                                                              | **File-backed** concurrent-read routing test (in-memory collapses both conns and masks a mis-route)                                                                                                                                                                                                                                     |
+| H10 | Schema/migration + `VACUUM INTO` backup + FK-rebuild + epoch                                                                                         | `schema_version`⇒12; migrate idempotent-at-HEAD; old-version migrates with backup; future-epoch⇒`UnsupportedEpoch`; corrupt config ⇒ `Migration`; `string→u32` parse                                                                                                                                                                    |
+
+(H9 HNSW-freshness removed from #630 scope per D3 — folded into the #631 collateral note.)
+
+---
+
+## 5. Sequenced tasks (retire top risks first; each commit carries its parity tests)
+
+- [ ] **T0 — Baseline.** Worktree `.worktrees/refactor-630-sqlite-backend` (off `main`, done). Gate green before touching code: `cargo build/test/clippy --workspace --all-targets` + `cargo test --all-features`.
+- [ ] **T1 — Seam core + the hardest method first.** `Cargo.toml`: add `"sync"` to the `async` feature's tokio list. `storage/sqlite/mod.rs` with the struct, ctors, `block_read`/`block_write`/`map_join`/`map_seam_err`/`for_each_streamed`, the `Send+Sync` static asserts, all `#[cfg(feature="async")]` (D1, D2, D4). Implement **only** `EventLog::{insert_event, get_event, for_each_event}` to exercise the D2 bridge before replicating it. **Prove:** helper unit tests (`block_write`→`ReadOnly`, panic→`Pool`, `for_each_streamed` callback-error precedence + mid-scan-error precedence + no-hang + order); `get_event(missing)`⇒`NotFound`; `insert_event` constraint violation ⇒ `Storage(Backend)` (D4 witness via a propagating method).
+- [ ] **T2 — `SearchIndex` + `convert.rs` (retire H1).** `lexical_search`/`vector_search` (brute-force, D3)/`lexical_count_expired`; `convert::search_params` projection + fail-loud. **Prove:** the full H1 matrix vs the free-fn oracle (distinct scores for order; set-compare ties); `Some(&[])`⇒empty; malformed⇒empty; wrong-dim⇒`EmbeddingDimension`; `convert` rejects non-`Active`/ids/pinned/metadata ⇒ `Internal`.
+- [ ] **T3 — `FactGraph` facts (retire H2, H3, H4, H7, H8).** All fact read/write methods delegating to `FactStore`, with `// READ`/`// WRITE` conn-selection markers. **Prove:** the 11-method empty-`scope_ids` parity table (H2); `marker_key` reject-set + happy path (H3); the error-variant matrix (H4); read-only mutators ⇒ `ReadOnly` (H7); a **file-backed** concurrent-read routing test (H8).
+- [ ] **T4 — `FactGraph` edges + scopes.** Delegate to `EdgeStore`/`ScopeStore`; `for_each_edge`/`for_each_scope` via the bridge. **Prove:** `edge_exists_active`, `list_active_edge_pairs_by_facts` (HashSet), `ensure_scope_path`, edge/scope streaming early-exit.
+- [ ] **T5 — `ConsolidationStore` + `SessionStore`.** Delegate to `SummaryStore`/`LineageStore` and `ActivityStore`/`CheckpointStore` (the `#[cfg(test)]` reads become unconditional). **Prove:** summary upsert/list-by-level; lineage insert/get + `Lineage` error on missing; activity dedup-window; `list_recent_activities_by_scope` empty-slice⇒empty; checkpoint upsert/get-by-scope.
+- [ ] **T6 — `SchemaManager` (retire H4-schema, H10).** Delegate `migrate`/`schema_version` (String→u32 parse, parse-fail ⇒ `Migration`)/`validate_schema_version` to `store::schema`; the four fingerprint methods to `store::embedding_meta`; sync `capabilities()` ⇒ `{ lexical_ranker: Bm25, true_idf: true, server_side_vector: false }`. **Prove:** the H10 matrix; `require_*_present` fresh ⇒ `Internal`; `record_*_if_absent` dim-mismatch ⇒ `EmbeddingDimension`.
+- [ ] **T7 — `ColdStorage`** under `#[cfg(all(async, archive))]`. Delegate manifest CRUD to `ArchiveManifestStore`; pak I/O stays free functions. **Prove:** manifest insert/list(oldest-first)/delete parity; `cargo test --features async,archive` green.
+- [ ] **T8 — `Arc<dyn StorageBackend>` realization proof (capped).** Construct a real `Arc<dyn StorageBackend>` from `SqliteBackend` and make **one** dispatch call per bounded trait through it — the value-level upgrade of #629's vtable-only test (`backend.rs:86-90` defers this to #630). One test driving `&dyn FactGraph = &backend`. (Semantic parity is #632, not here — review F5.)
+- [ ] **T9 — Workspace gate + lint** (see §7). Confirm `git diff --stat src/engine/` shows no production change (H5).
+- [ ] **T10 — Docs** (see §8).
+- [ ] **T11 — Collateral issues** filed + linked to #628 (see §9).
+- [ ] **T12 — Plan reference** posted as a comment on #630 (link the in-repo plan doc; one logical issue, no separate plan issue).
+- [ ] **T13 — PR** `Fixes #630`, labels `type:refactor` + `area:storage`, linked under epic #628 (`addSubIssue`, `replaceParent: true`).
+- [ ] **T14 — `/super-review`** (or 2–3 adversarial subagent reviewers per the under-budget preference). Reviewer focus: (1) the pinned seam-leak grep; (2) SQL truly verbatim (diff each delegated call vs its sync caller); (3) `for_each_streamed` hang/leak/precedence; (4) `convert.rs` fail-loud vs silent-drop; (5) D4 remap vs `error.rs:345-368`. Triage gemini-code-assist[bot] typed FPs. Re-gate after any rebase.
+- [ ] **T15 — Squash-merge** once green + approved.
+
+---
+
+## 6. Verification
+
+```bash
+cargo build  --workspace --all-targets          # default build: storage::sqlite fully cfg'd out, zero tokio
+cargo test   --workspace --all-targets
+cargo clippy --workspace --all-targets --all-features   # pedantic + nursery clean
+cargo test   --all-features                      # async + ann + archive: exercises SqliteBackend + parity
+cargo test   --features async                    # backend without ann/archive
+cargo test   --features async,archive
+cargo fmt --check                                # real cargo fmt, NOT rtk (rtk fmt summaries have masked exit codes)
+git diff --stat src/engine/                      # MUST be empty for production code (H5)
+
+# Seam-leak gate (review F2) — pinned, with the one legitimate exception (private helper bounds):
+! grep -rnE 'pub( |\().*\b(rusqlite|Connection)\b' src/storage/sqlite/ \
+  | grep -vE 'block_read|block_write|for_each_streamed'   # expect: no matches
+```
+
+Pass criteria: all green; no new clippy `allow`s beyond those the trait files already carry; the seam-leak grep yields nothing; `unsafe_code = "forbid"` holds. The `{async} × {archive}` matrix is non-negotiable — `ColdStorage` only compiles under `archive`. Drift-catching lives in the **parity assertions** (wrapper drift), not the compile.
+
+## 7. Documentation
+
+- [ ] **Module rustdoc** on `storage/sqlite/mod.rs`: ownership story; delegation-over-`block_read`/`block_write`; SQL lives in `src/store/*`+`src/search/*` (this adapts, does not own SQL); conn-selection rule (reads→`pool.read`, writes→`try_write`); D2 streaming semantics + the in-memory caveat; D4 error-mapping rule; the H5 caveat (single-op methods are independent writes; engine composes atomicity above the seam); D3 (brute-force vector_search; HNSW is #631). State D1–D4 inline for #634's author.
+- [ ] **`docs/reference/crate-layout.md`** — add the `src/storage/sqlite/*` subtree (one-file-per-trait; delegation-not-absorption note).
+- [ ] **`CLAUDE.md` Status** — mark #630 ✅ (A2) on merge; note #631 unblocked.
+- [ ] **ADR:** `N/A` — the seam ADR is a separate spec deliverable; #630 implements an already-decided seam.
+- [ ] **Narrative (Sphinx) docs:** `N/A` — #630 introduces no user-facing API (engine untouched until #631).
+
+## 8. Testing
+
+- **Positive differential proof** (`#[cfg(feature="async")] #[tokio::test]`): per trait-method group, drive `SqliteBackend` and assert results **identical** to the concrete-store/free-fn oracle on a shared fixture. These catch **wrapper** drift (the SQL is shared with the oracle; SQL correctness is the stores' own tests + #632). Property/proptest where one row is insufficient (FactFilter translation; the 11-method empty-scope table; streaming precedence).
+- **Error-variant fidelity** (H4): assert the _exact_ `MemoryError` variant per failure mode, not `is_err()`; the raw-driver witness uses a **propagating** method (FTS swallows errors to `Ok(empty)` and cannot witness it).
+- **File-backed routing** (H8) + **read-only enforcement** (H7): require a file-backed pool variant (in-memory collapses read/write conns).
+- **Feature-matrix builds**: `async`, `async,archive`, default (unchanged), `--all-features`.
+- **Existing suite stays green, untouched** — the addition is purely additive; the regression gate is "no existing test changes + all pass."
+- **Levels excluded:** e2e `N/A` (no process/IO boundary introduced; MCP/CLI binaries unaffected until #631). Benchmarks `N/A` for #630 (the efficiency×quality benchmark is the epic's piece D / memarch-bench).
+
+## 9. Collateral / follow-ups (separate issues, `type:*`+`area:*`, linked to #628)
+
+1. **`SchemaManager` trait-doc error-menu drift** (`type:docs`/`area:storage`): the trait rustdoc (`storage/schema.rs:22-27`) lists `EmbeddingDimension` but omits the `Internal` that `require_embedding_fingerprint_present` actually returns — reconcile the trait error menu.
+2. **Full `FactFilter`→SQLite-search translation** (`type:enhancement`/`area:retrieval`): `convert::search_params` fails loud on `temporal`/`ids`/`pinned`/`metadata`; whoever needs those on the SQLite search path implements + tests the richer SQL.
+3. **HNSW-in-backend + transaction atomicity (#631 notes, not new issues):** record on #631 that (a) per D3 it must move the engine's `hnsw_strategy` + `search_config` + `ann_threshold` dispatch policy into the backend when it flips `vector_search` over (else a real O(N) regression lands); (b) `add_fact`/`consolidate`'s multi-store `unchecked_transaction` cannot be replaced by two backend calls without a seam-level transaction primitive (or keeping it engine-side) — else the #614 orphan-vector window reopens.
+4. **`scope_ids` unification (#652-style, already tracked):** #630 mirrors the non-uniform empty contract verbatim; the H2 parity table is the regression net any future `ScopeSelector` unification must keep green.

--- a/docs/reference/crate-layout.md
+++ b/docs/reference/crate-layout.md
@@ -9,8 +9,9 @@ memory_engine (lib.rs)
   +-- error         Error enum and Result alias
   +-- traits        Consumer-implemented traits and policy types
   +-- storage/      Persistence PORT (StorageBackend trait family) — infra abstraction
+  |     +-- sqlite/  SqliteBackend: the SQLite impl of the port (cfg async)
   +-- search/       Hybrid retrieval pipeline
-  +-- store/        SQLite persistence layer (the de-facto SqliteBackend impl)
+  +-- store/        SQLite persistence layer (the SQL SqliteBackend delegates to)
   +-- graph         In-memory knowledge graph
   +-- consolidation Three-pass consolidation pipeline
   +-- forgetting    Ebbinghaus decay and importance scoring
@@ -47,7 +48,7 @@ memory_engine (lib.rs)
   Also defines `ForgetPolicy` (Ebbinghaus parameters and signal weights), `ConsolidationConfig`, `ConsolidationStats`, `PruneStats`, `ConflictResolution`, and `CrudDecision`.
 
 `storage`
-: The persistence **port** (infrastructure abstraction) — deliberately distinct from `traits` (consumer capability injection). Defines the `StorageBackend` umbrella supertrait over six bounded-context traits — `FactGraph`, `EventLog`, `SearchIndex`, `ConsolidationStore`, `SessionStore`, `SchemaManager` — plus the feature-gated `ColdStorage` (held separately, not a supertrait bound). Cross-cutting types: the closed `FactFilter` (with `TemporalFilter` / `MetadataPredicate`), the dialect-free `BackendCapabilities` / `LexicalRanker` tier signal, and `StorageError` (driver-opaque, in `error`). All traits are `async_trait`/`Send + Sync`; `SearchIndex` returns ranked `(id, f64)` pairs (RRF fuses by rank engine-side). The `store/` + `search/` modules are the de-facto SQLite implementation that a `SqliteBackend` will sit behind.
+: The persistence **port** (infrastructure abstraction) — deliberately distinct from `traits` (consumer capability injection). Defines the `StorageBackend` umbrella supertrait over six bounded-context traits — `FactGraph`, `EventLog`, `SearchIndex`, `ConsolidationStore`, `SessionStore`, `SchemaManager` — plus the feature-gated `ColdStorage` (held separately, not a supertrait bound). Cross-cutting types: the closed `FactFilter` (with `TemporalFilter` / `MetadataPredicate`), the dialect-free `BackendCapabilities` / `LexicalRanker` tier signal, and `StorageError` (driver-opaque, in `error`). All traits are `async_trait`/`Send + Sync`; `SearchIndex` returns ranked `(id, f64)` pairs (RRF fuses by rank engine-side). The concrete implementation lives in **`storage/sqlite/`** (`SqliteBackend`, feature `async`): one file per bounded trait, each a thin delegation over two private primitives — `block_read` / `block_write` (sync `rusqlite` wrapped in `spawn_blocking`) — plus a `for_each_streamed` bridge (cap-1 `tokio::sync::mpsc`) for the streaming methods. It **delegates** to the `store/` + `search/` SQL verbatim (it does not absorb it — `#634`'s `PgBackend` reuses none of those bodies). The seam confines `rusqlite` below it: a driver `Database` error is remapped to driver-opaque `StorageError::Backend`. The engine is wired to `Arc<dyn StorageBackend>` separately (#631).
 
 `search`
 : Hybrid search pipeline combining three retrieval modes:

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -35,6 +35,8 @@ pub mod graph;
 pub mod schema;
 pub mod search_index;
 pub mod session;
+#[cfg(feature = "async")]
+pub mod sqlite;
 
 pub use backend::StorageBackend;
 pub use capabilities::{BackendCapabilities, LexicalRanker};
@@ -47,3 +49,5 @@ pub use graph::FactGraph;
 pub use schema::SchemaManager;
 pub use search_index::SearchIndex;
 pub use session::SessionStore;
+#[cfg(feature = "async")]
+pub use sqlite::SqliteBackend;

--- a/src/storage/sqlite/cold_storage.rs
+++ b/src/storage/sqlite/cold_storage.rs
@@ -1,0 +1,167 @@
+//! `impl ColdStorage for SqliteBackend` — delegates to [`ArchiveManifestStore`],
+//! the concrete SQL owner of the `archive_manifest` table.
+//!
+//! Feature-gated: `#[cfg(all(feature = "async", feature = "archive"))]`.
+//! Only the manifest CRUD is on this trait; `.pak` file I/O stays as free
+//! functions in `archive/pak.rs` — filesystem/codec plumbing, not a port concern.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use super::SqliteBackend;
+use crate::archive::ArchiveManifestEntry;
+use crate::error::Result;
+use crate::storage::cold_storage::ColdStorage;
+use crate::store::archive_manifest::ArchiveManifestStore;
+
+#[async_trait]
+impl ColdStorage for SqliteBackend {
+    // WRITE
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_archive_manifest(
+        &self,
+        pak_path: &str,
+        created_at: DateTime<Utc>,
+        fact_count: i64,
+        edge_count: i64,
+        fact_id_min: i64,
+        fact_id_max: i64,
+        t_created_min: DateTime<Utc>,
+        t_created_max: DateTime<Utc>,
+        size_bytes: i64,
+        blake3_hash: &str,
+    ) -> Result<i64> {
+        let pak_path = pak_path.to_owned();
+        let blake3_hash = blake3_hash.to_owned();
+        self.block_write(move |c| {
+            ArchiveManifestStore::new(c).insert(
+                &pak_path,
+                created_at,
+                fact_count,
+                edge_count,
+                fact_id_min,
+                fact_id_max,
+                t_created_min,
+                t_created_max,
+                size_bytes,
+                &blake3_hash,
+            )
+        })
+        .await
+    }
+
+    // READ
+    async fn list_archive_manifest(&self) -> Result<Vec<ArchiveManifestEntry>> {
+        self.block_read(|c| ArchiveManifestStore::new(c).list())
+            .await
+    }
+
+    // WRITE
+    async fn delete_archive_manifest(&self, id: i64) -> Result<bool> {
+        self.block_write(move |c| ArchiveManifestStore::new(c).delete(id))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+
+    use super::super::SqliteBackend;
+    use crate::pool::ConnectionPool;
+    use crate::storage::cold_storage::ColdStorage;
+    use crate::store::upcaster::UpcasterRegistry;
+
+    const DIM: usize = 4;
+
+    fn backend() -> SqliteBackend {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+    }
+
+    async fn insert_entry(be: &SqliteBackend, pak_path: &str) -> i64 {
+        let now = Utc::now();
+        be.insert_archive_manifest(
+            pak_path,
+            now,
+            10,
+            5,
+            1,
+            10,
+            now,
+            now,
+            1024,
+            "deadbeefdeadbeefdeadbeefdeadbeef",
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn manifest_insert_list_oldest_first() {
+        let be = backend();
+        assert!(be.list_archive_manifest().await.unwrap().is_empty());
+
+        let id1 = insert_entry(&be, "archives/2026-01.pak").await;
+        let id2 = insert_entry(&be, "archives/2026-02.pak").await;
+
+        let list = be.list_archive_manifest().await.unwrap();
+        assert_eq!(list.len(), 2);
+        // list returns oldest-first (ORDER BY created_at ASC).
+        assert_eq!(list[0].id, id1);
+        assert_eq!(list[1].id, id2);
+        assert_eq!(list[0].pak_path, "archives/2026-01.pak");
+        assert_eq!(list[1].pak_path, "archives/2026-02.pak");
+    }
+
+    #[tokio::test]
+    async fn manifest_delete_existing_returns_true() {
+        let be = backend();
+        let id = insert_entry(&be, "archives/del.pak").await;
+        assert_eq!(be.list_archive_manifest().await.unwrap().len(), 1);
+
+        let deleted = be.delete_archive_manifest(id).await.unwrap();
+        assert!(deleted);
+        assert!(be.list_archive_manifest().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn manifest_delete_nonexistent_returns_false() {
+        let be = backend();
+        let deleted = be.delete_archive_manifest(9999).await.unwrap();
+        assert!(!deleted);
+    }
+
+    #[tokio::test]
+    async fn manifest_round_trip_fields() {
+        let be = backend();
+        let now = Utc::now();
+        let id = be
+            .insert_archive_manifest(
+                "archives/full.pak",
+                now,
+                42,
+                7,
+                100,
+                141,
+                now,
+                now,
+                65536,
+                "cafebabecafebabecafebabecafebabe",
+            )
+            .await
+            .unwrap();
+
+        let list = be.list_archive_manifest().await.unwrap();
+        let entry = list.iter().find(|e| e.id == id).unwrap();
+        assert_eq!(entry.pak_path, "archives/full.pak");
+        assert_eq!(entry.fact_count, 42);
+        assert_eq!(entry.edge_count, 7);
+        assert_eq!(entry.fact_id_min, 100);
+        assert_eq!(entry.fact_id_max, 141);
+        assert_eq!(entry.size_bytes, 65536);
+        assert_eq!(entry.blake3_hash, "cafebabecafebabecafebabecafebabe");
+    }
+}

--- a/src/storage/sqlite/consolidation.rs
+++ b/src/storage/sqlite/consolidation.rs
@@ -1,0 +1,451 @@
+//! `impl ConsolidationStore for SqliteBackend` — delegates to [`SummaryStore`]
+//! and [`LineageStore`], the concrete SQL owners of the `summaries` and `lineage`
+//! tables.
+//!
+//! **Conn selection rule:**
+//! - `insert_*` / `delete_*` → [`super::SqliteBackend::block_write`].
+//! - `get_*` / `list_*` / `has_*` / `for_each_*` →
+//!   [`super::SqliteBackend::block_read`] / [`super::SqliteBackend::for_each_streamed`].
+//!
+//! Summary methods that (de)serialize embeddings capture `self.embed_dim` as a
+//! `let` binding outside the closure — the `'static` closures cannot borrow `self`.
+
+use async_trait::async_trait;
+
+use super::{SqliteBackend, stream_consumer_dropped};
+use crate::error::Result;
+use crate::storage::consolidation::ConsolidationStore;
+use crate::store::lineage::LineageStore;
+use crate::store::summaries::SummaryStore;
+use crate::types::{
+    ConsolidationLevel, LineageRecord, LineageSnapshotEntry, NewLineageRecord, NewSummary,
+    PromotionProvenance, Summary,
+};
+
+#[async_trait]
+impl ConsolidationStore for SqliteBackend {
+    // -------------------------------------------------------------------------
+    // summaries
+    // -------------------------------------------------------------------------
+
+    // WRITE
+    async fn insert_summary(&self, summary: &NewSummary) -> Result<i64> {
+        let summary = summary.clone();
+        let dim = self.embed_dim;
+        self.block_write(move |c| SummaryStore::new(c, dim).insert(&summary))
+            .await
+    }
+
+    // READ
+    async fn get_summary(&self, id: i64) -> Result<Summary> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| SummaryStore::new(c, dim).get(id))
+            .await
+    }
+
+    // READ
+    async fn list_summaries_by_level(&self, level: &ConsolidationLevel) -> Result<Vec<Summary>> {
+        let level = level.clone();
+        let dim = self.embed_dim;
+        self.block_read(move |c| SummaryStore::new(c, dim).list_by_level(&level))
+            .await
+    }
+
+    // READ
+    async fn list_all_summaries(&self) -> Result<Vec<Summary>> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| SummaryStore::new(c, dim).list_all())
+            .await
+    }
+
+    // READ (streaming)
+    async fn for_each_summary(
+        &self,
+        f: &mut (dyn FnMut(Summary) -> Result<()> + Send),
+    ) -> Result<()> {
+        let dim = self.embed_dim;
+        self.for_each_streamed(
+            move |conn, tx| {
+                SummaryStore::new(conn, dim).for_each(|summary| {
+                    tx.blocking_send(summary)
+                        .map_err(|_| stream_consumer_dropped())
+                })
+            },
+            f,
+        )
+        .await
+    }
+
+    // WRITE
+    async fn delete_summaries_by_level(&self, level: &ConsolidationLevel) -> Result<usize> {
+        let level = level.clone();
+        let dim = self.embed_dim;
+        self.block_write(move |c| SummaryStore::new(c, dim).delete_by_level(&level))
+            .await
+    }
+
+    // -------------------------------------------------------------------------
+    // lineage
+    // -------------------------------------------------------------------------
+
+    // WRITE
+    async fn insert_lineage(
+        &self,
+        record: &NewLineageRecord,
+        provenance: &PromotionProvenance,
+    ) -> Result<i64> {
+        let record = record.clone();
+        let provenance = provenance.clone();
+        self.block_write(move |c| LineageStore::new(c).insert(&record, &provenance))
+            .await
+    }
+
+    // WRITE
+    async fn insert_lineage_raw(&self, entry: &LineageSnapshotEntry) -> Result<()> {
+        let entry = entry.clone();
+        self.block_write(move |c| LineageStore::new(c).insert_raw(&entry))
+            .await
+    }
+
+    // READ
+    async fn get_lineage_by_wisdom_fact(
+        &self,
+        wisdom_fact_id: i64,
+    ) -> Result<(LineageRecord, PromotionProvenance)> {
+        self.block_read(move |c| LineageStore::new(c).get_by_wisdom_fact(wisdom_fact_id))
+            .await
+    }
+
+    // READ
+    async fn get_lineage_source_fact_ids(&self, wisdom_fact_id: i64) -> Result<Vec<i64>> {
+        self.block_read(move |c| LineageStore::new(c).get_source_fact_ids(wisdom_fact_id))
+            .await
+    }
+
+    // WRITE
+    async fn delete_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
+        self.block_write(move |c| LineageStore::new(c).delete(wisdom_fact_id))
+            .await
+    }
+
+    // READ
+    async fn has_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
+        self.block_read(move |c| LineageStore::new(c).has_lineage(wisdom_fact_id))
+            .await
+    }
+
+    // READ (streaming)
+    async fn for_each_lineage(
+        &self,
+        f: &mut (dyn FnMut(LineageSnapshotEntry) -> Result<()> + Send),
+    ) -> Result<()> {
+        self.for_each_streamed(
+            move |conn, tx| {
+                LineageStore::new(conn).for_each(|entry| {
+                    tx.blocking_send(entry)
+                        .map_err(|_| stream_consumer_dropped())
+                })
+            },
+            f,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+
+    use super::super::SqliteBackend;
+    use crate::error::MemoryError;
+    use crate::pool::ConnectionPool;
+    use crate::storage::consolidation::ConsolidationStore;
+    use crate::store::facts::FactStore;
+    use crate::store::upcaster::UpcasterRegistry;
+    use crate::types::{
+        ConsolidationLevel, FactType, LineageSnapshotEntry, NewFact, NewLineageRecord, NewSummary,
+        PromotionProvenance,
+    };
+
+    const DIM: usize = 4;
+
+    fn backend() -> SqliteBackend {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+    }
+
+    fn make_summary(level: ConsolidationLevel) -> NewSummary {
+        NewSummary {
+            content: "test summary".into(),
+            embedding: vec![0.1, 0.2, 0.3, 0.4],
+            level,
+            source_fact_ids: vec![1, 2],
+            created_at: Utc::now(),
+            scope_id: 1,
+        }
+    }
+
+    fn test_provenance() -> PromotionProvenance {
+        PromotionProvenance {
+            source_count: 2,
+            session_count: 1,
+            date_range_start: chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            date_range_end: chrono::DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            confidence: 0.9,
+            method_version: "dreamcycle-v1".into(),
+            representative_ids: vec![1, 2],
+            lineage_id: 0,
+        }
+    }
+
+    /// Seed two facts so FK constraints on lineage are satisfied.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "write guard held across seed loop"
+    )]
+    fn seeded_with_facts() -> SqliteBackend {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            for i in 0..2 {
+                store
+                    .insert(&NewFact {
+                        content: format!("source fact {i}"),
+                        content_hash: format!("h{i}"),
+                        embedding: vec![0.1, 0.2, 0.3, 0.4],
+                        fact_type: FactType::Semantic,
+                        t_created: Utc::now(),
+                        t_expired: None,
+                        t_valid: None,
+                        t_invalid: None,
+                        source_event_id: None,
+                        scope_id: 1,
+                        importance: 0.5,
+                        access_count: 0,
+                        last_accessed: Utc::now(),
+                        metadata: serde_json::json!({}),
+                        is_pinned: false,
+                    })
+                    .unwrap();
+            }
+        }
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+    }
+
+    // -------------------------------------------------------------------------
+    // summaries
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn summary_insert_then_list_by_level() {
+        let be = backend();
+        let id = be
+            .insert_summary(&make_summary(ConsolidationLevel::Cluster))
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        let list = be
+            .list_summaries_by_level(&ConsolidationLevel::Cluster)
+            .await
+            .unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, id);
+        assert_eq!(list[0].level, ConsolidationLevel::Cluster);
+
+        // Other level returns empty.
+        let empty = be
+            .list_summaries_by_level(&ConsolidationLevel::Global)
+            .await
+            .unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[tokio::test]
+    async fn summary_get_round_trip() {
+        let be = backend();
+        let s = make_summary(ConsolidationLevel::Local);
+        let id = be.insert_summary(&s).await.unwrap();
+        let got = be.get_summary(id).await.unwrap();
+        assert_eq!(got.content, s.content);
+        assert_eq!(got.embedding, s.embedding);
+        assert_eq!(got.level, ConsolidationLevel::Local);
+    }
+
+    #[tokio::test]
+    async fn summary_list_all_and_delete_by_level() {
+        let be = backend();
+        be.insert_summary(&make_summary(ConsolidationLevel::Local))
+            .await
+            .unwrap();
+        be.insert_summary(&make_summary(ConsolidationLevel::Cluster))
+            .await
+            .unwrap();
+
+        let all = be.list_all_summaries().await.unwrap();
+        assert_eq!(all.len(), 2);
+
+        let deleted = be
+            .delete_summaries_by_level(&ConsolidationLevel::Local)
+            .await
+            .unwrap();
+        assert_eq!(deleted, 1);
+
+        let remaining = be.list_all_summaries().await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].level, ConsolidationLevel::Cluster);
+    }
+
+    #[tokio::test]
+    async fn for_each_summary_parity() {
+        let be = backend();
+        be.insert_summary(&make_summary(ConsolidationLevel::Local))
+            .await
+            .unwrap();
+        be.insert_summary(&make_summary(ConsolidationLevel::Cluster))
+            .await
+            .unwrap();
+
+        let expected = be.list_all_summaries().await.unwrap();
+        let mut streamed: Vec<i64> = Vec::new();
+        be.for_each_summary(&mut |s| {
+            streamed.push(s.id);
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        let expected_ids: Vec<i64> = expected.iter().map(|s| s.id).collect();
+        assert_eq!(streamed, expected_ids);
+    }
+
+    #[tokio::test]
+    async fn for_each_summary_early_exit() {
+        let be = backend();
+        for _ in 0..5 {
+            be.insert_summary(&make_summary(ConsolidationLevel::Local))
+                .await
+                .unwrap();
+        }
+        let mut count = 0usize;
+        let err = be
+            .for_each_summary(&mut |_| {
+                count += 1;
+                if count == 2 {
+                    return Err(MemoryError::Internal("stop at 2".into()));
+                }
+                Ok(())
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::Internal(_)));
+        assert_eq!(count, 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // lineage
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn lineage_insert_then_get() {
+        let be = seeded_with_facts();
+        // Get fact ids from the seeded backend
+        let facts = {
+            use crate::storage::graph::FactGraph as _;
+            be.list_all_facts().await.unwrap()
+        };
+        let (wf_id, sf_id) = (facts[0].id, facts[1].id);
+
+        let record = NewLineageRecord {
+            wisdom_fact_id: wf_id,
+            source_fact_ids: vec![sf_id],
+        };
+        let lineage_id = be
+            .insert_lineage(&record, &test_provenance())
+            .await
+            .unwrap();
+        assert!(lineage_id > 0);
+
+        let (lr, prov) = be.get_lineage_by_wisdom_fact(wf_id).await.unwrap();
+        assert_eq!(lr.wisdom_fact_id, wf_id);
+        assert_eq!(lr.source_fact_ids, vec![sf_id]);
+        assert!((prov.confidence - 0.9).abs() < f64::EPSILON);
+
+        let ids = be.get_lineage_source_fact_ids(wf_id).await.unwrap();
+        assert_eq!(ids, vec![sf_id]);
+    }
+
+    #[tokio::test]
+    async fn lineage_missing_yields_lineage_error() {
+        let be = backend();
+        let err = be.get_lineage_by_wisdom_fact(9999).await.unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Lineage(_)),
+            "expected Lineage error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn lineage_has_and_delete() {
+        let be = seeded_with_facts();
+        let facts = {
+            use crate::storage::graph::FactGraph as _;
+            be.list_all_facts().await.unwrap()
+        };
+        let (wf_id, sf_id) = (facts[0].id, facts[1].id);
+
+        assert!(!be.has_lineage(wf_id).await.unwrap());
+        be.insert_lineage(
+            &NewLineageRecord {
+                wisdom_fact_id: wf_id,
+                source_fact_ids: vec![sf_id],
+            },
+            &test_provenance(),
+        )
+        .await
+        .unwrap();
+        assert!(be.has_lineage(wf_id).await.unwrap());
+
+        let deleted = be.delete_lineage(wf_id).await.unwrap();
+        assert!(deleted);
+        assert!(!be.has_lineage(wf_id).await.unwrap());
+
+        let not_deleted = be.delete_lineage(wf_id).await.unwrap();
+        assert!(!not_deleted);
+    }
+
+    #[tokio::test]
+    async fn lineage_insert_raw_and_for_each() {
+        let be = seeded_with_facts();
+        let facts = {
+            use crate::storage::graph::FactGraph as _;
+            be.list_all_facts().await.unwrap()
+        };
+        let (wf_id, sf_id) = (facts[0].id, facts[1].id);
+
+        let prov = test_provenance();
+        let entry = LineageSnapshotEntry {
+            lineage_id: 42,
+            wisdom_fact_id: wf_id,
+            source_fact_ids: vec![sf_id],
+            provenance: prov,
+        };
+        be.insert_lineage_raw(&entry).await.unwrap();
+
+        let mut collected: Vec<i64> = Vec::new();
+        be.for_each_lineage(&mut |e| {
+            collected.push(e.wisdom_fact_id);
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(collected, vec![wf_id]);
+    }
+}

--- a/src/storage/sqlite/convert.rs
+++ b/src/storage/sqlite/convert.rs
@@ -1,0 +1,82 @@
+//! `FactFilter` → verbatim-search-param projection.
+//!
+//! The [`SearchIndex`](crate::storage::SearchIndex) trait takes a rich
+//! [`FactFilter`], but the verbatim `search/{fts,vector}.rs` SQL honors only
+//! `fact_type` + `scope_ids` and hard-codes `t_expired IS NULL` (Active). This
+//! projects the filter onto what that SQL accepts and **errors loud** if a
+//! dimension the SQL cannot honor is set — rather than silently dropping a
+//! predicate and returning the wrong rows. Extending the SQL to honor the richer
+//! dimensions would be *new behavior* `#630` must not introduce (it is tracked as
+//! a separate follow-up).
+
+use crate::error::{MemoryError, Result};
+use crate::storage::{FactFilter, TemporalFilter};
+use crate::types::FactType;
+
+/// Project a [`FactFilter`] onto the `(fact_type, scope_ids)` the verbatim FTS5 /
+/// brute-force vector SQL accepts.
+///
+/// The `scope_ids` convention round-trips faithfully: `None` = no constraint,
+/// `Some(empty)` = matches nothing — passed straight to `serialize_scope_ids`,
+/// which the SQL turns into an empty `json_each` (excludes every row).
+///
+/// # Errors
+/// [`MemoryError::Internal`] if `temporal != Active`, or `ids` / `pinned` /
+/// `metadata` are set — dimensions the verbatim search SQL does not honor. The
+/// engine query path never sets these on a search filter.
+pub(super) fn search_params(filter: &FactFilter) -> Result<(Option<FactType>, Option<Vec<i64>>)> {
+    if filter.temporal != TemporalFilter::Active
+        || filter.ids.is_some()
+        || filter.pinned.is_some()
+        || !filter.metadata.is_empty()
+    {
+        return Err(MemoryError::Internal(
+            "SqliteBackend search path received a FactFilter dimension the verbatim \
+             FTS5/vector SQL does not honor (temporal != Active, ids, pinned, or metadata); \
+             the engine query path does not set these on a search filter"
+                .into(),
+        ));
+    }
+    Ok((filter.fact_type, filter.scope_ids.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::MetadataPredicate;
+
+    #[test]
+    fn passes_supported_dimensions() {
+        let f = FactFilter::new()
+            .fact_type(FactType::Semantic)
+            .scope_ids(vec![1, 2]);
+        let (ft, scopes) = search_params(&f).unwrap();
+        assert_eq!(ft, Some(FactType::Semantic));
+        assert_eq!(scopes, Some(vec![1, 2]));
+    }
+
+    #[test]
+    fn empty_scope_ids_round_trip_preserved() {
+        // Some(empty) must stay Some(empty) (matches nothing), NOT normalized to None.
+        let f = FactFilter::new().scope_ids(Vec::<i64>::new());
+        let (_, scopes) = search_params(&f).unwrap();
+        assert_eq!(scopes, Some(vec![]));
+    }
+
+    #[test]
+    fn rejects_unsupported_dimensions() {
+        use chrono::Utc;
+        for f in [
+            FactFilter::new().temporal(TemporalFilter::IncludeExpired),
+            FactFilter::new().temporal(TemporalFilter::AsOf(Utc::now())),
+            FactFilter::new().ids(vec![1]),
+            FactFilter::new().pinned(true),
+            FactFilter::new().with_metadata(MetadataPredicate::KeyPresent("k".into())),
+        ] {
+            assert!(
+                matches!(search_params(&f), Err(MemoryError::Internal(_))),
+                "expected Internal for {f:?}"
+            );
+        }
+    }
+}

--- a/src/storage/sqlite/event_log.rs
+++ b/src/storage/sqlite/event_log.rs
@@ -1,0 +1,226 @@
+//! `impl EventLog for SqliteBackend` — delegates to [`EventStore`] verbatim.
+//!
+//! The [`UpcasterRegistry`](crate::store::upcaster::UpcasterRegistry) is a backend
+//! construction detail (cloned into each closure), never crossing a method boundary.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::{SqliteBackend, stream_consumer_dropped};
+use crate::error::Result;
+use crate::storage::EventLog;
+use crate::store::events::EventStore;
+use crate::types::{Event, EventFilter, NewEvent};
+
+#[async_trait]
+impl EventLog for SqliteBackend {
+    async fn insert_event(&self, event: &NewEvent) -> Result<i64> {
+        let event = event.clone();
+        let registry = Arc::clone(&self.upcaster_registry);
+        self.block_write(move |c| EventStore::new(c, &registry).insert(&event))
+            .await
+    }
+
+    async fn get_event(&self, id: i64) -> Result<Event> {
+        let registry = Arc::clone(&self.upcaster_registry);
+        self.block_read(move |c| EventStore::new(c, &registry).get(id))
+            .await
+    }
+
+    async fn list_events(&self, filter: &EventFilter) -> Result<Vec<Event>> {
+        let filter = filter.clone();
+        let registry = Arc::clone(&self.upcaster_registry);
+        self.block_read(move |c| EventStore::new(c, &registry).list(&filter))
+            .await
+    }
+
+    async fn count_events(&self, filter: &EventFilter) -> Result<i64> {
+        let filter = filter.clone();
+        let registry = Arc::clone(&self.upcaster_registry);
+        self.block_read(move |c| EventStore::new(c, &registry).count(&filter))
+            .await
+    }
+
+    async fn for_each_event(&self, f: &mut (dyn FnMut(Event) -> Result<()> + Send)) -> Result<()> {
+        let registry = Arc::clone(&self.upcaster_registry);
+        self.for_each_streamed(
+            move |conn, tx| {
+                EventStore::new(conn, &registry)
+                    .for_each(|ev| tx.blocking_send(ev).map_err(|_| stream_consumer_dropped()))
+            },
+            f,
+        )
+        .await
+    }
+
+    async fn get_upcasted_event(&self, id: i64) -> Result<Event> {
+        let registry = Arc::clone(&self.upcaster_registry);
+        self.block_read(move |c| EventStore::new(c, &registry).get_upcasted(id))
+            .await
+    }
+
+    async fn list_upcasted_events(&self, filter: &EventFilter) -> Result<Vec<Event>> {
+        let filter = filter.clone();
+        let registry = Arc::clone(&self.upcaster_registry);
+        self.block_read(move |c| EventStore::new(c, &registry).list_upcasted(&filter))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+
+    use super::super::SqliteBackend;
+    use crate::error::MemoryError;
+    use crate::pool::ConnectionPool;
+    use crate::storage::EventLog;
+    use crate::store::upcaster::UpcasterRegistry;
+    use crate::types::{Event, EventFilter, EventType, NewEvent};
+
+    fn backend() -> SqliteBackend {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        SqliteBackend::from_pool(Arc::new(pool), Arc::new(UpcasterRegistry::new()))
+    }
+
+    fn make_event(source: &str, session_id: Option<&str>) -> NewEvent {
+        NewEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::Interaction,
+            payload: serde_json::json!({ "k": "v" }),
+            source: source.into(),
+            session_id: session_id.map(Into::into),
+            scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_get_round_trip() {
+        let be = backend();
+        let id = be
+            .insert_event(&make_event("s1", Some("sess")))
+            .await
+            .unwrap();
+        assert_eq!(id, 1);
+        let ev = be.get_event(id).await.unwrap();
+        assert_eq!(ev.source, "s1");
+        assert_eq!(ev.session_id, Some("sess".into()));
+        assert_eq!(ev.event_type, EventType::Interaction);
+    }
+
+    #[tokio::test]
+    async fn get_missing_yields_not_found() {
+        // H4: a missing id is a semantic NotFound, NOT remapped to Storage(Backend).
+        let be = backend();
+        let err = be.get_event(999).await.unwrap_err();
+        assert!(matches!(err, MemoryError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn list_and_count_filter_parity() {
+        let be = backend();
+        be.insert_event(&make_event("a", Some("s1"))).await.unwrap();
+        be.insert_event(&make_event("b", Some("s2"))).await.unwrap();
+        be.insert_event(&make_event("c", Some("s1"))).await.unwrap();
+        let filter = EventFilter {
+            session_id: Some("s1".into()),
+            ..EventFilter::default()
+        };
+        let listed = be.list_events(&filter).await.unwrap();
+        let count = be.count_events(&filter).await.unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(count, 2);
+        assert!(listed.iter().all(|e| e.session_id == Some("s1".into())));
+    }
+
+    #[tokio::test]
+    async fn for_each_event_collects_all_in_scan_order() {
+        let be = backend();
+        for s in ["a", "b", "c"] {
+            be.insert_event(&make_event(s, None)).await.unwrap();
+        }
+        let mut seen: Vec<String> = Vec::new();
+        be.for_each_event(&mut |ev: Event| {
+            seen.push(ev.source);
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(seen, vec!["a".to_string(), "b".into(), "c".into()]);
+    }
+
+    #[tokio::test]
+    async fn for_each_event_callback_error_propagates() {
+        let be = backend();
+        for s in ["a", "b", "c"] {
+            be.insert_event(&make_event(s, None)).await.unwrap();
+        }
+        let mut n = 0;
+        let err = be
+            .for_each_event(&mut |_ev: Event| {
+                n += 1;
+                if n == 2 {
+                    return Err(MemoryError::Lineage("stop".into()));
+                }
+                Ok(())
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::Lineage(_)), "got {err:?}");
+        assert_eq!(n, 2);
+    }
+
+    #[tokio::test]
+    async fn upcasted_read_applies_registry() {
+        // Insert with an empty registry (stored at revision 1), read through a
+        // backend whose registry upcasts 1→2.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ev.db");
+        let id = {
+            let raw = SqliteBackend::from_pool(
+                Arc::new(ConnectionPool::open(&path, 4, 2, None).unwrap()),
+                Arc::new(UpcasterRegistry::new()),
+            );
+            raw.insert_event(&make_event("x", None)).await.unwrap()
+        };
+        let mut registry = UpcasterRegistry::new();
+        registry.register("Interaction", 1, |mut v| {
+            v["upcasted"] = serde_json::json!(true);
+            Ok(v)
+        });
+        let be = SqliteBackend::from_pool(
+            Arc::new(ConnectionPool::open(&path, 4, 2, None).unwrap()),
+            Arc::new(registry),
+        );
+        let raw = be.get_event(id).await.unwrap();
+        assert!(
+            raw.payload.get("upcasted").is_none(),
+            "raw read is unmodified"
+        );
+        let up = be.get_upcasted_event(id).await.unwrap();
+        assert_eq!(up.payload["upcasted"], true);
+        assert_eq!(up.event_revision, 2);
+    }
+
+    #[tokio::test]
+    async fn insert_on_read_only_backend_yields_read_only() {
+        // H7 via a real trait method (write path through try_write).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro.db");
+        {
+            let _rw = ConnectionPool::open(&path, 4, 2, None).unwrap();
+        }
+        let be = SqliteBackend::from_pool(
+            Arc::new(ConnectionPool::open_read_only(&path, 4, 2).unwrap()),
+            Arc::new(UpcasterRegistry::new()),
+        );
+        let err = be.insert_event(&make_event("x", None)).await.unwrap_err();
+        assert!(matches!(err, MemoryError::ReadOnly), "got {err:?}");
+    }
+}

--- a/src/storage/sqlite/graph.rs
+++ b/src/storage/sqlite/graph.rs
@@ -1,0 +1,932 @@
+//! `impl FactGraph for SqliteBackend` — delegates to [`FactStore`], [`EdgeStore`],
+//! and [`ScopeStore`] verbatim.
+//!
+//! **Conn selection rule (D-design):**
+//! - READ methods (`get_*`, `list_*`, `find_*`, `max_*`, `next_*`, `edge_exists_*`,
+//!   `for_each_*`) → [`super::SqliteBackend::block_read`].
+//! - WRITE methods (`insert_*`, `expire_*`, `update_*`, `increment_*`, `merge_*`,
+//!   `mark_*`, `set_*`, `stamp_*`, `hard_delete_*`, `ensure_scope_path`) →
+//!   [`super::SqliteBackend::block_write`].
+//!
+//! Borrowed arguments are cloned to owned before entering the `'static` closure.
+//! `embed_dim` is captured as a `let` binding outside the closure so `FactStore`
+//! construction is not coupled to `self` inside the blocking thread.
+
+use std::collections::{HashMap, HashSet};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use super::{SqliteBackend, stream_consumer_dropped};
+use crate::error::Result;
+use crate::storage::graph::FactGraph;
+use crate::store::edges::EdgeStore;
+use crate::store::facts::FactStore;
+use crate::store::scopes::ScopeStore;
+use crate::types::{
+    Edge, Fact, FactScoringRow, FactType, NewEdge, NewFact, ScopeNode, SessionFact,
+};
+
+#[async_trait]
+impl FactGraph for SqliteBackend {
+    // -------------------------------------------------------------------------
+    // facts: write
+    // -------------------------------------------------------------------------
+
+    // WRITE
+    async fn insert_fact(&self, fact: &NewFact) -> Result<i64> {
+        let fact = fact.clone();
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).insert(&fact))
+            .await
+    }
+
+    // WRITE
+    async fn insert_or_reinforce_fact(&self, fact: &NewFact) -> Result<(i64, bool)> {
+        let fact = fact.clone();
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).insert_or_reinforce(&fact))
+            .await
+    }
+
+    // WRITE
+    async fn expire_fact(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).expire(id, now))
+            .await
+    }
+
+    // WRITE
+    async fn set_fact_pinned(&self, id: i64, pinned: bool) -> Result<()> {
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).set_pinned(id, pinned))
+            .await
+    }
+
+    // WRITE
+    async fn update_fact_importance(&self, id: i64, importance: f64) -> Result<()> {
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).update_importance(id, importance))
+            .await
+    }
+
+    // WRITE
+    async fn update_fact_importance_score(&self, id: i64, score: f64) -> Result<()> {
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).update_importance_score(id, score))
+            .await
+    }
+
+    // WRITE
+    async fn increment_fact_access(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).increment_access(id, now))
+            .await
+    }
+
+    // WRITE
+    async fn merge_fact_metadata(&self, id: i64, patch: &serde_json::Value) -> Result<()> {
+        let patch = patch.clone();
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).merge_metadata(id, &patch))
+            .await
+    }
+
+    // WRITE
+    async fn mark_facts_dream_cycled(
+        &self,
+        ids: &[i64],
+        cycle_id: u64,
+        now: DateTime<Utc>,
+    ) -> Result<()> {
+        let ids = ids.to_vec();
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).mark_dream_cycled(&ids, cycle_id, now))
+            .await
+    }
+
+    // WRITE
+    async fn stamp_facts_surfaced(
+        &self,
+        fact_ids: &[i64],
+        now: DateTime<Utc>,
+    ) -> Result<Vec<(i64, DateTime<Utc>)>> {
+        let fact_ids = fact_ids.to_vec();
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).stamp_surfaced(&fact_ids, now))
+            .await
+    }
+
+    // WRITE
+    async fn hard_delete_facts(&self, ids: &[i64]) -> Result<usize> {
+        let ids = ids.to_vec();
+        let dim = self.embed_dim;
+        self.block_write(move |c| FactStore::new(c, dim).hard_delete_ids(&ids))
+            .await
+    }
+
+    // -------------------------------------------------------------------------
+    // facts: read (single / batch / full scan)
+    // -------------------------------------------------------------------------
+
+    // READ
+    async fn get_fact(&self, id: i64) -> Result<Fact> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).get(id))
+            .await
+    }
+
+    // READ
+    async fn get_facts(&self, ids: &[i64]) -> Result<HashMap<i64, Fact>> {
+        let ids = ids.to_vec();
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).get_many(&ids))
+            .await
+    }
+
+    // READ
+    async fn list_all_facts(&self) -> Result<Vec<Fact>> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).list_all())
+            .await
+    }
+
+    // READ (streaming)
+    async fn for_each_fact(&self, f: &mut (dyn FnMut(Fact) -> Result<()> + Send)) -> Result<()> {
+        let dim = self.embed_dim;
+        self.for_each_streamed(
+            move |conn, tx| {
+                FactStore::new(conn, dim).for_each(|fact| {
+                    tx.blocking_send(fact)
+                        .map_err(|_| stream_consumer_dropped())
+                })
+            },
+            f,
+        )
+        .await
+    }
+
+    // READ
+    async fn max_caller_written_fact_id(&self) -> Result<Option<i64>> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).max_caller_written_fact_id())
+            .await
+    }
+
+    // -------------------------------------------------------------------------
+    // facts: read (filtered / scored lists)
+    // -------------------------------------------------------------------------
+
+    // READ
+    async fn list_active_facts(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).list_active(limit))
+            .await
+    }
+
+    // READ
+    async fn list_active_facts_scoring(&self) -> Result<Vec<FactScoringRow>> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).list_active_scoring())
+            .await
+    }
+
+    // READ
+    async fn list_active_facts_at(&self, valid_at: DateTime<Utc>) -> Result<Vec<Fact>> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).list_active_at(valid_at))
+            .await
+    }
+
+    // READ
+    async fn list_dormant_facts(
+        &self,
+        importance_threshold: f64,
+        scope_ids: Option<&[i64]>,
+    ) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.map(<[i64]>::to_vec);
+        let dim = self.embed_dim;
+        self.block_read(move |c| {
+            FactStore::new(c, dim).list_dormant(importance_threshold, scope_ids.as_deref())
+        })
+        .await
+    }
+
+    // READ
+    async fn list_facts_by_scope_importance(
+        &self,
+        scope_id: i64,
+        limit: usize,
+    ) -> Result<Vec<Fact>> {
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).list_by_scope_importance(scope_id, limit))
+            .await
+    }
+
+    // READ
+    async fn list_facts_by_scopes_importance(
+        &self,
+        scope_ids: &[i64],
+        min_importance: f64,
+        limit: usize,
+        exclude_ids: &HashSet<i64>,
+    ) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.to_vec();
+        let exclude_ids = exclude_ids.clone();
+        let dim = self.embed_dim;
+        self.block_read(move |c| {
+            FactStore::new(c, dim).list_by_scopes_importance(
+                &scope_ids,
+                min_importance,
+                limit,
+                &exclude_ids,
+            )
+        })
+        .await
+    }
+
+    // READ
+    async fn list_facts_by_importance_score(
+        &self,
+        scope_ids: &[i64],
+        min_score: f64,
+        limit: usize,
+        exclude: &HashSet<i64>,
+    ) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.to_vec();
+        let exclude = exclude.clone();
+        let dim = self.embed_dim;
+        self.block_read(move |c| {
+            FactStore::new(c, dim).list_by_importance_score(&scope_ids, min_score, limit, &exclude)
+        })
+        .await
+    }
+
+    // READ
+    async fn list_pinned_facts(&self, scope_ids: &[i64]) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.to_vec();
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).list_pinned(&scope_ids))
+            .await
+    }
+
+    // READ
+    async fn list_due_facts(&self, now: DateTime<Utc>, scope_ids: &[i64]) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.to_vec();
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).list_due(now, &scope_ids))
+            .await
+    }
+
+    // READ
+    async fn next_due_time(
+        &self,
+        now: DateTime<Utc>,
+        scope_ids: &[i64],
+    ) -> Result<Option<DateTime<Utc>>> {
+        let scope_ids = scope_ids.to_vec();
+        let dim = self.embed_dim;
+        self.block_read(move |c| FactStore::new(c, dim).next_due_time(now, &scope_ids))
+            .await
+    }
+
+    // READ
+    async fn list_facts_by_scopes_recent(
+        &self,
+        scope_ids: &[i64],
+        limit: usize,
+        exclude_ids: &HashSet<i64>,
+    ) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.to_vec();
+        let exclude_ids = exclude_ids.clone();
+        let dim = self.embed_dim;
+        self.block_read(move |c| {
+            FactStore::new(c, dim).list_by_scopes_recent(&scope_ids, limit, &exclude_ids)
+        })
+        .await
+    }
+
+    // READ
+    async fn list_active_facts_by_metadata_key_recent(
+        &self,
+        scope_ids: &[i64],
+        marker_key: &str,
+        limit: usize,
+    ) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.to_vec();
+        let marker_key = marker_key.to_owned();
+        let dim = self.embed_dim;
+        self.block_read(move |c| {
+            FactStore::new(c, dim).list_active_by_metadata_key_recent(
+                &scope_ids,
+                &marker_key,
+                limit,
+            )
+        })
+        .await
+    }
+
+    // READ
+    async fn list_active_facts_in_period(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        scope_ids: &[i64],
+        fact_type: Option<&FactType>,
+    ) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.to_vec();
+        let fact_type = fact_type.copied();
+        let dim = self.embed_dim;
+        self.block_read(move |c| {
+            FactStore::new(c, dim).list_active_in_period(start, end, &scope_ids, fact_type.as_ref())
+        })
+        .await
+    }
+
+    // READ
+    async fn list_undreamt_facts_in_period(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        scope_ids: &[i64],
+        fact_type: Option<&FactType>,
+    ) -> Result<Vec<Fact>> {
+        let scope_ids = scope_ids.to_vec();
+        let fact_type = fact_type.copied();
+        let dim = self.embed_dim;
+        self.block_read(move |c| {
+            FactStore::new(c, dim).list_undreamt_in_period(
+                start,
+                end,
+                &scope_ids,
+                fact_type.as_ref(),
+            )
+        })
+        .await
+    }
+
+    // READ
+    async fn list_active_facts_by_session(
+        &self,
+        session_id: &str,
+        scope_ids: &[i64],
+    ) -> Result<Vec<SessionFact>> {
+        let session_id = session_id.to_owned();
+        let scope_ids = scope_ids.to_vec();
+        let dim = self.embed_dim;
+        self.block_read(move |c| {
+            FactStore::new(c, dim).list_active_by_session(&session_id, &scope_ids)
+        })
+        .await
+    }
+
+    // -------------------------------------------------------------------------
+    // edges
+    // -------------------------------------------------------------------------
+
+    // WRITE
+    async fn insert_edge(&self, edge: &NewEdge) -> Result<i64> {
+        let edge = edge.clone();
+        self.block_write(move |c| EdgeStore::new(c).insert(&edge))
+            .await
+    }
+
+    // READ
+    async fn get_edge(&self, id: i64) -> Result<Edge> {
+        self.block_read(move |c| EdgeStore::new(c).get(id)).await
+    }
+
+    // WRITE
+    async fn expire_edge(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
+        self.block_write(move |c| EdgeStore::new(c).expire(id, now))
+            .await
+    }
+
+    // WRITE
+    async fn expire_edges_by_fact(&self, fact_id: i64, now: DateTime<Utc>) -> Result<usize> {
+        self.block_write(move |c| EdgeStore::new(c).expire_by_fact(fact_id, now))
+            .await
+    }
+
+    // READ
+    async fn list_all_edges(&self) -> Result<Vec<Edge>> {
+        self.block_read(move |c| EdgeStore::new(c).list_all()).await
+    }
+
+    // READ (streaming)
+    async fn for_each_edge(&self, f: &mut (dyn FnMut(Edge) -> Result<()> + Send)) -> Result<()> {
+        self.for_each_streamed(
+            move |conn, tx| {
+                EdgeStore::new(conn).for_each(|edge| {
+                    tx.blocking_send(edge)
+                        .map_err(|_| stream_consumer_dropped())
+                })
+            },
+            f,
+        )
+        .await
+    }
+
+    // READ
+    async fn list_active_edges(&self) -> Result<Vec<Edge>> {
+        self.block_read(move |c| EdgeStore::new(c).list_active())
+            .await
+    }
+
+    // READ
+    async fn list_active_edges_by_source(&self, source_fact_id: i64) -> Result<Vec<Edge>> {
+        self.block_read(move |c| EdgeStore::new(c).list_active_by_source(source_fact_id))
+            .await
+    }
+
+    // READ
+    async fn list_active_edges_by_target(&self, target_fact_id: i64) -> Result<Vec<Edge>> {
+        self.block_read(move |c| EdgeStore::new(c).list_active_by_target(target_fact_id))
+            .await
+    }
+
+    // READ
+    async fn edge_exists_active(
+        &self,
+        source_fact_id: i64,
+        target_fact_id: i64,
+        relation_type: &str,
+    ) -> Result<bool> {
+        let relation_type = relation_type.to_owned();
+        self.block_read(move |c| {
+            EdgeStore::new(c).exists_active(source_fact_id, target_fact_id, &relation_type)
+        })
+        .await
+    }
+
+    // READ
+    async fn list_active_edge_pairs_by_facts(
+        &self,
+        fact_ids: &[i64],
+        relation_type: &str,
+    ) -> Result<HashSet<(i64, i64)>> {
+        let fact_ids = fact_ids.to_vec();
+        let relation_type = relation_type.to_owned();
+        self.block_read(move |c| {
+            EdgeStore::new(c).list_active_pairs_by_facts(&fact_ids, &relation_type)
+        })
+        .await
+    }
+
+    // WRITE
+    async fn hard_delete_edges_by_facts(&self, fact_ids: &[i64]) -> Result<usize> {
+        let fact_ids = fact_ids.to_vec();
+        self.block_write(move |c| EdgeStore::new(c).hard_delete_by_facts(&fact_ids))
+            .await
+    }
+
+    // -------------------------------------------------------------------------
+    // scopes
+    // -------------------------------------------------------------------------
+
+    // READ
+    async fn get_scope(&self, id: i64) -> Result<ScopeNode> {
+        self.block_read(move |c| ScopeStore::new(c).get(id)).await
+    }
+
+    // READ
+    async fn find_scope_by_label(&self, parent_id: i64, label: &str) -> Result<Option<ScopeNode>> {
+        let label = label.to_owned();
+        self.block_read(move |c| ScopeStore::new(c).find_by_label(parent_id, &label))
+            .await
+    }
+
+    // WRITE
+    async fn insert_scope(&self, parent_id: i64, label: &str, depth: i64) -> Result<ScopeNode> {
+        let label = label.to_owned();
+        self.block_write(move |c| ScopeStore::new(c).insert(parent_id, &label, depth))
+            .await
+    }
+
+    // WRITE
+    async fn ensure_scope_path(&self, path: &str) -> Result<i64> {
+        let path = path.to_owned();
+        self.block_write(move |c| ScopeStore::new(c).ensure_path(&path))
+            .await
+    }
+
+    // READ
+    async fn list_all_scopes(&self) -> Result<Vec<ScopeNode>> {
+        self.block_read(move |c| ScopeStore::new(c).list_all())
+            .await
+    }
+
+    // READ (streaming)
+    async fn for_each_scope(
+        &self,
+        f: &mut (dyn FnMut(ScopeNode) -> Result<()> + Send),
+    ) -> Result<()> {
+        self.for_each_streamed(
+            move |conn, tx| {
+                ScopeStore::new(conn).for_each(|scope| {
+                    tx.blocking_send(scope)
+                        .map_err(|_| stream_consumer_dropped())
+                })
+            },
+            f,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use chrono::Utc;
+
+    use super::super::SqliteBackend;
+    use crate::error::{ConflictError, MemoryError};
+    use crate::pool::ConnectionPool;
+    use crate::storage::graph::FactGraph;
+    use crate::store::facts::FactStore;
+    use crate::store::upcaster::UpcasterRegistry;
+    use crate::types::{Edge, Fact, FactType, NewEdge, NewFact};
+
+    const DIM: usize = 4;
+
+    /// Build a `NewFact` with the given content and embedding (`scope_id=1`).
+    fn fact(content: &str, embedding: [f32; DIM]) -> NewFact {
+        NewFact {
+            content: content.into(),
+            content_hash: String::new(),
+            embedding: embedding.to_vec(),
+            fact_type: FactType::Episodic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            scope_id: 1,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+            is_pinned: false,
+        }
+    }
+
+    /// Seed facts directly via `FactStore` (write-lock held across the loop),
+    /// return the shared pool. Pattern mirrors `search_index.rs::seeded()`.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the write guard is intentionally held across the seed loop"
+    )]
+    fn seeded(facts: &[NewFact]) -> Arc<ConnectionPool> {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            for f in facts {
+                store.insert(f).unwrap();
+            }
+        }
+        pool
+    }
+
+    fn backend(pool: Arc<ConnectionPool>) -> SqliteBackend {
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+    }
+
+    // -------------------------------------------------------------------------
+    // H4 — semantic errors pass through; read-only rejects writes
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn get_fact_missing_yields_not_found() {
+        // H4: missing id → NotFound, NOT remapped to Storage(Backend).
+        let be = backend(Arc::new(ConnectionPool::open_memory(DIM).unwrap()));
+        let err = be.get_fact(999).await.unwrap_err();
+        assert!(
+            matches!(err, MemoryError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_on_read_only_backend_yields_read_only() {
+        // H4: write through a read-only pool → ReadOnly.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro.db");
+        {
+            let _rw = ConnectionPool::open(&path, DIM, 2, None).unwrap();
+        }
+        let ro = ConnectionPool::open_read_only(&path, DIM, 2).unwrap();
+        let be = SqliteBackend::from_pool(Arc::new(ro), Arc::new(UpcasterRegistry::new()));
+        let err = be.insert_fact(&fact("x", [0.1; DIM])).await.unwrap_err();
+        assert!(matches!(err, MemoryError::ReadOnly), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn expire_on_read_only_backend_yields_read_only() {
+        // H4 (expire path): write through a read-only pool → ReadOnly.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro2.db");
+        {
+            let rw = SqliteBackend::from_pool(
+                Arc::new(ConnectionPool::open(&path, DIM, 2, None).unwrap()),
+                Arc::new(UpcasterRegistry::new()),
+            );
+            rw.insert_fact(&fact("x", [0.1; DIM])).await.unwrap();
+        }
+        let ro = ConnectionPool::open_read_only(&path, DIM, 2).unwrap();
+        let be = SqliteBackend::from_pool(Arc::new(ro), Arc::new(UpcasterRegistry::new()));
+        let err = be.expire_fact(1, Utc::now()).await.unwrap_err();
+        assert!(matches!(err, MemoryError::ReadOnly), "got {err:?}");
+    }
+
+    // -------------------------------------------------------------------------
+    // H2 — scope_ids contract: empty=ALL vs empty=NONE preserved verbatim
+    // -------------------------------------------------------------------------
+
+    /// `scope_ids=[]` on `list_pinned` means ALL scopes (empty=ALL).
+    #[tokio::test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "write guard is intentionally held across the seed block"
+    )]
+    async fn list_pinned_facts_empty_scope_means_all() {
+        // Seed: two pinned facts in scope_id=1 (the only scope guaranteed by schema init).
+        // The empty=ALL contract is about the filter being disabled, not about spanning
+        // physically distinct scopes — two rows in scope 1 with empty slice must return both.
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            let mut f1 = fact("pinned one", [0.1; DIM]);
+            f1.is_pinned = true;
+            let mut f2 = fact("pinned two", [0.2; DIM]);
+            f2.is_pinned = true;
+            store.insert(&f1).unwrap();
+            store.insert(&f2).unwrap();
+        }
+        // Oracle: direct FactStore call with empty slice.
+        let oracle: Vec<Fact> = {
+            let conn = pool.read().unwrap();
+            FactStore::new(&conn, DIM).list_pinned(&[]).unwrap()
+        };
+        let be = backend(Arc::clone(&pool));
+        let got = be.list_pinned_facts(&[]).await.unwrap();
+        // Both should return the same 2 rows (empty = ALL scopes).
+        assert_eq!(
+            got.len(),
+            2,
+            "empty scope_ids should return all pinned facts"
+        );
+        assert_eq!(
+            got.iter().map(|f| f.id).collect::<HashSet<_>>(),
+            oracle.iter().map(|f| f.id).collect::<HashSet<_>>(),
+        );
+    }
+
+    /// `scope_ids=[]` on `list_facts_by_scopes_recent` means NO scopes (empty=NONE).
+    #[tokio::test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "write guard is intentionally held across the seed block"
+    )]
+    async fn list_facts_by_scopes_recent_empty_scope_means_none() {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            store.insert(&fact("alpha", [0.1; DIM])).unwrap();
+            store.insert(&fact("beta", [0.2; DIM])).unwrap();
+        }
+        // Oracle: FactStore with empty scope_ids.
+        let oracle: Vec<Fact> = {
+            let conn = pool.read().unwrap();
+            FactStore::new(&conn, DIM)
+                .list_by_scopes_recent(&[], 10, &HashSet::new())
+                .unwrap()
+        };
+        let be = backend(Arc::clone(&pool));
+        let got = be
+            .list_facts_by_scopes_recent(&[], 10, &HashSet::new())
+            .await
+            .unwrap();
+        // Both oracle and backend should return 0 (empty = NO scopes).
+        assert!(got.is_empty(), "empty scope_ids should return no facts");
+        assert_eq!(got, oracle);
+    }
+
+    /// `scope_ids=[]` on `list_active_facts_by_metadata_key_recent` means NO scopes (empty=NONE).
+    #[tokio::test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "write guard is intentionally held across the seed block"
+    )]
+    async fn list_active_by_metadata_key_recent_empty_scope_means_none() {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            let mut f = fact("with key", [0.1; DIM]);
+            f.metadata = serde_json::json!({"insight": {"v": 1}});
+            store.insert(&f).unwrap();
+        }
+        let oracle: Vec<Fact> = {
+            let conn = pool.read().unwrap();
+            FactStore::new(&conn, DIM)
+                .list_active_by_metadata_key_recent(&[], "insight", 10)
+                .unwrap()
+        };
+        let be = backend(Arc::clone(&pool));
+        let got = be
+            .list_active_facts_by_metadata_key_recent(&[], "insight", 10)
+            .await
+            .unwrap();
+        assert!(got.is_empty(), "empty scope_ids = no scopes");
+        assert_eq!(got, oracle);
+    }
+
+    // -------------------------------------------------------------------------
+    // H3 — marker_key injection guard
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_active_by_metadata_key_recent_rejects_invalid_keys() {
+        let be = backend(Arc::new(ConnectionPool::open_memory(DIM).unwrap()));
+        let invalid_keys = ["", "in'sight", "$.x", "a b", "a;b"];
+        for key in invalid_keys {
+            let err = be
+                .list_active_facts_by_metadata_key_recent(&[1], key, 10)
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    MemoryError::Conflict(ConflictError::QueryValidation(_))
+                ),
+                "key {key:?} should yield QueryValidation, got {err:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "write guard is intentionally held across the seed block"
+    )]
+    async fn list_active_by_metadata_key_recent_happy_path_parity() {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            let mut f = fact("with marker", [0.1; DIM]);
+            f.metadata = serde_json::json!({"insight": {"v": 1}});
+            store.insert(&f).unwrap();
+            // A fact without the key — should not appear.
+            store.insert(&fact("no marker", [0.2; DIM])).unwrap();
+        }
+        let oracle: Vec<Fact> = {
+            let conn = pool.read().unwrap();
+            FactStore::new(&conn, DIM)
+                .list_active_by_metadata_key_recent(&[1], "insight", 10)
+                .unwrap()
+        };
+        let be = backend(Arc::clone(&pool));
+        let got = be
+            .list_active_facts_by_metadata_key_recent(&[1], "insight", 10)
+            .await
+            .unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got, oracle);
+    }
+
+    // -------------------------------------------------------------------------
+    // Streaming — for_each_fact / for_each_edge / for_each_scope
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn for_each_fact_collects_same_as_direct_store() {
+        let pool = seeded(&[
+            fact("alpha", [0.1; DIM]),
+            fact("beta", [0.2; DIM]),
+            fact("gamma", [0.3; DIM]),
+        ]);
+        let oracle: Vec<i64> = {
+            let conn = pool.read().unwrap();
+            let mut ids = Vec::new();
+            FactStore::new(&conn, DIM)
+                .for_each(|f| {
+                    ids.push(f.id);
+                    Ok(())
+                })
+                .unwrap();
+            ids
+        };
+        let be = backend(Arc::clone(&pool));
+        let mut got: Vec<i64> = Vec::new();
+        be.for_each_fact(&mut |f: Fact| {
+            got.push(f.id);
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(got, oracle);
+        assert_eq!(got.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn for_each_fact_callback_error_propagates_and_stops_early() {
+        let pool = seeded(&[
+            fact("a", [0.1; DIM]),
+            fact("b", [0.2; DIM]),
+            fact("c", [0.3; DIM]),
+        ]);
+        let be = backend(pool);
+        let mut count = 0usize;
+        let err = be
+            .for_each_fact(&mut |_f: Fact| {
+                count += 1;
+                if count == 2 {
+                    return Err(MemoryError::Lineage("stop at 2".into()));
+                }
+                Ok(())
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Lineage(ref m) if m == "stop at 2"),
+            "callback error must propagate, got {err:?}"
+        );
+        assert_eq!(count, 2, "must stop early at the erroring row");
+    }
+
+    // -------------------------------------------------------------------------
+    // Round-trips
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn fact_insert_get_round_trip() {
+        let be = backend(Arc::new(ConnectionPool::open_memory(DIM).unwrap()));
+        let f = fact("hello world", [0.1; DIM]);
+        let id = be.insert_fact(&f).await.unwrap();
+        let got = be.get_fact(id).await.unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn expire_fact_excludes_from_list_active() {
+        let pool = seeded(&[fact("live", [0.1; DIM]), fact("to_expire", [0.2; DIM])]);
+        let be = backend(Arc::clone(&pool));
+        // Get the id of the second fact.
+        let all = be.list_all_facts().await.unwrap();
+        let expire_id = all.iter().find(|f| f.content == "to_expire").unwrap().id;
+        be.expire_fact(expire_id, Utc::now()).await.unwrap();
+        let active = be.list_active_facts(None).await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert!(
+            active.iter().all(|f| f.id != expire_id),
+            "expired fact must not appear in list_active_facts"
+        );
+    }
+
+    #[tokio::test]
+    async fn edge_insert_get_list_by_source_round_trip() {
+        // Seed a fact first (FK constraint).
+        let pool = seeded(&[fact("src", [0.1; DIM]), fact("tgt", [0.2; DIM])]);
+        let be = backend(Arc::clone(&pool));
+        let all = be.list_all_facts().await.unwrap();
+        let src_id = all[0].id;
+        let tgt_id = all[1].id;
+        let new_edge = NewEdge {
+            source_fact_id: src_id,
+            target_fact_id: tgt_id,
+            relation_type: "related_to".into(),
+            weight: 0.9,
+            t_created: Utc::now(),
+            t_expired: None,
+            scope_id: 1,
+        };
+        let edge_id = be.insert_edge(&new_edge).await.unwrap();
+        let got: Edge = be.get_edge(edge_id).await.unwrap();
+        assert_eq!(got.source_fact_id, src_id);
+        assert_eq!(got.target_fact_id, tgt_id);
+        assert_eq!(got.relation_type, "related_to");
+
+        let by_source = be.list_active_edges_by_source(src_id).await.unwrap();
+        assert_eq!(by_source.len(), 1);
+        assert_eq!(by_source[0].id, edge_id);
+    }
+
+    #[tokio::test]
+    async fn scope_ensure_get_round_trip() {
+        let be = backend(Arc::new(ConnectionPool::open_memory(DIM).unwrap()));
+        let leaf_id = be
+            .ensure_scope_path("user:michael/project:demo")
+            .await
+            .unwrap();
+        let scope = be.get_scope(leaf_id).await.unwrap();
+        assert_eq!(scope.label, "project:demo");
+        assert_eq!(scope.depth, 2);
+    }
+}

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -38,7 +38,9 @@ use crate::error::{MemoryError, Result, StorageError};
 use crate::pool::ConnectionPool;
 use crate::store::upcaster::UpcasterRegistry;
 
+mod convert;
 mod event_log;
+mod search_index;
 
 /// The default, in-process `SQLite` implementation of [`StorageBackend`](crate::storage::StorageBackend).
 ///
@@ -48,7 +50,6 @@ mod event_log;
 /// pool so the two can never diverge.
 pub struct SqliteBackend {
     pool: Arc<ConnectionPool>,
-    #[allow(dead_code, reason = "read by the FactGraph/SearchIndex impls (T2/T3)")]
     embed_dim: usize,
     upcaster_registry: Arc<UpcasterRegistry>,
 }

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -44,6 +44,8 @@ mod consolidation;
 mod convert;
 mod event_log;
 mod graph;
+#[cfg(test)]
+mod realization;
 mod schema;
 mod search_index;
 mod session;

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -38,10 +38,15 @@ use crate::error::{MemoryError, Result, StorageError};
 use crate::pool::ConnectionPool;
 use crate::store::upcaster::UpcasterRegistry;
 
+#[cfg(all(feature = "async", feature = "archive"))]
+mod cold_storage;
+mod consolidation;
 mod convert;
 mod event_log;
 mod graph;
+mod schema;
 mod search_index;
+mod session;
 
 /// The default, in-process `SQLite` implementation of [`StorageBackend`](crate::storage::StorageBackend).
 ///

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -62,6 +62,14 @@ pub struct SqliteBackend {
     upcaster_registry: Arc<UpcasterRegistry>,
 }
 
+// Build-time witness (not test-gated): `SqliteBackend` must be `Send + Sync` for
+// `Arc<dyn StorageBackend>` and the `#[async_trait]` `Send` futures. A field that
+// breaks this fails `cargo build`, not merely `cargo test`.
+const _: fn() = || {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<SqliteBackend>();
+};
+
 impl SqliteBackend {
     /// Wrap an already-opened pool + upcaster registry. The canonical constructor
     /// `#631` will use where it builds the [`ConnectionPool`] today. `embed_dim` is
@@ -145,7 +153,8 @@ impl SqliteBackend {
     /// `scan` runs on a blocking thread and `blocking_send`s every row into a cap-1
     /// channel; the async side `recv().await`s and invokes `cb`. The cap-1 bound is
     /// backpressure (the scan stalls when the consumer is slow). On an early `cb`
-    /// error the receiver is dropped, the scan's next `blocking_send` fails and it
+    /// error the receiver is dropped, so the scan's next `blocking_send` fails (or
+    /// the scan finishes naturally if the cursor was already exhausted) and it
     /// stops — and the **callback** error is returned in preference to the scan's
     /// resulting send failure. A mid-scan SQL error (no callback error) is surfaced
     /// from the join handle.
@@ -193,13 +202,6 @@ fn stream_consumer_dropped() -> MemoryError {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn _assert_send_sync() {
-        fn f<T: Send + Sync>() {}
-        f::<SqliteBackend>();
-        f::<UpcasterRegistry>();
-        f::<ConnectionPool>();
-    }
 
     /// In-memory backend for tests (`embed_dim` 4).
     pub(super) fn memory_backend() -> SqliteBackend {

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -1,0 +1,345 @@
+//! The default, in-process `SQLite` implementation of the storage port (#630).
+//!
+//! `SqliteBackend` is the sole owner of every `SQLite`-private concern — the
+//! read-pool/write-mutex [`ConnectionPool`] and the event [`UpcasterRegistry`] —
+//! and the bounded-trait impls in this module's siblings are a thin, uniform
+//! delegation layer over two primitives: [`SqliteBackend::block_read`] and
+//! [`SqliteBackend::block_write`], which encapsulate *"acquire a connection and run
+//! a sync `rusqlite` closure on a blocking thread"*.
+//!
+//! ## Why delegation, not absorption
+//!
+//! The concrete `src/store/*` structs and `src/search/*` free functions stay the
+//! SQL's single source of truth (and keep their fast in-process unit tests). This
+//! backend *adapts* them: it owns connections and re-homes the borrow→own and
+//! sync→async concerns. `#634`'s `PgBackend` reuses none of these bodies, so the
+//! SQL must stay below the seam, not be welded into `impl FactGraph`.
+//!
+//! ## Seam invariants
+//!
+//! - **Conn selection (D-design):** read methods → [`ConnectionPool::read`]; write
+//!   methods → [`ConnectionPool::try_write`] (so a read-only pool rejects writes
+//!   with [`MemoryError::ReadOnly`] — Key Design Decision #6, preserved for free).
+//! - **No driver type crosses the seam (D4):** a `rusqlite` failure surfaces as
+//!   [`MemoryError::Database`] from the concrete store; [`map_seam_err`] maps it to
+//!   [`MemoryError::Storage`] wrapping [`StorageError::Backend`] at the boundary.
+//!   Semantic variants (`NotFound`, `Migration`, `EmbeddingDimension`, `Conflict`,
+//!   `ReadOnly`, `Internal`, …) already have a precise home and pass through.
+//! - **Async gating (D1):** the whole subtree is `#[cfg(feature = "async")]`;
+//!   `spawn_blocking` needs a tokio runtime, so default builds stay runtime-free.
+//! - **HNSW (D3):** `vector_search` is brute-force here; HNSW ownership + its
+//!   engine-owned dispatch policy move into the backend in `#631`.
+//! - **Atomicity (H5):** every trait method is an *independent* write — the engine
+//!   composes multi-store transactions *above* this seam, untouched by `#630`.
+
+use std::sync::Arc;
+
+use crate::error::{MemoryError, Result, StorageError};
+use crate::pool::ConnectionPool;
+use crate::store::upcaster::UpcasterRegistry;
+
+mod event_log;
+
+/// The default, in-process `SQLite` implementation of [`StorageBackend`](crate::storage::StorageBackend).
+///
+/// Holds the pool as `Arc<ConnectionPool>` (the `'static` `spawn_blocking` closures
+/// need an owned handle) and the [`UpcasterRegistry`] as `Arc` (cloned into every
+/// [`EventLog`](crate::storage::EventLog) closure). `embed_dim` is derived from the
+/// pool so the two can never diverge.
+pub struct SqliteBackend {
+    pool: Arc<ConnectionPool>,
+    #[allow(dead_code, reason = "read by the FactGraph/SearchIndex impls (T2/T3)")]
+    embed_dim: usize,
+    upcaster_registry: Arc<UpcasterRegistry>,
+}
+
+impl SqliteBackend {
+    /// Wrap an already-opened pool + upcaster registry. The canonical constructor
+    /// `#631` will use where it builds the [`ConnectionPool`] today. `embed_dim` is
+    /// read from the pool, so a backend's dimension cannot diverge from its pool's.
+    #[must_use]
+    pub fn from_pool(pool: Arc<ConnectionPool>, upcaster_registry: Arc<UpcasterRegistry>) -> Self {
+        let embed_dim = pool.embed_dim();
+        Self {
+            pool,
+            embed_dim,
+            upcaster_registry,
+        }
+    }
+}
+
+/// Map a tokio [`JoinError`](tokio::task::JoinError) (a panic or cancellation in the
+/// blocking task) to [`MemoryError::Pool`] — byte-identical to
+/// `async_engine::join_err`, so a panic surfaces the same way across both seams.
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "used as map_err(map_join) fn pointer"
+)]
+fn map_join(e: tokio::task::JoinError) -> MemoryError {
+    MemoryError::Pool(format!("task join error: {e}"))
+}
+
+/// D4: confine `rusqlite` below the seam. A raw driver failure
+/// ([`MemoryError::Database`]) becomes opaque [`StorageError::Backend`]; every
+/// semantic variant (which has a precise `MemoryError` home) passes through.
+fn map_seam_err<T>(r: Result<T>) -> Result<T> {
+    match r {
+        Err(MemoryError::Database(e)) => {
+            Err(MemoryError::Storage(StorageError::Backend(e.to_string())))
+        }
+        other => other,
+    }
+}
+
+impl SqliteBackend {
+    /// Acquire a READ connection and run `f` on a blocking thread.
+    ///
+    /// The pool `Arc` is cloned in; the `!Send` read guard is acquired *inside* the
+    /// closure (acquiring it on the executor would not compile and would serialize
+    /// the runtime). Driver errors are mapped at the boundary by [`map_seam_err`].
+    async fn block_read<T, F>(&self, f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static,
+    {
+        let pool = Arc::clone(&self.pool);
+        let out = tokio::task::spawn_blocking(move || {
+            let conn = pool.read()?;
+            f(&conn)
+        })
+        .await
+        .map_err(map_join)?;
+        map_seam_err(out)
+    }
+
+    /// Acquire the WRITE connection (via [`ConnectionPool::try_write`], so a
+    /// read-only pool yields [`MemoryError::ReadOnly`]) and run `f` on a blocking
+    /// thread.
+    async fn block_write<T, F>(&self, f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static,
+    {
+        let pool = Arc::clone(&self.pool);
+        let out = tokio::task::spawn_blocking(move || {
+            let conn = pool.try_write()?;
+            f(&conn)
+        })
+        .await
+        .map_err(map_join)?;
+        map_seam_err(out)
+    }
+
+    /// Stream rows produced by a blocking `&Connection` scan to a non-`'static`,
+    /// borrowing async-side callback, with O(1) peak memory.
+    ///
+    /// `scan` runs on a blocking thread and `blocking_send`s every row into a cap-1
+    /// channel; the async side `recv().await`s and invokes `cb`. The cap-1 bound is
+    /// backpressure (the scan stalls when the consumer is slow). On an early `cb`
+    /// error the receiver is dropped, the scan's next `blocking_send` fails and it
+    /// stops — and the **callback** error is returned in preference to the scan's
+    /// resulting send failure. A mid-scan SQL error (no callback error) is surfaced
+    /// from the join handle.
+    async fn for_each_streamed<T, S>(
+        &self,
+        scan: S,
+        cb: &mut (dyn FnMut(T) -> Result<()> + Send),
+    ) -> Result<()>
+    where
+        T: Send + 'static,
+        S: FnOnce(&rusqlite::Connection, &tokio::sync::mpsc::Sender<T>) -> Result<()>
+            + Send
+            + 'static,
+    {
+        let pool = Arc::clone(&self.pool);
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<T>(1);
+        let handle = tokio::task::spawn_blocking(move || {
+            let conn = pool.read()?;
+            scan(&conn, &tx)
+        });
+
+        let mut cb_err: Option<MemoryError> = None;
+        while let Some(row) = rx.recv().await {
+            if let Err(e) = cb(row) {
+                cb_err = Some(e);
+                break;
+            }
+        }
+        drop(rx); // unblock / abort the scan's next blocking_send
+
+        let scan_res = map_seam_err(handle.await.map_err(map_join)?);
+        // The callback error wins over the scan's induced send failure; otherwise
+        // surface any mid-scan SQL error.
+        cb_err.map_or(scan_res, Err)
+    }
+}
+
+/// Map a "stream consumer dropped" send failure to an internal error. The value is
+/// never surfaced (an early callback error always wins in
+/// [`SqliteBackend::for_each_streamed`]); it exists only to stop the scan.
+fn stream_consumer_dropped() -> MemoryError {
+    MemoryError::Internal("storage stream consumer dropped mid-scan".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn _assert_send_sync() {
+        fn f<T: Send + Sync>() {}
+        f::<SqliteBackend>();
+        f::<UpcasterRegistry>();
+        f::<ConnectionPool>();
+    }
+
+    /// In-memory backend for tests (`embed_dim` 4).
+    pub(super) fn memory_backend() -> SqliteBackend {
+        let pool = ConnectionPool::open_memory(4).unwrap();
+        SqliteBackend::from_pool(Arc::new(pool), Arc::new(UpcasterRegistry::new()))
+    }
+
+    #[tokio::test]
+    async fn block_read_runs_and_returns() {
+        let be = memory_backend();
+        let n: i64 = be
+            .block_read(|c| Ok(c.query_row("SELECT 1 + 1", [], |r| r.get(0))?))
+            .await
+            .unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[tokio::test]
+    async fn block_read_maps_database_error_to_storage_backend() {
+        // D4 witness, at the precise boundary where the mapping lives: a Database
+        // error returned from the closure must surface as Storage(Backend).
+        let be = memory_backend();
+        let err = be
+            .block_read(|_| -> Result<()> {
+                Err(MemoryError::Database(rusqlite::Error::QueryReturnedNoRows))
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Storage(StorageError::Backend(_))),
+            "expected Storage(Backend), got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn block_read_passes_semantic_variant_through() {
+        // A semantic variant must NOT be opacified by the seam remap.
+        let be = memory_backend();
+        let err = be
+            .block_read(|_| -> Result<()> { Err(MemoryError::NotFound("fact 7".into())) })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn block_read_panic_maps_to_pool() {
+        let be = memory_backend();
+        let err = be
+            .block_read(|_| -> Result<()> { panic!("boom") })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::Pool(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn block_write_on_read_only_pool_yields_read_only() {
+        // H7: a write through a read-only pool must yield ReadOnly (via try_write).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro.db");
+        // Initialize a real file-backed store, then drop it.
+        {
+            let _rw = ConnectionPool::open(&path, 4, 2, None).unwrap();
+        }
+        let ro = ConnectionPool::open_read_only(&path, 4, 2).unwrap();
+        let be = SqliteBackend::from_pool(Arc::new(ro), Arc::new(UpcasterRegistry::new()));
+        let err = be
+            .block_write(|c| Ok(c.execute("CREATE TABLE t (x)", [])?))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::ReadOnly), "got {err:?}");
+        // Reads still work on a read-only backend.
+        let one: i64 = be
+            .block_read(|c| Ok(c.query_row("SELECT 1", [], |r| r.get(0))?))
+            .await
+            .unwrap();
+        assert_eq!(one, 1);
+    }
+
+    #[tokio::test]
+    async fn for_each_streamed_delivers_in_order() {
+        let be = memory_backend();
+        let mut seen = Vec::new();
+        be.for_each_streamed(
+            |_conn, tx| {
+                for i in 0..5_i64 {
+                    tx.blocking_send(i).map_err(|_| stream_consumer_dropped())?;
+                }
+                Ok(())
+            },
+            &mut |row: i64| {
+                seen.push(row);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(seen, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn for_each_streamed_callback_error_wins_and_stops_early() {
+        // H6: callback Err at row k ⇒ that exact Err propagates, and exactly k rows
+        // were observed (early stop), not the scan's induced send failure.
+        let be = memory_backend();
+        let mut count = 0_usize;
+        let err = be
+            .for_each_streamed(
+                |_conn, tx| {
+                    for i in 0..100_i64 {
+                        tx.blocking_send(i).map_err(|_| stream_consumer_dropped())?;
+                    }
+                    Ok(())
+                },
+                &mut |_row: i64| {
+                    count += 1;
+                    if count == 3 {
+                        return Err(MemoryError::Lineage("stop at 3".into()));
+                    }
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Lineage(ref m) if m == "stop at 3"),
+            "callback error must win, got {err:?}"
+        );
+        assert_eq!(count, 3, "must stop early at the erroring row");
+    }
+
+    #[tokio::test]
+    async fn for_each_streamed_surfaces_mid_scan_error() {
+        // A scan SQL error (no callback error) is surfaced, remapped to Storage(Backend).
+        let be = memory_backend();
+        let err = be
+            .for_each_streamed(
+                |_conn, tx| {
+                    tx.blocking_send(0_i64)
+                        .map_err(|_| stream_consumer_dropped())?;
+                    Err(MemoryError::Database(rusqlite::Error::QueryReturnedNoRows))
+                },
+                &mut |_row: i64| Ok(()),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Storage(StorageError::Backend(_))),
+            "got {err:?}"
+        );
+    }
+}

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -40,6 +40,7 @@ use crate::store::upcaster::UpcasterRegistry;
 
 mod convert;
 mod event_log;
+mod graph;
 mod search_index;
 
 /// The default, in-process `SQLite` implementation of [`StorageBackend`](crate::storage::StorageBackend).

--- a/src/storage/sqlite/realization.rs
+++ b/src/storage/sqlite/realization.rs
@@ -1,0 +1,100 @@
+//! T8 — the value-level realization proof.
+//!
+//! `#629`'s `backend.rs` test proved only that the trait family is *vtable-safe*
+//! (a `&dyn StorageBackend` reference forms) and deferred constructing the full
+//! `~90`-method impl to `#630`. These tests close that: a real `SqliteBackend`
+//! coerces to `Arc<dyn StorageBackend>` and dispatches at least one method per
+//! bounded trait through the object — exercising async-through-`dyn` for the whole
+//! umbrella — and a bounded view (`&dyn FactGraph`) is shown independently usable
+//! (the mockability the trait family promised).
+
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use super::SqliteBackend;
+use crate::pool::ConnectionPool;
+use crate::storage::{FactFilter, FactGraph, StorageBackend};
+use crate::store::upcaster::UpcasterRegistry;
+use crate::types::{EventType, FactType, NewEvent, NewFact};
+
+const DIM: usize = 4;
+
+fn backend() -> SqliteBackend {
+    let pool = ConnectionPool::open_memory(DIM).unwrap();
+    SqliteBackend::from_pool(Arc::new(pool), Arc::new(UpcasterRegistry::new()))
+}
+
+fn new_fact() -> NewFact {
+    NewFact {
+        content: "hello world".into(),
+        content_hash: String::new(),
+        embedding: vec![0.1; DIM],
+        fact_type: FactType::Episodic,
+        t_created: Utc::now(),
+        t_expired: None,
+        t_valid: None,
+        t_invalid: None,
+        source_event_id: None,
+        scope_id: 1,
+        importance: 0.5,
+        access_count: 0,
+        last_accessed: Utc::now(),
+        metadata: serde_json::json!({}),
+        is_pinned: false,
+    }
+}
+
+fn new_event() -> NewEvent {
+    NewEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::Interaction,
+        payload: serde_json::json!({ "k": "v" }),
+        source: "t8".into(),
+        session_id: None,
+        scope_id: 1,
+        origin_node_id: "local".into(),
+        sequence_id: 0,
+        created_at: None,
+    }
+}
+
+#[tokio::test]
+async fn arc_dyn_storage_backend_dispatches_every_bounded_trait() {
+    let be: Arc<dyn StorageBackend> = Arc::new(backend());
+
+    // SchemaManager — one sync method + one async method through the object.
+    let _caps = be.capabilities();
+    assert!(be.schema_version().await.unwrap() >= 1);
+
+    // EventLog
+    let eid = be.insert_event(&new_event()).await.unwrap();
+    assert_eq!(be.get_event(eid).await.unwrap().id, eid);
+
+    // FactGraph
+    let fid = be.insert_fact(&new_fact()).await.unwrap();
+    assert_eq!(be.get_fact(fid).await.unwrap().id, fid);
+
+    // SearchIndex
+    let hits = be
+        .lexical_search("hello", &FactFilter::default(), 5)
+        .await
+        .unwrap();
+    assert!(hits.len() <= 5);
+
+    // ConsolidationStore
+    assert!(be.list_all_summaries().await.unwrap().is_empty());
+
+    // SessionStore
+    assert!(be.list_recent_checkpoints(10).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn bounded_trait_is_independently_usable_as_dyn() {
+    // The #629 mockability promise: a single bounded trait is usable in isolation
+    // through a trait object, now against a real impl.
+    let be = backend();
+    let fg: &dyn FactGraph = &be;
+    let fid = fg.insert_fact(&new_fact()).await.unwrap();
+    assert_eq!(fg.get_fact(fid).await.unwrap().id, fid);
+}

--- a/src/storage/sqlite/schema.rs
+++ b/src/storage/sqlite/schema.rs
@@ -221,16 +221,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn record_if_absent_stored_wins() {
+    async fn record_if_absent_returns_stored_when_candidate_matches() {
+        let be = backend();
+        let fp = EmbeddingFingerprint::new("model-a", "tei", DIM);
+        be.store_embedding_fingerprint(&fp).await.unwrap();
+        // A matching candidate is idempotent: the stored identity is returned.
+        let returned = be
+            .record_embedding_fingerprint_if_absent(&fp, DIM)
+            .await
+            .unwrap();
+        assert_eq!(returned, fp);
+    }
+
+    #[tokio::test]
+    async fn record_if_absent_rejects_model_mismatch() {
+        // #614: a candidate that differs from the stored identity is rejected, not
+        // silently ignored. The seam preserves the semantic variant (not opacified
+        // to Storage(Backend), since it is not a raw driver error).
         let be = backend();
         let fp_a = EmbeddingFingerprint::new("model-a", "tei", DIM);
         let fp_b = EmbeddingFingerprint::new("model-b", "tei", DIM);
         be.store_embedding_fingerprint(&fp_a).await.unwrap();
-        // Candidate fp_b is ignored; stored fp_a wins.
-        let returned = be
+        let err = be
             .record_embedding_fingerprint_if_absent(&fp_b, DIM)
             .await
-            .unwrap();
-        assert_eq!(returned, fp_a);
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::EmbeddingModelMismatch { .. }),
+            "got {err:?}"
+        );
     }
 }

--- a/src/storage/sqlite/schema.rs
+++ b/src/storage/sqlite/schema.rs
@@ -1,0 +1,236 @@
+//! `impl SchemaManager for SqliteBackend` — delegates to the concrete schema
+//! functions in [`crate::store::schema`] and [`crate::store::embedding_meta`].
+//!
+//! ## `migrate` / `backup_dir`
+//!
+//! The concrete `store::schema::migrate(conn, backup_dir: Option<&Path>)` accepts
+//! an optional WAL-safe backup directory. At `SqliteBackend` level we pass `None`:
+//! the pool already ran `init_schema` + `migrate` at open time, so calling
+//! `SchemaManager::migrate` is an idempotent at-HEAD re-check, not a first-time
+//! migration. No backup is taken here; the consumer is responsible for taking a
+//! backup before calling the pool's open path if one is needed. If a future
+//! engine path requires a backup at this level, this method must be extended and
+//! that decision surfaced to the caller — do not guess.
+//!
+//! ## `capabilities`
+//!
+//! **Synchronous** — fixed at open. `SQLite` tier: `Bm25` ranker (FTS5 `bm25()`),
+//! `true_idf = true`, `server_side_vector = false` (brute-force in-process scan;
+//! HNSW moves into the backend in #631).
+
+use async_trait::async_trait;
+
+use super::SqliteBackend;
+use crate::error::Result;
+use crate::storage::capabilities::{BackendCapabilities, LexicalRanker};
+use crate::storage::schema::SchemaManager;
+use crate::store::embedding_meta;
+use crate::store::schema::{get_config, migrate, validate_schema_version};
+use crate::types::EmbeddingFingerprint;
+
+#[async_trait]
+impl SchemaManager for SqliteBackend {
+    // WRITE (idempotent at HEAD — see module-level doc)
+    async fn migrate(&self) -> Result<()> {
+        self.block_write(|c| migrate(c, None)).await
+    }
+
+    // READ
+    async fn schema_version(&self) -> Result<u32> {
+        self.block_read(|c| {
+            let raw = get_config(c, "schema_version")?.unwrap_or_else(|| "1".to_string());
+            raw.parse::<u32>().map_err(|_| {
+                crate::error::MemoryError::Migration(crate::error::MigrationError::Incompatible(
+                    format!("invalid schema_version: {raw}"),
+                ))
+            })
+        })
+        .await
+    }
+
+    // READ
+    async fn validate_schema_version(&self) -> Result<()> {
+        self.block_read(validate_schema_version).await
+    }
+
+    /// `SQLite` capabilities: BM25 lexical ranker (FTS5), true corpus IDF,
+    /// in-process vector search (not server-side). Fixed at open.
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            lexical_ranker: LexicalRanker::Bm25,
+            server_side_vector: false,
+            true_idf: true,
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // embedding-fingerprint identity
+    // -------------------------------------------------------------------------
+
+    // READ
+    async fn load_embedding_fingerprint(&self) -> Result<Option<EmbeddingFingerprint>> {
+        self.block_read(embedding_meta::load).await
+    }
+
+    // WRITE
+    async fn store_embedding_fingerprint(&self, fp: &EmbeddingFingerprint) -> Result<()> {
+        let fp = fp.clone();
+        self.block_write(move |c| embedding_meta::store(c, &fp))
+            .await
+    }
+
+    // WRITE
+    async fn record_embedding_fingerprint_if_absent(
+        &self,
+        candidate: &EmbeddingFingerprint,
+        expected_dim: usize,
+    ) -> Result<EmbeddingFingerprint> {
+        let candidate = candidate.clone();
+        self.block_write(move |c| embedding_meta::record_if_absent(c, &candidate, expected_dim))
+            .await
+    }
+
+    // READ
+    async fn require_embedding_fingerprint_present(&self) -> Result<()> {
+        self.block_read(embedding_meta::require_present).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::super::SqliteBackend;
+    use crate::error::MemoryError;
+    use crate::pool::ConnectionPool;
+    use crate::storage::capabilities::{BackendCapabilities, LexicalRanker};
+    use crate::storage::schema::SchemaManager;
+    use crate::store::schema::CURRENT_SCHEMA_VERSION;
+    use crate::store::upcaster::UpcasterRegistry;
+    use crate::types::EmbeddingFingerprint;
+
+    const DIM: usize = 4;
+
+    fn backend() -> SqliteBackend {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+    }
+
+    #[tokio::test]
+    async fn schema_version_returns_current() {
+        let be = backend();
+        let v = be.schema_version().await.unwrap();
+        assert_eq!(v, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[tokio::test]
+    async fn migrate_is_idempotent_at_head() {
+        let be = backend();
+        // Should succeed without error on an already-at-HEAD schema.
+        be.migrate().await.unwrap();
+        // Calling twice is a no-op.
+        be.migrate().await.unwrap();
+        assert_eq!(be.schema_version().await.unwrap(), CURRENT_SCHEMA_VERSION);
+    }
+
+    #[tokio::test]
+    async fn validate_schema_version_ok_on_fresh_db() {
+        let be = backend();
+        be.validate_schema_version().await.unwrap();
+    }
+
+    #[test]
+    fn capabilities_sqlite_tier() {
+        let be = backend();
+        let caps: BackendCapabilities = be.capabilities();
+        assert_eq!(caps.lexical_ranker, LexicalRanker::Bm25);
+        assert!(caps.true_idf, "SQLite FTS5 uses true IDF");
+        assert!(
+            !caps.server_side_vector,
+            "SQLite uses in-process vector scan"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // embedding fingerprint
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn require_present_on_fresh_store_yields_internal() {
+        let be = backend();
+        let err = be
+            .require_embedding_fingerprint_present()
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Internal(_)),
+            "expected Internal error on fresh store, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_if_absent_dim_mismatch_yields_embedding_dimension() {
+        let be = backend();
+        let fp = EmbeddingFingerprint::new("model-a", "tei", 16); // dim 16 ≠ expected 4
+        let err = be
+            .record_embedding_fingerprint_if_absent(&fp, DIM)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                MemoryError::EmbeddingDimension {
+                    expected: DIM,
+                    actual: 16
+                }
+            ),
+            "expected EmbeddingDimension, got {err:?}"
+        );
+        // Nothing persisted.
+        assert!(be.load_embedding_fingerprint().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn record_store_load_round_trip() {
+        let be = backend();
+        assert!(be.load_embedding_fingerprint().await.unwrap().is_none());
+
+        let fp = EmbeddingFingerprint::new("Qwen/Qwen3-Embedding-0.6B", "tei", DIM);
+        let returned = be
+            .record_embedding_fingerprint_if_absent(&fp, DIM)
+            .await
+            .unwrap();
+        assert_eq!(returned, fp);
+
+        let loaded = be.load_embedding_fingerprint().await.unwrap().unwrap();
+        assert_eq!(loaded, fp);
+
+        // require_present now succeeds.
+        be.require_embedding_fingerprint_present().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn store_then_load_overwrite() {
+        let be = backend();
+        let fp1 = EmbeddingFingerprint::new("model-a", "tei", DIM);
+        let fp2 = EmbeddingFingerprint::new("model-b", "ollama", DIM);
+        be.store_embedding_fingerprint(&fp1).await.unwrap();
+        be.store_embedding_fingerprint(&fp2).await.unwrap();
+        let loaded = be.load_embedding_fingerprint().await.unwrap().unwrap();
+        assert_eq!(loaded, fp2);
+    }
+
+    #[tokio::test]
+    async fn record_if_absent_stored_wins() {
+        let be = backend();
+        let fp_a = EmbeddingFingerprint::new("model-a", "tei", DIM);
+        let fp_b = EmbeddingFingerprint::new("model-b", "tei", DIM);
+        be.store_embedding_fingerprint(&fp_a).await.unwrap();
+        // Candidate fp_b is ignored; stored fp_a wins.
+        let returned = be
+            .record_embedding_fingerprint_if_absent(&fp_b, DIM)
+            .await
+            .unwrap();
+        assert_eq!(returned, fp_a);
+    }
+}

--- a/src/storage/sqlite/search_index.rs
+++ b/src/storage/sqlite/search_index.rs
@@ -1,0 +1,258 @@
+//! `impl SearchIndex for SqliteBackend` — delegates to the verbatim `search/*`
+//! free functions, returning ranked `(fact_id, score)` pairs.
+//!
+//! D3: `vector_search` is brute-force here (HNSW ownership + its engine-owned
+//! dispatch policy move into the backend in `#631`). The vector score is widened
+//! `f32 → f64` (value-exact, order-preserving) to match the trait's `f64` return.
+
+use async_trait::async_trait;
+
+use super::{SqliteBackend, convert};
+use crate::error::Result;
+use crate::search::{fts_count_expired, fts_search, vector_search};
+use crate::storage::{FactFilter, SearchIndex};
+use crate::types::FactType;
+
+#[async_trait]
+impl SearchIndex for SqliteBackend {
+    async fn lexical_search(
+        &self,
+        query: &str,
+        filter: &FactFilter,
+        k: usize,
+    ) -> Result<Vec<(i64, f64)>> {
+        let (fact_type, scope_ids) = convert::search_params(filter)?;
+        let query = query.to_owned();
+        self.block_read(move |c| {
+            Ok(
+                fts_search(c, &query, k, fact_type.as_ref(), scope_ids.as_deref())?
+                    .into_iter()
+                    .map(|r| (r.fact_id, r.score))
+                    .collect(),
+            )
+        })
+        .await
+    }
+
+    async fn vector_search(
+        &self,
+        embedding: &[f32],
+        filter: &FactFilter,
+        k: usize,
+    ) -> Result<Vec<(i64, f64)>> {
+        let (fact_type, scope_ids) = convert::search_params(filter)?;
+        let dim = self.embed_dim;
+        let q = embedding.to_vec();
+        self.block_read(move |c| {
+            Ok(
+                vector_search(c, &q, dim, k, fact_type.as_ref(), scope_ids.as_deref())?
+                    .into_iter()
+                    .map(|r| (r.fact_id, f64::from(r.score)))
+                    .collect(),
+            )
+        })
+        .await
+    }
+
+    async fn lexical_count_expired(
+        &self,
+        query: &str,
+        fact_type: Option<&FactType>,
+        scope_ids: Option<&[i64]>,
+    ) -> Result<usize> {
+        let query = query.to_owned();
+        let fact_type = fact_type.copied();
+        let scope_ids = scope_ids.map(<[i64]>::to_vec);
+        self.block_read(move |c| {
+            fts_count_expired(c, &query, fact_type.as_ref(), scope_ids.as_deref())
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+
+    use super::super::SqliteBackend;
+    use crate::error::MemoryError;
+    use crate::pool::ConnectionPool;
+    use crate::search::{fts_count_expired, fts_search, vector_search};
+    use crate::storage::{FactFilter, SearchIndex};
+    use crate::store::facts::FactStore;
+    use crate::store::upcaster::UpcasterRegistry;
+    use crate::types::{FactType, NewFact};
+
+    const DIM: usize = 4;
+
+    fn fact(content: &str, embedding: [f32; DIM], expired: bool) -> NewFact {
+        NewFact {
+            content: content.into(),
+            content_hash: String::new(),
+            embedding: embedding.to_vec(),
+            fact_type: FactType::Episodic,
+            t_created: Utc::now(),
+            t_expired: expired.then(Utc::now),
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            scope_id: 1,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+            is_pinned: false,
+        }
+    }
+
+    /// Build a pool, seed it via the write conn, and return it shared. The backend
+    /// and the oracle then operate on the same in-memory DB.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the write guard is intentionally held across the seed loop"
+    )]
+    fn seeded(facts: &[NewFact]) -> Arc<ConnectionPool> {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            for f in facts {
+                store.insert(f).unwrap();
+            }
+        }
+        pool
+    }
+
+    fn backend(pool: Arc<ConnectionPool>) -> SqliteBackend {
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+    }
+
+    #[tokio::test]
+    async fn lexical_parity_default_filter_value_and_order() {
+        let pool = seeded(&[
+            fact("Rust Rust Rust systems programming", [0.1; DIM], false),
+            fact("Python data science", [0.1; DIM], false),
+            fact("Rust language", [0.1; DIM], false),
+        ]);
+        let oracle: Vec<(i64, f64)> = {
+            let c = pool.read().unwrap();
+            fts_search(&c, "Rust", 10, None, None)
+                .unwrap()
+                .into_iter()
+                .map(|r| (r.fact_id, r.score))
+                .collect()
+        };
+        let got = backend(Arc::clone(&pool))
+            .lexical_search("Rust", &FactFilter::default(), 10)
+            .await
+            .unwrap();
+        assert_eq!(got, oracle);
+        assert_eq!(got.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn lexical_scope_some_empty_matches_nothing_none_finds() {
+        let pool = seeded(&[fact("Rust language", [0.1; DIM], false)]);
+        let be = backend(Arc::clone(&pool));
+        // None = no scope constraint → finds the row.
+        let found = be
+            .lexical_search("Rust", &FactFilter::default(), 10)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1);
+        // Some(empty) = matches nothing (NOT normalized to "all").
+        let none = be
+            .lexical_search("Rust", &FactFilter::new().scope_ids(Vec::<i64>::new()), 10)
+            .await
+            .unwrap();
+        assert!(none.is_empty());
+    }
+
+    #[tokio::test]
+    async fn lexical_malformed_query_is_empty_not_error() {
+        let pool = seeded(&[fact("some content", [0.1; DIM], false)]);
+        let got = backend(pool)
+            .lexical_search("\"unbalanced", &FactFilter::default(), 10)
+            .await
+            .unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[tokio::test]
+    async fn vector_parity_distinct_scores_value_and_order() {
+        let pool = seeded(&[
+            fact("a", [1.0, 0.0, 0.0, 0.0], false),
+            fact("b", [0.0, 1.0, 0.0, 0.0], false),
+            fact("c", [0.9, 0.1, 0.0, 0.0], false),
+        ]);
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let oracle: Vec<(i64, f64)> = {
+            let c = pool.read().unwrap();
+            vector_search(&c, &query, DIM, 10, None, None)
+                .unwrap()
+                .into_iter()
+                .map(|r| (r.fact_id, f64::from(r.score)))
+                .collect()
+        };
+        let got = backend(Arc::clone(&pool))
+            .vector_search(&query, &FactFilter::default(), 10)
+            .await
+            .unwrap();
+        assert_eq!(got, oracle);
+    }
+
+    #[tokio::test]
+    async fn vector_wrong_dim_is_embedding_dimension_error() {
+        let pool = seeded(&[fact("a", [1.0, 0.0, 0.0, 0.0], false)]);
+        let err = backend(pool)
+            .vector_search(&[1.0_f32, 0.0, 0.0], &FactFilter::default(), 10)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                MemoryError::EmbeddingDimension {
+                    expected: DIM,
+                    actual: 3
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn count_expired_parity() {
+        let pool = seeded(&[
+            fact("Rust active", [0.1; DIM], false),
+            fact("Rust expired one", [0.1; DIM], true),
+            fact("Rust expired two", [0.1; DIM], true),
+        ]);
+        let oracle = {
+            let c = pool.read().unwrap();
+            fts_count_expired(&c, "Rust", None, None).unwrap()
+        };
+        let got = backend(Arc::clone(&pool))
+            .lexical_count_expired("Rust", None, None)
+            .await
+            .unwrap();
+        assert_eq!(got, oracle);
+        assert_eq!(got, 2);
+    }
+
+    #[tokio::test]
+    async fn search_rejects_unsupported_filter_dimension() {
+        use crate::storage::TemporalFilter;
+        let pool = seeded(&[fact("Rust", [0.1; DIM], false)]);
+        let err = backend(pool)
+            .lexical_search(
+                "Rust",
+                &FactFilter::new().temporal(TemporalFilter::IncludeExpired),
+                10,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::Internal(_)), "got {err:?}");
+    }
+}

--- a/src/storage/sqlite/session.rs
+++ b/src/storage/sqlite/session.rs
@@ -1,0 +1,328 @@
+//! `impl SessionStore for SqliteBackend` — delegates to [`ActivityStore`] and
+//! [`CheckpointStore`], the concrete SQL owners of the `activities` and
+//! `session_checkpoints` tables.
+//!
+//! **Conn selection rule:**
+//! - `insert_*` / `upsert_*` / `update_*` → [`super::SqliteBackend::block_write`].
+//! - `get_*` / `list_*` / `count_*` → [`super::SqliteBackend::block_read`].
+//!
+//! **Empty-scope quirk (preserved verbatim):** `list_recent_activities_by_scope`
+//! with an empty `scope_ids` slice returns an **empty** `Vec` — it does NOT mean
+//! "all scopes". This is explicitly pinned by the #632 conformance suite and
+//! matches the concrete [`ActivityStore::list_recent_by_scope`] behaviour.
+//!
+//! **`#[cfg(test)]` removal:** `ActivityStore::{get,list_by_session,count_by_session}`
+//! and `CheckpointStore::{get,list_recent}` were previously test-only; the gate
+//! was removed in the same commit so the trait can call them unconditionally (#630).
+
+use async_trait::async_trait;
+
+use super::SqliteBackend;
+use crate::error::Result;
+use crate::storage::session::SessionStore;
+use crate::store::activities::ActivityStore;
+use crate::store::checkpoints::CheckpointStore;
+use crate::types::{Activity, ActivityStatus, NewActivity, SessionCheckpoint};
+
+#[async_trait]
+impl SessionStore for SqliteBackend {
+    // -------------------------------------------------------------------------
+    // activities
+    // -------------------------------------------------------------------------
+
+    // WRITE
+    async fn insert_or_dedup_activity(
+        &self,
+        activity: &NewActivity,
+        dedup_window_secs: i64,
+    ) -> Result<(i64, bool)> {
+        let activity = activity.clone();
+        self.block_write(move |c| {
+            ActivityStore::new(c).insert_or_dedup(&activity, dedup_window_secs)
+        })
+        .await
+    }
+
+    // READ
+    async fn get_activity(&self, id: i64) -> Result<Activity> {
+        self.block_read(move |c| ActivityStore::new(c).get(id))
+            .await
+    }
+
+    // READ
+    async fn list_activities_by_session(
+        &self,
+        session_id: &str,
+        limit: Option<usize>,
+    ) -> Result<Vec<Activity>> {
+        let session_id = session_id.to_owned();
+        self.block_read(move |c| ActivityStore::new(c).list_by_session(&session_id, limit))
+            .await
+    }
+
+    // READ — empty scope_ids ⇒ empty result (NOT "all scopes"); preserved verbatim.
+    async fn list_recent_activities_by_scope(
+        &self,
+        scope_ids: &[i64],
+        limit: usize,
+    ) -> Result<Vec<Activity>> {
+        let scope_ids = scope_ids.to_vec();
+        self.block_read(move |c| ActivityStore::new(c).list_recent_by_scope(&scope_ids, limit))
+            .await
+    }
+
+    // WRITE
+    async fn update_activity_status(
+        &self,
+        id: i64,
+        status: ActivityStatus,
+        promoted_fact_id: Option<i64>,
+    ) -> Result<()> {
+        self.block_write(move |c| ActivityStore::new(c).update_status(id, status, promoted_fact_id))
+            .await
+    }
+
+    // READ
+    async fn count_activities_by_session(&self, session_id: &str) -> Result<i64> {
+        let session_id = session_id.to_owned();
+        self.block_read(move |c| ActivityStore::new(c).count_by_session(&session_id))
+            .await
+    }
+
+    // -------------------------------------------------------------------------
+    // checkpoints
+    // -------------------------------------------------------------------------
+
+    // WRITE
+    async fn upsert_checkpoint(&self, checkpoint: &SessionCheckpoint) -> Result<()> {
+        let checkpoint = checkpoint.clone();
+        self.block_write(move |c| CheckpointStore::new(c).upsert(&checkpoint))
+            .await
+    }
+
+    // READ
+    async fn get_checkpoint(&self, session_id: &str) -> Result<Option<SessionCheckpoint>> {
+        let session_id = session_id.to_owned();
+        self.block_read(move |c| CheckpointStore::new(c).get(&session_id))
+            .await
+    }
+
+    // READ
+    async fn get_checkpoint_by_scope(&self, scope_path: &str) -> Result<Option<SessionCheckpoint>> {
+        let scope_path = scope_path.to_owned();
+        self.block_read(move |c| CheckpointStore::new(c).get_by_scope(&scope_path))
+            .await
+    }
+
+    // READ
+    async fn list_recent_checkpoints(&self, limit: usize) -> Result<Vec<SessionCheckpoint>> {
+        self.block_read(move |c| CheckpointStore::new(c).list_recent(limit))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+
+    use super::super::SqliteBackend;
+    use crate::pool::ConnectionPool;
+    use crate::storage::session::SessionStore;
+    use crate::store::upcaster::UpcasterRegistry;
+    use crate::types::{ActivityStatus, NewActivity, SessionCheckpoint};
+
+    const DIM: usize = 4;
+
+    fn backend() -> SqliteBackend {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+    }
+
+    fn make_activity(session_id: &str, tool: &str) -> NewActivity {
+        NewActivity {
+            session_id: session_id.into(),
+            tool_name: tool.into(),
+            args_hash: format!("{tool:0<32}"),
+            args: serde_json::json!({}),
+            result_summary: None,
+            outcome_class: "success".into(),
+            timestamp: Utc::now(),
+            scope_id: 1,
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // activities
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn activity_insert_then_get_parity() {
+        let be = backend();
+        let a = make_activity("sess-1", "Read");
+        let (id, deduped) = be.insert_or_dedup_activity(&a, 300).await.unwrap();
+        assert!(!deduped);
+        assert!(id > 0);
+
+        let got = be.get_activity(id).await.unwrap();
+        assert_eq!(got.tool_name, "Read");
+        assert_eq!(got.occurrence_count, 1);
+        assert_eq!(got.status, ActivityStatus::Recorded);
+    }
+
+    #[tokio::test]
+    async fn activity_dedup_within_window() {
+        let be = backend();
+        let a = make_activity("sess-1", "Bash");
+        let (id1, d1) = be.insert_or_dedup_activity(&a, 300).await.unwrap();
+        assert!(!d1);
+        let (id2, d2) = be.insert_or_dedup_activity(&a, 300).await.unwrap();
+        assert!(d2);
+        assert_eq!(id1, id2);
+
+        let got = be.get_activity(id1).await.unwrap();
+        assert_eq!(got.occurrence_count, 2);
+        assert_eq!(got.status, ActivityStatus::Deduplicated);
+    }
+
+    #[tokio::test]
+    async fn list_activities_by_session_limit() {
+        let be = backend();
+        for i in 0..5 {
+            be.insert_or_dedup_activity(&make_activity("sess-list", &format!("Tool{i}")), 300)
+                .await
+                .unwrap();
+        }
+        let all = be
+            .list_activities_by_session("sess-list", None)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 5);
+
+        let limited = be
+            .list_activities_by_session("sess-list", Some(3))
+            .await
+            .unwrap();
+        assert_eq!(limited.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn count_activities_by_session() {
+        let be = backend();
+        for i in 0..4 {
+            be.insert_or_dedup_activity(&make_activity("sess-count", &format!("T{i}")), 300)
+                .await
+                .unwrap();
+        }
+        let count = be.count_activities_by_session("sess-count").await.unwrap();
+        assert_eq!(count, 4);
+        let zero = be.count_activities_by_session("other").await.unwrap();
+        assert_eq!(zero, 0);
+    }
+
+    #[tokio::test]
+    async fn list_recent_by_scope_empty_slice_returns_empty() {
+        // Pinned contract: empty scope_ids ⇒ NO results (not "all scopes").
+        let be = backend();
+        be.insert_or_dedup_activity(&make_activity("sess-scope", "Read"), 300)
+            .await
+            .unwrap();
+
+        let empty = be.list_recent_activities_by_scope(&[], 10).await.unwrap();
+        assert!(
+            empty.is_empty(),
+            "empty scope_ids must return empty, not all activities"
+        );
+
+        let found = be.list_recent_activities_by_scope(&[1], 10).await.unwrap();
+        assert_eq!(found.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn update_activity_status_round_trip() {
+        let be = backend();
+        let (id, _) = be
+            .insert_or_dedup_activity(&make_activity("sess-upd", "Bash"), 300)
+            .await
+            .unwrap();
+        be.update_activity_status(id, ActivityStatus::Promoted, None)
+            .await
+            .unwrap();
+        let got = be.get_activity(id).await.unwrap();
+        assert_eq!(got.status, ActivityStatus::Promoted);
+    }
+
+    // -------------------------------------------------------------------------
+    // checkpoints
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn checkpoint_upsert_get_by_scope() {
+        let be = backend();
+        let cp = SessionCheckpoint {
+            session_id: "sess-cp".into(),
+            scope_path: Some("project:memory-engine".into()),
+            summary: Some("initial summary".into()),
+            last_activity_id: None,
+            checkpoint_at: Utc::now(),
+            metadata: serde_json::json!({"count": 1}),
+        };
+        be.upsert_checkpoint(&cp).await.unwrap();
+
+        let got = be.get_checkpoint("sess-cp").await.unwrap().unwrap();
+        assert_eq!(got.session_id, "sess-cp");
+        assert_eq!(got.summary, Some("initial summary".into()));
+
+        let by_scope = be
+            .get_checkpoint_by_scope("project:memory-engine")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(by_scope.session_id, "sess-cp");
+
+        let none = be.get_checkpoint("nonexistent").await.unwrap();
+        assert!(none.is_none());
+    }
+
+    #[tokio::test]
+    async fn checkpoint_upsert_overwrites() {
+        let be = backend();
+        let cp1 = SessionCheckpoint {
+            session_id: "sess-overwrite".into(),
+            scope_path: None,
+            summary: Some("first".into()),
+            last_activity_id: None,
+            checkpoint_at: Utc::now(),
+            metadata: serde_json::json!({}),
+        };
+        be.upsert_checkpoint(&cp1).await.unwrap();
+        let cp2 = SessionCheckpoint {
+            summary: Some("second".into()),
+            ..cp1
+        };
+        be.upsert_checkpoint(&cp2).await.unwrap();
+
+        let got = be.get_checkpoint("sess-overwrite").await.unwrap().unwrap();
+        assert_eq!(got.summary, Some("second".into()));
+    }
+
+    #[tokio::test]
+    async fn list_recent_checkpoints() {
+        let be = backend();
+        for i in 0..5 {
+            be.upsert_checkpoint(&SessionCheckpoint {
+                session_id: format!("sess-{i}"),
+                scope_path: None,
+                summary: None,
+                last_activity_id: None,
+                checkpoint_at: Utc::now(),
+                metadata: serde_json::json!({}),
+            })
+            .await
+            .unwrap();
+        }
+        let list = be.list_recent_checkpoints(3).await.unwrap();
+        assert_eq!(list.len(), 3);
+    }
+}

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -99,9 +99,8 @@ impl<'a> ActivityStore<'a> {
 
     /// Get an activity by id.
     ///
-    /// Currently exercised only by unit tests; gated to keep the lib target
-    /// `dead_code`-clean until wired into the engine/MCP (see #95/#96).
-    #[cfg(test)]
+    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
+    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
     pub fn get(&self, id: i64) -> Result<Activity> {
         self.conn
             .query_row(
@@ -122,9 +121,8 @@ impl<'a> ActivityStore<'a> {
 
     /// List activities for a session, most recent first.
     ///
-    /// Currently exercised only by unit tests; gated to keep the lib target
-    /// `dead_code`-clean until wired into the engine/MCP (see #95/#96).
-    #[cfg(test)]
+    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
+    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
     pub fn list_by_session(&self, session_id: &str, limit: Option<usize>) -> Result<Vec<Activity>> {
         let base = "SELECT id, session_id, tool_name, args_hash, args, result_summary,
                         outcome_class, status, occurrence_count, first_seen, last_seen,
@@ -193,9 +191,8 @@ impl<'a> ActivityStore<'a> {
 
     /// Count activities in a session.
     ///
-    /// Currently exercised only by unit tests; gated to keep the lib target
-    /// `dead_code`-clean until wired into the engine/MCP (see #95/#96).
-    #[cfg(test)]
+    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
+    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
     pub fn count_by_session(&self, session_id: &str) -> Result<i64> {
         self.conn
             .query_row(

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -99,8 +99,8 @@ impl<'a> ActivityStore<'a> {
 
     /// Get an activity by id.
     ///
-    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
-    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
+    /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
+    /// impl can call it in non-test builds (#630).
     pub fn get(&self, id: i64) -> Result<Activity> {
         self.conn
             .query_row(
@@ -121,8 +121,8 @@ impl<'a> ActivityStore<'a> {
 
     /// List activities for a session, most recent first.
     ///
-    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
-    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
+    /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
+    /// impl can call it in non-test builds (#630).
     pub fn list_by_session(&self, session_id: &str, limit: Option<usize>) -> Result<Vec<Activity>> {
         let base = "SELECT id, session_id, tool_name, args_hash, args, result_summary,
                         outcome_class, status, occurrence_count, first_seen, last_seen,
@@ -191,8 +191,8 @@ impl<'a> ActivityStore<'a> {
 
     /// Count activities in a session.
     ///
-    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
-    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
+    /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
+    /// impl can call it in non-test builds (#630).
     pub fn count_by_session(&self, session_id: &str) -> Result<i64> {
         self.conn
             .query_row(

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -45,9 +45,8 @@ impl<'a> CheckpointStore<'a> {
 
     /// Get a checkpoint by `session_id`.
     ///
-    /// Currently exercised only by unit tests; gated to keep the lib target
-    /// `dead_code`-clean until wired into the engine/MCP (see #95/#96).
-    #[cfg(test)]
+    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
+    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
     pub fn get(&self, session_id: &str) -> Result<Option<SessionCheckpoint>> {
         self.conn
             .query_row(
@@ -79,9 +78,8 @@ impl<'a> CheckpointStore<'a> {
 
     /// List recent checkpoints, most recent first.
     ///
-    /// Currently exercised only by unit tests; gated to keep the lib target
-    /// `dead_code`-clean until wired into the engine/MCP (see #95/#96).
-    #[cfg(test)]
+    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
+    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
     pub fn list_recent(&self, limit: usize) -> Result<Vec<SessionCheckpoint>> {
         let mut stmt = self
             .conn

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -45,8 +45,8 @@ impl<'a> CheckpointStore<'a> {
 
     /// Get a checkpoint by `session_id`.
     ///
-    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
-    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
+    /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
+    /// impl can call it in non-test builds (#630).
     pub fn get(&self, session_id: &str) -> Result<Option<SessionCheckpoint>> {
         self.conn
             .query_row(
@@ -78,8 +78,8 @@ impl<'a> CheckpointStore<'a> {
 
     /// List recent checkpoints, most recent first.
     ///
-    /// Promoted to unconditional `pub(crate)` so the [`SessionStore`] trait impl
-    /// can call it in non-test builds (#630). Previously `#[cfg(test)]`.
+    /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
+    /// impl can call it in non-test builds (#630).
     pub fn list_recent(&self, limit: usize) -> Result<Vec<SessionCheckpoint>> {
         let mut stmt = self
             .conn


### PR DESCRIPTION
## Summary

Implements **#630** (epic **#628**, piece A2): adds **`SqliteBackend`**, the concrete SQLite implementation of the #629 `StorageBackend` trait family. It **delegates** to the existing `store/*` + `search/*` SQL **verbatim** — wrapping sync `rusqlite` in `spawn_blocking` — so this is a pure, additive **zero-behavior-change** refactor. The engine is **not** rewired here (that is #631); `SqliteBackend` is proven by new per-trait parity tests.

`storage/sqlite/` is one file per bounded trait, each a ~3-line delegation over two private primitives — `block_read` / `block_write` — plus a `for_each_streamed` bridge for the streaming methods. The whole subtree is behind `#[cfg(feature = "async")]`, so default builds are unchanged and tokio-free.

## The four decisions (see `docs/plans/2026-06-20-sqlite-backend-630.md`)

| | Decision | Why |
|---|---|---|
| **D1** async gating | `storage::sqlite` behind `#[cfg(feature = "async")]` | `spawn_blocking` needs tokio; default builds stay runtime-free (matches #629's landed callability test) |
| **D2** streaming | `tokio::sync::mpsc(1)` bridge (`blocking_send` / `recv().await`) | preserves O(1) peak memory + mid-stream early-exit error propagation, never parks the executor |
| **D3** HNSW | **deferred to #631** | `vector_search` is brute-force here; HNSW + its *engine-owned* dispatch policy (`search_config`/`ann_threshold`) move into the backend during the #631 rewire — the backend is unused until then, so no interim regression |
| **D4** errors | `Database` → `Storage(Backend)` at the seam; semantic variants pass through | `error.rs:345-368` — driver types must not cross the port; `Database` stays for SQLite-internal use |

## Verification

- `cargo test --all-features` — **1061 passed**, 4 ignored (incl. all SqliteBackend parity tests)
- `cargo test --workspace` (default) — **1339 passed** (cli/mcp/embed unaffected)
- `cargo clippy --workspace --all-targets --all-features` — clean (pedantic + nursery)
- `cargo build --workspace` (default) — `storage::sqlite` fully cfg'd out, zero tokio
- `cargo fmt --check` — clean
- **`src/engine/` byte-identical** (H5 — single-op trait methods are independent writes; the engine composes atomicity above the seam)
- **No `rusqlite`/`Connection` leaks** past the port (pinned grep)

## Hazard coverage (parity tests prove *wrapper* fidelity; the SQL is shared with the oracle)

- H1 search seam (FactFilter projection, `Some(&[])`=matches-nothing, malformed→empty, wrong-dim→`EmbeddingDimension`, f32→f64 order)
- H2 non-uniform `scope_ids` empty-slice (per-method parity table)
- H3 `marker_key` injection guard (reject-set → `Conflict(QueryValidation)`)
- H4 error-variant fidelity (`get_fact` missing→`NotFound`; raw driver→`Storage(Backend)`; `require_*_present`→`Internal`)
- H6 streaming early-exit precedence · H7 read-only→`ReadOnly` · H8 file-backed conn routing · H10 schema/migration/epoch

## Scope & follow-ups

- **Out of scope (later issues):** engine rewire (#631), conformance suite (#632), `PgBackend` (#633/#634).
- 5 `SessionStore`-backing reads in `store/{activities,checkpoints}.rs` promoted from `#[cfg(test)]` to unconditional `pub(crate)` (bodies unchanged) — the port is their non-test caller.
- Collateral (filed separately, linked to #628): `SchemaManager` trait-doc error-menu drift; full `FactFilter`→SQLite-search translation; #631 notes (HNSW policy move + transaction atomicity).

Fixes #630
