### PR TITLE
feat(retrieval): full FactFilter translation on the SQLite search path (#684)

### DIFF
--- a/src/search/filter_sql.rs
+++ b/src/search/filter_sql.rs
@@ -1,0 +1,78 @@
+//! `FilterSql` — a rendered SQL boolean fragment plus its bound parameters.
+//!
+//! The shared `search/{fts,vector}` cores accept this opaque fragment so a single
+//! base query serves both the verbatim active-only path and the richer
+//! `FactFilter` translation. Two builders feed it:
+//!
+//! - [`FilterSql::active`] (here) — the active-only fragment the verbatim
+//!   `fts_search`/`vector_search` wrappers use; mirrors the historical
+//!   `t_expired IS NULL (+ fact_type + scope)` SQL byte-for-byte in behavior.
+//! - `convert::build_filter_sql` (backend) — the full `temporal`/`ids`/`pinned`/
+//!   `metadata` translation (#684), owned by the backend's dialect layer.
+//!
+//! Keeping the *carrier* here (rather than in the backend's `convert`) lets the
+//! shared `search/` cores depend on it without inverting the layering.
+
+use rusqlite::ToSql;
+
+use crate::error::Result;
+use crate::search::serialize_scope_ids;
+use crate::store::facts::fact_type_to_str;
+use crate::types::FactType;
+
+/// A SQL boolean expression (a `WHERE`-clause body) and its positional params.
+///
+/// `where_clause` is a complete boolean expression suitable to drop straight
+/// after `WHERE`/`AND`. It is **never empty** — an unconstrained filter renders
+/// the literal `1` (always-true), so callers can always interpolate it without a
+/// special case. Every `?` placeholder in it binds, in order, from `params`.
+pub struct FilterSql {
+    /// Boolean expression with anonymous `?` placeholders (never empty).
+    pub where_clause: String,
+    /// Positional bind values — one per `?` in `where_clause`, in order.
+    pub params: Vec<Box<dyn ToSql>>,
+}
+
+impl FilterSql {
+    /// Build the **active-only** fragment: `t_expired IS NULL`, optionally
+    /// AND-ed with a single `fact_type` and/or a `scope_ids` membership test.
+    ///
+    /// `prefix` is the column qualifier the host query needs (`"f."` for the
+    /// FTS5 join, `""` for the bare-table vector scan). This reproduces exactly
+    /// the predicate set the historical hand-written SQL honored, so the verbatim
+    /// `fts_search`/`vector_search` wrappers stay behavior-identical.
+    ///
+    /// The `scope_ids` convention is preserved: `Some(empty)` serializes to an
+    /// empty `json_each`, which **matches nothing** (distinct from `None`, which
+    /// omits the clause entirely).
+    ///
+    /// # Errors
+    /// Propagates [`serialize_scope_ids`] failure (unreachable for `&[i64]`).
+    pub fn active(
+        prefix: &str,
+        fact_type: Option<&FactType>,
+        scope_ids: Option<&[i64]>,
+    ) -> Result<Self> {
+        let mut preds = vec![format!("{prefix}t_expired IS NULL")];
+        let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+        if let Some(ft) = fact_type {
+            preds.push(format!("{prefix}fact_type = ?"));
+            params.push(Box::new(fact_type_to_str(ft).to_string()));
+        }
+        if let Some(json) = serialize_scope_ids(scope_ids)? {
+            preds.push(format!(
+                "{prefix}scope_id IN (SELECT value FROM json_each(?))"
+            ));
+            params.push(Box::new(json));
+        }
+        Ok(Self {
+            where_clause: preds.join(" AND "),
+            params,
+        })
+    }
+
+    /// Borrow the params as `&dyn ToSql`, ready for `rusqlite::params_from_iter`.
+    pub(crate) fn bind_refs(&self) -> impl Iterator<Item = &dyn ToSql> {
+        self.params.iter().map(AsRef::as_ref)
+    }
+}

--- a/src/search/fts.rs
+++ b/src/search/fts.rs
@@ -1,7 +1,7 @@
-use rusqlite::Connection;
+use rusqlite::{Connection, ToSql, params_from_iter};
 
 use crate::error::Result;
-use crate::search::serialize_scope_ids;
+use crate::search::{FilterSql, serialize_scope_ids};
 use crate::store::facts::fact_type_to_str;
 use crate::types::FactType;
 
@@ -22,6 +22,10 @@ pub struct FtsResult {
 /// - `fact_type` restricts results to a single fact type when `Some`.
 /// - `scope_ids` restricts results to the given scope ids when `Some`.
 ///
+/// This is the verbatim active-only wrapper over [`fts_search_filtered`] used by
+/// the engine's hybrid path; richer `FactFilter` dimensions are translated by the
+/// backend (#684).
+///
 /// FTS5 syntax errors (e.g., unbalanced quotes) return an empty vec
 /// rather than propagating an error.
 ///
@@ -35,34 +39,60 @@ pub fn fts_search(
     fact_type: Option<&FactType>,
     scope_ids: Option<&[i64]>,
 ) -> Result<Vec<FtsResult>> {
-    let mut stmt = conn.prepare(
+    let filter = FilterSql::active("f.", fact_type, scope_ids)?;
+    fts_search_filtered(conn, query, limit, &filter)
+}
+
+/// Search the FTS5 index, applying a pre-rendered [`FilterSql`] fragment.
+///
+/// The single source of the BM25 query: the verbatim [`fts_search`] supplies an
+/// active-only fragment, while the backend supplies the full `temporal`/`ids`/
+/// `pinned`/`metadata` translation (#684). The fragment's `?` placeholders bind
+/// between the `MATCH` query and the trailing `LIMIT`, so the parameter order is
+/// `[query, ..filter, limit]`.
+///
+/// FTS5 syntax errors (e.g., unbalanced quotes) return an empty vec rather than
+/// propagating an error.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` for non-FTS5 database errors.
+pub fn fts_search_filtered(
+    conn: &Connection,
+    query: &str,
+    limit: usize,
+    filter: &FilterSql,
+) -> Result<Vec<FtsResult>> {
+    let sql = format!(
         "SELECT f.id, bm25(facts_fts) AS score \
          FROM facts_fts \
          JOIN facts AS f ON f.id = facts_fts.rowid \
-         WHERE facts_fts MATCH ?1 \
-           AND f.t_expired IS NULL \
-           AND (?2 IS NULL OR f.fact_type = ?2) \
-           AND (?3 IS NULL OR f.scope_id IN (SELECT value FROM json_each(?3))) \
-         ORDER BY score LIMIT ?4",
-    )?;
+         WHERE facts_fts MATCH ? \
+           AND {} \
+         ORDER BY score LIMIT ?",
+        filter.where_clause
+    );
+    let mut stmt = conn.prepare(&sql)?;
 
     let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
-    let fact_type_str: Option<&str> = fact_type.map(fact_type_to_str);
-    let scope_ids_json = serialize_scope_ids(scope_ids)?;
+    // Param order mirrors the `?` order in the SQL above: MATCH query first, then
+    // the filter fragment's binds, then LIMIT.
+    let query_param: Box<dyn ToSql> = Box::new(query.to_string());
+    let limit_param: Box<dyn ToSql> = Box::new(limit_i64);
+    let bound = std::iter::once(query_param.as_ref())
+        .chain(filter.bind_refs())
+        .chain(std::iter::once(limit_param.as_ref()));
 
     // FTS5 syntax errors surface at query_map execution time, not at prepare time.
     // They are indistinguishable from other rusqlite::Error variants at the type level,
     // so we catch all errors here. This is intentional: the only realistic failure mode
     // for a parameterized MATCH query is malformed FTS5 syntax from the caller.
-    let rows = match stmt.query_map(
-        rusqlite::params![query, fact_type_str, scope_ids_json, limit_i64],
-        |row| {
-            Ok(FtsResult {
-                fact_id: row.get(0)?,
-                score: row.get(1)?,
-            })
-        },
-    ) {
+    let rows = match stmt.query_map(params_from_iter(bound), |row| {
+        Ok(FtsResult {
+            fact_id: row.get(0)?,
+            score: row.get(1)?,
+        })
+    }) {
         Ok(rows) => rows,
         Err(e) => {
             tracing::warn!("FTS5 query failed (likely syntax error): {e}");

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "ann")]
 pub mod ann;
+pub mod filter_sql;
 pub mod fts;
 pub mod hybrid;
 pub mod query;
@@ -10,14 +11,15 @@ pub mod vector;
 
 #[cfg(feature = "ann")]
 pub use ann::HnswStrategy;
-pub use fts::{FtsResult, fts_count_expired, fts_search};
+pub use filter_sql::FilterSql;
+pub use fts::{FtsResult, fts_count_expired, fts_search, fts_search_filtered};
 pub use hybrid::{
     MatchType, QueryDiagnostics, QueryResponse, RRF_K, SearchMode, SearchQuery, SearchResult,
     hybrid_search, rrf_merge,
 };
 pub use query::MemoryQuery;
 pub use strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
-pub use vector::{VectorResult, cosine_similarity, vector_search};
+pub use vector::{VectorResult, cosine_similarity, vector_search, vector_search_filtered};
 
 /// Serialize an optional scope-ID slice to a JSON string for use as a SQL
 /// parameter in `json_each(?N)` expressions.

--- a/src/search/vector.rs
+++ b/src/search/vector.rs
@@ -1,9 +1,8 @@
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, params_from_iter};
 
 use crate::error::Result;
-use crate::search::serialize_scope_ids;
+use crate::search::FilterSql;
 use crate::store::deserialize_embedding;
-use crate::store::facts::fact_type_to_str;
 use crate::types::FactType;
 
 /// A single vector search result with fact id and cosine similarity score.
@@ -73,6 +72,29 @@ pub fn vector_search(
     fact_type: Option<&FactType>,
     scope_ids: Option<&[i64]>,
 ) -> Result<Vec<VectorResult>> {
+    let filter = FilterSql::active("", fact_type, scope_ids)?;
+    vector_search_filtered(conn, query_embedding, embed_dim, limit, &filter)
+}
+
+/// Brute-force vector similarity search applying a pre-rendered [`FilterSql`].
+///
+/// The single source of the brute-force scan: the verbatim [`vector_search`]
+/// supplies an active-only fragment, while the backend supplies the full
+/// `temporal`/`ids`/`pinned`/`metadata` translation (#684). The fragment's bare
+/// (un-aliased) column references match this query's single-table `FROM facts`.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on query failure, or
+/// `MemoryError::EmbeddingDimension` if a stored (or the query) embedding has the
+/// wrong size.
+pub fn vector_search_filtered(
+    conn: &Connection,
+    query_embedding: &[f32],
+    embed_dim: usize,
+    limit: usize,
+    filter: &FilterSql,
+) -> Result<Vec<VectorResult>> {
     if query_embedding.len() != embed_dim {
         return Err(crate::error::MemoryError::EmbeddingDimension {
             expected: embed_dim,
@@ -80,17 +102,13 @@ pub fn vector_search(
         });
     }
 
-    let ft_str: Option<&str> = fact_type.map(fact_type_to_str);
-    let scope_json = serialize_scope_ids(scope_ids)?;
+    let sql = format!(
+        "SELECT id, embedding FROM facts WHERE {}",
+        filter.where_clause
+    );
+    let mut stmt = conn.prepare(&sql)?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, embedding FROM facts
-         WHERE t_expired IS NULL
-           AND (?1 IS NULL OR fact_type = ?1)
-           AND (?2 IS NULL OR scope_id IN (SELECT value FROM json_each(?2)))",
-    )?;
-
-    let rows = stmt.query_map(params![ft_str, scope_json], |row| {
+    let rows = stmt.query_map(params_from_iter(filter.bind_refs()), |row| {
         let id: i64 = row.get(0)?;
         let blob: Vec<u8> = row.get(1)?;
         Ok((id, blob))

--- a/src/storage/filter.rs
+++ b/src/storage/filter.rs
@@ -97,11 +97,14 @@ pub enum TemporalFilter {
     /// System-time live rows: `t_expired IS NULL`. The common case — default.
     #[default]
     Active,
-    /// Valid at an instant: `(t_valid IS NULL OR t_valid <= t) AND
-    /// (t_invalid IS NULL OR t_invalid > t)`.
+    /// Active *and* valid at an instant: `t_expired IS NULL AND
+    /// (t_valid IS NULL OR t_valid <= t) AND (t_invalid IS NULL OR t_invalid > t)`.
+    /// Mirrors the store's `list_active_at` — soft-deleted rows never surface here
+    /// (only [`IncludeExpired`](Self::IncludeExpired) does).
     AsOf(DateTime<Utc>),
-    /// "Due now": `t_valid IS NOT NULL AND t_valid <= now AND
-    /// (t_invalid IS NULL OR t_invalid > now)`.
+    /// Active *and* "due now": `t_expired IS NULL AND t_valid IS NOT NULL AND
+    /// t_valid <= now AND (t_invalid IS NULL OR t_invalid > now)`. Mirrors the
+    /// store's `list_due`.
     ValidDue(DateTime<Utc>),
     /// No system-time filter — include expired (soft-deleted) rows.
     IncludeExpired,

--- a/src/storage/sqlite/convert.rs
+++ b/src/storage/sqlite/convert.rs
@@ -1,82 +1,281 @@
-//! `FactFilter` → verbatim-search-param projection.
+//! `FactFilter` → `FilterSql` translation for the `SQLite` search path.
 //!
 //! The [`SearchIndex`](crate::storage::SearchIndex) trait takes a rich
-//! [`FactFilter`], but the verbatim `search/{fts,vector}.rs` SQL honors only
-//! `fact_type` + `scope_ids` and hard-codes `t_expired IS NULL` (Active). This
-//! projects the filter onto what that SQL accepts and **errors loud** if a
-//! dimension the SQL cannot honor is set — rather than silently dropping a
-//! predicate and returning the wrong rows. Extending the SQL to honor the richer
-//! dimensions would be *new behavior* `#630` must not introduce (it is tracked as
-//! a separate follow-up).
+//! [`FactFilter`]; this renders **all** of its dimensions into a parametrized SQL
+//! boolean fragment ([`FilterSql`]) that the shared `search/{fts,vector}` cores
+//! drop after `WHERE`/`AND` (#684). Each predicate transcribes the *exact* `SQLite`
+//! SQL shape the hand-written store queries already use, so the lexical/vector path
+//! stays parity-faithful to the row store:
+//!
+//! | Dimension              | SQL (oracle in `store/facts.rs`)                          |
+//! |------------------------|-----------------------------------------------------------|
+//! | `Active`               | `t_expired IS NULL`                                       |
+//! | `IncludeExpired`       | *(no system-time predicate)*                              |
+//! | `AsOf(t)`              | `(t_valid IS NULL OR t_valid <= ?) AND (t_invalid IS NULL OR t_invalid > ?)` |
+//! | `ValidDue(t)`          | `t_valid IS NOT NULL AND t_valid <= ? AND (t_invalid IS NULL OR t_invalid > ?)` |
+//! | `fact_type`            | `fact_type = ?`                                           |
+//! | `scope_ids` / `ids`    | `<col> IN (SELECT value FROM json_each(?))`              |
+//! | `pinned`               | `is_pinned = ?` (`1`/`0`)                                 |
+//! | `KeyAbsent(k)`         | `json_type(metadata, ?) IS NULL`                         |
+//! | `KeyPresent(k)`        | `json_extract(metadata, ?) IS NOT NULL`                  |
+//! | `KeyEquals(k, v)`      | `json_extract(metadata, ?) = ?`                          |
+//!
+//! Timestamps bind as RFC3339 strings — the on-disk encoding (`facts.rs` writes
+//! `to_rfc3339()`), so lexicographic `<=`/`>` ordering is correct. The JSON path
+//! (`$.k`) binds as a **parameter**, not interpolated, closing the injection seam
+//! the store left open for its trusted-literal callers.
+
+use rusqlite::ToSql;
+use serde_json::Value;
 
 use crate::error::{MemoryError, Result};
-use crate::storage::{FactFilter, TemporalFilter};
-use crate::types::FactType;
+use crate::search::{FilterSql, serialize_scope_ids};
+use crate::storage::{FactFilter, MetadataPredicate, TemporalFilter};
+use crate::store::facts::fact_type_to_str;
 
-/// Project a [`FactFilter`] onto the `(fact_type, scope_ids)` the verbatim FTS5 /
-/// brute-force vector SQL accepts.
+/// Translate a [`FactFilter`] into a [`FilterSql`] fragment for the search cores.
 ///
-/// The `scope_ids` convention round-trips faithfully: `None` = no constraint,
-/// `Some(empty)` = matches nothing — passed straight to `serialize_scope_ids`,
-/// which the SQL turns into an empty `json_each` (excludes every row).
+/// `prefix` qualifies every column reference (`"f."` for the FTS5 join, `""` for
+/// the bare-table vector scan). The rendered `where_clause` is never empty (an
+/// unconstrained filter — e.g. `IncludeExpired` with no other dimension — renders
+/// the literal `1`).
 ///
 /// # Errors
-/// [`MemoryError::Internal`] if `temporal != Active`, or `ids` / `pinned` /
-/// `metadata` are set — dimensions the verbatim search SQL does not honor. The
-/// engine query path never sets these on a search filter.
-pub(super) fn search_params(filter: &FactFilter) -> Result<(Option<FactType>, Option<Vec<i64>>)> {
-    if filter.temporal != TemporalFilter::Active
-        || filter.ids.is_some()
-        || filter.pinned.is_some()
-        || !filter.metadata.is_empty()
-    {
-        return Err(MemoryError::Internal(
-            "SqliteBackend search path received a FactFilter dimension the verbatim \
-             FTS5/vector SQL does not honor (temporal != Active, ids, pinned, or metadata); \
-             the engine query path does not set these on a search filter"
-                .into(),
-        ));
+/// - [`MemoryError::Serialization`] if `scope_ids`/`ids` fail to serialize
+///   (unreachable for `&[i64]`).
+/// - [`MemoryError::Internal`] if a `KeyEquals` carries a non-scalar JSON value
+///   (array/object) or an unrepresentable number — `json_extract` comparison is
+///   defined only for scalars.
+pub(super) fn build_filter_sql(filter: &FactFilter, prefix: &str) -> Result<FilterSql> {
+    let mut preds: Vec<String> = Vec::new();
+    let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+
+    push_temporal(filter.temporal, prefix, &mut preds, &mut params);
+
+    if let Some(ft) = filter.fact_type {
+        preds.push(format!("{prefix}fact_type = ?"));
+        params.push(Box::new(fact_type_to_str(&ft).to_string()));
     }
-    Ok((filter.fact_type, filter.scope_ids.clone()))
+    if let Some(ref scope_ids) = filter.scope_ids {
+        push_id_membership(
+            &format!("{prefix}scope_id"),
+            scope_ids,
+            &mut preds,
+            &mut params,
+        )?;
+    }
+    if let Some(ref ids) = filter.ids {
+        push_id_membership(&format!("{prefix}id"), ids, &mut preds, &mut params)?;
+    }
+    if let Some(pinned) = filter.pinned {
+        preds.push(format!("{prefix}is_pinned = ?"));
+        params.push(Box::new(i64::from(pinned)));
+    }
+    for predicate in &filter.metadata {
+        push_metadata(predicate, prefix, &mut preds, &mut params)?;
+    }
+
+    let where_clause = if preds.is_empty() {
+        "1".to_string()
+    } else {
+        preds.join(" AND ")
+    };
+    Ok(FilterSql {
+        where_clause,
+        params,
+    })
+}
+
+/// Append the bi-temporal visibility predicate (and its params) for `temporal`.
+///
+/// Transcribes the four shapes documented on [`TemporalFilter`]; `IncludeExpired`
+/// contributes no predicate (all rows visible). `AsOf`/`ValidDue` bind their
+/// instant twice (once per `t_valid`/`t_invalid` comparison) as an RFC3339 string.
+fn push_temporal(
+    temporal: TemporalFilter,
+    prefix: &str,
+    preds: &mut Vec<String>,
+    params: &mut Vec<Box<dyn ToSql>>,
+) {
+    match temporal {
+        TemporalFilter::Active => preds.push(format!("{prefix}t_expired IS NULL")),
+        TemporalFilter::IncludeExpired => {}
+        TemporalFilter::AsOf(t) => {
+            preds.push(format!(
+                "({prefix}t_valid IS NULL OR {prefix}t_valid <= ?) \
+                 AND ({prefix}t_invalid IS NULL OR {prefix}t_invalid > ?)"
+            ));
+            params.push(Box::new(t.to_rfc3339()));
+            params.push(Box::new(t.to_rfc3339()));
+        }
+        TemporalFilter::ValidDue(t) => {
+            preds.push(format!(
+                "{prefix}t_valid IS NOT NULL AND {prefix}t_valid <= ? \
+                 AND ({prefix}t_invalid IS NULL OR {prefix}t_invalid > ?)"
+            ));
+            params.push(Box::new(t.to_rfc3339()));
+            params.push(Box::new(t.to_rfc3339()));
+        }
+    }
+}
+
+/// Append a `<col> IN (SELECT value FROM json_each(?))` membership predicate.
+///
+/// Preserves the `Some(empty)` = matches-nothing contract: an empty slice
+/// serializes to `[]`, yielding an empty `json_each` that excludes every row.
+fn push_id_membership(
+    col: &str,
+    ids: &[i64],
+    preds: &mut Vec<String>,
+    params: &mut Vec<Box<dyn ToSql>>,
+) -> Result<()> {
+    // `serialize_scope_ids(Some(_))` always yields `Some(json)`, so this `if let`
+    // never drops the clause — it just reuses the shared `&[i64] -> json` helper.
+    if let Some(json) = serialize_scope_ids(Some(ids))? {
+        preds.push(format!("{col} IN (SELECT value FROM json_each(?))"));
+        params.push(Box::new(json));
+    }
+    Ok(())
+}
+
+/// Append a metadata predicate, transcribing the store's JSON1 idioms.
+///
+/// `json_type(...) IS NULL` for **absence** (an absent key is `NULL`; a
+/// present-`null` value has type `"null"`), `json_extract(...) IS NOT NULL` for
+/// **presence** (collapses absent and present-`null` — the deliberate asymmetry
+/// documented in `facts.rs`). The `$.k` path binds as a parameter.
+fn push_metadata(
+    predicate: &MetadataPredicate,
+    prefix: &str,
+    preds: &mut Vec<String>,
+    params: &mut Vec<Box<dyn ToSql>>,
+) -> Result<()> {
+    match predicate {
+        MetadataPredicate::KeyAbsent(key) => {
+            preds.push(format!("json_type({prefix}metadata, ?) IS NULL"));
+            params.push(Box::new(json_path(key)));
+        }
+        MetadataPredicate::KeyPresent(key) => {
+            preds.push(format!("json_extract({prefix}metadata, ?) IS NOT NULL"));
+            params.push(Box::new(json_path(key)));
+        }
+        MetadataPredicate::KeyEquals(key, value) => {
+            preds.push(format!("json_extract({prefix}metadata, ?) = ?"));
+            params.push(Box::new(json_path(key)));
+            params.push(value_to_sql(value)?);
+        }
+    }
+    Ok(())
+}
+
+/// Render a metadata key as a JSON path expression (`$.key`) for the path
+/// argument of `json_extract`/`json_type`.
+fn json_path(key: &str) -> String {
+    format!("$.{key}")
+}
+
+/// Bind a scalar `serde_json::Value` for comparison against a `json_extract`
+/// result, matching how `SQLite` surfaces extracted JSON scalars (text / integer /
+/// real; booleans as `1`/`0`).
+///
+/// Composite values (array/object) and non-finite numbers are rejected — equality
+/// against an extracted JSON scalar is undefined for them, so failing loud beats
+/// silently never matching.
+fn value_to_sql(value: &Value) -> Result<Box<dyn ToSql>> {
+    match value {
+        Value::String(s) => Ok(Box::new(s.clone())),
+        Value::Bool(b) => Ok(Box::new(i64::from(*b))),
+        Value::Number(n) => match (n.as_i64(), n.as_f64()) {
+            (Some(i), _) => Ok(Box::new(i)),
+            (None, Some(f)) => Ok(Box::new(f)),
+            (None, None) => Err(MemoryError::Internal(format!(
+                "metadata KeyEquals: unrepresentable JSON number {n}"
+            ))),
+        },
+        Value::Null => Ok(Box::new(rusqlite::types::Null)),
+        Value::Array(_) | Value::Object(_) => Err(MemoryError::Internal(
+            "metadata KeyEquals supports scalar JSON values only (string/number/bool/null); \
+             got a composite value"
+                .into(),
+        )),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::MetadataPredicate;
 
     #[test]
-    fn passes_supported_dimensions() {
+    fn unconstrained_active_filter_renders_expiry_only() {
+        let sql = build_filter_sql(&FactFilter::new(), "f.").unwrap();
+        assert_eq!(sql.where_clause, "f.t_expired IS NULL");
+        assert!(sql.params.is_empty());
+    }
+
+    #[test]
+    fn include_expired_with_no_other_dimension_renders_always_true() {
+        let f = FactFilter::new().temporal(TemporalFilter::IncludeExpired);
+        let sql = build_filter_sql(&f, "f.").unwrap();
+        assert_eq!(sql.where_clause, "1");
+        assert!(sql.params.is_empty());
+    }
+
+    #[test]
+    fn asof_binds_instant_twice() {
+        let t = chrono::Utc::now();
+        let f = FactFilter::new().temporal(TemporalFilter::AsOf(t));
+        let sql = build_filter_sql(&f, "").unwrap();
+        assert!(sql.where_clause.contains("t_valid <= ?"));
+        assert!(sql.where_clause.contains("t_invalid > ?"));
+        assert_eq!(sql.params.len(), 2, "AsOf binds its instant twice");
+    }
+
+    #[test]
+    fn every_dimension_contributes_exactly_one_clause_and_its_params() {
         let f = FactFilter::new()
-            .fact_type(FactType::Semantic)
-            .scope_ids(vec![1, 2]);
-        let (ft, scopes) = search_params(&f).unwrap();
-        assert_eq!(ft, Some(FactType::Semantic));
-        assert_eq!(scopes, Some(vec![1, 2]));
+            .fact_type(crate::types::FactType::Semantic)
+            .scope_ids(vec![1, 2])
+            .ids(vec![10])
+            .pinned(true)
+            .with_metadata(MetadataPredicate::KeyAbsent("dream_cycle".into()));
+        let sql = build_filter_sql(&f, "f.").unwrap();
+        // Active expiry + fact_type + scope + ids + pinned + metadata = 6 clauses.
+        assert_eq!(sql.where_clause.matches(" AND ").count(), 5);
+        assert!(sql.where_clause.contains("f.fact_type = ?"));
+        assert!(
+            sql.where_clause
+                .contains("f.id IN (SELECT value FROM json_each(?))")
+        );
+        assert!(sql.where_clause.contains("f.is_pinned = ?"));
+        assert!(
+            sql.where_clause
+                .contains("json_type(f.metadata, ?) IS NULL")
+        );
+        // params: fact_type, scope_json, ids_json, pinned, metadata-path = 5.
+        assert_eq!(sql.params.len(), 5);
     }
 
     #[test]
-    fn empty_scope_ids_round_trip_preserved() {
-        // Some(empty) must stay Some(empty) (matches nothing), NOT normalized to None.
+    fn key_equals_rejects_composite_value() {
+        let f = FactFilter::new().with_metadata(MetadataPredicate::KeyEquals(
+            "k".into(),
+            serde_json::json!([1, 2, 3]),
+        ));
+        assert!(matches!(
+            build_filter_sql(&f, ""),
+            Err(MemoryError::Internal(_))
+        ));
+    }
+
+    #[test]
+    fn empty_scope_ids_round_trips_to_empty_json_each() {
+        // Some(empty) must render the membership clause (matches nothing), NOT omit it.
         let f = FactFilter::new().scope_ids(Vec::<i64>::new());
-        let (_, scopes) = search_params(&f).unwrap();
-        assert_eq!(scopes, Some(vec![]));
-    }
-
-    #[test]
-    fn rejects_unsupported_dimensions() {
-        use chrono::Utc;
-        for f in [
-            FactFilter::new().temporal(TemporalFilter::IncludeExpired),
-            FactFilter::new().temporal(TemporalFilter::AsOf(Utc::now())),
-            FactFilter::new().ids(vec![1]),
-            FactFilter::new().pinned(true),
-            FactFilter::new().with_metadata(MetadataPredicate::KeyPresent("k".into())),
-        ] {
-            assert!(
-                matches!(search_params(&f), Err(MemoryError::Internal(_))),
-                "expected Internal for {f:?}"
-            );
-        }
+        let sql = build_filter_sql(&f, "").unwrap();
+        assert!(
+            sql.where_clause
+                .contains("scope_id IN (SELECT value FROM json_each(?))")
+        );
+        assert_eq!(sql.params.len(), 1);
     }
 }

--- a/src/storage/sqlite/convert.rs
+++ b/src/storage/sqlite/convert.rs
@@ -11,8 +11,8 @@
 //! |------------------------|-----------------------------------------------------------|
 //! | `Active`               | `t_expired IS NULL`                                       |
 //! | `IncludeExpired`       | *(no system-time predicate)*                              |
-//! | `AsOf(t)`              | `(t_valid IS NULL OR t_valid <= ?) AND (t_invalid IS NULL OR t_invalid > ?)` |
-//! | `ValidDue(t)`          | `t_valid IS NOT NULL AND t_valid <= ? AND (t_invalid IS NULL OR t_invalid > ?)` |
+//! | `AsOf(t)`              | `t_expired IS NULL AND (t_valid IS NULL OR t_valid <= ?) AND (t_invalid IS NULL OR t_invalid > ?)` |
+//! | `ValidDue(t)`          | `t_expired IS NULL AND t_valid IS NOT NULL AND t_valid <= ? AND (t_invalid IS NULL OR t_invalid > ?)` |
 //! | `fact_type`            | `fact_type = ?`                                           |
 //! | `scope_ids` / `ids`    | `<col> IN (SELECT value FROM json_each(?))`              |
 //! | `pinned`               | `is_pinned = ?` (`1`/`0`)                                 |
@@ -43,9 +43,9 @@ use crate::store::facts::fact_type_to_str;
 /// # Errors
 /// - [`MemoryError::Serialization`] if `scope_ids`/`ids` fail to serialize
 ///   (unreachable for `&[i64]`).
-/// - [`MemoryError::Internal`] if a `KeyEquals` carries a non-scalar JSON value
-///   (array/object) or an unrepresentable number — `json_extract` comparison is
-///   defined only for scalars.
+/// - [`MemoryError::Internal`] if a `KeyEquals` carries a null, a non-scalar JSON
+///   value (array/object), or an unrepresentable number — `json_extract` equality
+///   is defined only for non-null scalars (`= NULL` never matches).
 pub(super) fn build_filter_sql(filter: &FactFilter, prefix: &str) -> Result<FilterSql> {
     let mut preds: Vec<String> = Vec::new();
     let mut params: Vec<Box<dyn ToSql>> = Vec::new();
@@ -101,16 +101,22 @@ fn push_temporal(
         TemporalFilter::Active => preds.push(format!("{prefix}t_expired IS NULL")),
         TemporalFilter::IncludeExpired => {}
         TemporalFilter::AsOf(t) => {
+            // System-time guard included to match the store oracle `list_active_at`
+            // (`facts.rs`): AsOf is "active AND valid at t", so soft-deleted rows
+            // never surface — only `IncludeExpired` does.
             preds.push(format!(
-                "({prefix}t_valid IS NULL OR {prefix}t_valid <= ?) \
+                "{prefix}t_expired IS NULL \
+                 AND ({prefix}t_valid IS NULL OR {prefix}t_valid <= ?) \
                  AND ({prefix}t_invalid IS NULL OR {prefix}t_invalid > ?)"
             ));
             params.push(Box::new(t.to_rfc3339()));
             params.push(Box::new(t.to_rfc3339()));
         }
         TemporalFilter::ValidDue(t) => {
+            // Same system-time guard, matching the store oracle `list_due`.
             preds.push(format!(
-                "{prefix}t_valid IS NOT NULL AND {prefix}t_valid <= ? \
+                "{prefix}t_expired IS NULL \
+                 AND {prefix}t_valid IS NOT NULL AND {prefix}t_valid <= ? \
                  AND ({prefix}t_invalid IS NULL OR {prefix}t_invalid > ?)"
             ));
             params.push(Box::new(t.to_rfc3339()));
@@ -174,13 +180,13 @@ fn json_path(key: &str) -> String {
     format!("$.{key}")
 }
 
-/// Bind a scalar `serde_json::Value` for comparison against a `json_extract`
-/// result, matching how `SQLite` surfaces extracted JSON scalars (text / integer /
-/// real; booleans as `1`/`0`).
+/// Bind a non-null scalar `serde_json::Value` for comparison against a
+/// `json_extract` result, matching how `SQLite` surfaces extracted JSON scalars
+/// (text / integer / real; booleans as `1`/`0`).
 ///
-/// Composite values (array/object) and non-finite numbers are rejected — equality
-/// against an extracted JSON scalar is undefined for them, so failing loud beats
-/// silently never matching.
+/// `Null`, composite values (array/object), and non-finite numbers are rejected:
+/// `= NULL` is never true in SQL, and equality against an extracted JSON scalar is
+/// undefined for composites — so failing loud beats silently never matching.
 fn value_to_sql(value: &Value) -> Result<Box<dyn ToSql>> {
     match value {
         Value::String(s) => Ok(Box::new(s.clone())),
@@ -192,9 +198,16 @@ fn value_to_sql(value: &Value) -> Result<Box<dyn ToSql>> {
                 "metadata KeyEquals: unrepresentable JSON number {n}"
             ))),
         },
-        Value::Null => Ok(Box::new(rusqlite::types::Null)),
+        // `json_extract(...) = NULL` is never true in SQL, so a bound NULL would
+        // silently match nothing. Reject and direct callers to KeyAbsent/KeyPresent,
+        // which express null-ness correctly via `json_type`/`json_extract IS NULL`.
+        Value::Null => Err(MemoryError::Internal(
+            "metadata KeyEquals does not support a null value (`= NULL` never matches in SQL); \
+             use KeyAbsent or KeyPresent to test for null/absence"
+                .into(),
+        )),
         Value::Array(_) | Value::Object(_) => Err(MemoryError::Internal(
-            "metadata KeyEquals supports scalar JSON values only (string/number/bool/null); \
+            "metadata KeyEquals supports scalar JSON values only (string/number/bool); \
              got a composite value"
                 .into(),
         )),
@@ -260,6 +273,20 @@ mod tests {
         let f = FactFilter::new().with_metadata(MetadataPredicate::KeyEquals(
             "k".into(),
             serde_json::json!([1, 2, 3]),
+        ));
+        assert!(matches!(
+            build_filter_sql(&f, ""),
+            Err(MemoryError::Internal(_))
+        ));
+    }
+
+    #[test]
+    fn key_equals_rejects_null_value() {
+        // `json_extract(...) = NULL` is never true in SQL (would silently match
+        // nothing) — reject so callers use KeyAbsent/KeyPresent for null-ness.
+        let f = FactFilter::new().with_metadata(MetadataPredicate::KeyEquals(
+            "k".into(),
+            serde_json::Value::Null,
         ));
         assert!(matches!(
             build_filter_sql(&f, ""),

--- a/src/storage/sqlite/convert.rs
+++ b/src/storage/sqlite/convert.rs
@@ -165,6 +165,14 @@ fn push_metadata(
             preds.push(format!("json_extract({prefix}metadata, ?) IS NOT NULL"));
             params.push(Box::new(json_path(key)));
         }
+        // Present-and-explicitly-null: `json_extract(..) = NULL` is never true, so
+        // null equality is `json_type(..) = 'null'` (the 'null' type is returned
+        // only for a present JSON null, not for an absent key). The literal is
+        // inline (not a bind) — it is a fixed SQL string, not caller input.
+        MetadataPredicate::KeyEquals(key, Value::Null) => {
+            preds.push(format!("json_type({prefix}metadata, ?) = 'null'"));
+            params.push(Box::new(json_path(key)));
+        }
         MetadataPredicate::KeyEquals(key, value) => {
             preds.push(format!("json_extract({prefix}metadata, ?) = ?"));
             params.push(Box::new(json_path(key)));
@@ -174,10 +182,16 @@ fn push_metadata(
     Ok(())
 }
 
-/// Render a metadata key as a JSON path expression (`$.key`) for the path
-/// argument of `json_extract`/`json_type`.
+/// Render a metadata key as a JSON path expression for the path argument of
+/// `json_extract`/`json_type`.
+///
+/// The key is **double-quoted and escaped** (`$."key"`) so any valid JSON object
+/// key works — an unquoted `$.user-id` is a `SQLite` JSON-path syntax error.
+/// Quoting is identity-preserving for simple keys, so it stays parity-faithful to
+/// the store's unquoted `'$.dream_cycle'` literals.
 fn json_path(key: &str) -> String {
-    format!("$.{key}")
+    let escaped = key.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("$.\"{escaped}\"")
 }
 
 /// Bind a non-null scalar `serde_json::Value` for comparison against a
@@ -281,17 +295,29 @@ mod tests {
     }
 
     #[test]
-    fn key_equals_rejects_null_value() {
-        // `json_extract(...) = NULL` is never true in SQL (would silently match
-        // nothing) — reject so callers use KeyAbsent/KeyPresent for null-ness.
+    fn key_equals_null_renders_json_type_null_predicate() {
+        // `= NULL` is never true in SQL; present-null equality is `json_type(..) = 'null'`.
         let f = FactFilter::new().with_metadata(MetadataPredicate::KeyEquals(
             "k".into(),
             serde_json::Value::Null,
         ));
-        assert!(matches!(
-            build_filter_sql(&f, ""),
-            Err(MemoryError::Internal(_))
-        ));
+        let sql = build_filter_sql(&f, "").unwrap();
+        assert!(
+            sql.where_clause.contains("json_type(metadata, ?) = 'null'"),
+            "got: {}",
+            sql.where_clause
+        );
+        // Only the path param — the 'null' literal is inline, not bound.
+        assert_eq!(sql.params.len(), 1);
+    }
+
+    #[test]
+    fn json_path_quotes_and_escapes_special_keys() {
+        assert_eq!(json_path("dream_cycle"), "$.\"dream_cycle\"");
+        assert_eq!(json_path("user-id"), "$.\"user-id\"");
+        // Embedded quote/backslash must be escaped, not break out of the path.
+        assert_eq!(json_path("a\"b"), "$.\"a\\\"b\"");
+        assert_eq!(json_path("a\\b"), "$.\"a\\\\b\"");
     }
 
     #[test]

--- a/src/storage/sqlite/search_index.rs
+++ b/src/storage/sqlite/search_index.rs
@@ -452,6 +452,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_key_with_special_chars_is_a_valid_json_path() {
+        use crate::storage::MetadataPredicate;
+        // A hyphenated key must not break the JSON path (`$.user-id` is a SQLite
+        // path syntax error — the key has to be quoted + escaped).
+        let pool = seeded(&[
+            fact_meta("Rust tagged", serde_json::json!({"user-id": 1}), false),
+            fact_meta("Rust untagged", serde_json::json!({}), false),
+        ]);
+        let got = lexical_ids(
+            &pool,
+            &FactFilter::new().with_metadata(MetadataPredicate::KeyPresent("user-id".into())),
+        )
+        .await;
+        assert_eq!(
+            got.len(),
+            1,
+            "hyphenated metadata key must match, not error"
+        );
+    }
+
+    #[tokio::test]
+    async fn key_equals_null_matches_present_null_only() {
+        use crate::storage::MetadataPredicate;
+        // KeyEquals(k, null) means "k present and explicitly JSON null" — it must
+        // match {"k": null} but NOT an absent key nor a non-null value.
+        let pool = seeded(&[
+            fact_meta("Rust isnull", serde_json::json!({"k": null}), false),
+            fact_meta("Rust hasval", serde_json::json!({"k": 5}), false),
+            fact_meta("Rust absent", serde_json::json!({}), false),
+        ]);
+        let got = lexical_ids(
+            &pool,
+            &FactFilter::new().with_metadata(MetadataPredicate::KeyEquals(
+                "k".into(),
+                serde_json::Value::Null,
+            )),
+        )
+        .await;
+        assert_eq!(
+            got.len(),
+            1,
+            "KeyEquals(null) matches only the present-null row"
+        );
+    }
+
+    #[tokio::test]
     async fn asof_excludes_expired_rows_even_inside_their_valid_window() {
         use crate::storage::TemporalFilter;
         use chrono::Utc;

--- a/src/storage/sqlite/search_index.rs
+++ b/src/storage/sqlite/search_index.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 
 use super::{SqliteBackend, convert};
 use crate::error::Result;
-use crate::search::{fts_count_expired, fts_search, vector_search};
+use crate::search::{fts_count_expired, fts_search_filtered, vector_search_filtered};
 use crate::storage::{FactFilter, SearchIndex};
 use crate::types::FactType;
 
@@ -21,15 +21,17 @@ impl SearchIndex for SqliteBackend {
         filter: &FactFilter,
         k: usize,
     ) -> Result<Vec<(i64, f64)>> {
-        let (fact_type, scope_ids) = convert::search_params(filter)?;
+        // Clone the filter into the blocking closure so the rendered `FilterSql`
+        // (with its boxed, non-`Send` bind params) is built and consumed entirely
+        // on the pool thread — no params cross the await boundary.
+        let filter = filter.clone();
         let query = query.to_owned();
         self.block_read(move |c| {
-            Ok(
-                fts_search(c, &query, k, fact_type.as_ref(), scope_ids.as_deref())?
-                    .into_iter()
-                    .map(|r| (r.fact_id, r.score))
-                    .collect(),
-            )
+            let fsql = convert::build_filter_sql(&filter, "f.")?;
+            Ok(fts_search_filtered(c, &query, k, &fsql)?
+                .into_iter()
+                .map(|r| (r.fact_id, r.score))
+                .collect())
         })
         .await
     }
@@ -40,16 +42,16 @@ impl SearchIndex for SqliteBackend {
         filter: &FactFilter,
         k: usize,
     ) -> Result<Vec<(i64, f64)>> {
-        let (fact_type, scope_ids) = convert::search_params(filter)?;
+        let filter = filter.clone();
         let dim = self.embed_dim;
         let q = embedding.to_vec();
         self.block_read(move |c| {
-            Ok(
-                vector_search(c, &q, dim, k, fact_type.as_ref(), scope_ids.as_deref())?
-                    .into_iter()
-                    .map(|r| (r.fact_id, f64::from(r.score)))
-                    .collect(),
-            )
+            // Bare (un-aliased) columns: the vector scan is a single-table `FROM facts`.
+            let fsql = convert::build_filter_sql(&filter, "")?;
+            Ok(vector_search_filtered(c, &q, dim, k, &fsql)?
+                .into_iter()
+                .map(|r| (r.fact_id, f64::from(r.score)))
+                .collect())
         })
         .await
     }
@@ -242,17 +244,210 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn search_rejects_unsupported_filter_dimension() {
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "oracle read guard intentionally spans prepare + query_map"
+    )]
+    async fn lexical_include_expired_returns_active_and_expired() {
         use crate::storage::TemporalFilter;
-        let pool = seeded(&[fact("Rust", [0.1; DIM], false)]);
-        let err = backend(pool)
+        let pool = seeded(&[
+            fact("Rust active", [0.1; DIM], false),
+            fact("Rust expired", [0.1; DIM], true),
+        ]);
+        // Oracle: every "Rust" match regardless of expiry, BM25-ordered.
+        let oracle: Vec<i64> = {
+            let c = pool.read().unwrap();
+            let mut stmt = c
+                .prepare(
+                    "SELECT f.id FROM facts_fts JOIN facts AS f ON f.id = facts_fts.rowid \
+                     WHERE facts_fts MATCH ?1 ORDER BY bm25(facts_fts)",
+                )
+                .unwrap();
+            stmt.query_map(["Rust"], |r| r.get::<_, i64>(0))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+        let got = backend(Arc::clone(&pool))
             .lexical_search(
                 "Rust",
                 &FactFilter::new().temporal(TemporalFilter::IncludeExpired),
                 10,
             )
             .await
-            .unwrap_err();
-        assert!(matches!(err, MemoryError::Internal(_)), "got {err:?}");
+            .unwrap();
+        let got_ids: Vec<i64> = got.iter().map(|(id, _)| *id).collect();
+        assert_eq!(got_ids, oracle);
+        assert_eq!(
+            got_ids.len(),
+            2,
+            "IncludeExpired must surface the expired row"
+        );
+    }
+
+    /// Lexical-search ids restricted to `ids`, BM25-ordered, against a raw oracle.
+    async fn lexical_ids(pool: &Arc<ConnectionPool>, filter: &FactFilter) -> Vec<i64> {
+        backend(Arc::clone(pool))
+            .lexical_search("Rust", filter, 10)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect()
+    }
+
+    /// Seed a metadata/pinned/valid-window-bearing fact (the base `fact` helper
+    /// fixes those to empty/false/none).
+    fn fact_meta(content: &str, metadata: serde_json::Value, pinned: bool) -> NewFact {
+        let mut f = fact(content, [0.1; DIM], false);
+        f.metadata = metadata;
+        f.is_pinned = pinned;
+        f
+    }
+
+    #[tokio::test]
+    async fn lexical_ids_filter_restricts_to_listed_ids() {
+        let pool = seeded(&[
+            fact("Rust one", [0.1; DIM], false),
+            fact("Rust two", [0.1; DIM], false),
+        ]);
+        let first = {
+            let c = pool.read().unwrap();
+            c.query_row("SELECT MIN(id) FROM facts", [], |r| r.get::<_, i64>(0))
+                .unwrap()
+        };
+        let got = lexical_ids(&pool, &FactFilter::new().ids(vec![first])).await;
+        assert_eq!(got, vec![first], "ids filter must keep only the listed id");
+    }
+
+    #[tokio::test]
+    async fn lexical_pinned_filter_partitions_pinned_and_unpinned() {
+        let pool = seeded(&[
+            fact_meta("Rust pinned", serde_json::json!({}), true),
+            fact_meta("Rust loose", serde_json::json!({}), false),
+        ]);
+        let pinned = lexical_ids(&pool, &FactFilter::new().pinned(true)).await;
+        let unpinned = lexical_ids(&pool, &FactFilter::new().pinned(false)).await;
+        assert_eq!(pinned.len(), 1, "pinned(true) keeps only the pinned row");
+        assert_eq!(
+            unpinned.len(),
+            1,
+            "pinned(false) keeps only the unpinned row"
+        );
+        assert_ne!(pinned[0], unpinned[0]);
+    }
+
+    #[tokio::test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "oracle read guard intentionally spans prepare + query_map"
+    )]
+    async fn lexical_metadata_absent_present_split_matches_store_idiom() {
+        use crate::storage::MetadataPredicate;
+        let pool = seeded(&[
+            fact_meta("Rust marked", serde_json::json!({"dream_cycle": 1}), false),
+            fact_meta("Rust unmarked", serde_json::json!({}), false),
+        ]);
+        // Oracle: the store's own json_type-absence idiom.
+        let oracle_absent: Vec<i64> = {
+            let c = pool.read().unwrap();
+            let mut stmt = c
+                .prepare(
+                    "SELECT f.id FROM facts_fts JOIN facts AS f ON f.id = facts_fts.rowid \
+                     WHERE facts_fts MATCH ?1 AND f.t_expired IS NULL \
+                       AND json_type(f.metadata, '$.dream_cycle') IS NULL ORDER BY bm25(facts_fts)",
+                )
+                .unwrap();
+            stmt.query_map(["Rust"], |r| r.get::<_, i64>(0))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+        let absent = lexical_ids(
+            &pool,
+            &FactFilter::new().with_metadata(MetadataPredicate::KeyAbsent("dream_cycle".into())),
+        )
+        .await;
+        let present = lexical_ids(
+            &pool,
+            &FactFilter::new().with_metadata(MetadataPredicate::KeyPresent("dream_cycle".into())),
+        )
+        .await;
+        assert_eq!(
+            absent, oracle_absent,
+            "KeyAbsent must match the json_type oracle"
+        );
+        assert_eq!(absent.len(), 1);
+        assert_eq!(present.len(), 1, "KeyPresent is the complement");
+        assert_ne!(absent[0], present[0]);
+    }
+
+    #[tokio::test]
+    async fn lexical_metadata_key_equals_binds_scalar_and_path() {
+        use crate::storage::MetadataPredicate;
+        // Verifies the empirically-uncertain bit: a *parameter-bound* JSON path
+        // (`json_extract(metadata, ?)`) plus a scalar value bind.
+        let pool = seeded(&[
+            fact_meta("Rust hot", serde_json::json!({"score": 42}), false),
+            fact_meta("Rust cold", serde_json::json!({"score": 7}), false),
+        ]);
+        let got = lexical_ids(
+            &pool,
+            &FactFilter::new().with_metadata(MetadataPredicate::KeyEquals(
+                "score".into(),
+                serde_json::json!(42),
+            )),
+        )
+        .await;
+        assert_eq!(got.len(), 1, "KeyEquals(42) keeps only the score=42 row");
+    }
+
+    #[tokio::test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "oracle read guard intentionally spans prepare + query_map"
+    )]
+    async fn vector_asof_matches_temporal_window_oracle() {
+        use crate::storage::TemporalFilter;
+        use chrono::{Duration, Utc};
+        let now = Utc::now();
+        // valid: [now-1h, now+1h) — visible at `now`.
+        let mut in_window = fact("a", [1.0, 0.0, 0.0, 0.0], false);
+        in_window.t_valid = Some(now - Duration::hours(1));
+        in_window.t_invalid = Some(now + Duration::hours(1));
+        // valid only in the future: [now+1h, ..) — NOT visible at `now`.
+        let mut future = fact("b", [0.9, 0.1, 0.0, 0.0], false);
+        future.t_valid = Some(now + Duration::hours(1));
+        let pool = seeded(&[in_window, future]);
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        // Oracle: the store's AsOf shape (facts.rs `list_active_at`).
+        let oracle: Vec<i64> = {
+            let c = pool.read().unwrap();
+            let mut stmt = c
+                .prepare(
+                    "SELECT id FROM facts WHERE t_expired IS NULL \
+                       AND (t_valid IS NULL OR t_valid <= ?1) \
+                       AND (t_invalid IS NULL OR t_invalid > ?1) ORDER BY id",
+                )
+                .unwrap();
+            stmt.query_map([now.to_rfc3339()], |r| r.get::<_, i64>(0))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+        let mut got: Vec<i64> = backend(Arc::clone(&pool))
+            .vector_search(
+                &query,
+                &FactFilter::new().temporal(TemporalFilter::AsOf(now)),
+                10,
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        got.sort_unstable();
+        assert_eq!(got, oracle, "AsOf must honor the valid-window oracle");
+        assert_eq!(got.len(), 1, "only the in-window fact is visible at `now`");
     }
 }

--- a/src/storage/sqlite/search_index.rs
+++ b/src/storage/sqlite/search_index.rs
@@ -450,4 +450,27 @@ mod tests {
         assert_eq!(got, oracle, "AsOf must honor the valid-window oracle");
         assert_eq!(got.len(), 1, "only the in-window fact is visible at `now`");
     }
+
+    #[tokio::test]
+    async fn asof_excludes_expired_rows_even_inside_their_valid_window() {
+        use crate::storage::TemporalFilter;
+        use chrono::Utc;
+        // Both facts have an open valid window (t_valid/t_invalid = None), so the
+        // only thing that may exclude the expired one is the system-time guard
+        // `t_expired IS NULL` — the store's `list_active_at` keeps it; AsOf must too.
+        let pool = seeded(&[
+            fact("Rust active", [0.1; DIM], false),
+            fact("Rust expired", [0.1; DIM], true),
+        ]);
+        let got = lexical_ids(
+            &pool,
+            &FactFilter::new().temporal(TemporalFilter::AsOf(Utc::now())),
+        )
+        .await;
+        assert_eq!(
+            got.len(),
+            1,
+            "AsOf must NOT surface soft-deleted (expired) rows; got {got:?}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #684. Part of epic #628.

## What
`SearchIndex::{lexical,vector}_search` take a rich `FactFilter`, but `SqliteBackend` honored only `(fact_type, scope_ids)` and rejected `temporal != Active` / `ids` / `pinned` / `metadata` with a loud `Internal` — the zero-behavior-change projection #630 deliberately shipped. This closes the gap so **both** search paths honor the whole filter.

**Why now:** prerequisite for #632 conformance — a `PgBackend` honors the full filter, and conformance tests assert the two backends agree.

## Design
Chosen approach: **fragment builder in the backend `convert` layer** emits a `{where_clause, params}` `FilterSql`; the shared `search/{fts,vector}` cores gain a parametrized `_filtered` entry point, and the verbatim `fts_search`/`vector_search` wrappers now delegate to it with an active-only fragment.

- **One SQL source** — the base FTS5/vector query lives once; both the verbatim wrappers and the rich backend translation feed it.
- **Legacy path byte-identical** — `hybrid.rs` / `strategy.rs` / `ann.rs` call the unchanged wrappers; their behavior is unchanged (verified by the pre-existing verbatim tests, all green).
- **Carrier (`FilterSql`) lives in `search/`**, the rich translation (`build_filter_sql`) in the backend's `convert.rs` — no layering inversion.

## Parity — each predicate transcribes the store's own SQL (`store/facts.rs` is the oracle)
| Dimension | SQL |
|---|---|
| `Active` / `IncludeExpired` | `t_expired IS NULL` / *(none)* |
| `AsOf(t)` | `(t_valid IS NULL OR t_valid <= ?) AND (t_invalid IS NULL OR t_invalid > ?)` |
| `ValidDue(t)` | `t_valid IS NOT NULL AND t_valid <= ? AND (t_invalid IS NULL OR t_invalid > ?)` |
| `ids` / `scope_ids` | `<col> IN (SELECT value FROM json_each(?))` (preserves `Some(empty)`=matches-nothing) |
| `pinned` | `is_pinned = ?` (1/0) |
| `KeyAbsent` / `KeyPresent` | `json_type(metadata, ?) IS NULL` / `json_extract(metadata, ?) IS NOT NULL` (the store's documented absence-vs-presence asymmetry) |
| `KeyEquals(k, v)` | `json_extract(metadata, ?) = ?` (scalar only; composite fails loud) |

Timestamps bind as **RFC3339 strings** (the on-disk encoding), so lexicographic `<=`/`>` ordering is correct.

## Notable
- **JSON path binds as a parameter** (`json_extract(metadata, ?)`), not interpolated as the store does for its trusted literals — closing the injection seam for general filter input. A test empirically confirms the bundled SQLite accepts a bound path, contra the store's `facts.rs:1001` "cannot be parameterized portably" caveat (the store remains safe — it only passes trusted literals).
- `KeyEquals` on an array/object value returns `Internal` — equality against an extracted JSON scalar is undefined for composites.

## Tests
- `convert.rs` unit tests pin each rendered fragment + param count (incl. composite-rejection, `Some(empty)` round-trip).
- `search_index.rs` parity tests exercise every dimension against a hand-written SQL oracle on the same in-memory DB (IncludeExpired, ids, pinned, metadata absent/present/equals, vector AsOf window).

## Verification
- `cargo build --workspace --features async` ✓
- `cargo test --workspace --features async` ✓ (1449 passed, 9 ignored)
- `cargo clippy --workspace --all-targets --all-features` ✓ (clean)
- `cargo fmt --check` ✓
- `cargo deny check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)