### PR TITLE
refactor(core): single-source FactType string parser; reconcile CLI/MCP casing

### DIFF
--- a/memory-engine-cli/src/commands/add_fact.rs
+++ b/memory-engine-cli/src/commands/add_fact.rs
@@ -14,8 +14,8 @@ pub struct AddFactArgs {
     #[arg(long)]
     content: String,
 
-    /// Fact type
-    #[arg(long, value_enum)]
+    /// Fact type (episodic, semantic, procedural; case-insensitive)
+    #[arg(long, value_enum, ignore_case = true)]
     fact_type: CliFactType,
 
     /// Pre-computed embedding as a JSON array of floats (e.g., "[0.1, 0.2, 0.3]")

--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -5,11 +5,11 @@ use std::time::Instant;
 use chrono::{DateTime, Utc};
 use memory_engine::MemoryEngine;
 use memory_engine::traits::EmbeddingProvider;
-use memory_engine::types::{AddFactOptions, AddFactRequest};
+use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
 use serde::{Deserialize, Serialize};
 
 use crate::commands::embedding_args::EmbeddingArgs;
-use crate::commands::types::CliFactType;
+use crate::commands::types::deserialize_fact_type;
 use crate::db::{open_engine_writable, open_engine_writable_with_dim};
 use crate::output::{OutputFormat, print_json};
 
@@ -52,7 +52,8 @@ pub struct BatchIngestArgs {
 #[derive(Debug, Deserialize)]
 struct JsonlFact {
     content: String,
-    fact_type: CliFactType,
+    #[serde(deserialize_with = "deserialize_fact_type")]
+    fact_type: FactType,
     #[serde(default)]
     source_event_id: Option<i64>,
     #[serde(default)]
@@ -103,7 +104,7 @@ fn jsonl_to_request(fact: JsonlFact, default_scope: Option<&str>) -> AddFactRequ
     };
     AddFactRequest {
         content: fact.content,
-        fact_type: fact.fact_type.into(),
+        fact_type: fact.fact_type,
         source_event_id: fact.source_event_id,
         scope: fact.scope.or_else(|| default_scope.map(str::to_owned)),
         opts: Some(opts),
@@ -428,15 +429,15 @@ mod tests {
     fn jsonl_fact_deserialize_lowercase() {
         let line = r#"{"content":"hello","fact_type":"episodic"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        assert!(matches!(fact.fact_type, CliFactType::Episodic));
+        assert!(matches!(fact.fact_type, FactType::Episodic));
 
         let line = r#"{"content":"hello","fact_type":"semantic"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        assert!(matches!(fact.fact_type, CliFactType::Semantic));
+        assert!(matches!(fact.fact_type, FactType::Semantic));
 
         let line = r#"{"content":"hello","fact_type":"procedural"}"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
-        assert!(matches!(fact.fact_type, CliFactType::Procedural));
+        assert!(matches!(fact.fact_type, FactType::Procedural));
     }
 
     #[test]
@@ -464,7 +465,7 @@ mod tests {
         }"#;
         let fact: JsonlFact = serde_json::from_str(line).unwrap();
         assert_eq!(fact.content, "User moved to Istanbul");
-        assert!(matches!(fact.fact_type, CliFactType::Episodic));
+        assert!(matches!(fact.fact_type, FactType::Episodic));
         assert_eq!(fact.importance, Some(0.7));
         assert!(fact.t_valid.is_some());
         assert!(fact.t_invalid.is_some());
@@ -495,7 +496,7 @@ mod tests {
     fn validate_importance_out_of_range() {
         let fact = JsonlFact {
             content: "test".into(),
-            fact_type: CliFactType::Semantic,
+            fact_type: FactType::Semantic,
             source_event_id: None,
             scope: None,
             importance: Some(1.5),
@@ -515,7 +516,7 @@ mod tests {
         let t2 = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let fact = JsonlFact {
             content: "test".into(),
-            fact_type: CliFactType::Semantic,
+            fact_type: FactType::Semantic,
             source_event_id: None,
             scope: None,
             importance: None,
@@ -533,7 +534,7 @@ mod tests {
     fn validate_valid_fact_passes() {
         let fact = JsonlFact {
             content: "test".into(),
-            fact_type: CliFactType::Semantic,
+            fact_type: FactType::Semantic,
             source_event_id: None,
             scope: None,
             importance: Some(0.5),

--- a/memory-engine-cli/src/commands/types.rs
+++ b/memory-engine-cli/src/commands/types.rs
@@ -1,19 +1,29 @@
-//! CLI-local fact-type wrapper shared across subcommands.
+//! CLI-local fact-type plumbing.
 //!
-//! `memory_engine::FactType` deliberately exposes no `clap::ValueEnum`,
-//! `serde::Deserialize`, or `FromStr` impl (the core crate has no CLI/serde
-//! concerns), so the CLI needs a thin local wrapper. This is the single source of
-//! truth for it: `add-fact` (clap arg), `query` (clap arg), and `batch-ingest`
-//! (JSONL field) all parse into [`CliFactType`] and convert via `From`.
+//! The canonical string→[`FactType`] mapping lives in **core** as
+//! [`FactType::from_str`] (case-insensitive, accepts both `snake_case` and
+//! `PascalCase`) — it is the single source of truth shared with the MCP server
+//! (#678). This module holds only the two CLI-framework shims that cannot live in
+//! the framework-free core crate:
+//!
+//! * [`CliFactType`] — a `clap::ValueEnum` so `--fact-type` gets `[possible
+//!   values: …]` in `--help` and shell completion. Its tokens are locked to
+//!   core's canonical casing by a round-trip test below, so they cannot drift.
+//! * [`deserialize_fact_type`] — a serde adapter that parses the JSONL
+//!   `fact_type` field through core's `FromStr`, so batch-ingest shares the exact
+//!   same parser as every other surface.
+
+use std::str::FromStr;
 
 use memory_engine::types::FactType;
+use serde::Deserialize;
 
-/// Fact type as accepted on the CLI (`--fact-type`) and in JSONL (`fact_type`).
+/// Fact type as accepted on the CLI (`--fact-type` on `add-fact` / `query`).
 ///
-/// The clap value tokens and the serde field values are both the lower-cased
-/// variant names (`episodic`, `semantic`, `procedural`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
+/// This exists solely to give clap a `ValueEnum` (core stays framework-free). The
+/// value tokens are the lower-cased variant names (`episodic`, `semantic`,
+/// `procedural`), matching core's canonical [`FactType`] `Display`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum CliFactType {
     Episodic,
     Semantic,
@@ -30,6 +40,20 @@ impl From<CliFactType> for FactType {
     }
 }
 
+/// Serde adapter for the JSONL `fact_type` field, routing through core's
+/// canonical [`FactType::from_str`].
+///
+/// Use via `#[serde(deserialize_with = "crate::commands::types::deserialize_fact_type")]`.
+/// Because it delegates to core, the CLI's JSONL ingest accepts the same casings
+/// as every other surface (`snake_case` and `PascalCase`) and can never diverge.
+pub fn deserialize_fact_type<'de, D>(deserializer: D) -> Result<FactType, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    FactType::from_str(&s).map_err(serde::de::Error::custom)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -44,13 +68,19 @@ mod tests {
         );
     }
 
+    /// The JSONL adapter delegates to core, so it accepts the canonical
+    /// `snake_case` and rejects unknown tokens.
     #[test]
-    fn deserializes_snake_case() {
-        assert_eq!(
-            serde_json::from_str::<CliFactType>("\"episodic\"").unwrap(),
-            CliFactType::Episodic
-        );
-        assert!(serde_json::from_str::<CliFactType>("\"unknown\"").is_err());
+    fn deserialize_fact_type_parses_snake_case() {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(deserialize_with = "deserialize_fact_type")]
+            fact_type: FactType,
+        }
+
+        let w: Wrapper = serde_json::from_str(r#"{"fact_type":"episodic"}"#).unwrap();
+        assert_eq!(w.fact_type, FactType::Episodic);
+        assert!(serde_json::from_str::<Wrapper>(r#"{"fact_type":"unknown"}"#).is_err());
     }
 
     #[test]
@@ -61,5 +91,20 @@ mod tests {
             .map(|v| v.to_possible_value().unwrap().get_name().to_owned())
             .collect();
         assert_eq!(tokens, ["episodic", "semantic", "procedural"]);
+    }
+
+    /// Structural lock: every clap token must parse through core's canonical
+    /// `FromStr` to the same `FactType` the clap `From` conversion yields, and
+    /// core's `Display` must reproduce that token. This makes the clap surface
+    /// unable to silently drift from the core single source of truth (#678).
+    #[test]
+    fn clap_tokens_round_trip_through_core_from_str() {
+        use clap::ValueEnum;
+        for &variant in CliFactType::value_variants() {
+            let token = variant.to_possible_value().unwrap().get_name().to_owned();
+            let parsed: FactType = token.parse().expect("clap token must parse via core");
+            assert_eq!(parsed, FactType::from(variant));
+            assert_eq!(parsed.to_string(), token);
+        }
     }
 }

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -616,13 +616,14 @@ fn parse_event_type(s: &str) -> Result<EventType, ValidationError> {
     }
 }
 
+/// Parse an MCP `fact_type` tool parameter into the core [`FactType`].
+///
+/// Delegates to core's canonical [`FactType::from_str`] (the single source of
+/// truth shared with the CLI), so casing is reconciled across surfaces: the JSON
+/// schemas advertise `PascalCase` (`"Episodic"`), but `snake_case` is also accepted.
 fn parse_fact_type(s: &str) -> Result<FactType, ValidationError> {
-    match s {
-        "Episodic" => Ok(FactType::Episodic),
-        "Semantic" => Ok(FactType::Semantic),
-        "Procedural" => Ok(FactType::Procedural),
-        other => Err(ValidationError::UnknownFactType(other.to_owned())),
-    }
+    s.parse()
+        .map_err(|_| ValidationError::UnknownFactType(s.to_owned()))
 }
 
 /// Like `get_f64`, but returns a validation error if the key is present with a non-numeric type.
@@ -1750,9 +1751,34 @@ fn handle_get_recent_insights(
 
 #[cfg(test)]
 mod tests {
-    use super::{default_dump_name, default_dump_path, parse_consolidate_config};
+    use super::{default_dump_name, default_dump_path, parse_consolidate_config, parse_fact_type};
+    use memory_engine::types::FactType;
     use serde_json::json;
     use std::collections::HashSet;
+
+    #[test]
+    fn parse_fact_type_accepts_schema_pascal_case() {
+        // The JSON schemas advertise PascalCase tokens — these must still parse.
+        assert_eq!(parse_fact_type("Episodic").unwrap(), FactType::Episodic);
+        assert_eq!(parse_fact_type("Semantic").unwrap(), FactType::Semantic);
+        assert_eq!(parse_fact_type("Procedural").unwrap(), FactType::Procedural);
+    }
+
+    #[test]
+    fn parse_fact_type_reconciles_cli_snake_case() {
+        // After delegating to core's canonical FromStr, the MCP surface also
+        // accepts the CLI's snake_case casing (#678 reconciliation).
+        assert_eq!(parse_fact_type("episodic").unwrap(), FactType::Episodic);
+        assert_eq!(parse_fact_type("semantic").unwrap(), FactType::Semantic);
+    }
+
+    #[test]
+    fn parse_fact_type_rejects_unknown_preserving_token() {
+        let err = parse_fact_type("wisdom").unwrap_err();
+        // ValidationError is a thiserror enum; the offending token is preserved
+        // in its Display string.
+        assert!(err.to_string().contains("wisdom"), "{err}");
+    }
 
     /// Build a `memory_consolidate` argument map from key/value pairs.
     fn cfg_args(pairs: &[(&str, serde_json::Value)]) -> serde_json::Map<String, serde_json::Value> {

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -48,13 +48,16 @@ pub const fn fact_type_to_str(ft: &FactType) -> &'static str {
     }
 }
 
+/// Parse a `fact_type` string read back from the store into the core [`FactType`].
+///
+/// Delegates to core's canonical [`FactType::from_str`] (the single source of
+/// truth shared with the CLI and MCP, #678) rather than re-matching the variants
+/// here. Stored values are written as `snake_case` via [`fact_type_to_str`]; the
+/// canonical parser accepts that (and is case-insensitive), so the DB round-trip
+/// is unaffected.
 fn str_to_fact_type(s: &str) -> Result<FactType> {
-    match s {
-        "episodic" => Ok(FactType::Episodic),
-        "semantic" => Ok(FactType::Semantic),
-        "procedural" => Ok(FactType::Procedural),
-        other => Err(MemoryError::NotFound(format!("unknown fact type: {other}"))),
-    }
+    s.parse::<FactType>()
+        .map_err(|e| MemoryError::NotFound(e.to_string()))
 }
 
 /// Compute blake3 hex hash of content, truncated to first 32 characters (128 bits).

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 // --- Enums ---
 
@@ -62,6 +64,38 @@ impl fmt::Display for FactType {
             Self::Episodic => write!(f, "episodic"),
             Self::Semantic => write!(f, "semantic"),
             Self::Procedural => write!(f, "procedural"),
+        }
+    }
+}
+
+/// Error returned when a string does not name a known [`FactType`] variant.
+///
+/// Carries the offending token so callers can surface an actionable message.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("unknown fact type: {0}")]
+pub struct ParseFactTypeError(pub String);
+
+impl FromStr for FactType {
+    type Err = ParseFactTypeError;
+
+    /// Canonical, case-insensitive parse of the `FactType` variant names.
+    ///
+    /// This is the **single source of truth** for the string→`FactType` mapping
+    /// shared by every consumer surface (the CLI's `--fact-type` arg and JSONL
+    /// ingest, the MCP server's tool parameters). It is intentionally lenient on
+    /// casing so it accepts both wire conventions present in the codebase:
+    /// `Display` emits `snake_case` (`"episodic"`), while serde-derive and the MCP
+    /// JSON-schema enums use `PascalCase` (`"Episodic"`). Parsing reconciles both
+    /// to one canonical enum; [`FactType::to_string`] remains the canonical output.
+    ///
+    /// Note: this is orthogonal to the serde `Deserialize` derive, which stays
+    /// `PascalCase` to preserve `.pak` cold-storage archive back-compat.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "episodic" => Ok(Self::Episodic),
+            "semantic" => Ok(Self::Semantic),
+            "procedural" => Ok(Self::Procedural),
+            _ => Err(ParseFactTypeError(s.to_owned())),
         }
     }
 }
@@ -1018,11 +1052,57 @@ mod tests {
         assert_eq!(ConsolidationLevel::Cluster.to_string(), "cluster");
         assert_eq!(ConsolidationLevel::Global.to_string(), "global");
 
+        // (FactType FromStr parsing is exercised in `fact_type_from_str_*` below)
+
         // ActivityStatus
         assert_eq!(ActivityStatus::Recorded.to_string(), "recorded");
         assert_eq!(ActivityStatus::Deduplicated.to_string(), "deduplicated");
         assert_eq!(ActivityStatus::Ignored.to_string(), "ignored");
         assert_eq!(ActivityStatus::Promoted.to_string(), "promoted");
+    }
+
+    // --- FactType FromStr (canonical string parse, shared by CLI + MCP) ---
+
+    #[test]
+    fn fact_type_from_str_canonical_snake_case() {
+        assert_eq!("episodic".parse::<FactType>().unwrap(), FactType::Episodic);
+        assert_eq!("semantic".parse::<FactType>().unwrap(), FactType::Semantic);
+        assert_eq!(
+            "procedural".parse::<FactType>().unwrap(),
+            FactType::Procedural
+        );
+    }
+
+    #[test]
+    fn fact_type_from_str_accepts_pascal_case() {
+        // PascalCase is the serde-derive / MCP-JSON-schema wire form; the parser
+        // accepts it so both casings reconcile to one canonical enum.
+        assert_eq!("Episodic".parse::<FactType>().unwrap(), FactType::Episodic);
+        assert_eq!("Semantic".parse::<FactType>().unwrap(), FactType::Semantic);
+        assert_eq!(
+            "Procedural".parse::<FactType>().unwrap(),
+            FactType::Procedural
+        );
+    }
+
+    #[test]
+    fn fact_type_from_str_is_case_insensitive() {
+        assert_eq!("EPISODIC".parse::<FactType>().unwrap(), FactType::Episodic);
+        assert_eq!("sEmAnTiC".parse::<FactType>().unwrap(), FactType::Semantic);
+    }
+
+    #[test]
+    fn fact_type_from_str_rejects_unknown() {
+        let err = "wisdom".parse::<FactType>().unwrap_err();
+        // The unknown token is preserved in the error for actionable messages.
+        assert!(err.to_string().contains("wisdom"));
+    }
+
+    #[test]
+    fn fact_type_display_round_trips_through_from_str() {
+        for ft in [FactType::Episodic, FactType::Semantic, FactType::Procedural] {
+            assert_eq!(ft.to_string().parse::<FactType>().unwrap(), ft);
+        }
     }
 
     // --- NewFactBuilder ---

--- a/src/types.rs
+++ b/src/types.rs
@@ -91,11 +91,15 @@ impl FromStr for FactType {
     /// Note: this is orthogonal to the serde `Deserialize` derive, which stays
     /// `PascalCase` to preserve `.pak` cold-storage archive back-compat.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "episodic" => Ok(Self::Episodic),
-            "semantic" => Ok(Self::Semantic),
-            "procedural" => Ok(Self::Procedural),
-            _ => Err(ParseFactTypeError(s.to_owned())),
+        // Zero-allocation case-insensitive match (no temporary lowercased String).
+        if s.eq_ignore_ascii_case("episodic") {
+            Ok(Self::Episodic)
+        } else if s.eq_ignore_ascii_case("semantic") {
+            Ok(Self::Semantic)
+        } else if s.eq_ignore_ascii_case("procedural") {
+            Ok(Self::Procedural)
+        } else {
+            Err(ParseFactTypeError(s.to_owned()))
         }
     }
 }
@@ -1096,6 +1100,15 @@ mod tests {
         let err = "wisdom".parse::<FactType>().unwrap_err();
         // The unknown token is preserved in the error for actionable messages.
         assert!(err.to_string().contains("wisdom"));
+    }
+
+    #[test]
+    fn fact_type_from_str_rejects_surrounding_whitespace() {
+        // The parser is intentionally strict on whitespace — it does not trim.
+        // Surrounding whitespace is a malformed token, not a valid variant.
+        assert!(" episodic".parse::<FactType>().is_err());
+        assert!("semantic ".parse::<FactType>().is_err());
+        assert!("".parse::<FactType>().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Why

The MCP server and CLI each rolled their **own** string→`FactType` parser, and they **diverged on wire casing** — MCP matched PascalCase (`"Episodic"`, per the serde derive + JSON-schema enums) while the CLI matched snake_case (`"episodic"`, per `Display`). Two parsers for one core enum, disagreeing on input. That is the divergence flagged in #678.

Root cause: core `FactType` exposed **no canonical string parse**, so every consumer invented one — and core was itself self-inconsistent (`Display` → snake_case, serde derive → PascalCase; each consumer bound to a different one of the two).

## What (single source of truth lifted into core)

- **core** (`src/types.rs`): add a case-insensitive `impl FromStr for FactType` + `ParseFactTypeError` (thiserror, already a core dep). It accepts **both** casings present in the codebase and reconciles them to one enum; `Display` stays the canonical snake_case output. **Orthogonal to the serde derive** — serde stays PascalCase on purpose to keep `.pak` cold-storage archives readable.
- **mcp** (`tools/mod.rs`): `parse_fact_type` now delegates to `FactType::from_str`, deleting the duplicate match. The JSON schemas still advertise PascalCase; parsing merely **widens** to also accept snake_case.
- **cli** (`commands/types.rs`, `batch_ingest.rs`): JSONL ingest routes through core via a `deserialize_fact_type` serde adapter; `CliFactType` shrinks to a **clap-only `ValueEnum` shim** (clap needs an owned enum for `--help`/completion; core must stay framework-free). A **round-trip test** locks the clap tokens to core's canonical casing so they cannot drift. Also fixed a CLI doc comment that falsely claimed core exposes no `Deserialize`.

Behavior is preserved for existing inputs; both surfaces now **also** accept the other's casing (back-compatible widening). No new dependencies.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean ✓
- `cargo test --workspace` — 1525 passed ✓ · `--all-features` — 1559 passed ✓
- `cargo deny check` — advisories / bans / licenses / sources ok ✓

Closes #678