### PR TITLE
chore(consolidation): clear the #495 low/info rollup

### DIFF
--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -25,6 +25,10 @@ use crate::types::{ConsolidationLevel, Fact, NewSummary};
 /// Returns `MemoryError::EmbeddingDimension` if the embedder returns an embedding
 /// whose length does not match `embed_dim`.
 /// Returns `MemoryError::Serialization` on JSON serialization failure.
+// Interim arity: the run-level `now` (#495) pushed this to 8 params. Wave 5b's
+// read→compute→write restructure collapses these passes behind a plan type, which
+// removes the bloat; allow until then rather than introduce a throwaway params struct.
+#[allow(clippy::too_many_arguments)]
 pub fn cluster_fusion(
     conn: &Connection,
     facts: &[&Fact],
@@ -33,6 +37,7 @@ pub fn cluster_fusion(
     embed_dim: usize,
     min_cluster_size: usize,
     cluster_threshold: f32,
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Result<usize> {
     // `facts` is the post-dedup active set, loaded once by the caller and shared
     // with the dedup pass (#389). Safety cap (`super::MAX_FACTS_FOR_CLUSTERING`,
@@ -92,7 +97,7 @@ pub fn cluster_fusion(
             level: ConsolidationLevel::Cluster,
             source_fact_ids: source_ids,
             scope_id,
-            created_at: chrono::Utc::now(),
+            created_at: now,
         })?;
 
         clusters_created += 1;
@@ -170,6 +175,7 @@ mod tests {
             dim,
             min_cluster_size,
             cluster_threshold,
+            Utc::now(),
         )
     }
 

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -417,7 +417,30 @@ mod tests {
             })
             .unwrap();
 
-        // Insert a "new" near-duplicate
+        // Insert a SECOND old fact that is a near-duplicate of "old fact". Both
+        // predate `since`, so the filter must keep them from being compared against
+        // each other — this is what makes the test diverge from a no-filter run.
+        store
+            .insert(&NewFact {
+                content: "old dup".into(),
+                content_hash: "h_old2".into(),
+                embedding: vec![0.999, 0.001, 0.0, 0.0],
+                fact_type: FactType::Semantic,
+                t_created: old_time,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                scope_id: 1,
+                importance: 0.5,
+                access_count: 0,
+                last_accessed: old_time,
+                metadata: serde_json::json!({}),
+                is_pinned: false,
+            })
+            .unwrap();
+
+        // Insert a "new" near-duplicate (lower importance, so it expires when driven).
         store
             .insert(&NewFact {
                 content: "new duplicate".into(),
@@ -438,16 +461,30 @@ mod tests {
             })
             .unwrap();
 
-        // Only compare facts created since `old_time + 1 day`
+        // Only facts created since `old_time + 1 day` DRIVE comparisons — i.e. just
+        // the new one. It compares against all active and is expired against "old
+        // fact" (lower importance). Crucially, the two OLD near-duplicates are never
+        // compared against each other (neither drives), so both survive. Without the
+        // since-filter, "old fact" would drive and expire "old dup" too (removed=2,
+        // one survivor) — so this fixture's result genuinely depends on the filter.
         let since = old_time + Duration::days(1);
         let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, Some(since), base)
             .unwrap()
             .expect_ran();
-        assert_eq!(removed, 1); // new duplicate should be expired against old
+        assert_eq!(
+            removed, 1,
+            "only the new duplicate is expired (it alone drives)"
+        );
 
         let active = store.list_active(None).unwrap();
-        assert_eq!(active.len(), 1);
-        assert_eq!(active[0].content, "old fact"); // old survives (higher importance wins)
+        let mut survivors: Vec<&str> = active.iter().map(|f| f.content.as_str()).collect();
+        survivors.sort_unstable();
+        assert_eq!(
+            survivors,
+            vec!["old dup", "old fact"],
+            "both pre-`since` near-duplicates survive — the filter kept them from \
+             driving a comparison against each other"
+        );
     }
 
     #[test]
