### PR TITLE
refactor(consolidation): load active facts once; cluster borrows survivors (#389, #679)

### DIFF
--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -2,7 +2,6 @@ use rusqlite::Connection;
 
 use crate::error::Result;
 use crate::search::vector::cosine_similarity;
-use crate::store::facts::FactStore;
 use crate::store::summaries::SummaryStore;
 use crate::traits::{EmbeddingProvider, SummarizableContent, SummaryGenerator};
 use crate::types::{ConsolidationLevel, Fact, NewSummary};
@@ -28,22 +27,20 @@ use crate::types::{ConsolidationLevel, Fact, NewSummary};
 /// Returns `MemoryError::Serialization` on JSON serialization failure.
 pub fn cluster_fusion(
     conn: &Connection,
+    facts: &[&Fact],
     generator: &dyn SummaryGenerator,
     embedder: &dyn EmbeddingProvider,
     embed_dim: usize,
     min_cluster_size: usize,
     cluster_threshold: f32,
 ) -> Result<usize> {
-    // Safety cap lifted to the shared `super::MAX_FACTS_FOR_CLUSTERING` (#345) so
-    // the dedup and cluster caps live in one place with their divergent skip
-    // policies documented side by side. Checked BEFORE deleting existing summaries
-    // to avoid wiping them without producing replacements.
-    let fact_store = FactStore::new(conn, embed_dim);
-    let active_facts = fact_store.list_active(None)?;
-
-    if active_facts.len() > super::MAX_FACTS_FOR_CLUSTERING {
+    // `facts` is the post-dedup active set, loaded once by the caller and shared
+    // with the dedup pass (#389). Safety cap (`super::MAX_FACTS_FOR_CLUSTERING`,
+    // #345) checked BEFORE deleting existing summaries so we never wipe them
+    // without producing replacements.
+    if facts.len() > super::MAX_FACTS_FOR_CLUSTERING {
         tracing::warn!(
-            count = active_facts.len(),
+            count = facts.len(),
             max = super::MAX_FACTS_FOR_CLUSTERING,
             "clustering skipped: too many active facts for O(N^2) comparison"
         );
@@ -56,7 +53,7 @@ pub fn cluster_fusion(
     summary_store.delete_by_level(&ConsolidationLevel::Cluster)?;
 
     // Greedy single-linkage clustering
-    let clusters = greedy_cluster(&active_facts, cluster_threshold);
+    let clusters = greedy_cluster(facts, cluster_threshold);
 
     let mut clusters_created = 0;
     for cluster in &clusters {
@@ -64,15 +61,13 @@ pub fn cluster_fusion(
             continue;
         }
 
-        let cluster_facts: Vec<Fact> = cluster
-            .iter()
-            .map(|&idx| active_facts[idx].clone())
-            .collect();
-        let source_ids: Vec<i64> = cluster_facts.iter().map(|f| f.id).collect();
+        // #679: index directly into the borrowed `facts` — no per-member `Fact`
+        // clone (the cluster pass previously cloned every member into a `Vec<Fact>`).
+        let source_ids: Vec<i64> = cluster.iter().map(|&idx| facts[idx].id).collect();
 
-        let items: Vec<SummarizableContent<'_>> = cluster_facts
+        let items: Vec<SummarizableContent<'_>> = cluster
             .iter()
-            .map(|f| SummarizableContent::new(&f.content, &f.embedding))
+            .map(|&idx| SummarizableContent::new(&facts[idx].content, &facts[idx].embedding))
             .collect();
         let (summary_text, summary_embedding) =
             super::summarize_and_embed(generator, embedder, &items, embed_dim)?;
@@ -82,8 +77,8 @@ pub fn cluster_fusion(
         let scope_id = {
             let mut scope_counts: std::collections::HashMap<i64, usize> =
                 std::collections::HashMap::new();
-            for fact in &cluster_facts {
-                *scope_counts.entry(fact.scope_id).or_default() += 1;
+            for &idx in cluster {
+                *scope_counts.entry(facts[idx].scope_id).or_default() += 1;
             }
             scope_counts
                 .into_iter()
@@ -110,7 +105,7 @@ pub fn cluster_fusion(
 ///
 /// For each unassigned fact, find all facts with cosine similarity > threshold.
 /// Group them into a cluster.
-fn greedy_cluster(facts: &[Fact], threshold: f32) -> Vec<Vec<usize>> {
+fn greedy_cluster(facts: &[&Fact], threshold: f32) -> Vec<Vec<usize>> {
     let n = facts.len();
     let mut assigned = vec![false; n];
     let mut clusters = Vec::new();
@@ -151,8 +146,32 @@ mod tests {
     use super::*;
     use chrono::Utc;
 
+    use crate::store::facts::FactStore;
     use crate::store::schema::{init_schema, open_memory};
     use crate::types::{FactType, NewFact};
+
+    /// Load the active facts and run `cluster_fusion` over borrowed references —
+    /// the orchestrator now owns the single load (#389), so tests mirror that here.
+    fn cluster(
+        conn: &Connection,
+        generator: &dyn SummaryGenerator,
+        embedder: &dyn EmbeddingProvider,
+        dim: usize,
+        min_cluster_size: usize,
+        cluster_threshold: f32,
+    ) -> Result<usize> {
+        let active = FactStore::new(conn, dim).list_active(None)?;
+        let refs: Vec<&Fact> = active.iter().collect();
+        cluster_fusion(
+            conn,
+            &refs,
+            generator,
+            embedder,
+            dim,
+            min_cluster_size,
+            cluster_threshold,
+        )
+    }
 
     /// Mock generator that concatenates fact contents.
     struct MockGenerator;
@@ -219,7 +238,7 @@ mod tests {
 
         let mock_gen = MockGenerator;
         let mock_embed = MockEmbedder { embed_dim: dim };
-        let clusters = cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 3, 0.85).unwrap();
+        let clusters = cluster(&conn, &mock_gen, &mock_embed, dim, 3, 0.85).unwrap();
         assert_eq!(clusters, 2);
 
         let summaries = SummaryStore::new(&conn, dim)
@@ -240,7 +259,7 @@ mod tests {
 
         let mock_gen = MockGenerator;
         let mock_embed = MockEmbedder { embed_dim: dim };
-        let clusters = cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 3, 0.85).unwrap();
+        let clusters = cluster(&conn, &mock_gen, &mock_embed, dim, 3, 0.85).unwrap();
         assert_eq!(clusters, 0);
     }
 
@@ -256,7 +275,7 @@ mod tests {
 
         let mock_gen = MockGenerator;
         let mock_embed = MockEmbedder { embed_dim: dim };
-        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
+        cluster(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
 
         let summaries = SummaryStore::new(&conn, dim)
             .list_by_level(&ConsolidationLevel::Cluster)
@@ -280,8 +299,8 @@ mod tests {
         let mock_embed = MockEmbedder { embed_dim: dim };
 
         // Run twice — should have exactly the same result
-        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
-        cluster_fusion(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
+        cluster(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
+        cluster(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
 
         let summaries = SummaryStore::new(&conn, dim)
             .list_by_level(&ConsolidationLevel::Cluster)
@@ -305,7 +324,7 @@ mod tests {
         init_schema(&loose).unwrap();
         insert_fact(&loose, dim, "a", a.clone());
         insert_fact(&loose, dim, "b", b.clone());
-        let made = cluster_fusion(
+        let made = cluster(
             &loose,
             &MockGenerator,
             &MockEmbedder { embed_dim: dim },
@@ -321,7 +340,7 @@ mod tests {
         init_schema(&strict).unwrap();
         insert_fact(&strict, dim, "a", a);
         insert_fact(&strict, dim, "b", b);
-        let made = cluster_fusion(
+        let made = cluster(
             &strict,
             &MockGenerator,
             &MockEmbedder { embed_dim: dim },

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -56,7 +56,11 @@ pub enum DedupOutcome {
 /// fact. Deterministic tie-break: on equal importance, the newer fact (higher id) is
 /// expired. A `threshold` of 1.0 therefore merges only exact duplicates.
 ///
-/// When the active corpus exceeds `max_facts` the O(N*M) pairwise comparison is
+/// `active_facts` is the current active set, loaded once by the caller and shared
+/// with the cluster pass (#389) — `local_dedup` reads it for comparison and writes
+/// expirations through `conn`, but does not re-query the store.
+///
+/// When `active_facts.len()` exceeds `max_facts` the O(N*M) pairwise comparison is
 /// skipped and [`DedupOutcome::Skipped`] is returned (the orchestrator then leaves
 /// the watermark unadvanced); otherwise [`DedupOutcome::Ran`] carries the removed
 /// count and the expired ids. The cap is injected so callers own the policy and
@@ -69,6 +73,7 @@ pub enum DedupOutcome {
 pub fn local_dedup(
     conn: &Connection,
     embed_dim: usize,
+    active_facts: &[Fact],
     threshold: f32,
     max_facts: usize,
     since: Option<DateTime<Utc>>,
@@ -76,7 +81,6 @@ pub fn local_dedup(
 ) -> Result<DedupOutcome> {
     let fact_store = FactStore::new(conn, embed_dim);
     let edge_store = EdgeStore::new(conn);
-    let active_facts = fact_store.list_active(None)?;
 
     if active_facts.len() > max_facts {
         tracing::warn!(
@@ -115,7 +119,7 @@ pub fn local_dedup(
             continue; // pinned facts are never dedup candidates
         }
 
-        for candidate in &active_facts {
+        for candidate in active_facts {
             if candidate.id == new_fact.id
                 || expired_ids.contains(&candidate.id)
                 || candidate.is_pinned
@@ -261,6 +265,20 @@ mod tests {
         (conn, 4)
     }
 
+    /// Load the active facts and run `local_dedup` over them — the orchestrator now
+    /// owns the single load (#389), so tests mirror that here.
+    fn dedup(
+        conn: &Connection,
+        dim: usize,
+        threshold: f32,
+        max_facts: usize,
+        since: Option<DateTime<Utc>>,
+        now: DateTime<Utc>,
+    ) -> Result<DedupOutcome> {
+        let active = FactStore::new(conn, dim).list_active(None)?;
+        local_dedup(conn, dim, &active, threshold, max_facts, since, now)
+    }
+
     fn insert_fact(
         conn: &Connection,
         embed_dim: usize,
@@ -297,7 +315,7 @@ mod tests {
         insert_fact(&conn, dim, "fact A", vec![1.0, 0.0, 0.0, 0.0], 0.5);
         insert_fact(&conn, dim, "fact B", vec![0.99, 0.01, 0.0, 0.0], 0.3);
 
-        let (removed, _) = local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 1);
@@ -326,7 +344,7 @@ mod tests {
         insert_fact(&conn, dim, "identical A", emb.clone(), 0.7);
         insert_fact(&conn, dim, "identical B", emb, 0.3);
 
-        let (removed, _) = local_dedup(&conn, dim, 1.0, NO_CAP, None, Utc::now())
+        let (removed, _) = dedup(&conn, dim, 1.0, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 1, "threshold 1.0 must dedup exact duplicates");
@@ -345,7 +363,7 @@ mod tests {
         insert_fact(&conn, dim, "fact X", vec![1.0, 0.0, 0.0, 0.0], 0.5);
         insert_fact(&conn, dim, "fact Y", vec![0.0, 1.0, 0.0, 0.0], 0.5);
 
-        let (removed, _) = local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 0);
@@ -404,7 +422,7 @@ mod tests {
 
         // Only compare facts created since `old_time + 1 day`
         let since = old_time + Duration::days(1);
-        let (removed, _) = local_dedup(&conn, dim, 0.90, NO_CAP, Some(since), Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, Some(since), Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 1); // new duplicate should be expired against old
@@ -426,7 +444,7 @@ mod tests {
             0.8,
         );
 
-        local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
 
@@ -443,7 +461,7 @@ mod tests {
         insert_fact(&conn, dim, "older fact", vec![1.0, 0.0, 0.0, 0.0], 0.5);
         insert_fact(&conn, dim, "newer fact", vec![0.99, 0.01, 0.0, 0.0], 0.5);
 
-        local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
 
@@ -504,7 +522,7 @@ mod tests {
             false,
         );
 
-        let (removed, _) = local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
         // Neither should be deduped because one is pinned
@@ -528,7 +546,7 @@ mod tests {
             true,
         );
 
-        let (removed, _) = local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 0);
@@ -549,7 +567,7 @@ mod tests {
         store.update_importance_score(1, 0.8).unwrap(); // low imp fact gets higher score
         store.update_importance_score(2, 0.4).unwrap(); // high imp fact gets lower score
 
-        local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
 
@@ -592,7 +610,7 @@ mod tests {
         store.update_importance_score(b, 0.8).unwrap(); // the true maximum
         store.update_importance_score(c, 0.5).unwrap();
 
-        let (removed, _) = local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 2, "B and C both collapse onto A");
@@ -635,7 +653,7 @@ mod tests {
         store.update_importance_score(b, 0.1).unwrap();
         store.update_importance_score(a, 0.1).unwrap();
 
-        let (removed, _) = local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 2, "L collapses onto B, then B onto A");
@@ -655,7 +673,7 @@ mod tests {
     fn empty_db_dedup_is_noop() {
         let (conn, dim) = setup();
         // No facts in the DB — dedup must return (0, []) without error.
-        let (removed, expired) = local_dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+        let (removed, expired) = dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 0);
@@ -677,7 +695,7 @@ mod tests {
         insert_fact(&conn, dim, "dup B", vec![0.99, 0.01, 0.0, 0.0], 0.5);
 
         // ...but a cap of 1 (corpus is 2) trips the safety skip.
-        let outcome = local_dedup(&conn, dim, 0.90, 1, None, Utc::now()).unwrap();
+        let outcome = dedup(&conn, dim, 0.90, 1, None, Utc::now()).unwrap();
         assert_eq!(
             outcome,
             DedupOutcome::Skipped { active_count: 2 },
@@ -698,7 +716,7 @@ mod tests {
         insert_fact(&conn, dim, "dup B", vec![0.99, 0.01, 0.0, 0.0], 0.5);
 
         // corpus len == cap (2 == 2): NOT over cap → runs and collapses the pair.
-        let (removed, _) = local_dedup(&conn, dim, 0.90, 2, None, Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, 2, None, Utc::now())
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 1, "a corpus exactly at the cap must run, not skip");

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -166,6 +166,12 @@ fn consolidate_with_caps(
     // dedup just expired (no re-query, borrowed so no clone — #679/#389). On the
     // dedup-skip path `expired_ids` is empty, so this is the full loaded set, which
     // `cluster_fusion`'s own cap then skips (the two caps are equal).
+    //
+    // These survivors carry the PRE-dedup `importance`/`importance_score` — dedup
+    // mutates those columns in the DB but not the in-memory `Fact`s. Inert today:
+    // `cluster_fusion` reads only `id`/`content`/`embedding`/`scope_id`. A future
+    // cluster pass that reads importance would need a re-read (or #264's running-max
+    // treatment) here.
     let expired_set: std::collections::HashSet<i64> = expired_ids.iter().copied().collect();
     let survivors: Vec<&Fact> = active_facts
         .iter()

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -19,6 +19,7 @@ use crate::traits::{
     ConsolidationConfig, ConsolidationStats, EmbeddingProvider, SummarizableContent,
     SummaryGenerator,
 };
+use crate::types::Fact;
 
 /// Safety cap for the O(N·M) [`local_dedup`] pass. Beyond this many active facts
 /// the pass is **skipped and the consolidation watermark is NOT advanced**, so the
@@ -136,6 +137,11 @@ fn consolidate_with_caps(
 
     let tx = conn.unchecked_transaction()?;
 
+    // #389: load the active set ONCE and share it across the dedup and cluster
+    // passes, instead of each pass re-querying the store (and re-deserializing
+    // every embedding BLOB — ~147 MB for 50k×768-dim, previously paid twice).
+    let active_facts = crate::store::facts::FactStore::new(&tx, embed_dim).list_active(None)?;
+
     // The dedup-skip state is carried in the return type ([`DedupOutcome`]), not an
     // in-band `usize::MAX` sentinel (#272). A `Skipped` pass contributes no
     // removals and leaves the watermark unadvanced so the over-cap facts are
@@ -143,6 +149,7 @@ fn consolidate_with_caps(
     let (duplicates_removed, expired_ids, dedup_skipped) = match local_dedup(
         &tx,
         embed_dim,
+        &active_facts,
         config.dedup_threshold,
         max_dedup_facts,
         last,
@@ -155,8 +162,19 @@ fn consolidate_with_caps(
         DedupOutcome::Skipped { .. } => (0, Vec::new(), true),
     };
 
+    // Cluster operates on the post-dedup survivors: the loaded facts minus the ones
+    // dedup just expired (no re-query, borrowed so no clone — #679/#389). On the
+    // dedup-skip path `expired_ids` is empty, so this is the full loaded set, which
+    // `cluster_fusion`'s own cap then skips (the two caps are equal).
+    let expired_set: std::collections::HashSet<i64> = expired_ids.iter().copied().collect();
+    let survivors: Vec<&Fact> = active_facts
+        .iter()
+        .filter(|f| !expired_set.contains(&f.id))
+        .collect();
+
     let clusters_created = cluster_fusion(
         &tx,
+        &survivors,
         generator,
         embedder,
         embed_dim,


### PR DESCRIPTION
## What

Wave 5a of the **#253 consolidation sweep** — the contained load-pattern half (the engine lock-free restructure for #409 follows as Wave 5b).

## Changes

- **#389** — dedup and cluster each independently called `list_active(None)`, re-deserializing every embedding BLOB (~147 MB at 50k×768-dim, **twice** per run). Now the orchestrator loads the active set **once** and threads it through both passes: `local_dedup(&[Fact])` and `cluster_fusion(&[&Fact])` take borrowed facts instead of re-querying.
- Cluster runs over the **post-dedup survivors** (loaded set minus dedup's expirations), built as `Vec<&Fact>`. On the dedup-skip path the survivor set is the full load, which `cluster_fusion`'s own (equal) cap then skips — behavior-preserving.
- **#679** — `greedy_cluster` and the cluster build path index directly into the borrowed slice, removing the per-member `Fact` clone the cluster pass previously did.

## Not in this PR

#409 (run consumer summarize/embed **lock-free**) is an engine-level restructure (the `write_conn()` Mutex guard is held across `consolidate()`); it's Wave 5b, with #659 (count-before-load) folded into its read phase.

## Verification

Behavior-preserving (same expirations, clusters, summaries, watermark). `cargo test --workspace --all-features` 37 binaries pass; `clippy -D warnings` + `fmt` + `cargo deny` clean.

Closes #389. Closes #679. Part of #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)