### PR TITLE
fix(cli): validate embedder before creating DB on --create (#681)

### DIFF
--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -349,8 +349,15 @@ pub fn run(db: &Path, args: &BatchIngestArgs, format: OutputFormat) -> anyhow::R
         args.batch_size,
     );
 
-    // Open or create engine
-    let engine = if args.create {
+    // Open or create the engine, plus its embedding provider (shared config —
+    // provider/MRL identity per #619).
+    //
+    // On --create the embed dim is known up front (--embed-dim), so the embedder is
+    // validated BEFORE the DB file is created: a misconfigured embedder must not
+    // leave an orphan empty database behind (#681). On the open paths the dim is
+    // only known after opening, but opening does not create a file, so building the
+    // embedder afterwards carries no orphan risk.
+    let (engine, embedder) = if args.create {
         let embed_dim = args
             .embed_dim
             .ok_or_else(|| anyhow::anyhow!("--embed-dim is required when using --create"))?;
@@ -359,20 +366,23 @@ pub fn run(db: &Path, args: &BatchIngestArgs, format: OutputFormat) -> anyhow::R
             "database {} already exists — remove it first or omit --create",
             db.display()
         );
-        MemoryEngine::builder(embed_dim)
+        let embedder = args.embed.build_required(embed_dim)?;
+        let engine = MemoryEngine::builder(embed_dim)
             .path(db.to_path_buf())
-            .build()?
-    } else if let Some(dim) = args.embed_dim {
-        // Existing DB: accept an explicit --embed-dim so a never-embedded store (no
-        // recorded identity yet under #613) is still writable. The engine's open path
-        // rejects a mismatch against any recorded identity.
-        open_engine_writable_with_dim(db, dim)?
+            .build()?;
+        (engine, embedder)
     } else {
-        open_engine_writable(db)?
+        let engine = if let Some(dim) = args.embed_dim {
+            // Existing DB: accept an explicit --embed-dim so a never-embedded store (no
+            // recorded identity yet under #613) is still writable. The engine's open path
+            // rejects a mismatch against any recorded identity.
+            open_engine_writable_with_dim(db, dim)?
+        } else {
+            open_engine_writable(db)?
+        };
+        let embedder = args.embed.build_required(engine.embed_dim())?;
+        (engine, embedder)
     };
-
-    // Build embedding provider (shared config — provider/MRL identity per #619).
-    let embedder = args.embed.build_required(engine.embed_dim())?;
 
     // Open input — bind stdin before locking to extend lifetime
     let stdin = std::io::stdin();
@@ -784,6 +794,38 @@ not valid json
         assert_eq!(summary.total_ingested, 3);
         assert_eq!(summary.total_skipped, 0);
         assert_eq!(summary.failed_batches, 0);
+    }
+
+    #[test]
+    fn create_with_misconfigured_embedder_leaves_no_orphan_db() {
+        // #681: a --create run whose embedder is misconfigured (url without model →
+        // build_required errors) must fail BEFORE the DB file is created, so no orphan
+        // empty database is left behind for the next run to trip over.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("orphan.db");
+        let args = BatchIngestArgs {
+            file: PathBuf::from("-"),
+            embed: EmbeddingArgs {
+                embed_url: Some("http://127.0.0.1:0/v1/embeddings".into()),
+                embed_model: None, // partial config → build_required errors
+                embed_provider: "ollama".into(),
+                embed_api_key: None,
+                native_dim: None,
+                query_instruction: None,
+                mrl_dim: None,
+                embed_timeout: 5,
+            },
+            batch_size: 100,
+            create: true,
+            embed_dim: Some(4),
+            scope: None,
+        };
+        let result = run(&db, &args, OutputFormat::Json);
+        assert!(result.is_err(), "misconfigured embedder must error");
+        assert!(
+            !db.exists(),
+            "no orphan DB file may be created when the embedder fails to build"
+        );
     }
 
     #[test]

--- a/memory-engine-cli/src/commands/bootstrap.rs
+++ b/memory-engine-cli/src/commands/bootstrap.rs
@@ -157,8 +157,15 @@ pub fn run(db: &Path, args: &BootstrapArgs, format: OutputFormat) -> anyhow::Res
         "pass --jsonl-dir and/or --memory-dir"
     );
 