@@ -637,9 +674,8 @@ mod tests {
         assert_eq!(active.len(), 1);
         // Pin the collapse topology: A is the survivor. The 0.8-vs-0.5 regression
         // value is order-sensitive — it assumes the merge order A→B then A→C, which
-        // holds because `local_dedup` scans `list_active` in rowid (insertion) order.
-        // That ordering is not yet guaranteed by the query (no ORDER BY — #495); when
-        // that lands this coupling becomes a contract rather than an SQLite default.
+        // now holds as a contract: `list_active` is `ORDER BY id` (#495), so it scans
+        // in rowid (insertion) order rather than relying on an implicit SQLite default.
         assert_eq!(active[0].id, a);
         assert_eq!(active[0].content, "A");
         assert!(

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -139,14 +139,12 @@ pub fn local_dedup(
             // duplicates without folding in genuinely distinct facts.
             if similarity >= threshold - DEDUP_SIMILARITY_EPSILON {
                 // Expire the lower-importance fact. Tie-break: higher id (newer) expires.
-                let expire_id = if new_fact.importance < candidate.importance {
-                    new_fact.id
-                } else if new_fact.importance > candidate.importance {
-                    candidate.id
-                } else {
-                    // Equal importance: expire the newer one (higher id)
-                    new_fact.id.max(candidate.id)
-                };
+                let expire_id = choose_expiry(
+                    new_fact.importance,
+                    new_fact.id,
+                    candidate.importance,
+                    candidate.id,
+                );
 
                 fact_store.expire(expire_id, now)?;
                 edge_store.expire_by_fact(expire_id, now)?;
@@ -176,7 +174,23 @@ pub fn local_dedup(
     })
 }
 
-/// Inherit the higher importance values from `loser` into `survivor`.
+/// Choose which of two near-duplicate facts to expire: the **lower-importance**
+/// one, breaking ties (equal importance) by expiring the **newer** (higher id).
+///
+/// Pure and total over distinct ids — extracted from the dedup loop so the
+/// tie-break rule is property-testable in isolation (#495).
+fn choose_expiry(a_importance: f64, a_id: i64, b_importance: f64, b_id: i64) -> i64 {
+    if a_importance < b_importance {
+        a_id
+    } else if a_importance > b_importance {
+        b_id
+    } else {
+        // Equal importance: expire the newer one (higher id).
+        a_id.max(b_id)
+    }
+}
+
+/// Inherit the higher importance values from the loser into the survivor.
 ///
 /// Called after a dedup merge to ensure the surviving fact retains the maximum
 /// base `importance` and `importance_score` across the merged pair — and,
@@ -375,7 +389,11 @@ mod tests {
     #[test]
     fn only_compares_new_facts_against_active() {
         let (conn, dim) = setup();
-        let old_time = Utc::now() - Duration::days(10);
+        // #495: derive every timestamp from a single captured `base` so the test is
+        // deterministic — no race between independent `Utc::now()` calls for the
+        // fixture, the `since` filter, and the dedup clock.
+        let base = Utc::now();
+        let old_time = base - Duration::days(10);
 
         // Insert an "old" fact
         let store = FactStore::new(&conn, dim);
@@ -406,7 +424,7 @@ mod tests {
                 content_hash: "h_new".into(),
                 embedding: vec![0.99, 0.01, 0.0, 0.0],
                 fact_type: FactType::Semantic,
-                t_created: Utc::now(),
+                t_created: base,
                 t_expired: None,
                 t_valid: None,
                 t_invalid: None,
@@ -414,7 +432,7 @@ mod tests {
                 scope_id: 1,
                 importance: 0.3,
                 access_count: 0,
-                last_accessed: Utc::now(),
+                last_accessed: base,
                 metadata: serde_json::json!({}),
                 is_pinned: false,
             })
@@ -422,7 +440,7 @@ mod tests {
 
         // Only compare facts created since `old_time + 1 day`
         let since = old_time + Duration::days(1);
-        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, Some(since), Utc::now())
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, Some(since), base)
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 1); // new duplicate should be expired against old
@@ -720,5 +738,40 @@ mod tests {
             .unwrap()
             .expect_ran();
         assert_eq!(removed, 1, "a corpus exactly at the cap must run, not skip");
+    }
+
+    // --- #495: property-based coverage of the dedup tie-break (`choose_expiry`) ---
+
+    use proptest::prelude::*;
+
+    proptest! {
+        /// For distinct importances, the lower-importance fact is always expired
+        /// (the survivor keeps the higher importance).
+        #[test]
+        fn choose_expiry_expires_lower_importance(
+            a_imp in 0.0f64..=1.0,
+            a_id in 1i64..10_000,
+            b_imp in 0.0f64..=1.0,
+            b_id in 1i64..10_000,
+        ) {
+            prop_assume!(a_id != b_id);
+            // Meaningfully distinct importances so the `<`/`>` branch is unambiguous.
+            prop_assume!((a_imp - b_imp).abs() > 1e-9);
+            let expired = choose_expiry(a_imp, a_id, b_imp, b_id);
+            let lower_id = if a_imp < b_imp { a_id } else { b_id };
+            prop_assert_eq!(expired, lower_id);
+        }
+
+        /// On equal importance, the newer (higher id) fact is expired — the
+        /// deterministic tie-break.
+        #[test]
+        fn choose_expiry_tie_breaks_to_higher_id(
+            imp in 0.0f64..=1.0,
+            a_id in 1i64..10_000,
+            b_id in 1i64..10_000,
+        ) {
+            prop_assume!(a_id != b_id);
+            prop_assert_eq!(choose_expiry(imp, a_id, imp, b_id), a_id.max(b_id));
+        }
     }
 }

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -24,6 +24,7 @@ pub fn global_integration(
     generator: &dyn SummaryGenerator,
     embedder: &dyn EmbeddingProvider,
     embed_dim: usize,
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Result<usize> {
     let summary_store = SummaryStore::new(conn, embed_dim);
 
@@ -65,7 +66,7 @@ pub fn global_integration(
         level: ConsolidationLevel::Global,
         source_fact_ids: all_source_ids,
         scope_id: 1,
-        created_at: chrono::Utc::now(),
+        created_at: now,
     })?;
 
     Ok(1)
@@ -125,7 +126,8 @@ mod tests {
 
         let mock_gen = MockGenerator;
         let mock_embed = MockEmbedder { embed_dim: dim };
-        let count = global_integration(&conn, &mock_gen, &mock_embed, dim).unwrap();
+        let count =
+            global_integration(&conn, &mock_gen, &mock_embed, dim, chrono::Utc::now()).unwrap();
         assert_eq!(count, 1);
 
         let global = store.list_by_level(&ConsolidationLevel::Global).unwrap();
@@ -146,7 +148,8 @@ mod tests {
 
         let mock_gen = MockGenerator;
         let mock_embed = MockEmbedder { embed_dim: dim };
-        let count = global_integration(&conn, &mock_gen, &mock_embed, dim).unwrap();
+        let count =
+            global_integration(&conn, &mock_gen, &mock_embed, dim, chrono::Utc::now()).unwrap();
         assert_eq!(count, 0);
     }
 
@@ -172,8 +175,8 @@ mod tests {
         let mock_embed = MockEmbedder { embed_dim: dim };
 
         // Run twice
-        global_integration(&conn, &mock_gen, &mock_embed, dim).unwrap();
-        global_integration(&conn, &mock_gen, &mock_embed, dim).unwrap();
+        global_integration(&conn, &mock_gen, &mock_embed, dim, chrono::Utc::now()).unwrap();
+        global_integration(&conn, &mock_gen, &mock_embed, dim, chrono::Utc::now()).unwrap();
 
         let global = store.list_by_level(&ConsolidationLevel::Global).unwrap();
         assert_eq!(global.len(), 1); // Not 2

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -178,6 +178,9 @@ fn consolidate_with_caps(
         .filter(|f| !expired_set.contains(&f.id))
         .collect();
 
+    // #495: thread the single run-level `now` through both summary-writing passes
+    // so all summaries from one consolidation share a created_at, instead of each
+    // pass calling `Utc::now()` independently.
     let clusters_created = cluster_fusion(
         &tx,
         &survivors,
@@ -186,8 +189,9 @@ fn consolidate_with_caps(
         embed_dim,
         config.min_cluster_size,
         config.cluster_threshold,
+        now,
     )?;
-    let global_summaries = global_integration(&tx, generator, embedder, embed_dim)?;
+    let global_summaries = global_integration(&tx, generator, embedder, embed_dim, now)?;
 
     // Record the embedding identity on first write (#613, ADR 0015 §2) — but only
     // once a summary vector has actually been written (#643). `local_dedup` only

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -262,10 +262,12 @@ impl<'a> FactStore<'a> {
         Ok(out)
     }
 
-    /// List active facts (`t_expired IS NULL`), optionally limited.
+    /// List active facts (`t_expired IS NULL`), optionally limited, in ascending
+    /// `id` (insertion) order (#495).
     ///
     /// When `limit` is `Some(n)`, a SQL `LIMIT n` clause is pushed into the
-    /// query so that at most `n` rows are materialized. `None` returns all.
+    /// query so that at most `n` rows are materialized — the `n` **oldest** active
+    /// facts, since results are ordered by `id`. `None` returns all.
     ///
     /// # Errors
     ///

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -273,7 +273,11 @@ impl<'a> FactStore<'a> {
     pub fn list_active(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
         let base = format!("SELECT {FACT_COLUMNS} FROM facts WHERE t_expired IS NULL");
         let limit_i64: i64 = limit.map_or(-1, |n| i64::try_from(n).unwrap_or(i64::MAX));
-        let sql = format!("{base} LIMIT ?1");
+        // ORDER BY id (#495): deterministic iteration order across SQLite versions,
+        // vacuums, and query plans. Consolidation's greedy dedup/cluster passes are
+        // order-sensitive, so a stable insertion (rowid) order makes their output
+        // reproducible rather than dependent on the storage engine's scan choice.
+        let sql = format!("{base} ORDER BY id LIMIT ?1");
         let mut stmt = self.conn.prepare(&sql)?;
         let dim = self.embed_dim;
         let rows = stmt.query_map(params![limit_i64], |row| row_to_fact(row, dim))?;


### PR DESCRIPTION
## What

Wave 7 of the **#253 consolidation sweep** — disposition of the grouped low/info rollup #495 (8 items).

### Fixed
- **`ORDER BY id`** on `FactStore::list_active` — deterministic iteration (the order-sensitive greedy dedup/cluster passes relied on an implicit rowid scan order).
- **Single run-level `now`** threaded through `cluster_fusion`/`global_integration` — all summaries from a run share one `created_at`.
- **`choose_expiry`** extracted (pure) + proptests for the dedup tie-break (lower-importance expires; ties → higher id).
- **De-flaked** `only_compares_new_facts_against_active` — all timestamps derive from one captured `base`.

### Already done earlier in the sweep
- Cluster threshold configurable + documented → #344 (Wave 3).
- Pseudo-`Fact` clone removed → #273 (Wave 4).

### Won't-fix (documented)
- Faster hasher: not worth a new dep for a handful of i64-keyed ops/run.
- Doc-test examples: the module is `pub(crate)` → rustdoc examples don't execute as doctests; fns already documented.

`cluster_fusion` temporarily carries `#[allow(clippy::too_many_arguments)]` (the `now` made it 8); Wave 5b's restructure removes it.

## Verification

`cargo test --workspace --all-features` 37 binaries pass; `clippy -D warnings` + `fmt` + `cargo deny` clean.

Closes #495. Part of #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)