### PR TITLE
test(core): async-engine delegation + vector-ranking + resume-ancestor coverage (#254 wave2)

### DIFF
--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -692,12 +692,8 @@ mod tests {
     /// the `consolidate` delegation arm.
     struct MockGen;
     impl SummaryGenerator for MockGen {
-        fn summarize(&self, facts: &[Fact]) -> Result<String> {
-            Ok(facts
-                .iter()
-                .map(|f| f.content.as_str())
-                .collect::<Vec<_>>()
-                .join("; "))
+        fn summarize(&self, items: &[crate::traits::SummarizableContent<'_>]) -> Result<String> {
+            Ok(items.iter().map(|c| c.text).collect::<Vec<_>>().join("; "))
         }
     }
 

--- a/src/async_engine.rs
+++ b/src/async_engine.rs
@@ -682,6 +682,51 @@ mod tests {
         }
     }
 
+    /// Convenience: a freshly built `Arc<dyn EmbeddingProvider>` for the tests
+    /// that pass an embedder to a delegated async method.
+    fn embedder() -> Arc<dyn EmbeddingProvider + Send + Sync> {
+        Arc::new(MockEmbedder { dim: DIM })
+    }
+
+    /// Minimal summary generator: concatenates fact contents. Used to exercise
+    /// the `consolidate` delegation arm.
+    struct MockGen;
+    impl SummaryGenerator for MockGen {
+        fn summarize(&self, facts: &[Fact]) -> Result<String> {
+            Ok(facts
+                .iter()
+                .map(|f| f.content.as_str())
+                .collect::<Vec<_>>()
+                .join("; "))
+        }
+    }
+
+    /// Arbiter that always returns a fixed decision. Used to drive
+    /// `resolve_conflict` deterministically across the `spawn_blocking` boundary.
+    struct FixedArbiter {
+        decision: crate::traits::CrudDecision,
+    }
+    impl ConflictArbiter for FixedArbiter {
+        fn arbitrate(&self, _: &Fact, _: &Fact) -> Result<crate::traits::CrudDecision> {
+            Ok(self.decision)
+        }
+    }
+
+    /// Build a simple `NewEvent` for the `ingest` delegation tests.
+    fn make_event() -> NewEvent {
+        NewEvent {
+            timestamp: Utc::now(),
+            event_type: crate::types::EventType::Interaction,
+            payload: serde_json::json!({"msg": "hello"}),
+            source: "test".into(),
+            session_id: None,
+            scope_id: 1,
+            origin_node_id: "local".into(),
+            sequence_id: 0,
+            created_at: None,
+        }
+    }
+
     #[tokio::test]
     async fn async_add_fact_and_query() {
         let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
@@ -934,5 +979,355 @@ mod tests {
                 "expected MemoryError::Pool from delegate_blocking! instance arm, got: {other:?}"
             ),
         }
+    }
+
+    // --- Issue #308: delegation coverage for the spawn_blocking shim ---
+    //
+    // The async wrapper's only value-add is dispatching each sync method onto
+    // `tokio::task::spawn_blocking`. The original suite covered add_fact / query
+    // / graph / list_due / pin / config plus the two join-error oracles, leaving
+    // the bulk of the delegated surface (ingest, execute_query, consolidate,
+    // forget, resolve_conflict, statistics, the inspection readers, scheduling,
+    // session linking, snapshotting, and the trivial getters) with no async
+    // test. Each test below asserts the async method round-trips to its sync
+    // counterpart across the spawn_blocking boundary — the result is observed
+    // through a *second* async hop where possible, so a broken delegation (wrong
+    // method, dropped argument, or a closure that never runs) fails the oracle.
+
+    #[tokio::test]
+    async fn async_ingest_appends_event() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        let id = engine.ingest(make_event()).await.unwrap();
+        assert_eq!(id, 1, "first ingested event gets id 1");
+        // A second ingest advances the id — proves the write actually committed.
+        let id2 = engine.ingest(make_event()).await.unwrap();
+        assert_eq!(id2, 2);
+    }
+
+    #[tokio::test]
+    async fn async_add_facts_batch_round_trip() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        let reqs = vec![
+            AddFactRequest {
+                content: "batch fact one".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+            AddFactRequest {
+                content: "batch fact two".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+        ];
+        let ids = engine
+            .add_facts_batch(reqs, embedder(), None)
+            .await
+            .unwrap();
+        assert_eq!(ids.len(), 2);
+        let active = engine.list_active_facts(None).await.unwrap();
+        assert_eq!(active.len(), 2, "both batch facts persisted");
+    }
+
+    #[tokio::test]
+    async fn async_execute_query_returns_active_facts() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        engine
+            .add_fact(
+                AddFactRequest {
+                    content: "composed query fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                embedder(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let resp = engine
+            .execute_query(crate::search::query::MemoryQuery::new())
+            .await
+            .unwrap();
+        assert_eq!(resp.results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn async_consolidate_dedups_duplicates() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        // Two facts with identical (constant) embeddings → cosine 1.0 → dedup.
+        for content in ["duplicate alpha", "duplicate beta"] {
+            engine
+                .add_fact(
+                    AddFactRequest {
+                        content: content.into(),
+                        fact_type: FactType::Semantic,
+                        source_event_id: None,
+                        scope: None,
+                        opts: None,
+                    },
+                    embedder(),
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        let config = ConsolidationConfig::builder()
+            .dedup_threshold(0.90)
+            .min_cluster_size(10) // high so no clusters form; isolate dedup
+            .build();
+        let generator: Arc<dyn SummaryGenerator + Send + Sync> = Arc::new(MockGen);
+        let stats = engine
+            .consolidate(generator, embedder(), config)
+            .await
+            .unwrap();
+        assert_eq!(stats.duplicates_removed, 1);
+        assert_eq!(engine.list_active_facts(None).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn async_forget_prunes_and_rejects_invalid_policy() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        // Backdate the fact 200 days so Ebbinghaus decay drives its computed
+        // importance below the threshold (Episodic decays by design). A fresh
+        // fact would survive — this mirrors the sync `forget_prunes_stale_facts`
+        // setup, exercising real pruning through the shim rather than a no-op.
+        let old_time = Utc::now() - chrono::Duration::days(200);
+        engine
+            .add_fact(
+                AddFactRequest {
+                    content: "forgettable".into(),
+                    fact_type: FactType::Episodic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: Some(AddFactOptions {
+                        importance: Some(0.01),
+                        t_created: Some(old_time),
+                        last_accessed: Some(old_time),
+                        ..Default::default()
+                    }),
+                },
+                embedder(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Valid policy prunes the low-importance fact.
+        let policy = ForgetPolicy {
+            min_importance: 0.3,
+            ..ForgetPolicy::default()
+        };
+        let stats = engine.forget(policy).await.unwrap();
+        assert_eq!(stats.facts_expired, 1);
+
+        // Invalid policy surfaces an error through the shim (not a panic/hang).
+        let bad = ForgetPolicy {
+            half_life_days: 0.0,
+            ..ForgetPolicy::default()
+        };
+        assert!(engine.forget(bad).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn async_resolve_conflict_expires_old_fact() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        let old_id = engine
+            .add_fact(
+                AddFactRequest {
+                    content: "outdated belief".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                embedder(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let arbiter: Arc<dyn ConflictArbiter + Send + Sync> = Arc::new(FixedArbiter {
+            decision: crate::traits::CrudDecision::Update,
+        });
+        let new_fact = NewFact::builder("updated belief", vec![0.5; DIM], FactType::Semantic)
+            .content_hash("h_updated")
+            .build();
+        let resolution = engine
+            .resolve_conflict(arbiter, old_id, new_fact)
+            .await
+            .unwrap();
+        // An Update resolution supersedes the old fact with a new one.
+        assert_eq!(resolution.decision, crate::traits::CrudDecision::Update);
+        assert_eq!(resolution.old_fact_id, old_id);
+        assert!(
+            resolution.new_fact_id.is_some(),
+            "Update must create a superseding fact"
+        );
+        // Old fact is soft-deleted (expired); a new active fact replaces it.
+        assert!(engine.get_fact(old_id).await.unwrap().t_expired.is_some());
+    }
+
+    #[tokio::test]
+    async fn async_statistics_counts_facts() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        engine
+            .add_fact(
+                AddFactRequest {
+                    content: "counted".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                embedder(),
+                None,
+            )
+            .await
+            .unwrap();
+        let stats = engine.statistics().await.unwrap();
+        assert_eq!(stats.facts.active, 1);
+    }
+
+    #[tokio::test]
+    async fn async_list_summaries_empty() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        let summaries = engine
+            .list_summaries(ConsolidationLevel::Global)
+            .await
+            .unwrap();
+        assert!(summaries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn async_resume_context_surfaces_pinned() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        engine
+            .add_fact(
+                AddFactRequest {
+                    content: "pinned identity".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: Some(AddFactOptions {
+                        pinned: Some(true),
+                        importance: Some(0.95),
+                        ..Default::default()
+                    }),
+                },
+                embedder(),
+                None,
+            )
+            .await
+            .unwrap();
+        let ctx = engine
+            .resume_context(ResumeConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(ctx.pinned.len(), 1);
+        assert!(ctx.pinned[0].is_pinned);
+    }
+
+    #[tokio::test]
+    async fn async_link_session_facts_creates_edges() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        // Two facts sharing a session via their source events.
+        for content in ["session fact a", "session fact b"] {
+            let mut event = make_event();
+            event.session_id = Some("s1".into());
+            let event_id = engine.ingest(event).await.unwrap();
+            engine
+                .add_fact(
+                    AddFactRequest {
+                        content: content.into(),
+                        fact_type: FactType::Semantic,
+                        source_event_id: Some(event_id),
+                        scope: None,
+                        opts: None,
+                    },
+                    embedder(),
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+        let created = engine.link_session_facts("s1".into(), None).await.unwrap();
+        assert_eq!(created, 2, "A→B and B→A co-session edges");
+    }
+
+    #[tokio::test]
+    async fn async_next_due_time_none_when_no_future_facts() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        assert!(engine.next_due_time(None).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn async_replay_events_returns_ingested() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        engine.ingest(make_event()).await.unwrap();
+        let filter = crate::inspect::ReplayFilter::default();
+        let events = engine.replay_events(&filter).await.unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn async_explain_and_history_for_fact() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        let id = engine
+            .add_fact(
+                AddFactRequest {
+                    content: "explainable fact".into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                embedder(),
+                None,
+            )
+            .await
+            .unwrap();
+        let explanation = engine.explain_fact(id).await.unwrap();
+        assert_eq!(explanation.fact_id, id);
+        let history = engine.fact_history(id).await.unwrap();
+        assert_eq!(history.fact_id, id);
+        // Missing fact surfaces NotFound through the shim.
+        assert!(matches!(
+            engine.explain_fact(999_999).await,
+            Err(MemoryError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn async_write_snapshot_in_memory_is_noop() {
+        // In-memory engines have no sidecar path, so write_snapshot returns
+        // Ok(false) — the point is the delegation runs without panicking.
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        assert!(!engine.write_snapshot().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn async_getters_reflect_inner_engine() {
+        let engine = AsyncMemoryEngine::open_memory(DIM).await.unwrap();
+        assert_eq!(engine.embed_dim(), DIM);
+        assert!(!engine.is_file_backed());
+        assert!(engine.reranker_name().is_none());
+    }
+
+    #[tokio::test]
+    async fn async_open_file_backed_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("async_open.db");
+        let config = EngineConfig::new(db_path, DIM);
+        let engine = AsyncMemoryEngine::open(config).await.unwrap();
+        assert!(engine.is_file_backed());
+        let id = engine.ingest(make_event()).await.unwrap();
+        assert_eq!(id, 1);
     }
 }

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -1382,6 +1382,112 @@ fn resume_does_not_stamp_invalidated_pinned_due_fact() {
     );
 }
 
+// --- Issue #474: resume_context scope ancestor-chain filtering ---
+
+/// `resume_context` with `scope_path = Some(<existing child>)` must scope the
+/// `recent` and `high_importance` tiers to the resolved scope's ancestor chain
+/// (`tree.ancestors(id)` = `[child, …parents, root]`), excluding facts from a
+/// *sibling* scope that is not on that chain.
+///
+/// Every prior resume test passes `scope_path = None` (root only) or a
+/// nonexistent path (`NotFound` short-circuit), so the success branch at
+/// `engine/resume.rs` — `resolve_path` → `ancestors(id)` → a non-root
+/// `scope_ids` slice into `list_by_importance_score` / `list_by_scopes_recent`
+/// — was never exercised. This test creates two sibling scopes under a common
+/// parent, populates both, resumes from one, and asserts the sibling's facts
+/// are absent from both scope-filtered tiers.
+///
+/// **Discrimination**: if `ancestors(id)` were replaced by `subtree(id)`,
+/// `[root]`, or an over-broad set that leaked the sibling scope, the
+/// `does_not_contain` assertions on the `beta`/sibling facts would fail. With
+/// `scope_path = None` (the only previously-tested path) the slice is always
+/// `[root]` and a child/sibling distinction can never arise.
+#[test]
+fn resume_with_existing_scope_path_excludes_sibling_scope() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let embedder = MockEmbedder { dim: DIM };
+
+    // Two sibling scopes under a common parent: project/alpha and project/beta.
+    let alpha_id = engine.ensure_scope_path("project/alpha").unwrap();
+    let beta_id = engine.ensure_scope_path("project/beta").unwrap();
+    assert_ne!(alpha_id, beta_id, "siblings must be distinct scopes");
+
+    // Helper: add a non-pinned fact at a given scope path with a chosen
+    // importance (which materializes importance_score 1:1 at insert time).
+    let add = |scope: &str, content: &str, importance: f64| {
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: content.into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: Some(scope.into()),
+                    opts: Some(AddFactOptions {
+                        importance: Some(importance),
+                        ..Default::default()
+                    }),
+                },
+                &embedder,
+                None,
+            )
+            .unwrap()
+    };
+
+    // recent-tier facts (low importance, below the 0.7 high-importance floor).
+    add("project/alpha", "alpha recent note", 0.1);
+    add("project/beta", "beta recent note", 0.1);
+    // high-importance-tier facts (importance_score >= 0.7).
+    add("project/alpha", "alpha critical decision", 0.9);
+    add("project/beta", "beta critical decision", 0.9);
+
+    let config = ResumeConfig {
+        scope_path: Some("project/alpha".into()),
+        ..ResumeConfig::default()
+    };
+    let ctx = engine.resume_context(&config).unwrap();
+
+    let recent_contents: Vec<&str> = ctx.recent.iter().map(|f| f.content.as_str()).collect();
+    let high_contents: Vec<&str> = ctx
+        .high_importance
+        .iter()
+        .map(|f| f.content.as_str())
+        .collect();
+
+    // alpha (resolved scope, on its own ancestor chain) is present.
+    assert!(
+        recent_contents.contains(&"alpha recent note"),
+        "alpha-scope recent fact must surface, got recent={recent_contents:?}"
+    );
+    assert!(
+        high_contents.contains(&"alpha critical decision"),
+        "alpha-scope high-importance fact must surface, got high={high_contents:?}"
+    );
+
+    // beta (sibling, NOT on alpha's ancestor chain) is excluded from both
+    // scope-filtered tiers.
+    assert!(
+        !recent_contents.contains(&"beta recent note"),
+        "sibling-scope recent fact must be excluded, got recent={recent_contents:?}"
+    );
+    assert!(
+        !high_contents.contains(&"beta critical decision"),
+        "sibling-scope high-importance fact must be excluded, got high={high_contents:?}"
+    );
+
+    // Cross-tier safety net: no fact from the sibling scope appears anywhere in
+    // the non-pinned tiers (the sibling's scope_id must never enter the chain).
+    let sibling_leak = ctx
+        .high_importance
+        .iter()
+        .chain(ctx.due.iter())
+        .chain(ctx.recent.iter())
+        .any(|f| f.scope_id == beta_id);
+    assert!(
+        !sibling_leak,
+        "no sibling-scope fact may leak into any tier"
+    );
+}
+
 // --- Phase 3b / T6: SearchConfig in EngineConfig ---
 
 #[test]

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -27,6 +27,68 @@ impl EmbeddingProvider for MockEmbedder {
     }
 }
 
+/// Keyword-driven embedder that maps a small fixed vocabulary to orthogonal
+/// basis vectors in a 4-dimensional space (issue #453).
+///
+/// `MockEmbedder` returns the same constant vector for every input, so every
+/// fact ties on cosine similarity and the vector-ranking path is never
+/// discriminated. This embedder instead projects each known keyword onto a
+/// distinct unit axis:
+///
+/// | keyword | vector        |
+/// | ------- | ------------- |
+/// | `cats`  | `[1, 0, 0, 0]`|
+/// | `dogs`  | `[0, 1, 0, 0]`|
+/// | `birds` | `[0, 0, 1, 0]`|
+/// | `fish`  | `[0, 0, 0, 1]`|
+///
+/// The first keyword found in the (lowercased) text wins; text with no known
+/// keyword embeds to the zero vector (cosine 0 against every axis). Because the
+/// axes are orthonormal, a query embedded as one axis scores cosine `1.0`
+/// against the matching fact and `0.0` against the others — an unambiguous
+/// ranking oracle for the brute-force cosine scan and RRF blending.
+struct DeterministicEmbedder {
+    dim: usize,
+}
+
+impl DeterministicEmbedder {
+    /// The orthogonal vocabulary: keyword → basis axis index.
+    const VOCAB: [(&'static str, usize); 4] = [("cats", 0), ("dogs", 1), ("birds", 2), ("fish", 3)];
+
+    /// Build the basis vector for a single keyword (panics in tests if the
+    /// keyword is outside the vocabulary or the axis exceeds `self.dim`).
+    fn axis(&self, keyword: &str) -> Vec<f32> {
+        let (_, idx) = Self::VOCAB
+            .iter()
+            .find(|(kw, _)| *kw == keyword)
+            .copied()
+            .unwrap_or_else(|| panic!("keyword '{keyword}' not in DeterministicEmbedder vocab"));
+        let mut v = vec![0.0_f32; self.dim];
+        v[idx] = 1.0;
+        v
+    }
+}
+
+impl EmbeddingProvider for DeterministicEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        let lower = text.to_ascii_lowercase();
+        let mut v = vec![0.0_f32; self.dim];
+        // First vocabulary keyword present in the text wins.
+        if let Some((_, idx)) = Self::VOCAB
+            .iter()
+            .find(|(kw, _)| lower.contains(kw))
+            .copied()
+        {
+            v[idx] = 1.0;
+        }
+        Ok(v)
+    }
+
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("deterministic", "test", self.dim)
+    }
+}
+
 struct MockGen;
 impl SummaryGenerator for MockGen {
     fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String> {
@@ -161,6 +223,118 @@ fn query_returns_results_after_adding_facts() {
     let results = engine.query(&query).unwrap();
     assert_eq!(results.len(), 1);
     assert!(results[0].fact.content.contains("Rust"));
+}
+
+// --- Issue #453: vector ranking discriminated by distinct embeddings ---
+
+/// Vector-only search must rank the semantically-closest fact first when the
+/// embeddings are actually distinct.
+///
+/// `MockEmbedder` returns a constant vector, so every fact ties on cosine and
+/// this ordering is invisible. With [`DeterministicEmbedder`] each keyword maps
+/// to an orthogonal basis axis, so a query embedded as the `cats` axis scores
+/// cosine `1.0` against the cats fact and `0.0` against every other fact — a
+/// strict ordering the brute-force cosine scan must honor.
+///
+/// **Discrimination**: if the vector path stopped ordering by cosine (e.g. an
+/// off-by-one in `select_nth_unstable_by` / `sort_by`, or a sign flip in
+/// `cosine_similarity`), the top result would no longer be the cats fact and
+/// this assertion would fail. With a constant embedder it could never fail.
+#[test]
+fn vector_query_ranks_closest_embedding_first() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let embedder = DeterministicEmbedder { dim: DIM };
+
+    for content in ["cats are independent", "dogs are loyal", "birds can fly"] {
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: content.into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                &embedder,
+                None,
+            )
+            .unwrap();
+    }
+
+    // Query embedded as the "cats" axis — orthogonal to dogs/birds.
+    let results = engine
+        .query(&SearchQuery {
+            text: None,
+            embedding: Some(embedder.axis("cats")),
+            mode: SearchMode::Vector,
+            limit: 10,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        })
+        .unwrap();
+
+    assert_eq!(results.len(), 3, "all three facts are vector candidates");
+    assert!(
+        results[0].fact.content.contains("cats"),
+        "closest embedding (cats) must rank first, got: {}",
+        results[0].fact.content
+    );
+    // Cosine 1.0 for the matching axis strictly dominates the 0.0 ties below it.
+    assert!(
+        results[0].score > results[1].score,
+        "cats score ({}) must strictly exceed the next ({})",
+        results[0].score,
+        results[1].score
+    );
+}
+
+/// A second axis confirms the ranking tracks the query, not insertion order:
+/// querying the "dogs" axis surfaces the dogs fact first even though it was
+/// inserted second. A constant embedder would tie all facts and fall back to a
+/// stable/insertion order, masking this.
+#[test]
+fn vector_query_ranking_follows_query_axis() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let embedder = DeterministicEmbedder { dim: DIM };
+
+    for content in ["cats are independent", "dogs are loyal", "fish swim"] {
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: content.into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                &embedder,
+                None,
+            )
+            .unwrap();
+    }
+
+    let results = engine
+        .query(&SearchQuery {
+            text: None,
+            embedding: Some(embedder.axis("dogs")),
+            mode: SearchMode::Vector,
+            limit: 10,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        })
+        .unwrap();
+
+    assert_eq!(results.len(), 3);
+    assert!(
+        results[0].fact.content.contains("dogs"),
+        "query axis (dogs) must rank the dogs fact first, got: {}",
+        results[0].fact.content
+    );
+    assert!(results[0].score > results[1].score);
 }
 
 #[test]


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 2). Subsystem-cohesive PR closing 3 findings.

## Findings closed

- **#308** [test/medium] — AsyncMemoryEngine spawn_blocking shim has thin async test coverage (~25 public methods untested)
- **#453** [test/medium] — MockEmbedder returns constant vector, masking vector-ranking correctness
- **#474** [test/medium] — resume_context with scope_path=Some(existing path) ancestor branch untested

## Review (internal diverse-lens subagents — no external models)

3 clean-slate adversarial reviewers (correctness / security & soundness / api-surface & test-quality): **0 blocker, 0 major**, all addressed in fix commits.

## Gate
`cargo build/test/clippy --workspace --all-features` + `cargo fmt --check` + `cargo deny` (CI) — green (rebased on current main).

Fixes #308, fixes #453, fixes #474