### PR TITLE
fix(core): bound bootstrap parse DoS + O(n) reconstruction + serde/test fixes (#254 wave2)

### DIFF
--- a/memory-engine-cli/src/commands/bootstrap.rs
+++ b/memory-engine-cli/src/commands/bootstrap.rs
@@ -207,6 +207,11 @@ pub fn run(db: &Path, args: &BootstrapArgs, format: OutputFormat) -> anyhow::Res
         skip_existing: !args.reprocess,
         redact: true, // no bypass in normal CLI operation (#51)
         denylist,
+        // #293 hostile-input caps (max_session_bytes / max_entries): no CLI flag
+        // exposes them, so inherit the library defaults. This is what wires the
+        // caps into the CLI `bootstrap` command — the real untrusted-input entry
+        // point — rather than leaving it uncapped.
+        ..BootstrapConfig::default()
     };
 
     let report = run_bootstrap(

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1487,6 +1487,11 @@ fn handle_bootstrap_session(
         skip_existing: get_bool(args, "skip_existing").unwrap_or(true),
         redact: true,
         denylist,
+        // #293 hostile-input caps (max_session_bytes / max_entries): the MCP
+        // bootstrap tool exposes no schema for them, so inherit the library
+        // defaults. This wires the caps into the `memory_bootstrap` tool — the
+        // real untrusted-input entry point — rather than leaving it uncapped.
+        ..BootstrapConfig::default()
     };
 
     let reader = Cursor::new(jsonl_data.into_bytes());

--- a/src/bootstrap/extract.rs
+++ b/src/bootstrap/extract.rs
@@ -75,7 +75,11 @@ impl SessionExtractor for KeywordExtractor {
 
         let mut metadata = serde_json::json!({
             "session_id": episode.session_id,
-            "category": format!("{:?}", episode.category),
+            // Stable lowercase kebab form (#334) — schema-independent of the Rust
+            // variant name and consistent with the `session_outcome` convention
+            // set just below. Avoid the previous `format!("{:?}", ...)` Debug repr,
+            // which emitted capitalized strings and would silently change on rename.
+            "category": episode.category.as_str(),
             "matched_keywords": episode.matched_keywords,
         });
 
@@ -179,6 +183,34 @@ mod tests {
         assert_eq!(facts[0].fact_type, FactType::Episodic);
         assert!((facts[0].importance - 0.4).abs() < f64::EPSILON);
         assert_eq!(facts[0].metadata["session_outcome"], "failure");
+    }
+
+    #[test]
+    fn category_metadata_is_lowercase_and_roundtrips() {
+        // #334: the stored `category` must be lowercase (matching the adjacent
+        // `session_outcome` "failure"/"success"/"indeterminate" convention),
+        // schema-stable, and independent of the Rust variant name. Each variant
+        // serializes to its kebab string and parses back to the same variant.
+        for (cat, expected) in [
+            (EpisodeCategory::Bug, "bug"),
+            (EpisodeCategory::Decision, "decision"),
+            (EpisodeCategory::Convention, "convention"),
+            (EpisodeCategory::Learning, "learning"),
+        ] {
+            let ep = make_episode(cat, "x", "y");
+            let ext = KeywordExtractor;
+            let facts = ext.extract(&ep, &SessionOutcome::Success).unwrap();
+            let stored = facts[0].metadata["category"].as_str().unwrap();
+            assert_eq!(
+                stored, expected,
+                "category must be the lowercase kebab form"
+            );
+            assert_eq!(
+                stored.parse::<EpisodeCategory>(),
+                Ok(cat),
+                "stored category string must round-trip back to its variant"
+            );
+        }
     }
 
     #[test]

--- a/src/bootstrap/extract.rs
+++ b/src/bootstrap/extract.rs
@@ -302,16 +302,29 @@ mod tests {
                 user in "[\u{0}-\u{10FFFF}]{0,1500}",
                 assistant in "[\u{0}-\u{10FFFF}]{0,1500}",
             ) {
+                // build_content slices on a manual char-boundary walk-back: if it
+                // ever cut mid-codepoint, the str index would PANIC inside the
+                // call below, so simply reaching the asserts proves no split
+                // codepoint for this input (that is the real #425 guarantee).
                 let content = build_content(&episode(user, assistant));
-                // String is always valid UTF-8; assert the end is a char boundary
-                // (it always is for a String, but documents the invariant) and that
-                // the output never exceeds MAX_LEN (2000) + "..." (3 bytes).
-                prop_assert!(content.is_char_boundary(content.len()));
+                // The output never exceeds MAX_LEN (2000) + the "..." marker (3 bytes).
                 prop_assert!(
                     content.len() <= 2003,
                     "content too long: {} bytes",
                     content.len()
                 );
+                // When truncation fired, the marker must be present and the body
+                // before it must be re-sliceable on a char boundary (this slice
+                // would panic if the walk-back had split a codepoint), exercising
+                // the walk-back's boundary correctness rather than a tautology.
+                if content.len() > 2000 {
+                    prop_assert!(
+                        content.ends_with("..."),
+                        "truncated content must carry the ... marker"
+                    );
+                    let body = &content[..content.len() - 3];
+                    prop_assert!(!body.is_empty());
+                }
             }
         }
     }

--- a/src/bootstrap/extract.rs
+++ b/src/bootstrap/extract.rs
@@ -267,6 +267,55 @@ mod tests {
         assert!(facts[0].content.len() <= 2003);
     }
 
