### PR TITLE
test(cli): db/embedding inline + outcome/dump/inspect/explain coverage (#303, #304, #428, #429, #271)

### DIFF
--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -150,3 +150,91 @@ pub fn open_engine_writable_with_dim(
     let engine = builder.build()?;
     Ok(engine)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+    use tempfile::TempDir;
+
+    use super::{peek_embed_dim_from_db, peek_schema_version_from_db};
+
+    // --- peek_embed_dim_from_db ---
+
+    #[test]
+    fn peek_embed_dim_from_db_nonexistent_path_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("missing.db");
+        let err = peek_embed_dim_from_db(&missing).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not found") || msg.contains("directory"),
+            "expected 'not found' or 'directory' in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn peek_embed_dim_from_db_non_sqlite_file_returns_error() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(b"this is not a sqlite database\n").unwrap();
+        // Either fails because it's not a valid SQLite file or has no config table.
+        let result = peek_embed_dim_from_db(tmp.path());
+        assert!(result.is_err(), "expected Err for non-SQLite file");
+    }
+
+    #[test]
+    fn peek_embed_dim_from_db_fresh_engine_no_embedding_returns_error() {
+        // A freshly created engine with no facts yet has no embedding_meta.
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("fresh.db");
+        let engine = memory_engine::MemoryEngine::builder(4)
+            .path(db_path.clone())
+            .build()
+            .unwrap();
+        drop(engine);
+
+        let err = peek_embed_dim_from_db(&db_path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no embedding identity") || msg.contains("embed_dim"),
+            "expected 'no embedding identity' or 'embed_dim' in error, got: {msg}"
+        );
+    }
+
+    // --- peek_schema_version_from_db ---
+
+    #[test]
+    fn peek_schema_version_from_db_nonexistent_path_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("missing.db");
+        let err = peek_schema_version_from_db(&missing).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not found") || msg.contains("directory"),
+            "expected 'not found' or 'directory' in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn peek_schema_version_from_db_non_sqlite_file_returns_error() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(b"not a real database\n").unwrap();
+        let result = peek_schema_version_from_db(tmp.path());
+        assert!(result.is_err(), "expected Err for non-SQLite file");
+    }
+
+    #[test]
+    fn peek_schema_version_from_db_valid_engine_returns_current_version() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let engine = memory_engine::MemoryEngine::builder(4)
+            .path(db_path.clone())
+            .build()
+            .unwrap();
+        drop(engine);
+
+        let version = peek_schema_version_from_db(&db_path).unwrap();
+        assert_eq!(version, memory_engine::CURRENT_SCHEMA_VERSION);
+    }
+}

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -153,9 +153,6 @@ pub fn open_engine_writable_with_dim(
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
-    use tempfile::NamedTempFile;
     use tempfile::TempDir;
 
     use super::{peek_embed_dim_from_db, peek_schema_version_from_db};
@@ -176,11 +173,14 @@ mod tests {
 
     #[test]
     fn peek_embed_dim_from_db_non_sqlite_file_returns_error() {
-        let mut tmp = NamedTempFile::new().unwrap();
-        tmp.write_all(b"this is not a sqlite database\n").unwrap();
+        // `std::fs::write` closes the file handle before SQLite opens the path,
+        // avoiding file-locking conflicts on Windows (per gemini review).
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("garbage.db");
+        std::fs::write(&path, b"this is not a sqlite database\n").unwrap();
         // A non-SQLite file opens lazily, then the config-table query fails with
         // the rusqlite "not a database" error — pin that, not just any Err.
-        let err = peek_embed_dim_from_db(tmp.path()).unwrap_err();
+        let err = peek_embed_dim_from_db(&path).unwrap_err();
         assert!(
             err.to_string().contains("not a database"),
             "expected 'not a database', got: {err}"
@@ -222,10 +222,11 @@ mod tests {
 
     #[test]
     fn peek_schema_version_from_db_non_sqlite_file_returns_error() {
-        let mut tmp = NamedTempFile::new().unwrap();
-        tmp.write_all(b"not a real database\n").unwrap();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("garbage.db");
+        std::fs::write(&path, b"not a real database\n").unwrap();
         // Wrapped as "… is this a memory-engine database? (… not a database …)".
-        let err = peek_schema_version_from_db(tmp.path()).unwrap_err();
+        let err = peek_schema_version_from_db(&path).unwrap_err();
         assert!(
             err.to_string().contains("not a database"),
             "expected 'not a database', got: {err}"

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -178,9 +178,13 @@ mod tests {
     fn peek_embed_dim_from_db_non_sqlite_file_returns_error() {
         let mut tmp = NamedTempFile::new().unwrap();
         tmp.write_all(b"this is not a sqlite database\n").unwrap();
-        // Either fails because it's not a valid SQLite file or has no config table.
-        let result = peek_embed_dim_from_db(tmp.path());
-        assert!(result.is_err(), "expected Err for non-SQLite file");
+        // A non-SQLite file opens lazily, then the config-table query fails with
+        // the rusqlite "not a database" error — pin that, not just any Err.
+        let err = peek_embed_dim_from_db(tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("not a database"),
+            "expected 'not a database', got: {err}"
+        );
     }
 
     #[test]
@@ -220,8 +224,12 @@ mod tests {
     fn peek_schema_version_from_db_non_sqlite_file_returns_error() {
         let mut tmp = NamedTempFile::new().unwrap();
         tmp.write_all(b"not a real database\n").unwrap();
-        let result = peek_schema_version_from_db(tmp.path());
-        assert!(result.is_err(), "expected Err for non-SQLite file");
+        // Wrapped as "… is this a memory-engine database? (… not a database …)".
+        let err = peek_schema_version_from_db(tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("not a database"),
+            "expected 'not a database', got: {err}"
+        );
     }
 
     #[test]

--- a/memory-engine-cli/src/embedding.rs
+++ b/memory-engine-cli/src/embedding.rs
@@ -34,3 +34,80 @@ impl EmbeddingProvider for PassthroughEmbedder {
         EmbeddingFingerprint::new("precomputed", "passthrough", self.embedding.len())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use memory_engine::traits::EmbeddingProvider;
+
+    use super::PassthroughEmbedder;
+
+    fn make_embedder() -> PassthroughEmbedder {
+        PassthroughEmbedder::new(vec![1.0, 2.0, 3.0, 4.0])
+    }
+
+    // --- embed ---
+
+    #[test]
+    fn embed_returns_stored_embedding() {
+        let emb = make_embedder();
+        let result = emb.embed("any text").unwrap();
+        assert_eq!(result, vec![1.0_f32, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn embed_ignores_input_text() {
+        let emb = make_embedder();
+        assert_eq!(emb.embed("hello").unwrap(), emb.embed("world").unwrap());
+    }
+
+    // --- embed_batch ---
+
+    #[test]
+    fn embed_batch_with_one_text_succeeds() {
+        let emb = make_embedder();
+        let result = emb.embed_batch(&["hello"]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], vec![1.0_f32, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn embed_batch_with_zero_texts_returns_error() {
+        let emb = make_embedder();
+        let err = emb.embed_batch(&[]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains('0'),
+            "error message should mention count 0, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn embed_batch_with_two_texts_returns_error() {
+        let emb = make_embedder();
+        let err = emb.embed_batch(&["a", "b"]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains('2'),
+            "error message should mention count 2, got: {msg}"
+        );
+    }
+
+    // --- fingerprint ---
+
+    #[test]
+    fn fingerprint_dim_matches_embedding_length() {
+        let embedding = vec![0.1_f32, 0.2, 0.3];
+        let emb = PassthroughEmbedder::new(embedding.clone());
+        let fp = emb.fingerprint();
+        assert_eq!(fp.dim, embedding.len());
+    }
+
+    #[test]
+    fn fingerprint_reports_precomputed_model_and_passthrough_provider() {
+        let emb = make_embedder();
+        let fp = emb.fingerprint();
+        // new("precomputed", "passthrough", dim): first arg is model, second is provider.
+        assert_eq!(fp.model, "precomputed");
+        assert_eq!(fp.provider, "passthrough");
+    }
+}

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -806,14 +806,18 @@ fn record_outcome_nonexistent_fact_fails() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error"));
+        // MemoryError::NotFound renders as "not found: fact 9999" — pin the
+        // failure cause, not just any line containing "error".
+        .stderr(predicate::str::contains("not found"));
 }
 
 #[test]
-fn outcome_counts_json_format_contains_positive_field() {
+fn outcome_counts_json_reflects_recorded_positive() {
     let (_dir, db_path) = create_test_db();
     let db = db_path.to_str().unwrap();
-    // Record one outcome so the counts query has something to inspect.
+    // Record a *positive* outcome so the asserted value ties to the recorded
+    // signal (the `positive` key is emitted unconditionally; asserting the value
+    // proves record-outcome actually incremented it).
     cli()
         .args([
             "--db",
@@ -822,7 +826,7 @@ fn outcome_counts_json_format_contains_positive_field() {
             "--fact-id",
             "2",
             "--outcome",
-            "neutral",
+            "positive",
         ])
         .assert()
         .success();
@@ -838,7 +842,7 @@ fn outcome_counts_json_format_contains_positive_field() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("\"positive\""));
+        .stdout(predicate::str::contains("\"positive\": 1"));
 }
 
 // --- dump all + dump JSON (#428) ---

--- a/memory-engine-cli/tests/cli_integration.rs
+++ b/memory-engine-cli/tests/cli_integration.rs
@@ -755,3 +755,200 @@ fn import_rejects_existing_db() {
         .failure()
         .stderr(predicate::str::contains("already exists"));
 }
+
+// --- record-outcome + outcome-counts (#304) ---
+
+#[test]
+fn record_outcome_positive_then_outcome_counts_shows_plus1() {
+    let (_dir, db_path) = create_test_db();
+    let db = db_path.to_str().unwrap();
+    // Record a positive outcome for fact 1.
+    cli()
+        .args([
+            "--db",
+            db,
+            "record-outcome",
+            "--fact-id",
+            "1",
+            "--outcome",
+            "positive",
+        ])
+        .assert()
+        .success();
+    // Plain format: "+P -N ~Z"
+    cli()
+        .args([
+            "--db",
+            db,
+            "--format",
+            "plain",
+            "outcome-counts",
+            "--fact-id",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("+1"));
+}
+
+#[test]
+fn record_outcome_nonexistent_fact_fails() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "record-outcome",
+            "--fact-id",
+            "9999",
+            "--outcome",
+            "positive",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn outcome_counts_json_format_contains_positive_field() {
+    let (_dir, db_path) = create_test_db();
+    let db = db_path.to_str().unwrap();
+    // Record one outcome so the counts query has something to inspect.
+    cli()
+        .args([
+            "--db",
+            db,
+            "record-outcome",
+            "--fact-id",
+            "2",
+            "--outcome",
+            "neutral",
+        ])
+        .assert()
+        .success();
+    cli()
+        .args([
+            "--db",
+            db,
+            "--format",
+            "json",
+            "outcome-counts",
+            "--fact-id",
+            "2",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"positive\""));
+}
+
+// --- dump all + dump JSON (#428) ---
+
+#[test]
+fn dump_all_json_contains_facts_and_events_keys() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "dump",
+            "all",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"facts\""))
+        .stdout(predicate::str::contains("\"events\""));
+}
+
+#[test]
+fn dump_facts_json_contains_fact_content() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "dump",
+            "facts",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sky is blue"));
+}
+
+// --- inspect JSON and plain formats (#429) ---
+
+#[test]
+fn inspect_json_format_contains_id_field() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "inspect",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"id\""));
+}
+
+#[test]
+fn inspect_plain_format_emits_content() {
+    let (_dir, db_path) = create_test_db();
+    // Plain format for inspect prints the fact content string.
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "plain",
+            "inspect",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("The sky is blue"));
+}
+
+// --- explain JSON and plain formats (#429) ---
+
+#[test]
+fn explain_json_format_contains_fact_id_field() {
+    let (_dir, db_path) = create_test_db();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "json",
+            "explain",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"fact_id\""));
+}
+
+#[test]
+fn explain_plain_format_emits_state_and_scope() {
+    let (_dir, db_path) = create_test_db();
+    // Plain format for explain prints "state: ..." and "scope: ...".
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--format",
+            "plain",
+            "explain",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("state:"))
+        .stdout(predicate::str::contains("scope:"));
+}


### PR DESCRIPTION
Wave 4 of the #251 area:cli super-qa sweep. **Test coverage only — zero production-code change** (362 insertions, 0 deletions; verified the diff touches only `#[cfg(test)]` mods + `tests/`).

## Inline unit tests
- **embedding.rs** — `PassthroughEmbedder`: `embed`, `embed_batch` (0/1/2-text paths — it errors unless exactly one text), `fingerprint` dim. (#303, plus the passthrough-zero-texts item of #493.)
- **db.rs** — `peek_embed_dim_from_db` / `peek_schema_version_from_db` error paths (missing file, non-sqlite bytes, no-embedding-identity) + a valid-DB schema-version read. (#303)

## Integration tests (cli_integration.rs)
- **record-outcome + outcome-counts** (#304): record → counts plain `+1`, nonexistent-fact failure, outcome-counts JSON.
- **dump** (#428): `dump all --format json` (facts + events keys), `dump facts --format json`.
- **inspect / explain** (#429): JSON + plain output formats.

## #271 (inline-test umbrella) — also closed
db.rs + embedding.rs now have inline tests; add_fact.rs's metadata-rejection branches are already covered by `tests/add_fact.rs::add_fact_metadata_non_object`; query.rs's former stringly-typed bail path was removed by #270. All formerly-untested paths are now exercised.

## Verification (exact CI commands)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean ✓
- `cargo test --workspace --all-features` — all green (37 suites) ✓
- `cargo deny check` — advisories ok ✓
- `cargo fmt --check` ✓

Closes #303.
Closes #304.
Closes #428.
Closes #429.
Closes #271.