### PR TITLE
docs(storage): align SchemaManager error menu + document both-direction in-memory pool deadlock (#683, #688)

### DIFF
--- a/src/pool/connection_pool.rs
+++ b/src/pool/connection_pool.rs
@@ -548,12 +548,19 @@ impl ConnectionPool {
     ///
     /// # In-memory reentrancy hazard (#278)
     ///
-    /// In in-memory mode [`read`](Self::read) locks this same connection. The
-    /// `parking_lot::Mutex` is **non-reentrant**, so a thread that holds the
-    /// guard returned here MUST NOT call `read()` on the same thread — doing so
-    /// self-deadlocks (in release it hangs forever; in debug a reentrancy
-    /// assertion fires). File-backed pools are unaffected (reads come from a
-    /// separate pool).
+    /// In in-memory mode [`read`](Self::read) locks this **same** connection —
+    /// the [`SerializedReadGuard`] it returns holds `write_conn`'s lock to
+    /// serialize reads. The `parking_lot::Mutex` is **non-reentrant**, so the
+    /// hazard runs in *both* directions on one thread, and both self-deadlock
+    /// (release: hangs forever; debug: the shared reentrancy marker fires):
+    /// - holding the guard returned here, then calling `read()`; and
+    /// - holding an in-memory `read()` guard, then calling `write()` or
+    ///   [`try_write`](Self::try_write) — the re-lock blocks on `write_conn`
+    ///   (the `try` in `try_write` is the `read_only` check, *not* a `try_lock`,
+    ///   so it blocks rather than failing fast).
+    ///
+    /// Drop every guard locking `write_conn` before re-entering on either side.
+    /// File-backed pools are unaffected (reads come from a separate pool).
     pub(crate) fn write(&self) -> WriteGuard<'_> {
         #[cfg(debug_assertions)]
         assert_not_reentrant(std::ptr::from_ref::<Self>(self) as usize);
@@ -564,9 +571,13 @@ impl ConnectionPool {
     ///
     /// Returns `MemoryError::ReadOnly` if the pool was opened read-only.
     ///
-    /// The same in-memory reentrancy hazard as [`write`](Self::write) applies:
-    /// never call [`read`](Self::read) on the same thread while holding the
-    /// returned guard on an in-memory pool.
+    /// The same in-memory reentrancy hazard as [`write`](Self::write) applies in
+    /// both directions: never call [`read`](Self::read) while holding the guard
+    /// returned here, and never call `try_write()` while already holding an
+    /// in-memory [`read`](Self::read) guard. Either re-locks the non-reentrant
+    /// `write_conn` `Mutex` on the same thread and self-deadlocks — `try_write`
+    /// blocks on `write_conn.lock()` (the `try` only gates `read_only`), it does
+    /// not fail fast. File-backed pools are immune.
     pub fn try_write(&self) -> Result<WriteGuard<'_>> {
         if self.read_only {
             return Err(MemoryError::ReadOnly);

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -22,9 +22,13 @@ use crate::types::EmbeddingFingerprint;
 /// # Errors
 /// Async methods return [`MemoryError::Storage`](crate::error::MemoryError::Storage)
 /// on a backend failure, or [`MemoryError::Migration`](crate::error::MemoryError::Migration)
-/// for a migration/compatibility failure, or
-/// [`MemoryError::EmbeddingDimension`](crate::error::MemoryError::EmbeddingDimension)
-/// from the fingerprint guard.
+/// for a migration/compatibility failure. The fingerprint methods add two:
+/// [`record_embedding_fingerprint_if_absent`](Self::record_embedding_fingerprint_if_absent)
+/// returns [`MemoryError::EmbeddingDimension`](crate::error::MemoryError::EmbeddingDimension)
+/// when `candidate.dim` disagrees with the recorded (or expected) identity, and
+/// [`require_embedding_fingerprint_present`](Self::require_embedding_fingerprint_present)
+/// returns [`MemoryError::Internal`](crate::error::MemoryError::Internal) when no
+/// fingerprint has been recorded yet (the open-time identity guard).
 #[async_trait]
 pub trait SchemaManager: Send + Sync {
     /// Run all pending migrations to the current schema version. Idempotent at HEAD.


### PR DESCRIPTION
Two rustdoc-contract fixes surfaced during #630 (PR #682). Both pure docs, no code change, no behavior change.

## #683 — `SchemaManager` error menu omits `Internal`
The trait's `# Errors` section listed `EmbeddingDimension` for "the fingerprint guard" but omitted `MemoryError::Internal` — what `require_embedding_fingerprint_present` actually returns when no fingerprint is recorded (via `store::embedding_meta::require_present`, `src/store/embedding_meta.rs:166`). `SqliteBackend` preserves `Internal` verbatim, so the trait doc undersold the real error menu.

**Fix:** attribute each fingerprint method to its own error —
- `record_embedding_fingerprint_if_absent` → `EmbeddingDimension` (dim disagreement)
- `require_embedding_fingerprint_present` → `Internal` (identity-absent, open-time guard)

## #688 — in-memory `ConnectionPool` deadlock documented only one direction
`read`, `write`, and `try_write` all documented the in-memory reentrancy hazard (#278) — but only the *read-while-holding-a-write-guard* direction. The **reverse** also self-deadlocks: holding an in-memory `read()` guard (a `SerializedReadGuard` that itself holds `write_conn`'s lock), then calling `write()`/`try_write()`, blocks forever on `write_conn.lock()`. The `try` in `try_write` gates only `read_only` (`src/pool/connection_pool.rs:571`) — it is **not** a `try_lock`, so it blocks rather than failing fast.

**Fix:** made the `write` hazard section bidirectional and called the direction out explicitly on `try_write`. No #630 call site hits either path.

## Verification
- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets` ✓ (no issues — full compile)
- `cargo doc --no-deps -p memory-engine` ✓ (all added intra-doc links resolve)
- `cargo test --workspace --doc` ✓ (12 passed, 1 ignored)

Closes #683, #688. Part of #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)