### PR TITLE
test(cli): property-based parser fuzzing + #493 low/info rollup (#433, #493)

### DIFF
--- a/memory-engine-cli/Cargo.toml
+++ b/memory-engine-cli/Cargo.toml
@@ -24,6 +24,7 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+proptest = "1"
 tempfile = "3"
 wiremock = "0.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -846,4 +846,17 @@ not valid json
         let msg = format!("{}", result.unwrap_err());
         assert!(msg.contains("no facts ingested"), "got: {msg}");
     }
+
+    #[test]
+    fn ingest_from_reader_never_panics() {
+        // Fuzz the JSONL ingest path (#433): arbitrary attacker-controlled bytes
+        // (the --file trust boundary) must never panic or hang — only ever
+        // Ok(summary) or an Err (e.g. the all-bad-lines bail). The engine is built
+        // once and reused across cases; ingest_from_reader only appends, so cases
+        // don't interfere.
+        let engine = MemoryEngine::builder(4).build().unwrap();
+        proptest::proptest!(|(data in proptest::collection::vec(proptest::prelude::any::<u8>(), 0..4096))| {
+            let _ = ingest_from_reader(&engine, data.as_slice(), &CapEmbed, 8, None, OutputFormat::Json);
+        });
+    }
 }

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -849,13 +849,38 @@ not valid json
 
     #[test]
     fn ingest_from_reader_never_panics() {
-        // Fuzz the JSONL ingest path (#433): arbitrary attacker-controlled bytes
-        // (the --file trust boundary) must never panic or hang — only ever
-        // Ok(summary) or an Err (e.g. the all-bad-lines bail). The engine is built
-        // once and reused across cases; ingest_from_reader only appends, so cases
-        // don't interfere.
+        use proptest::prelude::*;
+
+        // Fuzz the JSONL ingest path (#433): the --file argument is the trust
+        // boundary, so no input may panic or hang — only ever Ok(summary) or an Err
+        // (e.g. the all-bad-lines bail). Two strategies are mixed so both the early
+        // parse-reject path AND the deeper machine are exercised:
+        //  - raw arbitrary bytes (mostly hit serde's parse error), and
+        //  - structurally-valid-ish JSONL documents (reach validate_jsonl_fact —
+        //    incl. importance out of [0,1] — jsonl_to_request, batching, and
+        //    flush_batch, since batch_size=8 forces mid-stream flushes).
+        let valid_line = (
+            "[a-z ]{0,40}",
+            prop_oneof!["episodic", "semantic", "procedural"],
+            proptest::option::of(-2.0f64..2.0),
+        )
+            .prop_map(|(content, ft, importance)| {
+                let mut obj = serde_json::json!({ "content": content, "fact_type": ft });
+                if let Some(i) = importance {
+                    obj["importance"] = serde_json::json!(i);
+                }
+                obj.to_string()
+            });
+        let jsonl_doc = proptest::collection::vec(prop_oneof![valid_line, "[^\n]{0,40}"], 0..16)
+            .prop_map(|lines| lines.join("\n").into_bytes());
+
+        // Built once and reused across cases; ingest_from_reader only appends, so
+        // cases cannot interfere.
         let engine = MemoryEngine::builder(4).build().unwrap();
-        proptest::proptest!(|(data in proptest::collection::vec(proptest::prelude::any::<u8>(), 0..4096))| {
+        proptest::proptest!(|(data in prop_oneof![
+            proptest::collection::vec(any::<u8>(), 0..4096),
+            jsonl_doc,
+        ])| {
             let _ = ingest_from_reader(&engine, data.as_slice(), &CapEmbed, 8, None, OutputFormat::Json);
         });
     }

--- a/memory-engine-cli/src/commands/embedding_args.rs
+++ b/memory-engine-cli/src/commands/embedding_args.rs
@@ -16,7 +16,10 @@ use memory_engine_embed::HttpEmbeddingProvider;
 /// `embed_url` + `embed_model` are optional at the clap layer (a query with neither is
 /// FTS-only); commands that require an embedder call [`build_required`](Self::build_required),
 /// which errors clearly when they are absent.
-#[derive(clap::Args, Clone, Debug)]
+// No `Debug` derive: this struct holds `embed_api_key` in cleartext, and a
+// derived `Debug` would print it under any `{:?}` / `tracing::debug!(?args)`.
+// (The built `HttpEmbeddingProvider` likewise has no `Debug`.)
+#[derive(clap::Args, Clone)]
 pub struct EmbeddingArgs {
     /// OpenAI-compatible embedding endpoint URL (e.g. `http://localhost:11434/v1/embeddings`).
     #[arg(long, env = "MEMORY_ENGINE_EMBED_URL")]

--- a/memory-engine-cli/src/commands/import.rs
+++ b/memory-engine-cli/src/commands/import.rs
@@ -257,4 +257,16 @@ mod tests {
         let dim = peek_embed_dim_from_reader(snapshot.as_bytes()).unwrap();
         assert_eq!(dim, 4);
     }
+
+    proptest::proptest! {
+        /// Fuzz the snapshot-header peek (#433): arbitrary attacker-controlled
+        /// bytes must never panic or hang — only ever Ok(dim) or a parse Err,
+        /// bounded by the MAX_HEADER_BYTES cap.
+        #[test]
+        fn peek_embed_dim_never_panics(
+            data in proptest::collection::vec(proptest::prelude::any::<u8>(), 0..4096)
+        ) {
+            let _ = peek_embed_dim_from_reader(data.as_slice());
+        }
+    }
 }

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -115,13 +115,16 @@ pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
     Ok(engine)
 }
 
-/// Open a `MemoryEngine` with **write** capability.
+/// Open a `MemoryEngine` with **write** capability, peeking the dimension from
+/// the existing store.
 ///
-/// Needed by every command that mutates the database — `record-outcome`,
-/// `consolidate`, `migrate`, and `export` with `SQLite` format (`VACUUM INTO`).
-/// (`add-fact` and `batch-ingest` derive the dimension from their own input and
-/// use [`open_engine_writable_with_dim`] instead of peeking.) Sets `backup_dir`
-/// next to the database so any schema migration creates a WAL-safe backup first.
+/// Used by every command that mutates a previously-embedded database and does not
+/// already know its embedding dimension — e.g. `record-outcome`, `consolidate`,
+/// `migrate`, `export` with `SQLite` format, and the no-`--embed-dim` branch of
+/// `batch-ingest` / `bootstrap`. Commands that derive the dimension from their own
+/// input (`add-fact`, and `batch-ingest` / `bootstrap` *with* `--embed-dim`) use
+/// [`open_engine_writable_with_dim`] instead. Sets `backup_dir` next to the
+/// database so any schema migration creates a WAL-safe backup first.
 pub fn open_engine_writable(path: &Path) -> anyhow::Result<MemoryEngine> {
     let embed_dim = peek_embed_dim_from_db(path)?;
     open_engine_writable_with_dim(path, embed_dim)

--- a/memory-engine-cli/src/db.rs
+++ b/memory-engine-cli/src/db.rs
@@ -117,9 +117,11 @@ pub fn open_engine(path: &Path) -> anyhow::Result<MemoryEngine> {
 
 /// Open a `MemoryEngine` with **write** capability.
 ///
-/// Needed for commands that mutate the database (e.g., `add-fact`, `export`
-/// with `SQLite` format). Sets `backup_dir` next to the database so any
-/// schema migration creates a WAL-safe backup first.
+/// Needed by every command that mutates the database — `record-outcome`,
+/// `consolidate`, `migrate`, and `export` with `SQLite` format (`VACUUM INTO`).
+/// (`add-fact` and `batch-ingest` derive the dimension from their own input and
+/// use [`open_engine_writable_with_dim`] instead of peeking.) Sets `backup_dir`
+/// next to the database so any schema migration creates a WAL-safe backup first.
 pub fn open_engine_writable(path: &Path) -> anyhow::Result<MemoryEngine> {
     let embed_dim = peek_embed_dim_from_db(path)?;
     open_engine_writable_with_dim(path, embed_dim)

--- a/memory-engine-cli/src/output.rs
+++ b/memory-engine-cli/src/output.rs
@@ -108,4 +108,19 @@ mod tests {
         assert!(parse_datetime("not-a-date").is_err());
         assert!(parse_datetime("2026-13-01T00:00:00Z").is_err());
     }
+
+    proptest::proptest! {
+        /// Property: for any string and bound, `truncate_str` never panics and
+        /// never returns more than `max_chars` characters (the documented
+        /// contract, including the `max_chars < 3` boundary).
+        #[test]
+        fn truncate_str_respects_max_chars(s in ".{0,400}", max in 0usize..64) {
+            let out = truncate_str(&s, max);
+            proptest::prop_assert!(
+                out.chars().count() <= max,
+                "got {} chars for max {max}",
+                out.chars().count()
+            );
+        }
+    }
 }

--- a/memory-engine-cli/src/output.rs
+++ b/memory-engine-cli/src/output.rs
@@ -109,18 +109,23 @@ mod tests {
         assert!(parse_datetime("2026-13-01T00:00:00Z").is_err());
     }
 
-    proptest::proptest! {
-        /// Property: for any string and bound, `truncate_str` never panics and
-        /// never returns more than `max_chars` characters (the documented
-        /// contract, including the `max_chars < 3` boundary).
-        #[test]
-        fn truncate_str_respects_max_chars(s in ".{0,400}", max in 0usize..64) {
+    /// Property: for any string and bound, `truncate_str` never panics and never
+    /// returns more than `max_chars` characters (the documented contract, incl.
+    /// the `max_chars < 3` boundary). The input is arbitrary Unicode — multi-byte
+    /// chars, newlines, control chars — since the function's whole point is
+    /// multi-byte-UTF-8 safety.
+    #[test]
+    fn truncate_str_respects_max_chars() {
+        use proptest::prelude::*;
+        let arbitrary_unicode =
+            proptest::collection::vec(any::<char>(), 0..200).prop_map(String::from_iter);
+        proptest!(|(s in arbitrary_unicode, max in 0usize..64)| {
             let out = truncate_str(&s, max);
-            proptest::prop_assert!(
+            prop_assert!(
                 out.chars().count() <= max,
                 "got {} chars for max {max}",
                 out.chars().count()
             );
-        }
+        });
     }
 }


### PR DESCRIPTION
Final wave (W5) of the #251 area:cli super-qa sweep.

## #433 — property-based parser fuzzing (`test`)
`cargo-fuzz` needs nightly, which this stable-only repo (MSRV 1.88, stable CI) won't carry — so `proptest` random-input tests run **inside the existing `cargo test` CI**:
- `peek_embed_dim_from_reader` — arbitrary bytes never panic/hang (bounded by `MAX_HEADER_BYTES`).
- `ingest_from_reader` — mixes **raw arbitrary bytes** *and* a **structurally-valid JSONL strategy** (arb content + valid fact_type + importance in/out of [0,1]) so both the parse-reject path AND the deeper machine (`validate_jsonl_fact`, batching, `flush_batch`) are fuzzed (review-strengthened from a parse-only smoke test).
- `truncate_str` — for any string + bound, never panics and never exceeds `max_chars`.

No panics found.

## #493 — low/info rollup disposition (8 items)
| Item | Disposition |
|---|---|
| `import-doc-misleading-peek` (info) | ✅ fixed W1 (#654) |
| `passthrough-embedder-zero-texts` (low) | ✅ tested W4 (#686) |
| `dump-unreachable-brittle` (low) | stale — no `unreachable!()` in dump.rs |
| `duplicate-parse-datetime` (info) | stale — single def in `output.rs` |
| `secret-api-key-in-process-args` (low) | ✅ env path (`MEMORY_ENGINE_EMBED_API_KEY`, #619) + **dropped the `EmbeddingArgs` `Debug` derive** here (was a latent cleartext-key leak); CLI flag retained by design |
| `documentation-incomplete-writable-examples` (low) | ✅ fixed here (accurate, non-enumerative `open_engine_writable` doc) |
| `proptest-candidates-no-coverage` (low) | ✅ added here (`truncate_str` proptest) |
| `no-doc-tests-on-public-api` (low) | N/A — `memory-engine-cli` is a binary crate (no lib target); `cargo test` runs doc-tests only for lib |

## Verification (exact CI commands)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean ✓
- `cargo test --workspace --all-features` — all green ✓
- `cargo deny check` — advisories ok ✓ · `cargo fmt --check` ✓

Closes #433.
Closes #493.