+    mod proptest_build_content {
+        use proptest::prelude::*;
+
+        use super::super::build_content;
+        use crate::bootstrap::filter::{CandidateEpisode, ConversationTurn, EpisodeCategory};
+        use chrono::Utc;
+
+        /// Build a one-turn episode from arbitrary user/assistant text.
+        fn episode(user: String, assistant: String) -> CandidateEpisode {
+            CandidateEpisode {
+                category: EpisodeCategory::Bug,
+                turns: vec![ConversationTurn {
+                    timestamp: Utc::now(),
+                    user_text: user,
+                    assistant_text: assistant,
+                    tool_calls: vec![],
+                    uuid: "t".into(),
+                }],
+                matched_keywords: vec![],
+                session_id: "s".into(),
+                timestamp: Utc::now(),
+            }
+        }
+
+        proptest! {
+            // #425: the manual char-boundary walk-back in build_content must never
+            // cut a multi-byte codepoint or overrun the MAX_LEN + "..." bound, for
+            // ANY UTF-8 input. The strategy spans the full Unicode range up to
+            // 4-byte codepoints (`\u{10FFFF}`), so a multi-byte char can straddle
+            // the 2000-byte truncation point — the case ASCII-only tests cannot hit.
+            #[test]
+            fn truncated_content_is_valid_utf8_and_bounded(
+                user in "[\u{0}-\u{10FFFF}]{0,1500}",
+                assistant in "[\u{0}-\u{10FFFF}]{0,1500}",
+            ) {
+                let content = build_content(&episode(user, assistant));
+                // String is always valid UTF-8; assert the end is a char boundary
+                // (it always is for a String, but documents the invariant) and that
+                // the output never exceeds MAX_LEN (2000) + "..." (3 bytes).
+                prop_assert!(content.is_char_boundary(content.len()));
+                prop_assert!(
+                    content.len() <= 2003,
+                    "content too long: {} bytes",
+                    content.len()
+                );
+            }
+        }
+    }
+
     #[test]
     fn custom_extractor() {
         /// A mock extractor that always returns an empty vec.

--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -828,6 +828,37 @@ mod tests {
     }
 
     #[test]
+    fn keyword_match_bug_error_in_assistant_with_context() {
+        // #423: the second branch of `check_error_keyword` fires when "error"
+        // appears in assistant text AND a bug-context word (fix/bug/issue) is
+        // also present — with no tool stderr. Previously only the stderr branch
+        // was covered.
+        let turn = make_turn("", "There is an error in the fix, see below.");
+        let episodes = keyword_prefilter(&[turn], "s1");
+        let bug = episodes
+            .iter()
+            .find(|e| e.category == EpisodeCategory::Bug)
+            .expect("assistant 'error' + 'fix' context must produce a Bug episode");
+        assert!(
+            bug.matched_keywords.contains(&"error".to_owned()),
+            "the special-cased 'error' keyword must be recorded"
+        );
+    }
+
+    #[test]
+    fn keyword_no_bug_error_without_context() {
+        // #423 negative: "error" in assistant text with NO bug-context word and
+        // no other bug keyword (root cause/traceback/exception/fix) and no
+        // stderr must NOT classify as Bug — `check_error_keyword` returns false.
+        let turn = make_turn("", "An error occurred during compilation overnight.");
+        let episodes = keyword_prefilter(&[turn], "s1");
+        assert!(
+            !episodes.iter().any(|e| e.category == EpisodeCategory::Bug),
+            "bare 'error' without bug context must not be a Bug episode"
+        );
+    }
+
+    #[test]
     fn keyword_match_decision() {
         let turn = make_turn("which approach?", "I decided to use serde for parsing.");
         let episodes = keyword_prefilter(&[turn], "s1");

--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -4,7 +4,7 @@
 //! then applies rule-based keyword matching to surface [`CandidateEpisode`]s worth
 //! promoting to long-term memory.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
 
@@ -131,11 +131,48 @@ pub fn reconstruct_turns(entries: &[SessionEntry]) -> Vec<ConversationTurn> {
     let mut used: HashSet<&str> = HashSet::new();
     let mut turns: Vec<ConversationTurn> = Vec::new();
 
-    // --- UUID-linked pairing ---
     // Separate user entries that are tool results (carry tool_use_result)
     // from user entries that are genuine prompts.
     let is_tool_result = |e: &SessionEntry| -> bool { e.tool_use_result.is_some() };
 
+    // --- Pre-index for O(n) pairing (#406) ---
+    // Two indices over the attacker-controlled `relevant` slice, each built in a
+    // single O(n) pass, replace the per-user linear scans that made the original
+    // reconstruction O(n^2) (an algorithmic-complexity DoS amplifier).
+    //
+    // `assistant_by_parent`: parent_uuid -> the FIRST assistant carrying it (slice
+    // order preserved via `entry`/`or_insert`), matching the old `.find()` which
+    // returned the first such assistant. The `used` check stays at the call site.
+    //
+    // `tool_results_by_parent`: parent_uuid -> the tool-result user entries that
+    // follow an assistant, in slice order — the O(1) replacement for the
+    // per-call full scan in `collect_tool_result_entries`.
+    let mut assistant_by_parent: HashMap<&str, &SessionEntry> = HashMap::new();
+    let mut tool_results_by_parent: HashMap<&str, Vec<&SessionEntry>> = HashMap::new();
+    for entry in &relevant {
+        match entry.entry_type {
+            EntryType::Assistant => {
+                if let Some(parent) = entry.parent_uuid.as_deref()
+                    && !parent.is_empty()
+                {
+                    assistant_by_parent.entry(parent).or_insert(entry);
+                }
+            }
+            EntryType::User if is_tool_result(entry) => {
+                if let Some(parent) = entry.parent_uuid.as_deref()
+                    && !parent.is_empty()
+                {
+                    tool_results_by_parent
+                        .entry(parent)
+                        .or_default()
+                        .push(entry);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // --- UUID-linked pairing ---
     for entry in &relevant {
         if !matches!(entry.entry_type, EntryType::User) || is_tool_result(entry) {
             continue;
@@ -147,18 +184,16 @@ pub fn reconstruct_turns(entries: &[SessionEntry]) -> Vec<ConversationTurn> {
             continue;
         }
 
-        // Find assistant reply whose parent_uuid matches this user's uuid.
-        let assistant = relevant.iter().find(|a| {
-            matches!(a.entry_type, EntryType::Assistant)
-                && a.parent_uuid
-                    .as_deref()
-                    .is_some_and(|p| !p.is_empty() && p == user_uuid)
-                && a.uuid.as_deref().is_some_and(|u| !used.contains(u))
-        });
+        // O(1) lookup of the assistant whose parent_uuid matches this user's uuid;
+        // re-apply the `used` guard the old `.find()` carried inline.
+        let assistant = assistant_by_parent
+            .get(user_uuid.as_str())
+            .copied()
+            .filter(|a| a.uuid.as_deref().is_some_and(|u| !used.contains(u)));
 
         if let Some(assistant) = assistant {
             // Collect tool-result user entries that follow this assistant.
-            let tool_results = collect_tool_result_entries(&relevant, assistant);
+            let tool_results = collect_tool_result_entries(&tool_results_by_parent, assistant);
             turns.push(build_turn(entry, assistant, &tool_results));
             used.insert(user_uuid.as_str());
             if let Some(ref a_uuid) = assistant.uuid {
@@ -194,7 +229,7 @@ pub fn reconstruct_turns(entries: &[SessionEntry]) -> Vec<ConversationTurn> {
                 });
 
             if let Some(assistant) = assistant {
-                let tool_results = collect_tool_result_entries(&relevant, assistant);
+                let tool_results = collect_tool_result_entries(&tool_results_by_parent, assistant);
                 turns.push(build_turn(entry, assistant, &tool_results));
                 used.insert(entry_uuid);
                 if let Some(ref a_uuid) = assistant.uuid {
@@ -248,25 +283,25 @@ fn build_turn(
     }
 }
 
-/// Collect user entries that carry `tool_use_result` and whose `parent_uuid`
-/// points to the given assistant entry. These are the tool-result rows that
-/// follow an assistant's `tool_use` blocks in Claude Code JSONL.
+/// Look up the user entries that carry `tool_use_result` and whose `parent_uuid`
+/// points to the given assistant entry — the tool-result rows that follow an
+/// assistant's `tool_use` blocks in Claude Code JSONL.
+///
+/// O(1) lookup into the `tool_results_by_parent` index built once by
+/// [`reconstruct_turns`] (#406), replacing the former per-call O(n) scan. Slice
+/// order within each group is preserved by the index, so positional pairing in
+/// [`extract_tool_calls`] is unchanged.
 fn collect_tool_result_entries<'a>(
-    all: &[&'a SessionEntry],
+    tool_results_by_parent: &HashMap<&str, Vec<&'a SessionEntry>>,
     assistant: &SessionEntry,
 ) -> Vec<&'a SessionEntry> {
     let Some(ref assistant_uuid) = assistant.uuid else {
         return Vec::new();
     };
-    all.iter()
-        .filter(|e| {
-            e.tool_use_result.is_some()
-                && e.parent_uuid
-                    .as_deref()
-                    .is_some_and(|p| p == assistant_uuid)
-        })
-        .copied()
-        .collect()
+    tool_results_by_parent
+        .get(assistant_uuid.as_str())
+        .cloned()
+        .unwrap_or_default()
 }
 
 /// Extract plain text from an entry's message content blocks.
@@ -700,6 +735,45 @@ mod tests {
         let turns = reconstruct_turns(&entries);
         assert_eq!(turns.len(), 1);
         assert!(!turns[0].tool_calls[0].interrupted);
+    }
+
+    #[test]
+    fn reconstruct_pairs_multiple_tool_results_in_order() {
+        // #406 regression guard: the O(n) `tool_results_by_parent` index must
+        // preserve slice order WITHIN a parent group, so two tool-result rows
+        // pair POSITIONALLY with the assistant's two tool_use blocks (1st→1st,
+        // 2nd→2nd). A HashMap that lost intra-group order would mis-pair them.
+        let assistant = SessionEntry {
+            entry_type: EntryType::Assistant,
+            session_id: Some("sess-1".into()),
+            timestamp: ts(101).map(|t| t.to_rfc3339()),
+            uuid: opt("a1"),
+            parent_uuid: opt("u1"),
+            cwd: None,
+            git_branch: None,
+            message: Some(MessagePayload {
+                role: Some("assistant".into()),
+                content: Some(json!([
+                    {"type": "tool_use", "name": "Bash", "input": {"cmd": "first"}},
+                    {"type": "tool_use", "name": "Read", "input": {"path": "second"}}
+                ])),
+            }),
+            tool_use_result: None,
+            data: None,
+        };
+        let entries = vec![
+            user_entry("u1", "", "do two things", 100),
+            assistant,
+            user_with_tool_result("u2", "a1", "", Some("out-first"), None, false, 102),
+            user_with_tool_result("u3", "a1", "", Some("out-second"), None, false, 103),
+        ];
+        let turns = reconstruct_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 2);
+        assert_eq!(turns[0].tool_calls[0].tool_name, "Bash");
+        assert_eq!(turns[0].tool_calls[0].stdout.as_deref(), Some("out-first"));
+        assert_eq!(turns[0].tool_calls[1].tool_name, "Read");
+        assert_eq!(turns[0].tool_calls[1].stdout.as_deref(), Some("out-second"));
     }
 
     // -- keyword_prefilter tests --

--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -140,14 +140,17 @@ pub fn reconstruct_turns(entries: &[SessionEntry]) -> Vec<ConversationTurn> {
     // single O(n) pass, replace the per-user linear scans that made the original
     // reconstruction O(n^2) (an algorithmic-complexity DoS amplifier).
     //
-    // `assistant_by_parent`: parent_uuid -> the FIRST assistant carrying it (slice
-    // order preserved via `entry`/`or_insert`), matching the old `.find()` which
-    // returned the first such assistant. The `used` check stays at the call site.
+    // `assistant_by_parent`: parent_uuid -> ALL assistants carrying it, in slice
+    // order. The lookup picks the first VALID (uuid present) and not-yet-`used`
+    // candidate, exactly matching the old linear `.find()` — keeping a single
+    // entry would drop the turn when the first assistant for a parent is invalid
+    // (uuid-less) or already used, even though a later valid one exists (a
+    // corrupt/partial JSONL case).
     //
     // `tool_results_by_parent`: parent_uuid -> the tool-result user entries that
     // follow an assistant, in slice order — the O(1) replacement for the
     // per-call full scan in `collect_tool_result_entries`.
-    let mut assistant_by_parent: HashMap<&str, &SessionEntry> = HashMap::new();
+    let mut assistant_by_parent: HashMap<&str, Vec<&SessionEntry>> = HashMap::new();
     let mut tool_results_by_parent: HashMap<&str, Vec<&SessionEntry>> = HashMap::new();
     for entry in &relevant {
         match entry.entry_type {
@@ -155,7 +158,7 @@ pub fn reconstruct_turns(entries: &[SessionEntry]) -> Vec<ConversationTurn> {
                 if let Some(parent) = entry.parent_uuid.as_deref()
                     && !parent.is_empty()
                 {
-                    assistant_by_parent.entry(parent).or_insert(entry);
+                    assistant_by_parent.entry(parent).or_default().push(entry);
                 }
             }
             EntryType::User if is_tool_result(entry) => {
@@ -184,12 +187,18 @@ pub fn reconstruct_turns(entries: &[SessionEntry]) -> Vec<ConversationTurn> {
             continue;
         }
 
-        // O(1) lookup of the assistant whose parent_uuid matches this user's uuid;
-        // re-apply the `used` guard the old `.find()` carried inline.
+        // Lookup the assistants whose parent_uuid matches this user's uuid and
+        // pick the first valid (uuid present) and not-yet-`used` one — the same
+        // selection the old linear `.find()` made, now scoped to this parent's
+        // (typically singleton) candidate list rather than the whole slice.
         let assistant = assistant_by_parent
             .get(user_uuid.as_str())
-            .copied()
-            .filter(|a| a.uuid.as_deref().is_some_and(|u| !used.contains(u)));
+            .and_then(|cands| {
+                cands
+                    .iter()
+                    .copied()
+                    .find(|a| a.uuid.as_deref().is_some_and(|u| !used.contains(u)))
+            });
 
         if let Some(assistant) = assistant {
             // Collect tool-result user entries that follow this assistant.
@@ -773,6 +782,23 @@ mod tests {
         assert_eq!(turns[0].tool_calls[0].stdout.as_deref(), Some("out-first"));
         assert_eq!(turns[0].tool_calls[1].tool_name, "Read");
         assert_eq!(turns[0].tool_calls[1].stdout.as_deref(), Some("out-second"));
+    }
+
+    /// Regression (#406 index): when the first assistant carrying a `parent_uuid`
+    /// is invalid (uuid-less), the per-parent index must still find a LATER valid
+    /// assistant for the same parent, matching the old linear `.find()`. A single
+    /// first-only index dropped the turn here.
+    #[test]
+    fn parent_index_skips_invalid_assistant_to_later_valid_one() {
+        let entries = vec![
+            user_entry("u1", "", "please fix it", 0),
+            // Invalid assistant for u1 first (no uuid) — must NOT shadow the valid one.
+            assistant_entry("", "u1", "corrupt partial row", 1),
+            assistant_entry("a1", "u1", "the real reply", 2),
+        ];
+        let turns = reconstruct_turns(&entries);
+        assert_eq!(turns.len(), 1, "the valid later assistant must still pair");
+        assert!(turns[0].assistant_text.contains("the real reply"));
     }
 
     // -- keyword_prefilter tests --

--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -194,12 +194,12 @@ pub fn reconstruct_turns(entries: &[SessionEntry]) -> Vec<ConversationTurn> {
         if let Some(assistant) = assistant {
             // Collect tool-result user entries that follow this assistant.
             let tool_results = collect_tool_result_entries(&tool_results_by_parent, assistant);
-            turns.push(build_turn(entry, assistant, &tool_results));
+            turns.push(build_turn(entry, assistant, tool_results));
             used.insert(user_uuid.as_str());
             if let Some(ref a_uuid) = assistant.uuid {
                 used.insert(a_uuid.as_str());
             }
-            for tr in &tool_results {
+            for tr in tool_results {
                 if let Some(ref u) = tr.uuid {
                     used.insert(u.as_str());
                 }
@@ -230,12 +230,12 @@ pub fn reconstruct_turns(entries: &[SessionEntry]) -> Vec<ConversationTurn> {
 
             if let Some(assistant) = assistant {
                 let tool_results = collect_tool_result_entries(&tool_results_by_parent, assistant);
-                turns.push(build_turn(entry, assistant, &tool_results));
+                turns.push(build_turn(entry, assistant, tool_results));
                 used.insert(entry_uuid);
                 if let Some(ref a_uuid) = assistant.uuid {
                     used.insert(a_uuid.as_str());
                 }
-                for tr in &tool_results {
+                for tr in tool_results {
                     if let Some(ref u) = tr.uuid {
                         used.insert(u.as_str());
                     }
@@ -291,17 +291,16 @@ fn build_turn(
 /// [`reconstruct_turns`] (#406), replacing the former per-call O(n) scan. Slice
 /// order within each group is preserved by the index, so positional pairing in
 /// [`extract_tool_calls`] is unchanged.
-fn collect_tool_result_entries<'a>(
-    tool_results_by_parent: &HashMap<&str, Vec<&'a SessionEntry>>,
+fn collect_tool_result_entries<'a, 'b>(
+    tool_results_by_parent: &'b HashMap<&str, Vec<&'a SessionEntry>>,
     assistant: &SessionEntry,
-) -> Vec<&'a SessionEntry> {
+) -> &'b [&'a SessionEntry] {
     let Some(ref assistant_uuid) = assistant.uuid else {
-        return Vec::new();
+        return &[];
     };
     tool_results_by_parent
         .get(assistant_uuid.as_str())
-        .cloned()
-        .unwrap_or_default()
+        .map_or(&[], Vec::as_slice)
 }
 
 /// Extract plain text from an entry's message content blocks.

--- a/src/bootstrap/filter.rs
+++ b/src/bootstrap/filter.rs
@@ -44,6 +44,42 @@ pub enum EpisodeCategory {
     Learning,
 }
 
+impl EpisodeCategory {
+    /// Stable lowercase string stored in fact metadata (the `category` key).
+    ///
+    /// This is the persisted on-wire form and must not change — it aligns with
+    /// the adjacent `session_outcome` convention (`"failure"`/`"success"`/…)
+    /// and decouples the stored schema from the Rust variant names, so a variant
+    /// rename can no longer silently alter stored data (#334). Round-trips via
+    /// [`EpisodeCategory::from_str`].
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Bug => "bug",
+            Self::Decision => "decision",
+            Self::Convention => "convention",
+            Self::Learning => "learning",
+        }
+    }
+}
+
+impl std::str::FromStr for EpisodeCategory {
+    type Err = ();
+
+    /// Parse the stored [`EpisodeCategory::as_str`] form back into a variant.
+    ///
+    /// Returns `Err(())` for any unrecognized string.
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "bug" => Ok(Self::Bug),
+            "decision" => Ok(Self::Decision),
+            "convention" => Ok(Self::Convention),
+            "learning" => Ok(Self::Learning),
+            _ => Err(()),
+        }
+    }
+}
+
 /// A candidate episode extracted by the rule-based pre-filter.
 #[derive(Debug, Clone)]
 pub struct CandidateEpisode {

--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -30,6 +30,18 @@ pub struct BootstrapConfig {
     /// signature detectors; empty = signatures-only. Ignored when `redact` is
     /// `false`.
     pub denylist: Vec<String>,
+    /// Maximum total bytes read from a single session stream before parsing
+    /// stops (#293). Bounds the per-stream I/O against a hostile or corrupt
+    /// `.jsonl` of many in-bounds lines; the reader is wrapped in
+    /// [`std::io::Read::take`]. `0` = no per-stream limit. Defaults to
+    /// [`crate::bootstrap::parse::DEFAULT_MAX_SESSION_BYTES`] (256 MiB).
+    pub max_session_bytes: u64,
+    /// Maximum number of parsed entries retained from a single session before
+    /// parsing stops with a truncation `warn` (#293). Bounds the in-memory
+    /// entry `Vec` — and every downstream linear pass — against an entry-count
+    /// flood. `0` = no entry-count limit. Defaults to
+    /// [`crate::bootstrap::parse::DEFAULT_MAX_ENTRIES`] (1,000,000).
+    pub max_entries: usize,
 }
 
 impl Default for BootstrapConfig {
@@ -40,6 +52,8 @@ impl Default for BootstrapConfig {
             skip_existing: true,
             redact: true,
             denylist: Vec::new(),
+            max_session_bytes: super::parse::DEFAULT_MAX_SESSION_BYTES,
+            max_entries: super::parse::DEFAULT_MAX_ENTRIES,
         }
     }
 }

--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -9,6 +9,13 @@ pub struct BootstrapConfig {
     /// `None` falls back to the root scope.
     pub scope: Option<String>,
     /// Maximum turns to process per session. `0` = no limit.
+    ///
+    /// When the session exceeds this limit the **most-recent** turns are kept
+    /// (tail selection), because outcome evidence — commits, test results —
+    /// concentrates at the end of sessions. Outcome classification always runs
+    /// on the full turn list *before* truncation, so capping does not change the
+    /// session outcome; it only bounds how many turns reach the keyword
+    /// pre-filter and fact extraction.
     pub max_turns: usize,
     /// Skip sessions already bootstrapped (idempotency via `session_id` check).
     pub skip_existing: bool,

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -352,7 +352,12 @@ fn bootstrap_within_savepoint(
     // Apply max_turns limit AFTER outcome classification, keeping the TAIL
     // (most recent turns) since they contain resolution evidence.
     let turns = if ctx.config.max_turns > 0 && turns.len() > ctx.config.max_turns {
-        turns[turns.len() - ctx.config.max_turns..].to_vec()
+        // Keep the TAIL in place: drain the head prefix rather than cloning the
+        // kept turns via slice + to_vec (each ConversationTurn owns strings/vecs).
+        let mut turns = turns;
+        let drop_head = turns.len() - ctx.config.max_turns;
+        turns.drain(..drop_head);
+        turns
     } else {
         turns
     };

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,7 +1,7 @@
 //! Session log bootstrap: parse Claude Code JSONL session logs into historical memory.
 //!
-//! Pipeline: JSONL → parse → reconstruct turns → classify outcome → keyword pre-filter
-//! → extract facts → ingest marker event + add facts.
+//! Pipeline: JSONL → parse → [idempotency check] → ingest marker event (savepoint anchor)
+//! → reconstruct turns → classify outcome → keyword pre-filter → extract facts → add facts.
 
 pub(crate) mod extract;
 pub(crate) mod filter;
@@ -37,8 +37,10 @@ pub use redact::{
 
 /// Bootstrap one session from a JSONL reader into the memory engine.
 ///
-/// Pipeline: parse → reconstruct turns → classify outcome → keyword pre-filter
-/// → extract facts → ingest marker event + add facts (within a savepoint).
+/// Pipeline: parse → [idempotency check] → ingest marker event (savepoint anchor)
+/// → reconstruct turns → classify outcome → keyword pre-filter → extract facts → add facts.
+/// The marker event is ingested *first* inside the savepoint so it can anchor the
+/// idempotency check; turn reconstruction, classification, and extraction follow.
 ///
 /// # Errors
 ///

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -35,6 +35,32 @@ pub use redact::{
     shannon_entropy,
 };
 
+/// Shared dependencies threaded through the JSONL bootstrap pipeline (#123).
+///
+/// Bundles the engine-level handles and per-run configuration that every stage
+/// of `bootstrap_session_inner` → `bootstrap_within_savepoint` →
+/// `store_extracted_fact` (and the directory driver) needs, so each function
+/// takes the context plus only its own stage-specific arguments instead of a
+/// 9-to-11-parameter list. All members are borrows scoped to one bootstrap call.
+pub(crate) struct BootstrapContext<'a> {
+    /// Open write connection (the caller holds the write lock).
+    pub conn: &'a Connection,
+    /// Embedding dimensionality the [`FactStore`] is opened with.
+    pub embed_dim: usize,
+    /// Event-schema upcaster registry for the marker/event writes.
+    pub upcaster_registry: &'a UpcasterRegistry,
+    /// Consumer-supplied embedder (no LLM/network owned by the engine).
+    pub embedder: &'a dyn EmbeddingProvider,
+    /// Fact extractor (default keyword, or a consumer LLM extractor).
+    pub extractor: &'a dyn SessionExtractor,
+    /// Per-run configuration (scope, caps, redaction, idempotency).
+    pub config: &'a BootstrapConfig,
+    /// Optional auto-pin classifier consulted per created fact.
+    pub classifier: Option<&'a dyn PersistenceClassifier>,
+    /// Resolved scope id facts are ingested into.
+    pub scope_id: i64,
+}
+
 /// Bootstrap one session from a JSONL reader into the memory engine.
 ///
 /// Pipeline: parse → [idempotency check] → ingest marker event (savepoint anchor)
@@ -46,23 +72,15 @@ pub use redact::{
 ///
 /// Returns errors from the engine (DB, embedding) or extraction failures.
 /// Malformed JSONL lines are skipped with `tracing::warn`.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn bootstrap_session_inner(
-    conn: &Connection,
-    embed_dim: usize,
-    upcaster_registry: &UpcasterRegistry,
+    ctx: &BootstrapContext<'_>,
     reader: impl BufRead,
-    embedder: &dyn EmbeddingProvider,
-    extractor: &dyn SessionExtractor,
-    config: &BootstrapConfig,
-    classifier: Option<&dyn PersistenceClassifier>,
-    scope_id: i64,
 ) -> Result<BootstrapReport> {
     let mut report = BootstrapReport::default();
 
     // --- Parse (bounded against hostile/corrupt input, #293) ---
     let (entries, malformed) =
-        parse::parse_session_file(reader, config.max_session_bytes, config.max_entries);
+        parse::parse_session_file(reader, ctx.config.max_session_bytes, ctx.config.max_entries);
     report.entries_parsed = entries.len();
     report.entries_malformed = malformed;
 
@@ -78,8 +96,8 @@ pub(crate) fn bootstrap_session_inner(
     }
 
     // --- Idempotency check ---
-    if config.skip_existing {
-        let event_store = EventStore::new(conn, upcaster_registry);
+    if ctx.config.skip_existing {
+        let event_store = EventStore::new(ctx.conn, ctx.upcaster_registry);
         let filter = EventFilter {
             session_id: Some(session_id.clone()),
             source: Some("bootstrap".into()),
@@ -93,25 +111,13 @@ pub(crate) fn bootstrap_session_inner(
     }
 
     // --- Savepoint for crash safety ---
-    conn.execute_batch("SAVEPOINT bootstrap")?;
+    ctx.conn.execute_batch("SAVEPOINT bootstrap")?;
 
-    let result = bootstrap_within_savepoint(
-        conn,
-        embed_dim,
-        upcaster_registry,
-        &entries,
-        &session_id,
-        embedder,
-        extractor,
-        config,
-        classifier,
-        scope_id,
-        &mut report,
-    );
+    let result = bootstrap_within_savepoint(ctx, &entries, &session_id, &mut report);
 
     match result {
         Ok(()) => {
-            conn.execute_batch("RELEASE bootstrap")?;
+            ctx.conn.execute_batch("RELEASE bootstrap")?;
             report.sessions_processed = 1;
             Ok(report)
         }
@@ -119,10 +125,10 @@ pub(crate) fn bootstrap_session_inner(
             // ROLLBACK TO restores the savepoint but keeps it open —
             // we must RELEASE to close it and avoid leaving the writer
             // in an open transaction.
-            if let Err(rb_err) = conn.execute_batch("ROLLBACK TO bootstrap") {
+            if let Err(rb_err) = ctx.conn.execute_batch("ROLLBACK TO bootstrap") {
                 tracing::warn!(error = %rb_err, "savepoint ROLLBACK TO bootstrap failed");
             }
-            if let Err(rel_err) = conn.execute_batch("RELEASE bootstrap") {
+            if let Err(rel_err) = ctx.conn.execute_batch("RELEASE bootstrap") {
                 tracing::warn!(error = %rel_err, "savepoint RELEASE bootstrap (after rollback) failed");
             }
             Err(e)
@@ -192,16 +198,12 @@ fn redact_turns(turns: &mut [ConversationTurn], denylist: &[String]) -> usize {
 /// fact was *reinforced* rather than created. Updates `report`'s
 /// `facts_created`/`facts_reinforced`/`secrets_redacted` and the prewarm tallies
 /// in place. The session-path analogue of `memory_dir::import_one_memory`.
-#[allow(clippy::too_many_arguments)]
 fn store_extracted_fact(
+    ctx: &BootstrapContext<'_>,
     fact_store: &FactStore,
-    embedder: &dyn EmbeddingProvider,
-    config: &BootstrapConfig,
-    classifier: Option<&dyn PersistenceClassifier>,
     fact: &ExtractedFact,
     effective_created: DateTime<Utc>,
     marker_event_id: i64,
-    scope_id: i64,
     report: &mut BootstrapReport,
 ) -> Result<f64> {
     // Defense-in-depth redaction (#45/#51): the turns were already scrubbed
@@ -213,8 +215,9 @@ fn store_extracted_fact(
     // re-scrubs but does not re-count). Disabled only when `config.redact` is
     // false (library/test callers); the CLI has no bypass.
     let mut redactions = 0usize;
-    let content = if config.redact {
-        let (clean, findings) = redact::redact_text_with_denylist(&fact.content, &config.denylist);
+    let content = if ctx.config.redact {
+        let (clean, findings) =
+            redact::redact_text_with_denylist(&fact.content, &ctx.config.denylist);
         redactions += findings.len();
         clean
     } else {
@@ -225,8 +228,8 @@ fn store_extracted_fact(
     // may place turn-derived text in metadata, and the stored row must carry no
     // unredacted secret anywhere (not just in content). Keys are left intact.
     let mut metadata = fact.metadata.clone();
-    if config.redact {
-        redactions += redact::redact_json_strings(&mut metadata, &config.denylist);
+    if ctx.config.redact {
+        redactions += redact::redact_json_strings(&mut metadata, &ctx.config.denylist);
     }
 
     // Session files are third-party input: a fact whose (redacted) content or
@@ -241,9 +244,9 @@ fn store_extracted_fact(
         return Ok(0.0);
     }
 
-    let embedding = embedder.embed(&content)?;
+    let embedding = ctx.embedder.embed(&content)?;
 
-    let is_pinned = classifier.is_some_and(|c| {
+    let is_pinned = ctx.classifier.is_some_and(|c| {
         let temp = crate::types::Fact {
             id: 0,
             content: content.clone(),
@@ -259,7 +262,7 @@ fn store_extracted_fact(
             access_count: 0,
             last_accessed: effective_created,
             metadata: metadata.clone(),
-            scope_id,
+            scope_id: ctx.scope_id,
             is_pinned: false,
             importance_score: fact.importance,
             surfaced_at: None,
@@ -284,7 +287,7 @@ fn store_extracted_fact(
         t_valid: None,
         t_invalid: None,
         source_event_id: Some(marker_event_id),
-        scope_id,
+        scope_id: ctx.scope_id,
         importance: fact.importance,
         access_count: 0,
         last_accessed: effective_created,
@@ -314,22 +317,15 @@ fn store_extracted_fact(
 }
 
 /// Inner pipeline logic running within a savepoint.
-#[allow(clippy::too_many_arguments)]
 fn bootstrap_within_savepoint(
-    conn: &Connection,
-    embed_dim: usize,
-    upcaster_registry: &UpcasterRegistry,
+    ctx: &BootstrapContext<'_>,
     entries: &[parse::SessionEntry],
     session_id: &str,
-    embedder: &dyn EmbeddingProvider,
-    extractor: &dyn SessionExtractor,
-    config: &BootstrapConfig,
-    classifier: Option<&dyn PersistenceClassifier>,
-    scope_id: i64,
     report: &mut BootstrapReport,
 ) -> Result<()> {
     // --- Ingest marker event (idempotency anchor) ---
-    let marker_event_id = ingest_bootstrap_marker(conn, upcaster_registry, session_id, scope_id)?;
+    let marker_event_id =
+        ingest_bootstrap_marker(ctx.conn, ctx.upcaster_registry, session_id, ctx.scope_id)?;
     report.events_ingested = 1;
 
     // --- Reconstruct turns ---
@@ -344,8 +340,8 @@ fn bootstrap_within_savepoint(
     // perturb classification or the keyword pre-filter. Counted here (per
     // session); a redundant re-run is skipped on the bootstrap marker before
     // reaching this point, so the count stays idempotent.
-    if config.redact {
-        report.secrets_redacted += redact_turns(&mut turns, &config.denylist);
+    if ctx.config.redact {
+        report.secrets_redacted += redact_turns(&mut turns, &ctx.config.denylist);
     }
 
     // --- Classify outcome on FULL turns (before truncation) ---
@@ -355,8 +351,8 @@ fn bootstrap_within_savepoint(
 
     // Apply max_turns limit AFTER outcome classification, keeping the TAIL
     // (most recent turns) since they contain resolution evidence.
-    let turns = if config.max_turns > 0 && turns.len() > config.max_turns {
-        turns[turns.len() - config.max_turns..].to_vec()
+    let turns = if ctx.config.max_turns > 0 && turns.len() > ctx.config.max_turns {
+        turns[turns.len() - ctx.config.max_turns..].to_vec()
     } else {
         turns
     };
@@ -388,20 +384,17 @@ fn bootstrap_within_savepoint(
     // When the `ann` feature is enabled, bootstrapped facts won't be in the
     // HNSW index until the engine is reopened (index is built from DB at open).
     // This is acceptable for a batch import operation.
-    let fact_store = FactStore::new(conn, embed_dim);
+    let fact_store = FactStore::new(ctx.conn, ctx.embed_dim);
 
     for candidate in &candidates {
-        let facts = extractor.extract(candidate, &outcome)?;
+        let facts = ctx.extractor.extract(candidate, &outcome)?;
         for fact in &facts {
             importance_sum += store_extracted_fact(
+                ctx,
                 &fact_store,
-                embedder,
-                config,
-                classifier,
                 fact,
                 candidate.timestamp,
                 marker_event_id,
-                scope_id,
                 report,
             )?;
         }
@@ -428,7 +421,11 @@ fn bootstrap_within_savepoint(
     // landmine this averts). The `embedder.fingerprint()` and `embed_dim` are the same
     // values the engine's `record_embedding_identity` seam would have used.
     if report.facts_created > 0 {
-        crate::store::embedding_meta::record_if_absent(conn, &embedder.fingerprint(), embed_dim)?;
+        crate::store::embedding_meta::record_if_absent(
+            ctx.conn,
+            &ctx.embedder.fingerprint(),
+            ctx.embed_dim,
+        )?;
     }
 
     Ok(())
@@ -471,17 +468,9 @@ fn collect_jsonl_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) -> std::io
 ///
 /// Returns `MemoryError::Io` for directory traversal failures.
 /// Individual session failures are logged and skipped (not fatal).
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn bootstrap_directory_inner(
-    conn: &Connection,
-    embed_dim: usize,
-    upcaster_registry: &UpcasterRegistry,
+    ctx: &BootstrapContext<'_>,
     dir: &Path,
-    embedder: &dyn EmbeddingProvider,
-    extractor: &dyn SessionExtractor,
-    config: &BootstrapConfig,
-    classifier: Option<&dyn PersistenceClassifier>,
-    scope_id: i64,
 ) -> Result<BootstrapReport> {
     let mut aggregate = BootstrapReport::default();
 
@@ -499,17 +488,7 @@ pub(crate) fn bootstrap_directory_inner(
         };
         let reader = std::io::BufReader::new(file);
 
-        match bootstrap_session_inner(
-            conn,
-            embed_dim,
-            upcaster_registry,
-            reader,
-            embedder,
-            extractor,
-            config,
-            classifier,
-            scope_id,
-        ) {
+        match bootstrap_session_inner(ctx, reader) {
             Ok(report) => aggregate.merge(&report),
             Err(e) => {
                 tracing::warn!(path = %path.display(), error = %e, "skipping session file");
@@ -554,18 +533,18 @@ mod tests {
         let config = BootstrapConfig::default();
         let extractor = extract::KeywordExtractor;
 
-        let report = bootstrap_session_inner(
-            &conn,
-            4,
-            &registry,
-            reader,
-            &NeverCalledEmbedder,
-            &extractor,
-            &config,
-            None,
-            1, // root scope id
-        )
-        .expect("bootstrap_session_inner should succeed");
+        let ctx = BootstrapContext {
+            conn: &conn,
+            embed_dim: 4,
+            upcaster_registry: &registry,
+            embedder: &NeverCalledEmbedder,
+            extractor: &extractor,
+            config: &config,
+            classifier: None,
+            scope_id: 1, // root scope id
+        };
+        let report =
+            bootstrap_session_inner(&ctx, reader).expect("bootstrap_session_inner should succeed");
 
         // Early-exit path: entries parsed but nothing processed.
         assert!(report.entries_parsed > 0, "expected entries to be parsed");

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -60,8 +60,9 @@ pub(crate) fn bootstrap_session_inner(
 ) -> Result<BootstrapReport> {
     let mut report = BootstrapReport::default();
 
-    // --- Parse ---
-    let (entries, malformed) = parse::parse_session_file(reader);
+    // --- Parse (bounded against hostile/corrupt input, #293) ---
+    let (entries, malformed) =
+        parse::parse_session_file(reader, config.max_session_bytes, config.max_entries);
     report.entries_parsed = entries.len();
     report.entries_malformed = malformed;
 

--- a/src/bootstrap/parse.rs
+++ b/src/bootstrap/parse.rs
@@ -110,6 +110,34 @@ pub enum ContentBlock {
 /// worst-case working set to a constant.
 pub const MAX_JSONL_LINE_BYTES: usize = 8 * 1024 * 1024;
 
+/// Default ceiling on total bytes read from one session stream (#293).
+///
+/// The per-line cap ([`MAX_JSONL_LINE_BYTES`]) bounds a single allocation, but a
+/// hostile file of *many* in-bounds lines still streams unboundedly. This caps
+/// the whole stream: the reader is wrapped in `Read::take`, so reading stops
+/// after this many bytes regardless of line structure. Any logical line
+/// straddling the boundary is truncated and, lacking its terminating newline,
+/// is treated as a (final) malformed/oversized line rather than parsed.
+///
+/// 256 MiB is generously above any real Claude Code session file while keeping
+/// the worst-case I/O bounded. Surfaced as [`crate::bootstrap::BootstrapConfig::max_session_bytes`].
+pub const DEFAULT_MAX_SESSION_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Default ceiling on the number of [`SessionEntry`] values retained from one
+/// stream (#293).
+///
+/// Each parsed entry is pushed into an in-memory `Vec`, and every downstream
+/// pass (turn reconstruction, classification, extraction) is at least linear in
+/// the entry count — so an unbounded count is both a memory and a CPU `DoS`.
+/// Once this many entries are collected the parse loop stops with a `warn`,
+/// analogous to the oversized-line skip. The session is processed best-effort on
+/// the retained prefix.
+///
+/// 1,000,000 entries is far beyond any genuine session while bounding the
+/// working set to a constant. Surfaced as
+/// [`crate::bootstrap::BootstrapConfig::max_entries`].
+pub const DEFAULT_MAX_ENTRIES: usize = 1_000_000;
+
 /// Outcome of reading one logical line under a byte cap.
 enum BoundedLine {
     /// A complete line within the cap, trailing `\n` stripped.
@@ -167,28 +195,63 @@ fn read_bounded_line(
     Ok(BoundedLine::Oversized)
 }
 
-/// Parse a JSONL file into a sequence of [`SessionEntry`] values.
+/// Parse a JSONL file into a sequence of [`SessionEntry`] values, under three
+/// independent resource bounds against hostile or corrupt input (#293):
+///
+/// 1. **Per-line** ([`MAX_JSONL_LINE_BYTES`]): a single newline-free run cannot
+///    force an allocation proportional to its size.
+/// 2. **Per-stream** (`max_session_bytes`): the reader is wrapped in
+///    [`std::io::Read::take`], so total bytes read are capped even for a file of
+///    many in-bounds lines. A line straddling the boundary loses its newline and
+///    is counted as a (final) oversized line. `0` = no per-stream limit.
+/// 3. **Per-entry-count** (`max_entries`): parsing stops once this many entries
+///    are retained, so the in-memory `Vec` — and every downstream linear pass —
+///    stays bounded. `0` = no entry-count limit.
+///
+/// Both `0`-sentinels follow the `max_turns` convention (`0` = unbounded); the
+/// real defaults live in [`DEFAULT_MAX_SESSION_BYTES`] / [`DEFAULT_MAX_ENTRIES`].
 ///
 /// Malformed lines are skipped with a `tracing::warn`; this function never
-/// fails so callers always get a best-effort result. Lines longer than
-/// [`MAX_JSONL_LINE_BYTES`] are skipped (counted as malformed) to bound memory
-/// on hostile or corrupt input.
+/// fails so callers always get a best-effort result.
 ///
 /// Returns `(entries, malformed_count)` where `malformed_count` is the number
 /// of non-empty lines that failed to parse (including oversized ones).
-pub fn parse_session_file(reader: impl std::io::BufRead) -> (Vec<SessionEntry>, usize) {
-    parse_session_file_capped(reader, MAX_JSONL_LINE_BYTES)
+pub fn parse_session_file(
+    reader: impl std::io::BufRead,
+    max_session_bytes: u64,
+    max_entries: usize,
+) -> (Vec<SessionEntry>, usize) {
+    // `0` is the "no per-stream limit" sentinel (matching the `max_turns`
+    // convention); map it to the maximum so `Read::take` does not read *nothing*.
+    let stream_cap = if max_session_bytes == 0 {
+        u64::MAX
+    } else {
+        max_session_bytes
+    };
+    // `Read::take` enforces the per-stream byte ceiling; re-buffer because the
+    // `Take` adapter is `Read`, not `BufRead`, and the line reader needs the
+    // latter (`read_until`/`fill_buf`/`consume`).
+    let capped = std::io::BufReader::new(reader.take(stream_cap));
+    parse_session_file_capped(capped, MAX_JSONL_LINE_BYTES, max_entries)
 }
 
-/// [`parse_session_file`] with an explicit per-line byte cap (test seam).
+/// [`parse_session_file`] with explicit per-line and per-entry caps (test seam).
 fn parse_session_file_capped(
     mut reader: impl std::io::BufRead,
     cap: usize,
+    max_entries: usize,
 ) -> (Vec<SessionEntry>, usize) {
     let mut entries = Vec::new();
     let mut malformed = 0;
     let mut line_no = 0usize;
     loop {
+        if max_entries > 0 && entries.len() >= max_entries {
+            tracing::warn!(
+                max_entries,
+                "truncating session: reached entry-count cap (remaining lines discarded)"
+            );
+            break;
+        }
         match read_bounded_line(&mut reader, cap) {
             Ok(BoundedLine::Eof) => break,
             Ok(BoundedLine::Oversized) => {
@@ -318,10 +381,21 @@ mod tests {
     use super::*;
     use std::io::BufReader;
 
+    /// Parse with no per-stream/per-entry caps (per-line cap still applies).
+    /// Keeps the line-level tests focused on their own concern.
+    fn parse_all(reader: impl std::io::BufRead) -> (Vec<SessionEntry>, usize) {
+        parse_session_file(reader, 0, 0)
+    }
+
+    /// Parse with an explicit per-line cap and no entry-count cap.
+    fn parse_capped(reader: impl std::io::BufRead, cap: usize) -> (Vec<SessionEntry>, usize) {
+        parse_session_file_capped(reader, cap, 0)
+    }
+
     #[test]
     fn parse_empty_file() {
         let reader = BufReader::new(b"" as &[u8]);
-        let (entries, _malformed) = parse_session_file(reader);
+        let (entries, _malformed) = parse_all(reader);
         assert!(entries.is_empty());
     }
 
@@ -332,7 +406,7 @@ mod tests {
         // rather than emitting a cascade of fragment lines).
         let big = "x".repeat(200); // no embedded newline, far over the cap
         let input = format!("{big}\n{{\"type\":\"user\"}}\n");
-        let (entries, malformed) = parse_session_file_capped(input.as_bytes(), 64);
+        let (entries, malformed) = parse_capped(input.as_bytes(), 64);
         assert_eq!(
             entries.len(),
             1,
@@ -348,7 +422,7 @@ mod tests {
         // the cap is inclusive of legitimate lines, exclusive of overflow.
         let line = r#"{"type":"user"}"#;
         assert_eq!(line.len(), 15);
-        let (entries, malformed) = parse_session_file_capped(line.as_bytes(), 15);
+        let (entries, malformed) = parse_capped(line.as_bytes(), 15);
         assert_eq!(entries.len(), 1);
         assert_eq!(malformed, 0);
     }
@@ -358,9 +432,81 @@ mod tests {
         // An oversized final line with no trailing newline drains to EOF and is
         // counted once; the parser terminates rather than looping.
         let big = "y".repeat(100);
-        let (entries, malformed) = parse_session_file_capped(big.as_bytes(), 16);
+        let (entries, malformed) = parse_capped(big.as_bytes(), 16);
         assert!(entries.is_empty());
         assert_eq!(malformed, 1);
+    }
+
+    #[test]
+    fn parse_truncates_at_entry_count_cap() {
+        // #293 residual: a flood of small, individually-valid lines must not grow
+        // the entry Vec without bound. With max_entries=3, only the first 3 of
+        // 10 valid lines are retained; the rest are discarded (not parsed), so
+        // downstream linear passes stay bounded.
+        let mut input = String::new();
+        for _ in 0..10 {
+            input.push_str("{\"type\":\"user\"}\n");
+        }
+        let (entries, malformed) =
+            parse_session_file_capped(input.as_bytes(), MAX_JSONL_LINE_BYTES, 3);
+        assert_eq!(
+            entries.len(),
+            3,
+            "entry count must be capped at max_entries"
+        );
+        assert_eq!(
+            malformed, 0,
+            "truncated-away lines are discarded, not counted as malformed"
+        );
+    }
+
+    #[test]
+    fn parse_entry_count_cap_zero_is_unbounded() {
+        // max_entries == 0 disables the entry-count cap: all valid lines parse.
+        let mut input = String::new();
+        for _ in 0..10 {
+            input.push_str("{\"type\":\"user\"}\n");
+        }
+        let (entries, _malformed) =
+            parse_session_file_capped(input.as_bytes(), MAX_JSONL_LINE_BYTES, 0);
+        assert_eq!(entries.len(), 10);
+    }
+
+    #[test]
+    fn parse_truncates_at_session_byte_cap() {
+        // #293 residual: the per-stream byte ceiling (via Read::take) stops the
+        // reader mid-file. Three 15-byte lines + newlines = 48 bytes total; a
+        // 31-byte cap admits the first two whole lines (32 bytes would include
+        // the 2nd newline, but at 31 we stop one byte short, leaving the 2nd
+        // line unterminated → counted as a final oversized/malformed line).
+        let line = "{\"type\":\"user\"}"; // 15 bytes
+        assert_eq!(line.len(), 15);
+        let input = format!("{line}\n{line}\n{line}\n");
+        // Admit exactly the first full line + newline (16 bytes), then 15 bytes
+        // of the second line with no terminating newline.
+        let (entries, _malformed) = parse_session_file(input.as_bytes(), 31, 0);
+        assert_eq!(
+            entries.len(),
+            2,
+            "per-stream cap admits the first whole line plus the unterminated second"
+        );
+    }
+
+    #[test]
+    fn parse_session_byte_cap_zero_is_unbounded() {
+        // max_session_bytes == 0 is the "no per-stream limit" sentinel (matching
+        // the max_turns convention) — it must NOT be passed verbatim to
+        // Read::take, which would read nothing. All valid lines must parse.
+        let mut input = String::new();
+        for _ in 0..5 {
+            input.push_str("{\"type\":\"user\"}\n");
+        }
+        let (entries, _malformed) = parse_session_file(input.as_bytes(), 0, 0);
+        assert_eq!(
+            entries.len(),
+            5,
+            "the 0 sentinel must mean unbounded, not take(0)/read-nothing"
+        );
     }
 
     #[test]
@@ -369,7 +515,7 @@ mod tests {
 {"type":"user","sessionId":"a1b2c3"}
 "#;
         let reader = BufReader::new(input.as_bytes());
-        let (entries, malformed) = parse_session_file(reader);
+        let (entries, malformed) = parse_all(reader);
         assert_eq!(entries.len(), 1);
         assert_eq!(malformed, 1, "one malformed line should be counted");
         assert_eq!(entries[0].entry_type, EntryType::User);
@@ -379,7 +525,7 @@ mod tests {
     fn parse_user_message() {
         let line = r#"{"type":"user","sessionId":"sess-001","timestamp":"2026-03-19T10:00:00Z","uuid":"u1","parentUuid":null,"cwd":"/tmp","message":{"role":"user","content":[{"type":"text","text":"hello world"}]}}"#;
         let reader = BufReader::new(line.as_bytes());
-        let (entries, _malformed) = parse_session_file(reader);
+        let (entries, _malformed) = parse_all(reader);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].entry_type, EntryType::User);
         let msg = entries[0].message.as_ref().unwrap();
@@ -390,7 +536,7 @@ mod tests {
     fn parse_assistant_tool_use() {
         let line = r#"{"type":"assistant","sessionId":"sess-001","timestamp":"2026-03-19T10:01:00Z","uuid":"u2","parentUuid":"u1","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"cargo test"}}]}}"#;
         let reader = BufReader::new(line.as_bytes());
-        let (entries, _malformed) = parse_session_file(reader);
+        let (entries, _malformed) = parse_all(reader);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].entry_type, EntryType::Assistant);
         let content = entries[0]
@@ -409,7 +555,7 @@ mod tests {
     fn parse_tool_result_entry() {
         let line = r#"{"type":"user","sessionId":"sess-001","uuid":"u3","parentUuid":"u2","toolUseResult":{"stdout":"ok","stderr":"","isError":false}}"#;
         let reader = BufReader::new(line.as_bytes());
-        let (entries, _malformed) = parse_session_file(reader);
+        let (entries, _malformed) = parse_all(reader);
         assert_eq!(entries.len(), 1);
         let result = entries[0].tool_use_result.as_ref().unwrap();
         assert_eq!(result.stdout.as_deref(), Some("ok"));
@@ -420,7 +566,7 @@ mod tests {
     fn parse_progress_entry() {
         let line = r#"{"type":"progress","sessionId":"sess-001","data":{"status":"running"}}"#;
         let reader = BufReader::new(line.as_bytes());
-        let (entries, _malformed) = parse_session_file(reader);
+        let (entries, _malformed) = parse_all(reader);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].entry_type, EntryType::Progress);
     }

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -55,17 +55,17 @@ impl MemoryEngine {
         // The embedding identity is stamped (#613) inside the session savepoint, gated
         // on a fact actually being written (#643) — see `bootstrap_within_savepoint`.
         // A no-op session (zero extracted facts) therefore leaves the store unstamped.
-        crate::bootstrap::bootstrap_session_inner(
-            &conn,
-            self.embed_dim,
-            &self.upcaster_registry,
-            reader,
+        let ctx = crate::bootstrap::BootstrapContext {
+            conn: &conn,
+            embed_dim: self.embed_dim,
+            upcaster_registry: &self.upcaster_registry,
             embedder,
             extractor,
             config,
             classifier,
             scope_id,
-        )
+        };
+        crate::bootstrap::bootstrap_session_inner(&ctx, reader)
     }
 
     /// Bootstrap all JSONL session logs in a directory.
@@ -96,17 +96,17 @@ impl MemoryEngine {
         // being written (#643) — see `bootstrap_within_savepoint`. This preserves
         // per-session independence (each commits its identity atomically with its
         // facts) and leaves an empty/no-op directory unstamped.
-        crate::bootstrap::bootstrap_directory_inner(
-            &conn,
-            self.embed_dim,
-            &self.upcaster_registry,
-            dir,
+        let ctx = crate::bootstrap::BootstrapContext {
+            conn: &conn,
+            embed_dim: self.embed_dim,
+            upcaster_registry: &self.upcaster_registry,
             embedder,
             extractor,
             config,
             classifier,
             scope_id,
-        )
+        };
+        crate::bootstrap::bootstrap_directory_inner(&ctx, dir)
     }
 
     /// Import native `.md` memory files (recursive) from a directory.

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -28,6 +28,39 @@ const fn success_fixture() -> &'static str {
     include_str!("fixtures/success_session.jsonl")
 }
 
+/// Build a UUID-linked multi-turn JSONL session: each `(user, assistant)` pair
+/// becomes one reconstructable turn, chained `userN -> assistantN -> userN+1`,
+/// with one-minute-apart timestamps. Used to exercise `max_turns` truncation,
+/// which keeps the TAIL of the turn list.
+fn multi_turn_session(sid: &str, turns: &[(&str, &str)]) -> String {
+    let mut out = String::new();
+    let mut prev_uuid = String::new();
+    for (i, (user, assistant)) in turns.iter().enumerate() {
+        let u_uuid = format!("u{i}");
+        let a_uuid = format!("a{i}");
+        let minute = i; // distinct, monotonically increasing minute per turn
+        let user_entry = serde_json::json!({
+            "type": "user", "sessionId": sid,
+            "timestamp": format!("2024-06-01T10:{minute:02}:00Z"),
+            "uuid": u_uuid,
+            "parentUuid": if prev_uuid.is_empty() { serde_json::Value::Null } else { serde_json::Value::String(prev_uuid.clone()) },
+            "message": {"role": "user", "content": [{"type": "text", "text": user}]}
+        });
+        let asst_entry = serde_json::json!({
+            "type": "assistant", "sessionId": sid,
+            "timestamp": format!("2024-06-01T10:{minute:02}:05Z"),
+            "uuid": a_uuid, "parentUuid": u_uuid,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": assistant}]}
+        });
+        out.push_str(&user_entry.to_string());
+        out.push('\n');
+        out.push_str(&asst_entry.to_string());
+        out.push('\n');
+        prev_uuid = u_uuid;
+    }
+    out
+}
+
 const fn failed_fixture() -> &'static str {
     include_str!("fixtures/failed_session.jsonl")
 }
@@ -412,23 +445,70 @@ fn bootstrap_max_session_bytes_caps_stream() {
 
 #[test]
 fn bootstrap_max_turns_limits_processing() {
-    let engine = engine();
+    // #300: assert the DOWNSTREAM effect of max_turns truncation, not the
+    // pre-truncation `turns_reconstructed` count (which is set before the slice
+    // and so proves nothing). A 3-turn session where every turn carries a bug
+    // keyword yields 3 candidates uncapped; with max_turns=1 only the TAIL turn
+    // survives, so exactly 1 candidate/fact is produced — proving the slice fired.
     let extractor = KeywordExtractor;
-    let config = BootstrapConfig {
-        max_turns: 1,
-        ..Default::default()
-    };
+    let turns: &[(&str, &str)] = &[
+        ("first?", "The root cause was an off-by-one in turn one."),
+        ("second?", "The root cause was a null deref in turn two."),
+        (
+            "third?",
+            "The root cause was a race condition in turn three.",
+        ),
+    ];
 
-    let reader = Cursor::new(success_fixture());
-    let report = engine
-        .bootstrap_session(reader, &TestEmbedder, &extractor, &config, None)
+    // Uncapped baseline.
+    let engine_uncapped = engine();
+    let report_uncapped = engine_uncapped
+        .bootstrap_session(
+            Cursor::new(multi_turn_session("mt-uncapped", turns)),
+            &TestEmbedder,
+            &extractor,
+            &BootstrapConfig::default(),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        report_uncapped.turns_reconstructed, 3,
+        "fixture must yield 3 turns"
+    );
+    assert_eq!(
+        report_uncapped.candidates_found, 3,
+        "uncapped: every turn is a Bug candidate"
+    );
+    assert_eq!(report_uncapped.facts_created, 3, "uncapped: 3 facts");
+
+    // Capped to the tail turn only.
+    let engine_capped = engine();
+    let report_capped = engine_capped
+        .bootstrap_session(
+            Cursor::new(multi_turn_session("mt-capped", turns)),
+            &TestEmbedder,
+            &extractor,
+            &BootstrapConfig {
+                max_turns: 1,
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
 
-    assert_eq!(report.sessions_processed, 1);
-    // With max_turns=1, we process at most 1 turn
+    assert_eq!(report_capped.sessions_processed, 1);
     assert!(
-        report.turns_reconstructed <= 1,
-        "should process at most one turn, got {}",
-        report.turns_reconstructed
+        report_capped.candidates_found < report_uncapped.candidates_found,
+        "max_turns must reduce candidates: capped={} uncapped={}",
+        report_capped.candidates_found,
+        report_uncapped.candidates_found
+    );
+    assert_eq!(
+        report_capped.candidates_found, 1,
+        "max_turns=1 keeps exactly the tail turn"
+    );
+    assert_eq!(
+        report_capped.facts_created, 1,
+        "max_turns=1 produces one fact (the tail turn)"
     );
 }

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -369,6 +369,69 @@ fn bootstrap_with_scope() {
 }
 
 #[test]
+fn bootstrap_pins_facts_when_classifier_returns_true() {
+    // #301: the PersistenceClassifier branch in store_extracted_fact builds a
+    // temporary Fact, calls should_pin, and sets new_fact.is_pinned. Integration
+    // coverage existed only for should_pin == false (the dryrun recorder), so the
+    // is_pinned == true PROPAGATION into a stored bootstrap row was untested.
+    // Drive both poles and assert the stored flag follows the classifier.
+    use memory_engine::Fact;
+    use memory_engine::traits::PersistenceClassifier;
+
+    struct AlwaysPin;
+    impl PersistenceClassifier for AlwaysPin {
+        fn should_pin(&self, _fact: &Fact) -> bool {
+            true
+        }
+    }
+    struct NeverPin;
+    impl PersistenceClassifier for NeverPin {
+        fn should_pin(&self, _fact: &Fact) -> bool {
+            false
+        }
+    }
+
+    let extractor = KeywordExtractor;
+
+    // AlwaysPin: every bootstrapped fact must land pinned.
+    let engine_pin = engine();
+    let report_pin = engine_pin
+        .bootstrap_session(
+            Cursor::new(success_fixture()),
+            &TestEmbedder,
+            &extractor,
+            &BootstrapConfig::default(),
+            Some(&AlwaysPin),
+        )
+        .unwrap();
+    assert!(report_pin.facts_created > 0, "fixture should create facts");
+    let pinned = engine_pin.list_active_facts(None).unwrap();
+    assert_eq!(pinned.len(), report_pin.facts_created);
+    assert!(
+        pinned.iter().all(|f| f.is_pinned),
+        "AlwaysPin classifier must propagate is_pinned == true to every stored fact"
+    );
+
+    // NeverPin baseline: the flag is toggled by the classifier, not always true.
+    let engine_unpin = engine();
+    let report_unpin = engine_unpin
+        .bootstrap_session(
+            Cursor::new(success_fixture()),
+            &TestEmbedder,
+            &extractor,
+            &BootstrapConfig::default(),
+            Some(&NeverPin),
+        )
+        .unwrap();
+    assert!(report_unpin.facts_created > 0);
+    let unpinned = engine_unpin.list_active_facts(None).unwrap();
+    assert!(
+        unpinned.iter().all(|f| !f.is_pinned),
+        "NeverPin classifier must leave every stored fact unpinned"
+    );
+}
+
+#[test]
 fn bootstrap_max_entries_caps_parsed_entries() {
     // #293 residual: a session of many small, individually-valid lines must be
     // truncated at the per-stream entry-count cap surfaced on BootstrapConfig,

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -369,6 +369,61 @@ fn bootstrap_with_scope() {
 }
 
 #[test]
+fn bootstrap_savepoint_rolls_back_on_embed_failure() {
+    // #302: the error path in bootstrap_within_savepoint issues
+    // `ROLLBACK TO bootstrap; RELEASE bootstrap` to keep the connection usable
+    // after a mid-pipeline failure. An embedder that errors AFTER the marker
+    // event is inserted is the natural trigger. Assert the session returns Err,
+    // then that a SECOND, successful session on the SAME engine still processes —
+    // proving the savepoint was rolled back (marker gone, so not skipped) and
+    // released (no dangling open transaction).
+    struct FailEmbedder;
+    impl EmbeddingProvider for FailEmbedder {
+        fn embed(&self, _text: &str) -> Result<Vec<f32>, MemoryError> {
+            Err(MemoryError::NotFound("inject embed failure".into()))
+        }
+        fn fingerprint(&self) -> EmbeddingFingerprint {
+            EmbeddingFingerprint::new("mock", "test", 4)
+        }
+    }
+
+    let engine = engine();
+    let extractor = KeywordExtractor;
+    let config = BootstrapConfig::default();
+
+    // First session: embedding fails mid-pipeline (after the marker insert).
+    let err = engine.bootstrap_session(
+        Cursor::new(success_fixture()),
+        &FailEmbedder,
+        &extractor,
+        &config,
+        None,
+    );
+    assert!(
+        err.is_err(),
+        "embed failure must propagate as Err from bootstrap_session"
+    );
+
+    // Second session on the SAME engine with a working embedder: if the savepoint
+    // had been left open (or the marker not rolled back) this would fail or skip.
+    let report = engine
+        .bootstrap_session(
+            Cursor::new(success_fixture()),
+            &TestEmbedder,
+            &extractor,
+            &config,
+            None,
+        )
+        .expect("connection must remain usable after a rolled-back session");
+    assert_eq!(
+        report.sessions_processed, 1,
+        "second session must process (rollback removed the first marker; no open txn)"
+    );
+    assert_eq!(report.sessions_skipped, 0);
+    assert!(report.facts_created > 0, "second session must store facts");
+}
+
+#[test]
 fn bootstrap_pins_facts_when_classifier_returns_true() {
     // #301: the PersistenceClassifier branch in store_extracted_fact builds a
     // temporary Fact, calls should_pin, and sets new_fact.is_pinned. Integration

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -336,6 +336,81 @@ fn bootstrap_with_scope() {
 }
 
 #[test]
+fn bootstrap_max_entries_caps_parsed_entries() {
+    // #293 residual: a session of many small, individually-valid lines must be
+    // truncated at the per-stream entry-count cap surfaced on BootstrapConfig,
+    // bounding the in-memory entry Vec (and every downstream linear pass)
+    // regardless of file size. Build 50 valid entries but cap at 5.
+    let engine = engine();
+    let extractor = KeywordExtractor;
+    let config = BootstrapConfig {
+        max_entries: 5,
+        skip_existing: false,
+        ..Default::default()
+    };
+
+    let jsonl: String = (0..50)
+        .map(|i| {
+            serde_json::json!({
+                "type": "user", "sessionId": "cap-sess", "timestamp": "2024-05-01T10:00:00Z",
+                "uuid": format!("u{i}"), "parentUuid": serde_json::Value::Null,
+                "message": {"role": "user", "content": [{"type": "text", "text": format!("line {i}")}]}
+            })
+            .to_string()
+        })
+        .map(|s| s + "\n")
+        .collect();
+
+    let report = engine
+        .bootstrap_session(Cursor::new(jsonl), &TestEmbedder, &extractor, &config, None)
+        .unwrap();
+
+    assert_eq!(
+        report.entries_parsed, 5,
+        "entries_parsed must be capped at max_entries (5), got {}",
+        report.entries_parsed
+    );
+}
+
+#[test]
+fn bootstrap_max_session_bytes_caps_stream() {
+    // #293 residual: the per-stream byte ceiling stops the reader mid-file, so a
+    // huge session is bounded even before the entry-count cap. With a tight byte
+    // cap, only the prefix that fits is parsed; the rest is never read.
+    let engine = engine();
+    let extractor = KeywordExtractor;
+
+    let line = "{\"type\":\"user\",\"sessionId\":\"bytes-sess\",\"uuid\":\"u0\",\"parentUuid\":null,\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"x\"}]}}";
+    let one = format!("{line}\n");
+    let mut jsonl = String::new();
+    for _ in 0..50 {
+        jsonl.push_str(&one);
+    }
+    // Admit roughly two lines' worth of bytes.
+    let cap = (one.len() * 2) as u64;
+    let config = BootstrapConfig {
+        max_session_bytes: cap,
+        skip_existing: false,
+        ..Default::default()
+    };
+
+    let report = engine
+        .bootstrap_session(Cursor::new(jsonl), &TestEmbedder, &extractor, &config, None)
+        .unwrap();
+
+    assert!(
+        report.entries_parsed <= 3,
+        "per-stream byte cap must bound parsed entries to the admitted prefix, got {}",
+        report.entries_parsed
+    );
+    assert!(
+        report.entries_parsed >= 1,
+        "the admitted prefix should still parse at least one entry, got {}",
+        report.entries_parsed
+    );
+}
+
+#[test]
 fn bootstrap_max_turns_limits_processing() {
     let engine = engine();
     let extractor = KeywordExtractor;

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -630,3 +630,55 @@ fn bootstrap_max_turns_limits_processing() {
         "max_turns=1 produces one fact (the tail turn)"
     );
 }
+
+#[test]
+fn bootstrap_mixed_session_fixture() {
+    // #424: mixed_session.jsonl is the only fixture exercising thinking blocks,
+    // progress-noise filtering, and Decision + Learning + Convention categories in
+    // one session with UUID pairing across progress noise — yet it was referenced
+    // by no test. Lock its behavior end to end.
+    let engine = engine();
+    let extractor = KeywordExtractor;
+    let config = BootstrapConfig::default();
+
+    let report = engine
+        .bootstrap_session(
+            Cursor::new(include_str!("fixtures/mixed_session.jsonl")),
+            &TestEmbedder,
+            &extractor,
+            &config,
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(report.sessions_processed, 1);
+    assert!(report.entries_parsed > 0, "fixture entries must parse");
+    // Two genuine user/assistant pairs survive progress-noise filtering.
+    assert_eq!(
+        report.turns_reconstructed, 2,
+        "two turns reconstructed across the progress noise, got {}",
+        report.turns_reconstructed
+    );
+
+    // The categories come from real content keywords ("turns out"/"reason is" →
+    // Learning, "decided"/"went with" → Decision, "always use" → Convention), not
+    // from the thinking block (whose text "Let me look at the existing error
+    // handling patterns" carries no category keyword and seeds no spurious episode).
+    assert!(
+        report.category_counts.decision + report.category_counts.learning > 0,
+        "fixture must yield at least one Decision or Learning episode (d={}, l={})",
+        report.category_counts.decision,
+        report.category_counts.learning
+    );
+
+    // Stored facts must not contain the noise/thinking-only text as standalone
+    // leakage: every created fact traces to a keyword-matched turn.
+    assert!(report.facts_created > 0, "fixture must create facts");
+    let facts = engine.list_active_facts(None).unwrap();
+    assert!(
+        facts
+            .iter()
+            .all(|f| f.content.contains("User:") || f.content.contains("Assistant:")),
+        "every fact's content must come from reconstructed turn text"
+    );
+}


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 2). Subsystem-cohesive PR closing 12 findings.

## Findings closed

- **#293** [security/info] — Unbounded memory allocation parsing untrusted JSONL session logs
- **#123** [refactor/medium] — bootstrap_session_inner / bootstrap_within_savepoint take 9-11 args with too_many_arguments allow
- **#369** [docs/medium] — Bootstrap module/fn docs invert pipeline order: marker event ingested first, not last
- **#370** [docs/medium] — BootstrapConfig::max_turns doc omits tail-selection semantics
- **#406** [security/medium] — Quadratic turn reconstruction amplifies parse DoS into CPU exhaustion
- **#423** [test/medium] — check_error_keyword assistant+bug-context branch has no test
- **#425** [test/medium] — Property-based test missing for build_content multi-byte truncation invariant
- **#334** [bug/medium] — EpisodeCategory stored via Debug repr (capitalized) — inconsistent with lowercase outcome serialization
- **#300** [test/medium] — max_turns test asserts the pre-truncation turn count, proving nothing
- **#301** [test/low] — PersistenceClassifier path never exercised in integration tests
- **#302** [test/medium] — Savepoint rollback on mid-pipeline failure is never tested
- **#424** [test/medium] — mixed_session.jsonl fixture exists but is never referenced by any test

## Review (internal diverse-lens subagents — no external models)

3 clean-slate adversarial reviewers (correctness / security & soundness / api-surface & test-quality): **3 blocker, 0 major**, all addressed in fix commits.

The #293 caps (256 MiB / 1,000,000 entries, additive `BootstrapConfig` fields with Defaults) are wired into the CLI `bootstrap` command and MCP `memory_bootstrap` tool — the real untrusted-input entry points.

## Gate
`cargo build/test/clippy --workspace --all-features` + `cargo fmt --check` + `cargo deny` (CI) — green (rebased on current main).

Fixes #293, fixes #123, fixes #369, fixes #370, fixes #406, fixes #423, fixes #425, fixes #334, fixes #300, fixes #301, fixes #302, fixes #424