-    // Open or create the engine.
-    let engine = if args.create {
+    // Open or create the engine, plus its embedding provider (shared config —
+    // provider/MRL identity per #619).
+    //
+    // On --create the embed dim is known up front (--embed-dim), so the embedder is
+    // validated BEFORE the DB file is created: a misconfigured embedder must not
+    // leave an orphan empty database behind (#681). On the open paths the dim is
+    // only known after opening, but opening does not create a file, so building the
+    // embedder afterwards carries no orphan risk.
+    let (engine, embedder) = if args.create {
         let embed_dim = args
             .embed_dim
             .ok_or_else(|| anyhow::anyhow!("--embed-dim is required when using --create"))?;
@@ -167,20 +174,23 @@ pub fn run(db: &Path, args: &BootstrapArgs, format: OutputFormat) -> anyhow::Res
             "database {} already exists — remove it first or omit --create",
             db.display()
         );
-        MemoryEngine::builder(embed_dim)
+        let embedder = args.embed.build_required(embed_dim)?;
+        let engine = MemoryEngine::builder(embed_dim)
             .path(db.to_path_buf())
-            .build()?
-    } else if let Some(dim) = args.embed_dim {
-        // Existing DB: accept an explicit --embed-dim so a never-embedded store (no
-        // recorded identity yet under #613) is still writable. The engine's open path
-        // rejects a mismatch against any recorded identity.
-        open_engine_writable_with_dim(db, dim)?
+            .build()?;
+        (engine, embedder)
     } else {
-        open_engine_writable(db)?
+        let engine = if let Some(dim) = args.embed_dim {
+            // Existing DB: accept an explicit --embed-dim so a never-embedded store (no
+            // recorded identity yet under #613) is still writable. The engine's open path
+            // rejects a mismatch against any recorded identity.
+            open_engine_writable_with_dim(db, dim)?
+        } else {
+            open_engine_writable(db)?
+        };
+        let embedder = args.embed.build_required(engine.embed_dim())?;
+        (engine, embedder)
     };
-
-    // Embedding provider (shared config — provider/MRL identity per #619).
-    let embedder = args.embed.build_required(engine.embed_dim())?;
 
     // Author-seeded denylist (#51). Loud about how many literals loaded so an
     // unset env var (→ signatures-only) is never silently mistaken for "active".
@@ -317,6 +327,42 @@ mod tests {
         // jsonl session is skipped on the marker; the md memory reinforces.
         assert_eq!(report2.sessions_skipped, 1);
         assert_eq!(report2.facts_reinforced, 1, "the md memory reinforces");
+    }
+
+    #[test]
+    fn create_with_misconfigured_embedder_leaves_no_orphan_db() {
+        // #681: a --create run whose embedder is misconfigured (url without model →
+        // build_required errors) must fail BEFORE the DB file is created, so no orphan
+        // empty database is left behind for the next run to trip over.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("orphan.db");
+        let jsonl = tmp.path().join("jsonl");
+        fs::create_dir_all(&jsonl).unwrap();
+        let args = BootstrapArgs {
+            jsonl_dir: Some(jsonl),
+            memory_dir: None,
+            embed: EmbeddingArgs {
+                embed_url: Some("http://127.0.0.1:0/v1/embeddings".into()),
+                embed_model: None, // partial config → build_required errors
+                embed_provider: "ollama".into(),
+                embed_api_key: None,
+                native_dim: None,
+                query_instruction: None,
+                mrl_dim: None,
+                embed_timeout: 5,
+            },
+            scope: None,
+            max_turns: 0,
+            reprocess: false,
+            create: true,
+            embed_dim: Some(4),
+        };
+        let result = run(&db, &args, OutputFormat::Json);
+        assert!(result.is_err(), "misconfigured embedder must error");
+        assert!(
+            !db.exists(),
+            "no orphan DB file may be created when the embedder fails to build"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

On the `--create` path, `batch-ingest` and `bootstrap` built the `MemoryEngine` — which creates the database file on disk — **before** validating the embedding-provider configuration. A missing/partial `--embed-model` (or any other `EmbeddingArgs` validation failure) therefore left behind an **orphan empty database file** and then errored, so the next run tripped over `database … already exists — remove it first`.

## Why it happens

The two fallible operations were sequenced side-effect-first:

```rust
let engine = if args.create {
    let embed_dim = args.embed_dim.ok_or_else(...)?;
    anyhow::ensure!(!db.exists(), ...);
    MemoryEngine::builder(embed_dim).path(db).build()?   // creates the DB file
} else { ... };
let embedder = args.embed.build_required(engine.embed_dim())?;  // can fail AFTER the file exists
```

`build_required` is pure (constructs a reqwest client + validates dims, no I/O); `builder(...).build()` is the side-effecting op.

## Fix

On `--create` the engine `embed_dim` is known up front from `--embed-dim` (it is **not** read from the DB), so the embedder is now validated **before** the file is created. The open paths build the embedder afterwards as before — opening an existing DB creates no file, so there is no orphan risk there.

Only `batch-ingest` and `bootstrap` have a `--create` path; `consolidate`/`query` open existing DBs and were already safe.

## Tests

One regression test per command (`create_with_misconfigured_embedder_leaves_no_orphan_db`) asserting the DB file is absent after a misconfigured-embedder (`--embed-url` without `--embed-model`) failure.

## Provenance

Surfaced by agy during the #619 super-review (rated LOW/acceptable at the time); filed as collateral #681 per the repo's collateral-issue contract.

## Gate

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (1341 passed, 9 ignored)
- `cargo clippy --workspace --all-targets` ✅ clean
- `cargo fmt --check` ✅
- `cargo deny check` ✅ (advisories/bans/licenses/sources ok)

Closes #681.
