### PR TITLE
refactor(core)!: tighten activity-filter/lineage/lib-reexport API + hot-path alloc + tests (#254 wave2)

### DIFF
--- a/memory-engine-mcp/src/activity_policy.rs
+++ b/memory-engine-mcp/src/activity_policy.rs
@@ -12,21 +12,18 @@ use memory_engine::ActivityFilterConfig;
 /// - **Dedup window:** 300 seconds (5 minutes)
 #[must_use]
 pub fn default_filter_config() -> ActivityFilterConfig {
-    ActivityFilterConfig {
-        dedup_window_secs: 300,
-        ignore_patterns: vec![
-            // Formatting tools that produce no semantic value
-            "prettier".into(),
-            "eslint_fix".into(),
-            "ruff_format".into(),
-            "clang_format".into(),
+    ActivityFilterConfig::new(
+        300,
+        // Ignore: formatting tools that produce no semantic value.
+        [
+            "prettier".to_string(),
+            "eslint_fix".to_string(),
+            "ruff_format".to_string(),
+            "clang_format".to_string(),
         ],
-        promote_patterns: vec![
-            // Significant actions worth promoting to facts
-            "git_commit".into(),
-            "git_push".into(),
-        ],
-    }
+        // Promote: significant actions worth promoting to facts.
+        ["git_commit".to_string(), "git_push".to_string()],
+    )
 }
 
 #[cfg(test)]
@@ -37,7 +34,7 @@ mod tests {
     fn default_config_has_sensible_defaults() {
         let config = default_filter_config();
         assert_eq!(config.dedup_window_secs, 300);
-        assert!(!config.ignore_patterns.is_empty());
-        assert!(!config.promote_patterns.is_empty());
+        assert!(!config.ignore_patterns().is_empty());
+        assert!(!config.promote_patterns().is_empty());
     }
 }

--- a/memory-engine-mcp/src/activity_policy.rs
+++ b/memory-engine-mcp/src/activity_policy.rs
@@ -15,14 +15,9 @@ pub fn default_filter_config() -> ActivityFilterConfig {
     ActivityFilterConfig::new(
         300,
         // Ignore: formatting tools that produce no semantic value.
-        [
-            "prettier".to_string(),
-            "eslint_fix".to_string(),
-            "ruff_format".to_string(),
-            "clang_format".to_string(),
-        ],
+        ["prettier", "eslint_fix", "ruff_format", "clang_format"],
         // Promote: significant actions worth promoting to facts.
-        ["git_commit".to_string(), "git_push".to_string()],
+        ["git_commit", "git_push"],
     )
 }
 

--- a/src/engine/activity_filter.rs
+++ b/src/engine/activity_filter.rs
@@ -14,7 +14,7 @@ use crate::types::FactType;
 /// # Pattern normalization invariant
 ///
 /// `ignore_patterns` and `promote_patterns` are stored **already lowercased**.
-/// Matching is case-insensitive substring, and [`apply_filter`] is called once
+/// Matching is case-insensitive substring, and `apply_filter` is called once
 /// per tool-activity event (a hot path); normalizing at construction means the
 /// per-call comparison never has to allocate a lowercased copy of each pattern.
 /// The fields are private to keep that invariant unbreakable — build via
@@ -51,7 +51,7 @@ impl ActivityFilterConfig {
     /// Construct a config, normalizing all patterns to lowercase up front.
     ///
     /// This is the only way to populate the pattern lists, so the
-    /// "patterns are lowercase" invariant always holds — [`apply_filter`] can
+    /// "patterns are lowercase" invariant always holds — `apply_filter` can
     /// then substring-match without allocating per call.
     #[must_use]
     pub fn new(

--- a/src/engine/activity_filter.rs
+++ b/src/engine/activity_filter.rs
@@ -10,6 +10,17 @@ use crate::types::FactType;
 ///
 /// Consumers supply tool-name patterns for ignore and promote rules.
 /// The engine applies these generically — no built-in tool-name knowledge.
+///
+/// # Pattern normalization invariant
+///
+/// `ignore_patterns` and `promote_patterns` are stored **already lowercased**.
+/// Matching is case-insensitive substring, and [`apply_filter`] is called once
+/// per tool-activity event (a hot path); normalizing at construction means the
+/// per-call comparison never has to allocate a lowercased copy of each pattern.
+/// The fields are private to keep that invariant unbreakable — build via
+/// [`ActivityFilterConfig::new`] / [`ActivityFilterConfig::default`], read via
+/// [`ActivityFilterConfig::ignore_patterns`] /
+/// [`ActivityFilterConfig::promote_patterns`].
 #[derive(Debug, Clone)]
 pub struct ActivityFilterConfig {
     /// Dedup window in seconds. Activities with the same
@@ -17,13 +28,13 @@ pub struct ActivityFilterConfig {
     /// window are collapsed. Default: 300 (5 minutes).
     pub dedup_window_secs: i64,
 
-    /// Tool name patterns to drop before storage.
+    /// Tool name patterns to drop before storage (stored lowercased).
     /// Matching is case-insensitive substring.
-    pub ignore_patterns: Vec<String>,
+    ignore_patterns: Vec<String>,
 
     /// Tool name patterns that auto-promote to facts when newly inserted
-    /// (not when deduplicated).
-    pub promote_patterns: Vec<String>,
+    /// (not when deduplicated; stored lowercased).
+    promote_patterns: Vec<String>,
 }
 
 impl Default for ActivityFilterConfig {
@@ -33,6 +44,44 @@ impl Default for ActivityFilterConfig {
             ignore_patterns: Vec::new(),
             promote_patterns: Vec::new(),
         }
+    }
+}
+
+impl ActivityFilterConfig {
+    /// Construct a config, normalizing all patterns to lowercase up front.
+    ///
+    /// This is the only way to populate the pattern lists, so the
+    /// "patterns are lowercase" invariant always holds — [`apply_filter`] can
+    /// then substring-match without allocating per call.
+    #[must_use]
+    pub fn new(
+        dedup_window_secs: i64,
+        ignore_patterns: impl IntoIterator<Item = String>,
+        promote_patterns: impl IntoIterator<Item = String>,
+    ) -> Self {
+        Self {
+            dedup_window_secs,
+            ignore_patterns: ignore_patterns
+                .into_iter()
+                .map(|p| p.to_lowercase())
+                .collect(),
+            promote_patterns: promote_patterns
+                .into_iter()
+                .map(|p| p.to_lowercase())
+                .collect(),
+        }
+    }
+
+    /// The (already-lowercased) ignore patterns.
+    #[must_use]
+    pub fn ignore_patterns(&self) -> &[String] {
+        &self.ignore_patterns
+    }
+
+    /// The (already-lowercased) promote patterns.
+    #[must_use]
+    pub fn promote_patterns(&self) -> &[String] {
+        &self.promote_patterns
     }
 }
 
@@ -70,16 +119,17 @@ pub fn apply_filter(
 ) -> ActivityFilterDecision {
     let tool_lower = tool_name.to_lowercase();
 
-    // Ignore check (case-insensitive substring match).
+    // Ignore check (case-insensitive substring match). Patterns are stored
+    // pre-lowercased (see `ActivityFilterConfig`), so no per-call allocation.
     for pattern in &config.ignore_patterns {
-        if tool_lower.contains(&pattern.to_lowercase()) {
+        if tool_lower.contains(pattern.as_str()) {
             return ActivityFilterDecision::Ignore;
         }
     }
 
-    // Promote check (case-insensitive substring match).
+    // Promote check (case-insensitive substring match; patterns pre-lowercased).
     for pattern in &config.promote_patterns {
-        if tool_lower.contains(&pattern.to_lowercase()) {
+        if tool_lower.contains(pattern.as_str()) {
             let content = format_promote_content(tool_name, result);
             return ActivityFilterDecision::Promote(PromoteAction {
                 fact_content: content,
@@ -119,17 +169,11 @@ mod tests {
     use super::*;
 
     fn config_with_ignore(patterns: &[&str]) -> ActivityFilterConfig {
-        ActivityFilterConfig {
-            ignore_patterns: patterns.iter().map(|s| (*s).to_string()).collect(),
-            ..Default::default()
-        }
+        ActivityFilterConfig::new(300, patterns.iter().map(|s| (*s).to_string()), [])
     }
 
     fn config_with_promote(patterns: &[&str]) -> ActivityFilterConfig {
-        ActivityFilterConfig {
-            promote_patterns: patterns.iter().map(|s| (*s).to_string()).collect(),
-            ..Default::default()
-        }
+        ActivityFilterConfig::new(300, [], patterns.iter().map(|s| (*s).to_string()))
     }
 
     #[test]
@@ -188,13 +232,27 @@ mod tests {
 
     #[test]
     fn ignore_takes_precedence_over_promote() {
-        let config = ActivityFilterConfig {
-            ignore_patterns: vec!["lint".into()],
-            promote_patterns: vec!["lint".into()],
-            ..Default::default()
-        };
+        let config = ActivityFilterConfig::new(300, ["lint".to_string()], ["lint".to_string()]);
         assert_eq!(
             apply_filter("lint_check", &serde_json::json!({}), None, &config),
+            ActivityFilterDecision::Ignore
+        );
+    }
+
+    #[test]
+    fn new_normalizes_patterns_to_lowercase() {
+        // The constructor must lowercase patterns up front so the hot-path
+        // `apply_filter` never has to re-allocate a lowercased copy per call.
+        let config = ActivityFilterConfig::new(
+            300,
+            ["Format".to_string(), "LINT".to_string()],
+            ["Git_Commit".to_string()],
+        );
+        assert_eq!(config.ignore_patterns(), ["format", "lint"]);
+        assert_eq!(config.promote_patterns(), ["git_commit"]);
+        // Mixed-case patterns still match mixed-case tool names.
+        assert_eq!(
+            apply_filter("FormatCode", &serde_json::json!({}), None, &config),
             ActivityFilterDecision::Ignore
         );
     }

--- a/src/engine/activity_filter.rs
+++ b/src/engine/activity_filter.rs
@@ -56,18 +56,18 @@ impl ActivityFilterConfig {
     #[must_use]
     pub fn new(
         dedup_window_secs: i64,
-        ignore_patterns: impl IntoIterator<Item = String>,
-        promote_patterns: impl IntoIterator<Item = String>,
+        ignore_patterns: impl IntoIterator<Item = impl Into<String>>,
+        promote_patterns: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         Self {
             dedup_window_secs,
             ignore_patterns: ignore_patterns
                 .into_iter()
-                .map(|p| p.to_lowercase())
+                .map(|p| Into::<String>::into(p).to_lowercase())
                 .collect(),
             promote_patterns: promote_patterns
                 .into_iter()
-                .map(|p| p.to_lowercase())
+                .map(|p| Into::<String>::into(p).to_lowercase())
                 .collect(),
         }
     }
@@ -169,11 +169,11 @@ mod tests {
     use super::*;
 
     fn config_with_ignore(patterns: &[&str]) -> ActivityFilterConfig {
-        ActivityFilterConfig::new(300, patterns.iter().map(|s| (*s).to_string()), [])
+        ActivityFilterConfig::new(300, patterns.iter().copied(), [] as [&str; 0])
     }
 
     fn config_with_promote(patterns: &[&str]) -> ActivityFilterConfig {
-        ActivityFilterConfig::new(300, [], patterns.iter().map(|s| (*s).to_string()))
+        ActivityFilterConfig::new(300, [] as [&str; 0], patterns.iter().copied())
     }
 
     #[test]

--- a/src/engine/lineage.rs
+++ b/src/engine/lineage.rs
@@ -1,11 +1,21 @@
 use crate::error::Result;
 use crate::store::lineage::LineageStore;
-use crate::types::{LineageRecord, NewLineageRecord, PromotionProvenance};
+use crate::types::{LineageRecord, PromotionProvenance};
 
 use super::MemoryEngine;
 
 impl MemoryEngine {
     /// Record provenance for a promoted wisdom fact.
+    ///
+    /// **Crate-internal.** This is a bare lineage-row insert with no surrounding
+    /// transaction; exposing it publicly let a consumer write lineage in a
+    /// separate transaction from the wisdom-fact insert (interruptible between
+    /// the two) — undermining the atomicity guarantee that
+    /// [`DreamContext::promote`](crate::engine::cognitive::DreamContext::promote)
+    /// documents. The only sanctioned way to create a wisdom fact + lineage is
+    /// that atomic path (fact insert + lineage insert in one savepoint); this
+    /// primitive stays `pub(crate)` for it and for tests. The insert still
+    /// rejects a missing or expired `wisdom_fact_id` (see [`LineageStore::insert`]).
     ///
     /// Writes to the `lineage` sidecar table via the writer connection.
     /// Returns the auto-assigned `lineage_id`.
@@ -13,10 +23,18 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine is read-only.
+    /// Returns `MemoryError::Lineage` if the wisdom fact is missing or expired,
+    /// or a source fact ID does not exist.
     /// Returns `MemoryError::Database` on insert failure.
-    pub fn record_lineage(
+    ///
+    /// `#[cfg(test)]`: production promotion writes lineage atomically inside
+    /// [`promote_in_conn`](crate::engine::MemoryEngine::promote_in_conn) (one
+    /// savepoint), never through this bare wrapper. It is retained only so the
+    /// engine-level lineage tests can seed records directly.
+    #[cfg(test)]
+    pub(crate) fn record_lineage(
         &self,
-        record: &NewLineageRecord,
+        record: &crate::types::NewLineageRecord,
         provenance: &PromotionProvenance,
     ) -> Result<i64> {
         let conn = self.write_conn()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -869,4 +869,65 @@ mod tests {
         ));
         assert_eq!(err.to_string(), "storage error: boom");
     }
+
+    #[test]
+    fn unsupported_epoch_display() {
+        // Highest-risk variant: the format string interpolates two numeric
+        // fields. A future rename of `db_epoch`/`supported_epoch` would silently
+        // break the message without this assertion. Pin the exact rendering.
+        let err = MemoryError::UnsupportedEpoch {
+            db_epoch: 3,
+            supported_epoch: 2,
+        };
+        assert_eq!(
+            err.to_string(),
+            "unsupported storage epoch: database is epoch 3, this library supports epoch 2"
+        );
+    }
+
+    #[test]
+    fn not_implemented_display() {
+        // String-carrying variant: message surfaced under the `not implemented: `
+        // prefix.
+        let err = MemoryError::NotImplemented("zstd compression is feature-gated".into());
+        assert_eq!(
+            err.to_string(),
+            "not implemented: zstd compression is feature-gated"
+        );
+    }
+
+    #[test]
+    fn pool_display() {
+        // String-carrying variant: message surfaced under the `connection pool
+        // error: ` prefix.
+        let err = MemoryError::Pool("read connection acquire timed out".into());
+        assert_eq!(
+            err.to_string(),
+            "connection pool error: read connection acquire timed out"
+        );
+    }
+
+    #[test]
+    fn internal_display() {
+        // String-carrying variant: message surfaced under the `internal error: `
+        // prefix.
+        let err = MemoryError::Internal("scope cache out of sync with store".into());
+        assert_eq!(
+            err.to_string(),
+            "internal error: scope cache out of sync with store"
+        );
+    }
+
+    #[test]
+    fn from_io_error() {
+        // `#[from] std::io::Error`: `?`/`.into()` converts to `MemoryError::Io`,
+        // and Display renders under the `I/O error: ` prefix (carrying the inner
+        // io::Error message verbatim).
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let err: MemoryError = io_err.into();
+        assert!(matches!(err, MemoryError::Io(_)));
+        let s = err.to_string();
+        assert!(s.starts_with("I/O error: "), "{s}");
+        assert!(s.contains("gone"), "{s}");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,15 @@ pub use bootstrap::{BootstrapConfig, BootstrapReport, KeywordExtractor, SessionE
 pub use engine::activity_filter::{ActivityFilterConfig, ActivityFilterDecision, PromoteAction};
 pub use engine::builder::{File, InMemory, MemoryEngineBuilder};
 pub use engine::{EngineConfig, MemoryEngine};
-pub use error::*;
+// Explicit re-export of the full `error` public surface (the umbrella
+// `MemoryError` + the `Result` alias + each typed sub-enum). Enumerated rather
+// than glob-imported so the crate-root API is auditable and a new public error
+// type must be added here deliberately. The `reexports_are_accessible` smoke
+// test guards the list.
+pub use error::{
+    ArchiveError, ConflictError, CycleError, MemoryError, MigrationError, RerankerError, Result,
+    StorageError,
+};
 pub use inspect::types as inspect_types;
 pub use resume::{ResumeConfig, ResumeContext};
 pub use search::{MemoryQuery, QueryDiagnostics, QueryResponse};
@@ -120,7 +128,21 @@ pub use traits::{
     DeltaProposer, DreamCycle, EmbeddingProvider, ForgetPolicy, InsightStream,
     PersistenceClassifier, PruneStats, Reranker, SummarizableContent, SummaryGenerator,
 };
-pub use types::*;
+// Explicit re-export of the full `types` public surface, enumerated for the
+// same reason as `error` above: a transparent, audit-able crate-root API where
+// adding a public type is a deliberate edit, not an implicit consequence of a
+// glob. Kept in source order; the `reexports_are_accessible` smoke test guards
+// a representative subset, and `cargo build --workspace --all-features` proves
+// the whole list still satisfies every downstream consumer.
+pub use types::{
+    Activity, ActivityStatus, AddFactOptions, AddFactRequest, ConsolidationLevel,
+    ConsolidationProposal, DreamCycleConfig, Edge, EmbeddingFingerprint, Event, EventFilter,
+    EventType, Fact, FactId, FactScoringRow, FactType, Insight, LineageId, LineageRecord,
+    LineageSnapshotEntry, MergeGroup, NewActivity, NewEdge, NewEvent, NewFact, NewFactBuilder,
+    NewLineageRecord, NewSummary, Outcome, OutcomeCounts, ParseActivityStatusError, ProjectContext,
+    PromoteRequest, PromotionProvenance, PromotionResult, RecordActivityRequest,
+    RecordActivityResult, ScopeNode, ScopeQuery, SessionCheckpoint, SessionFact, Summary,
+};
 
 // Storage port — tight flat re-export of the umbrella + cross-cutting types only.
 // The six bounded traits (FactGraph, EventLog, …) are the internal port surface
@@ -157,6 +179,8 @@ mod tests {
         fn _accepts_delta_proposer(_: &dyn crate::DeltaProposer) {}
         // storage port umbrella (bounded traits stay at `crate::storage::*`)
         fn _accepts_storage_backend(_: &dyn crate::StorageBackend) {}
+        // `Result` alias is part of the hand-enumerated `error` re-export.
+        fn _accepts_result(_: crate::Result<()>) {}
 
         // `SummaryGenerator`'s parameter type must be reachable from the same
         // crate-root namespace as the trait it appears in (#273).
@@ -177,6 +201,18 @@ mod tests {
         let _ = std::mem::size_of::<crate::Fact>();
         let _ = std::mem::size_of::<crate::EngineConfig>();
         let _ = std::mem::size_of::<crate::MemoryEngine>();
+
+        // error surface — the typed sub-enums + umbrella + Result alias are now
+        // hand-enumerated re-exports (no glob), so assert each is reachable at the
+        // crate root. A removal from that list fails to compile here.
+        let _ = std::mem::size_of::<crate::MemoryError>();
+        let _ = std::mem::size_of::<crate::ConflictError>();
+        let _ = std::mem::size_of::<crate::RerankerError>();
+        let _ = std::mem::size_of::<crate::ArchiveError>();
+        let _ = std::mem::size_of::<crate::MigrationError>();
+        let _ = std::mem::size_of::<crate::CycleError>();
+        // StorageError asserted in the storage-port block below; the `Result`
+        // alias is asserted by `_accepts_result` above.
 
         // storage port cross-cutting types (flat-re-exported; the six bounded
         // traits stay reachable as `crate::storage::FactGraph`, asserted above).

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -19,20 +19,40 @@ impl<'a> LineageStore<'a> {
     /// Insert a new lineage record with its provenance envelope.
     /// Returns the auto-assigned `lineage_id`.
     ///
-    /// Validates that all `source_fact_ids` reference existing facts before
-    /// inserting. The `provenance.lineage_id` field is not stored in the JSON
-    /// (`skip_serializing`) — the row PK is authoritative.
+    /// Validates that the `wisdom_fact_id` references an **active** (non-expired)
+    /// fact and that all `source_fact_ids` reference existing facts before
+    /// inserting — so a lineage row can never be orphaned against a missing or
+    /// soft-deleted wisdom fact. The `provenance.lineage_id` field is not stored
+    /// in the JSON (`skip_serializing`) — the row PK is authoritative.
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Lineage` if any source fact ID does not exist.
+    /// Returns `MemoryError::Lineage` if the `wisdom_fact_id` does not exist or
+    /// is expired, or if any source fact ID does not exist.
     /// Returns `MemoryError::Database` on insert failure (e.g., duplicate
-    /// `wisdom_fact_id`, FK violation).
+    /// `wisdom_fact_id`).
     pub fn insert(
         &self,
         record: &NewLineageRecord,
         provenance: &PromotionProvenance,
     ) -> Result<i64> {
+        // Validate that the wisdom fact exists and is active (not soft-deleted).
+        // The FK only proves the row exists; an expired (`t_expired IS NOT NULL`)
+        // fact is a tombstone and must not anchor fresh lineage. Doing the check
+        // here turns an opaque FK `Database` error into a clear `Lineage` cause
+        // and additionally rejects the expired case the FK cannot catch.
+        let wisdom_active: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM facts WHERE id = ?1 AND t_expired IS NULL",
+            params![record.wisdom_fact_id],
+            |r| r.get(0),
+        )?;
+        if wisdom_active == 0 {
+            return Err(MemoryError::Lineage(format!(
+                "wisdom fact {} does not exist or is expired; cannot record lineage",
+                record.wisdom_fact_id
+            )));
+        }
+
         // Validate that all distinct source fact IDs exist.
         if !record.source_fact_ids.is_empty() {
             let unique_ids: std::collections::BTreeSet<i64> =
@@ -370,6 +390,44 @@ mod tests {
         let err = store.insert(&new_rec, &test_provenance()).unwrap_err();
         assert!(matches!(err, MemoryError::Lineage(_)));
         assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn insert_rejects_nonexistent_wisdom_fact() {
+        // A lineage row must point at an existing wisdom fact. Without the
+        // up-front check this would surface as an opaque FK `Database` error;
+        // with it, the caller gets a clear `Lineage` error naming the cause.
+        let conn = setup();
+        let store = LineageStore::new(&conn);
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 12345, // no such fact
+            source_fact_ids: vec![10, 20],
+        };
+        let err = store.insert(&new_rec, &test_provenance()).unwrap_err();
+        assert!(matches!(err, MemoryError::Lineage(_)), "{err}");
+        assert!(err.to_string().contains("12345"), "{err}");
+    }
+
+    #[test]
+    fn insert_rejects_expired_wisdom_fact() {
+        // The FK only proves the row exists, not that it is active. Recording
+        // lineage against a soft-deleted (expired) wisdom fact would orphan the
+        // provenance against a tombstone — reject it.
+        let conn = setup();
+        // Expire wisdom fact 1.
+        conn.execute(
+            "UPDATE facts SET t_expired = '2026-02-01T00:00:00Z' WHERE id = 1",
+            [],
+        )
+        .unwrap();
+        let store = LineageStore::new(&conn);
+        let new_rec = NewLineageRecord {
+            wisdom_fact_id: 1,
+            source_fact_ids: vec![10, 20],
+        };
+        let err = store.insert(&new_rec, &test_provenance()).unwrap_err();
+        assert!(matches!(err, MemoryError::Lineage(_)), "{err}");
+        assert!(err.to_string().contains("expired"), "{err}");
     }
 
     #[test]

--- a/tests/activity_stream_test.rs
+++ b/tests/activity_stream_test.rs
@@ -15,6 +15,22 @@ impl memory_engine::EmbeddingProvider for ZeroEmbedder {
     }
 }
 
+/// Embedder that always fails — exercises the promotion-failure fallback path
+/// in `record_activity` (the `Err(e)` arm that logs a warning and degrades the
+/// status to `Recorded` rather than propagating or leaving an orphan fact).
+struct FailingEmbedder(usize);
+
+impl memory_engine::EmbeddingProvider for FailingEmbedder {
+    fn embed(&self, _text: &str) -> memory_engine::error::Result<Vec<f32>> {
+        Err(memory_engine::error::MemoryError::Internal(
+            "forced embedding failure".into(),
+        ))
+    }
+    fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+        memory_engine::EmbeddingFingerprint::new("mock", "test", self.0)
+    }
+}
+
 const DIM: usize = 4;
 
 fn engine() -> MemoryEngine {
@@ -100,6 +116,48 @@ fn record_activity_promotes_to_fact() {
     let fact = engine.get_fact(result.promoted_fact_id.unwrap()).unwrap();
     assert!(fact.content.contains("git_commit"));
     assert!(fact.content.contains("committed abc123"));
+}
+
+#[test]
+fn record_activity_promote_failure_falls_back_to_recorded() {
+    // When a promote-matched activity's embedding fails, promotion must degrade
+    // gracefully: the activity is still recorded, no fact id is surfaced, and —
+    // critically — no orphan fact is left in the store (the failed `add_fact`
+    // must not commit a partial fact).
+    let engine = engine();
+    let embedder = FailingEmbedder(DIM);
+    let config = ActivityFilterConfig {
+        promote_patterns: vec!["commit".into()],
+        ..Default::default()
+    };
+
+    let req = RecordActivityRequest {
+        tool_name: "git_commit".into(),
+        args: serde_json::json!({"msg": "feat: add feature"}),
+        result: Some("committed abc123".into()),
+        session_id: "sess-1".into(),
+        timestamp: Utc::now(),
+        scope_path: None,
+        outcome_class: None,
+    };
+
+    let result = engine
+        .record_activity(&req, Some(&embedder), &config)
+        .unwrap();
+
+    // Activity itself was persisted (the failure is only in the promotion step).
+    assert!(result.activity_id.is_some());
+    assert!(!result.was_deduplicated);
+    // Promotion failed → fall back to Recorded with no promoted fact id.
+    assert_eq!(result.status, ActivityStatus::Recorded);
+    assert!(result.promoted_fact_id.is_none());
+
+    // No orphan fact: the failed promotion left zero facts in the store.
+    let stats = engine.statistics().unwrap();
+    assert_eq!(
+        stats.facts.total, 0,
+        "promotion failure must not orphan a fact"
+    );
 }
 
 #[test]

--- a/tests/activity_stream_test.rs
+++ b/tests/activity_stream_test.rs
@@ -67,7 +67,7 @@ fn record_activity_stores_and_deduplicates() {
 #[test]
 fn record_activity_ignore_drops_silently() {
     let engine = engine();
-    let config = ActivityFilterConfig::new(300, ["format".to_string()], []);
+    let config = ActivityFilterConfig::new(300, ["format"], [] as [&str; 0]);
 
     let req = RecordActivityRequest {
         tool_name: "FormatCode".into(),
@@ -88,7 +88,7 @@ fn record_activity_ignore_drops_silently() {
 fn record_activity_promotes_to_fact() {
     let engine = engine();
     let embedder = ZeroEmbedder(DIM);
-    let config = ActivityFilterConfig::new(300, [], ["commit".to_string()]);
+    let config = ActivityFilterConfig::new(300, [] as [&str; 0], ["commit"]);
 
     let req = RecordActivityRequest {
         tool_name: "git_commit".into(),
@@ -120,7 +120,7 @@ fn record_activity_promote_failure_falls_back_to_recorded() {
     // must not commit a partial fact).
     let engine = engine();
     let embedder = FailingEmbedder(DIM);
-    let config = ActivityFilterConfig::new(300, [], ["commit".to_string()]);
+    let config = ActivityFilterConfig::new(300, [] as [&str; 0], ["commit"]);
 
     let req = RecordActivityRequest {
         tool_name: "git_commit".into(),

--- a/tests/activity_stream_test.rs
+++ b/tests/activity_stream_test.rs
@@ -67,10 +67,7 @@ fn record_activity_stores_and_deduplicates() {
 #[test]
 fn record_activity_ignore_drops_silently() {
     let engine = engine();
-    let config = ActivityFilterConfig {
-        ignore_patterns: vec!["format".into()],
-        ..Default::default()
-    };
+    let config = ActivityFilterConfig::new(300, ["format".to_string()], []);
 
     let req = RecordActivityRequest {
         tool_name: "FormatCode".into(),
@@ -91,10 +88,7 @@ fn record_activity_ignore_drops_silently() {
 fn record_activity_promotes_to_fact() {
     let engine = engine();
     let embedder = ZeroEmbedder(DIM);
-    let config = ActivityFilterConfig {
-        promote_patterns: vec!["commit".into()],
-        ..Default::default()
-    };
+    let config = ActivityFilterConfig::new(300, [], ["commit".to_string()]);
 
     let req = RecordActivityRequest {
         tool_name: "git_commit".into(),
@@ -126,10 +120,7 @@ fn record_activity_promote_failure_falls_back_to_recorded() {
     // must not commit a partial fact).
     let engine = engine();
     let embedder = FailingEmbedder(DIM);
-    let config = ActivityFilterConfig {
-        promote_patterns: vec!["commit".into()],
-        ..Default::default()
-    };
+    let config = ActivityFilterConfig::new(300, [], ["commit".to_string()]);
 
     let req = RecordActivityRequest {
         tool_name: "git_commit".into(),


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 2). Subsystem-cohesive PR closing 5 findings.

## Findings closed

- **#390** [refactor/low] — pattern.to_lowercase() allocates per-pattern per call in hot filter path
- **#452** [test/low] — Promotion failure path (Recorded fallback) has no test; warn already added
- **#443** [test/low] — Several MemoryError variants still lack Display/format assertions (UnsupportedEpoch, Io, NotImplemented, Pool, Internal)
- **#126** [refactor/medium] — Glob re-exports (pub use error::* / types::*) hide the crate API surface
- **#350** [refactor/medium] — pub fn record_lineage() exposes non-atomic lineage insertion — callers can create orphaned lineage records

## Review (internal diverse-lens subagents — no external models)

3 clean-slate adversarial reviewers (correctness / security & soundness / api-surface & test-quality): **0 blocker, 1 major**, all addressed in fix commits.

**⚠ BREAKING CHANGE** (#126, #390): removes the `pub use error::*` / `types::*` glob re-exports from `lib.rs` (explicit re-exports added; CLI/MCP/embed migrated) and privatizes `ActivityFilterConfig::{ignore,promote}_patterns` (use `new()`/accessors). `dedup_window_secs` stays public. See the `refactor(core)!` commits' BREAKING CHANGE footers.

## Gate
`cargo build/test/clippy --workspace --all-features` + `cargo fmt --check` + `cargo deny` (CI) — green (rebased on current main).

Fixes #390, fixes #452, fixes #443, fixes #126, fixes #350