### PR TITLE
feat(storage): move HNSW ownership into SqliteBackend (#631 Stage B)

### DIFF
--- a/docs/plans/2026-06-21-stage-B-699-hnsw-fidelity-review.md
+++ b/docs/plans/2026-06-21-stage-B-699-hnsw-fidelity-review.md
@@ -1,0 +1,13 @@
+# Stage B (#699) HNSW fidelity — self-review
+
+The delegated adversarial reviewer hit the monthly subagent spend limit and produced no file; this review was conducted directly (subagents unavailable). Verdict: **faithful**.
+
+## Verified
+1. **Dispatch predicate** (`storage/sqlite/mod.rs:177` `should_use_hnsw`) replicates `engine/mod.rs:379-387` (`active_count() >= ann_threshold`) AND adds a necessary filter-compatibility gate: HNSW only when `temporal==Active && ids.is_none() && pinned.is_none() && metadata.is_empty()`. `HnswStrategy::check_fact_filters` honors only `t_expired IS NULL + fact_type + scope_ids`; the richer dims must fall through to brute-force — which, post-#684 (full FactFilter→SQL translation, now on main), honors them via `convert::build_filter_sql` + `vector_search_filtered`. So the gate is correct and composes with #684.
+2. **HNSW search path** (`storage/sqlite/search_index.rs:59-96`) passes `fact_type`/`scope_ids` to `HnswStrategy::search` (per-candidate `check_fact_filters` + exact `load_embedding` rescore), widens `f32→f64` at the boundary, applies `map_seam_err`. The read guard is held across the search (per-candidate DB reads share the conn). Matches the engine's HNSW handling.
+3. **Maintenance**: `notify_insert` (`search/ann.rs`) **tombstones the prior entry for the fact_id** before re-inserting → idempotent, so notifying on reinforce (`insert_or_reinforce_fact`) correctly updates, not duplicates. The backend notifies on its owned writes (insert/reinforce/atomic-insert/batch/expire/delete); cycle-apply returns `to_index` for the caller (Stage A contract). No double/under-notify.
+4. **Edges**: `search_config==None` ⇒ never HNSW; `ann_threshold==usize::MAX` ⇒ no index built. Non-ann build: `vector_search` always brute-force (`should_use_hnsw` is `const fn false`).
+5. **Engine byte-identical** (`git diff origin/main -- src/engine/` empty); engine keeps its own `hnsw_strategy` until Stage E.
+
+## Gate
+109 tests (async,ann,archive) · clippy clean (all-features / async / default) · default build compiles (2 pre-existing #630 dead_code warnings unrelated → collateral #712).

--- a/src/storage/sqlite/graph.rs
+++ b/src/storage/sqlite/graph.rs
@@ -36,25 +36,45 @@ impl FactGraph for SqliteBackend {
 
     // WRITE
     async fn insert_fact(&self, fact: &NewFact) -> Result<i64> {
+        // Capture embedding before moving `fact` into the closure so we can
+        // call notify_insert post-commit without re-borrowing `fact`.
+        #[cfg(feature = "ann")]
+        let embedding = fact.embedding.clone();
         let fact = fact.clone();
         let dim = self.embed_dim;
-        self.block_write(move |c| FactStore::new(c, dim).insert(&fact))
-            .await
+        let id = self
+            .block_write(move |c| FactStore::new(c, dim).insert(&fact))
+            .await?;
+        // Post-commit HNSW notification (mirrors engine/ingest.rs:235-238).
+        #[cfg(feature = "ann")]
+        self.hnsw_notify_insert(id, &embedding);
+        Ok(id)
     }
 
     // WRITE
     async fn insert_or_reinforce_fact(&self, fact: &NewFact) -> Result<(i64, bool)> {
+        #[cfg(feature = "ann")]
+        let embedding = fact.embedding.clone();
         let fact = fact.clone();
         let dim = self.embed_dim;
-        self.block_write(move |c| FactStore::new(c, dim).insert_or_reinforce(&fact))
-            .await
+        let result = self
+            .block_write(move |c| FactStore::new(c, dim).insert_or_reinforce(&fact))
+            .await?;
+        // Notify on any write that changes the active vector set (insert or reinforce).
+        #[cfg(feature = "ann")]
+        self.hnsw_notify_insert(result.0, &embedding);
+        Ok(result)
     }
 
     // WRITE
     async fn expire_fact(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
         let dim = self.embed_dim;
         self.block_write(move |c| FactStore::new(c, dim).expire(id, now))
-            .await
+            .await?;
+        // Post-commit HNSW notification (mirrors engine's notify_expire calls).
+        #[cfg(feature = "ann")]
+        self.hnsw_notify_expire(id);
+        Ok(())
     }
 
     // WRITE
@@ -120,10 +140,19 @@ impl FactGraph for SqliteBackend {
 
     // WRITE
     async fn hard_delete_facts(&self, ids: &[i64]) -> Result<usize> {
+        #[cfg(feature = "ann")]
+        let ids_for_notify = ids.to_vec();
         let ids = ids.to_vec();
         let dim = self.embed_dim;
-        self.block_write(move |c| FactStore::new(c, dim).hard_delete_ids(&ids))
-            .await
+        let count = self
+            .block_write(move |c| FactStore::new(c, dim).hard_delete_ids(&ids))
+            .await?;
+        // Post-commit HNSW notification: tombstone each hard-deleted fact.
+        #[cfg(feature = "ann")]
+        for id in ids_for_notify {
+            self.hnsw_notify_expire(id);
+        }
+        Ok(count)
     }
 
     // -------------------------------------------------------------------------
@@ -545,21 +574,28 @@ impl FactGraph for SqliteBackend {
         fingerprint: &EmbeddingFingerprint,
         expected_dim: usize,
     ) -> Result<i64> {
+        #[cfg(feature = "ann")]
+        let embedding = fact.embedding.clone();
         let fact = fact.clone();
         let fingerprint = fingerprint.clone();
         let dim = self.embed_dim;
-        self.block_write(move |conn| {
-            // Verbatim body of ingest.rs:228-231: one unchecked_transaction wrapping
-            // stamp_identity + FactStore::insert so a vector is never committed
-            // without an established, matching identity (the #614 silent-corruption guard).
-            let tx = conn.unchecked_transaction()?;
-            // stamp_identity equivalent: record-if-absent or compare-and-reject
-            crate::store::embedding_meta::record_if_absent(&tx, &fingerprint, expected_dim)?;
-            let id = FactStore::new(&tx, dim).insert(&fact)?;
-            tx.commit()?;
-            Ok(id)
-        })
-        .await
+        let id = self
+            .block_write(move |conn| {
+                // Verbatim body of ingest.rs:228-231: one unchecked_transaction wrapping
+                // stamp_identity + FactStore::insert so a vector is never committed
+                // without an established, matching identity (the #614 silent-corruption guard).
+                let tx = conn.unchecked_transaction()?;
+                // stamp_identity equivalent: record-if-absent or compare-and-reject
+                crate::store::embedding_meta::record_if_absent(&tx, &fingerprint, expected_dim)?;
+                let id = FactStore::new(&tx, dim).insert(&fact)?;
+                tx.commit()?;
+                Ok(id)
+            })
+            .await?;
+        // Post-commit HNSW notification (mirrors engine/ingest.rs:235-238).
+        #[cfg(feature = "ann")]
+        self.hnsw_notify_insert(id, &embedding);
+        Ok(id)
     }
 
     // ATOMIC WRITE — savepoint wrapping scope-resolution + batch fact insert.
@@ -572,72 +608,86 @@ impl FactGraph for SqliteBackend {
         fingerprint: &EmbeddingFingerprint,
         expected_dim: usize,
     ) -> Result<(Vec<i64>, Vec<i64>)> {
+        // Capture embeddings before moving `facts` into the closure.
+        #[cfg(feature = "ann")]
+        let embeddings: Vec<Vec<f32>> = facts.iter().map(|f| f.embedding.clone()).collect();
         let facts = facts.to_vec();
         let scope_paths = scope_paths.to_vec();
         let fingerprint = fingerprint.clone();
         let dim = self.embed_dim;
-        self.block_write(move |conn| {
-            // Verbatim body of ingest.rs:397-476: savepoint wrapping stamp +
-            // scope-resolve + per-fact insert.
-            conn.execute_batch("SAVEPOINT batch_insert")?;
+        let (ids, scope_ids_to_cache) = self
+            .block_write(move |conn| {
+                // Verbatim body of ingest.rs:397-476: savepoint wrapping stamp +
+                // scope-resolve + per-fact insert.
+                conn.execute_batch("SAVEPOINT batch_insert")?;
 
-            let result: Result<(Vec<i64>, Vec<i64>)> = (|| {
-                // Record the embedding identity on first write (#613), inside the
-                // savepoint so it commits atomically with the batch.
-                crate::store::embedding_meta::record_if_absent(conn, &fingerprint, expected_dim)?;
+                let result: Result<(Vec<i64>, Vec<i64>)> = (|| {
+                    // Record the embedding identity on first write (#613), inside the
+                    // savepoint so it commits atomically with the batch.
+                    crate::store::embedding_meta::record_if_absent(
+                        conn,
+                        &fingerprint,
+                        expected_dim,
+                    )?;
 
-                let scope_store = ScopeStore::new(conn);
-                let store = FactStore::new(conn, dim);
+                    let scope_store = ScopeStore::new(conn);
+                    let store = FactStore::new(conn, dim);
 
-                // Resolve scopes INSIDE the savepoint so they roll back on error.
-                // Deduplicate by path to avoid N redundant DB lookups.
-                let mut scope_cache: std::collections::HashMap<String, i64> =
-                    std::collections::HashMap::new();
-                let mut per_entry_scope_ids = Vec::with_capacity(facts.len());
-                for path_opt in &scope_paths {
-                    let scope_id = match path_opt {
-                        Some(path) => {
-                            if let Some(&cached) = scope_cache.get(path) {
-                                cached
-                            } else {
-                                let id = scope_store.ensure_path(path)?;
-                                scope_cache.insert(path.clone(), id);
-                                id
+                    // Resolve scopes INSIDE the savepoint so they roll back on error.
+                    // Deduplicate by path to avoid N redundant DB lookups.
+                    let mut scope_cache: std::collections::HashMap<String, i64> =
+                        std::collections::HashMap::new();
+                    let mut per_entry_scope_ids = Vec::with_capacity(facts.len());
+                    for path_opt in &scope_paths {
+                        let scope_id = match path_opt {
+                            Some(path) => {
+                                if let Some(&cached) = scope_cache.get(path) {
+                                    cached
+                                } else {
+                                    let id = scope_store.ensure_path(path)?;
+                                    scope_cache.insert(path.clone(), id);
+                                    id
+                                }
                             }
-                        }
-                        None => 1, // root scope
-                    };
-                    per_entry_scope_ids.push(scope_id);
-                }
-                let scope_ids_to_cache: Vec<i64> = scope_cache.into_values().collect();
+                            None => 1, // root scope
+                        };
+                        per_entry_scope_ids.push(scope_id);
+                    }
+                    let scope_ids_to_cache: Vec<i64> = scope_cache.into_values().collect();
 
-                let mut ids = Vec::with_capacity(facts.len());
-                for (i, fact) in facts.iter().enumerate() {
-                    // Patch scope_id from the resolved value (the NewFact coming in
-                    // may have a placeholder 0; in practice the engine already sets it,
-                    // but we honor the resolved scope_id from the savepoint).
-                    let mut f = fact.clone();
-                    f.scope_id = per_entry_scope_ids[i];
-                    let fact_id = store.insert(&f)?;
-                    ids.push(fact_id);
-                }
+                    let mut ids = Vec::with_capacity(facts.len());
+                    for (i, fact) in facts.iter().enumerate() {
+                        // Patch scope_id from the resolved value (the NewFact coming in
+                        // may have a placeholder 0; in practice the engine already sets it,
+                        // but we honor the resolved scope_id from the savepoint).
+                        let mut f = fact.clone();
+                        f.scope_id = per_entry_scope_ids[i];
+                        let fact_id = store.insert(&f)?;
+                        ids.push(fact_id);
+                    }
 
-                Ok((ids, scope_ids_to_cache))
-            })();
+                    Ok((ids, scope_ids_to_cache))
+                })();
 
-            match result {
-                Ok(pair) => {
-                    conn.execute_batch("RELEASE batch_insert")?;
-                    Ok(pair)
+                match result {
+                    Ok(pair) => {
+                        conn.execute_batch("RELEASE batch_insert")?;
+                        Ok(pair)
+                    }
+                    Err(e) => {
+                        let _ = conn.execute_batch("ROLLBACK TO batch_insert");
+                        let _ = conn.execute_batch("RELEASE batch_insert");
+                        Err(e)
+                    }
                 }
-                Err(e) => {
-                    let _ = conn.execute_batch("ROLLBACK TO batch_insert");
-                    let _ = conn.execute_batch("RELEASE batch_insert");
-                    Err(e)
-                }
-            }
-        })
-        .await
+            })
+            .await?;
+        // Post-commit HNSW notifications (mirrors engine/ingest.rs batch path).
+        #[cfg(feature = "ann")]
+        for (id, embedding) in ids.iter().zip(embeddings.iter()) {
+            self.hnsw_notify_insert(*id, embedding);
+        }
+        Ok((ids, scope_ids_to_cache))
     }
 
     // ATOMIC WRITE — co-session edge batch in one transaction.

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -36,6 +36,11 @@ use std::sync::Arc;
 
 use crate::error::{MemoryError, Result, StorageError};
 use crate::pool::ConnectionPool;
+#[cfg(feature = "ann")]
+use crate::search::ann::HnswStrategy;
+use crate::search::strategy::SearchConfig;
+#[cfg(feature = "ann")]
+use crate::search::strategy::VectorSearchStrategy as _;
 use crate::store::upcaster::UpcasterRegistry;
 
 #[cfg(all(feature = "async", feature = "archive"))]
@@ -56,15 +61,44 @@ mod session;
 /// need an owned handle) and the [`UpcasterRegistry`] as `Arc` (cloned into every
 /// [`EventLog`](crate::storage::EventLog) closure). `embed_dim` is derived from the
 /// pool so the two can never diverge.
+///
+/// ## HNSW ownership (Stage B, `ann` feature)
+///
+/// When the `ann` feature is enabled and a [`SearchConfig`] with
+/// `ann_threshold < usize::MAX` is provided via [`SqliteBackend::with_search_config`],
+/// an [`HnswStrategy`] is built from the database and stored here. `vector_search`
+/// dispatches to HNSW when `active_count() >= ann_threshold`, mirroring the engine's
+/// `should_use_hnsw()` predicate exactly. Without a `search_config` (the default),
+/// `vector_search` is always brute-force, preserving the `#630` behavior.
+///
+/// The HNSW index is maintained incrementally: `notify_insert` is called after every
+/// successful fact write (post-commit), and `notify_expire` after every expiry or hard
+/// delete — matching the engine's post-commit ordering in `ingest.rs` / `cognitive.rs`.
 pub struct SqliteBackend {
     pool: Arc<ConnectionPool>,
     embed_dim: usize,
     upcaster_registry: Arc<UpcasterRegistry>,
+    /// Optional vector search configuration — drives the HNSW dispatch predicate.
+    ///
+    /// `None` (the default from `from_pool`) ⇒ `ann_threshold` is effectively
+    /// `usize::MAX`, so HNSW never activates and `vector_search` is always
+    /// brute-force.
+    #[cfg_attr(not(feature = "ann"), allow(dead_code))]
+    search_config: Option<SearchConfig>,
+    /// Owned HNSW index, wrapped in `Arc` so the `'static` `spawn_blocking`
+    /// closures in `vector_search` can clone the reference without unsafe code.
+    /// Present only when the `ann` feature is enabled **and**
+    /// `with_search_config` was called with `ann_threshold < usize::MAX`.
+    #[cfg(feature = "ann")]
+    hnsw: Option<Arc<HnswStrategy>>,
 }
 
 // Build-time witness (not test-gated): `SqliteBackend` must be `Send + Sync` for
 // `Arc<dyn StorageBackend>` and the `#[async_trait]` `Send` futures. A field that
 // breaks this fails `cargo build`, not merely `cargo test`.
+//
+// `HnswStrategy` is `Send + Sync` because its interior `RwLock` (parking_lot) is
+// `Send + Sync`, and its `Hnsw<…>` is proven `Send + Sync` in `ann.rs:hnsw_is_send_sync`.
 const _: fn() = || {
     const fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<SqliteBackend>();
@@ -74,6 +108,10 @@ impl SqliteBackend {
     /// Wrap an already-opened pool + upcaster registry. The canonical constructor
     /// `#631` will use where it builds the [`ConnectionPool`] today. `embed_dim` is
     /// read from the pool, so a backend's dimension cannot diverge from its pool's.
+    ///
+    /// The backend produced by this constructor has no `SearchConfig`, so HNSW never
+    /// activates and `vector_search` is always brute-force — identical to the `#630`
+    /// behavior. Use [`with_search_config`](Self::with_search_config) to opt into HNSW.
     #[must_use]
     pub fn from_pool(pool: Arc<ConnectionPool>, upcaster_registry: Arc<UpcasterRegistry>) -> Self {
         let embed_dim = pool.embed_dim();
@@ -81,6 +119,170 @@ impl SqliteBackend {
             pool,
             embed_dim,
             upcaster_registry,
+            search_config: None,
+            #[cfg(feature = "ann")]
+            hnsw: None,
+        }
+    }
+
+    /// Attach a [`SearchConfig`] and, when the `ann` feature is enabled and
+    /// `cfg.ann_threshold < usize::MAX`, build the HNSW index from the database.
+    ///
+    /// This is the builder that replicates the engine's `init_from_pool` HNSW
+    /// construction (`engine/mod.rs:272-284`). It acquires a read connection,
+    /// runs the full `SELECT id, embedding FROM facts WHERE t_expired IS NULL`
+    /// scan, and constructs an in-memory index.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on a pool or query failure, or
+    /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
+    // Non-ann builds see only `self.search_config = Some(cfg); Ok(self)` which
+    // clippy flags as `missing_const_for_fn`. It is not const: under `ann` the
+    // method runs fallible DB I/O, and `const fn` cannot be conditionally const
+    // across feature flags. Suppress the FP on the non-ann build.
+    #[allow(
+        clippy::missing_const_for_fn,
+        reason = "under `ann` this runs fallible DB I/O; \
+                  the method cannot be `const` across all feature combos"
+    )]
+    pub fn with_search_config(mut self, cfg: SearchConfig) -> Result<Self> {
+        #[cfg(feature = "ann")]
+        {
+            self.hnsw = if cfg.ann_threshold < usize::MAX {
+                let conn = self.pool.read()?;
+                Some(Arc::new(HnswStrategy::build_from_db(
+                    &conn,
+                    self.embed_dim,
+                )?))
+            } else {
+                None
+            };
+        }
+        self.search_config = Some(cfg);
+        Ok(self)
+    }
+
+    /// Replicate the engine's `should_use_hnsw()` predicate exactly:
+    /// `hnsw.is_some_and(|h| h.active_count() >= ann_threshold)`.
+    ///
+    /// When the `ann` feature is disabled, or when no `search_config` was set,
+    /// this is always `false` (brute-force).
+    ///
+    /// The extra guard `filter_is_hnsw_compatible` ensures the filter does not
+    /// carry predicates that HNSW's `check_fact_filters` cannot honour (pinned,
+    /// metadata, ids, non-Active temporal). In those cases the richer brute-force
+    /// SQL path is used so no result is incorrectly included or excluded.
+    #[cfg(feature = "ann")]
+    fn should_use_hnsw(&self, filter: &crate::storage::FactFilter) -> bool {
+        use crate::storage::TemporalFilter;
+        // Replication of `engine/mod.rs:379-387` + filter-compatibility guard.
+        // HNSW's `check_fact_filters` only handles:
+        //   t_expired IS NULL  +  fact_type  +  scope_ids
+        // Any extra dimension (pinned, metadata, ids, non-Active temporal) must
+        // fall through to the full brute-force SQL path.
+        let filter_compatible = filter.temporal == TemporalFilter::Active
+            && filter.ids.is_none()
+            && filter.pinned.is_none()
+            && filter.metadata.is_empty();
+        if !filter_compatible {
+            return false;
+        }
+        self.hnsw.as_ref().is_some_and(|h| {
+            h.active_count()
+                >= self
+                    .search_config
+                    .as_ref()
+                    .map_or(usize::MAX, |c| c.ann_threshold)
+        })
+    }
+
+    #[cfg(not(feature = "ann"))]
+    #[allow(
+        dead_code,
+        clippy::unused_self,
+        reason = "non-ann build: method exists for symmetry but is never called; \
+                  the ann twin uses self.hnsw / self.search_config"
+    )]
+    const fn should_use_hnsw(&self, _filter: &crate::storage::FactFilter) -> bool {
+        false
+    }
+
+    /// Serialize the in-memory HNSW index to a snapshot (reads active embeddings
+    /// from the database via a read connection).
+    ///
+    /// Returns `Ok(None)` if HNSW is not active (no `search_config`, `ann` feature
+    /// disabled, or `ann_threshold == usize::MAX`). This is the piece that Stage E
+    /// wires into the engine's `close()`/snapshot path.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on pool or query failure, or
+    /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
+    #[cfg(feature = "ann")]
+    pub fn hnsw_snapshot(&self) -> Result<Option<crate::engine::snapshot::HnswSnapshot>> {
+        let Some(ref hnsw) = self.hnsw else {
+            return Ok(None);
+        };
+        let conn = self.pool.read()?;
+        hnsw.to_snapshot(&conn, self.embed_dim).map(Some)
+    }
+
+    /// Rebuild the HNSW index from a snapshot produced by
+    /// [`hnsw_snapshot`](Self::hnsw_snapshot), discarding the current in-memory
+    /// index.
+    ///
+    /// This replicates `engine/mod.rs:334-353`'s `try_load_snapshot` HNSW path.
+    /// Returns `Ok(())` if HNSW is not active (no-op for non-ann builds or
+    /// `ann_threshold == usize::MAX`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::EmbeddingDimension` if a snapshot entry has the wrong
+    /// embedding size (corrupt/version-skewed snapshot).
+    #[cfg(feature = "ann")]
+    pub fn load_hnsw_snapshot(
+        &mut self,
+        snap: &crate::engine::snapshot::HnswSnapshot,
+    ) -> Result<()> {
+        // Only meaningful if the config requires ANN.
+        let ann_threshold = self
+            .search_config
+            .as_ref()
+            .map_or(usize::MAX, |c| c.ann_threshold);
+        if ann_threshold == usize::MAX {
+            return Ok(());
+        }
+        self.hnsw = Some(Arc::new(HnswStrategy::from_snapshot(snap, self.embed_dim)?));
+        Ok(())
+    }
+}
+
+impl SqliteBackend {
+    /// Notify the HNSW index that a fact was inserted (post-commit).
+    ///
+    /// Mirrors the engine's post-commit `notify_insert` calls in `ingest.rs:235-238`
+    /// and `cognitive.rs:362-364`. Must be called **after** the write has committed
+    /// and the write lock has been released (matching the engine's ordering).
+    ///
+    /// No-op when the `ann` feature is disabled or when no HNSW index is active.
+    #[cfg(feature = "ann")]
+    pub(super) fn hnsw_notify_insert(&self, fact_id: i64, embedding: &[f32]) {
+        if let Some(ref hnsw) = self.hnsw {
+            hnsw.notify_insert(fact_id, embedding);
+        }
+    }
+
+    /// Notify the HNSW index that a fact was expired or hard-deleted (post-commit).
+    ///
+    /// Mirrors the engine's `notify_expire` calls. Must be called **after** the write
+    /// has committed and the write lock has been released.
+    ///
+    /// No-op when the `ann` feature is disabled or when no HNSW index is active.
+    #[cfg(feature = "ann")]
+    pub(super) fn hnsw_notify_expire(&self, fact_id: i64) {
+        if let Some(ref hnsw) = self.hnsw {
+            hnsw.notify_expire(fact_id);
         }
     }
 }

--- a/src/storage/sqlite/search_index.rs
+++ b/src/storage/sqlite/search_index.rs
@@ -1,9 +1,15 @@
 //! `impl SearchIndex for SqliteBackend` — delegates to the verbatim `search/*`
 //! free functions, returning ranked `(fact_id, score)` pairs.
 //!
-//! D3: `vector_search` is brute-force here (HNSW ownership + its engine-owned
-//! dispatch policy move into the backend in `#631`). The vector score is widened
-//! `f32 → f64` (value-exact, order-preserving) to match the trait's `f64` return.
+//! D3 (Stage B): `vector_search` now dispatches to HNSW when
+//! `should_use_hnsw()` returns true, falling back to brute-force otherwise.
+//! The vector score is widened `f32 → f64` (value-exact, order-preserving) to
+//! match the trait's `f64` return at both paths.
+//!
+//! HNSW search is CPU-heavy but in-memory (no DB I/O beyond the filter check
+//! per candidate). It runs synchronously inside `block_read` on a blocking
+//! thread — matching the engine's sync HNSW dispatch in `query.rs` and avoiding
+//! an extra `spawn_blocking` layer for the in-memory work.
 
 use async_trait::async_trait;
 
@@ -45,6 +51,50 @@ impl SearchIndex for SqliteBackend {
         let filter = filter.clone();
         let dim = self.embed_dim;
         let q = embedding.to_vec();
+
+        // HNSW dispatch (Stage B): mirrors `engine/mod.rs:should_use_hnsw()` exactly.
+        // `hnsw` is stored as `Arc<HnswStrategy>` so we can clone it into the
+        // `'static` `spawn_blocking` closure without unsafe code. The Arc clone is
+        // cheap (pointer copy + refcount bump); no data is copied.
+        #[cfg(feature = "ann")]
+        if self.should_use_hnsw(&filter) {
+            let fact_type = filter.fact_type;
+            let scope_ids = filter.scope_ids.clone();
+            let pool = std::sync::Arc::clone(&self.pool);
+            // `should_use_hnsw` already confirmed `self.hnsw.is_some()`.
+            let hnsw = std::sync::Arc::clone(
+                self.hnsw
+                    .as_ref()
+                    .expect("should_use_hnsw() is true only when hnsw is Some"),
+            );
+            // The read guard (`conn`) must be held for the entire HNSW search because
+            // per-candidate DB reads (`check_fact_filters`, `load_embedding`) all use
+            // the same connection. Dropping it early would require a separate `pool.read()`
+            // per candidate, which is both more expensive and semantically inconsistent.
+            #[allow(
+                clippy::significant_drop_tightening,
+                reason = "conn guard must outlive the HNSW search; early drop would \
+                          require a separate connection per candidate lookup"
+            )]
+            let out = tokio::task::spawn_blocking(move || {
+                use crate::search::strategy::VectorSearchStrategy as _;
+                let conn = pool.read()?;
+                // `HnswStrategy::search` post-filters each HNSW candidate via
+                // `check_fact_filters` (t_expired IS NULL + fact_type + scope_id),
+                // then exact-scores via `load_embedding` — all inside the closure.
+                let results =
+                    hnsw.search(&conn, &q, dim, k, fact_type.as_ref(), scope_ids.as_deref())?;
+                // Widen f32 → f64 at the backend boundary (value-exact, order-preserving).
+                Ok(results
+                    .into_iter()
+                    .map(|r| (r.fact_id, f64::from(r.score)))
+                    .collect::<Vec<_>>())
+            })
+            .await
+            .map_err(super::map_join)?;
+            return super::map_seam_err(out);
+        }
+
         self.block_read(move |c| {
             // Bare (un-aliased) columns: the vector scan is a single-table `FROM facts`.
             let fsql = convert::build_filter_sql(&filter, "")?;
@@ -517,6 +567,420 @@ mod tests {
             got.len(),
             1,
             "AsOf must NOT surface soft-deleted (expired) rows; got {got:?}"
+        );
+    }
+}
+
+// =============================================================================
+// Stage B — HNSW dispatch tests (feature = "ann" only)
+// =============================================================================
+
+#[cfg(all(test, feature = "ann"))]
+mod hnsw_tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+
+    use super::super::SqliteBackend;
+    use crate::pool::ConnectionPool;
+    use crate::search::strategy::SearchConfig;
+    use crate::storage::graph::FactGraph;
+    use crate::storage::{FactFilter, SearchIndex};
+    use crate::store::facts::FactStore;
+    use crate::store::upcaster::UpcasterRegistry;
+    use crate::types::{EmbeddingFingerprint, FactType, NewFact};
+
+    const DIM: usize = 4;
+
+    fn fact(content: &str, embedding: [f32; DIM]) -> NewFact {
+        NewFact {
+            content: content.into(),
+            content_hash: String::new(),
+            embedding: embedding.to_vec(),
+            fact_type: FactType::Semantic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            scope_id: 1,
+            importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+            is_pinned: false,
+        }
+    }
+
+    /// Seed facts via the write connection and return the shared pool.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "write guard intentionally held across the seed loop"
+    )]
+    fn seeded(facts: &[NewFact]) -> Arc<ConnectionPool> {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            for f in facts {
+                store.insert(f).unwrap();
+            }
+        }
+        pool
+    }
+
+    /// Build a backend with HNSW enabled at the given threshold.
+    fn backend_with_ann(pool: Arc<ConnectionPool>, threshold: usize) -> SqliteBackend {
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+            .with_search_config(SearchConfig {
+                ann_threshold: threshold,
+            })
+            .unwrap()
+    }
+
+    /// Build a backend without any search config (always brute-force).
+    fn backend_no_config(pool: Arc<ConnectionPool>) -> SqliteBackend {
+        SqliteBackend::from_pool(pool, Arc::new(UpcasterRegistry::new()))
+    }
+
+    // -------------------------------------------------------------------------
+    // B1 — HNSW vs brute-force recall parity on a small exact corpus
+    // -------------------------------------------------------------------------
+
+    /// With `ann_threshold = 0` (always-ANN), HNSW and brute-force must return
+    /// the same top-k ids and ordering for an exact-match corpus.
+    #[tokio::test]
+    async fn hnsw_vs_brute_recall_parity_top2() {
+        let facts = vec![
+            fact("north", [1.0, 0.0, 0.0, 0.0]),
+            fact("near-north", [0.9, 0.1, 0.0, 0.0]),
+            fact("east", [0.0, 1.0, 0.0, 0.0]),
+        ];
+        let pool = seeded(&facts);
+
+        // Brute-force oracle (no search config).
+        let brute = backend_no_config(Arc::clone(&pool));
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let oracle: Vec<(i64, f64)> = brute
+            .vector_search(&query, &FactFilter::default(), 2)
+            .await
+            .unwrap();
+        assert_eq!(oracle.len(), 2, "oracle must return 2 results");
+
+        // HNSW backend: threshold=0 ⇒ active_count (3) >= 0 ⇒ HNSW always active.
+        let hnsw_be = backend_with_ann(Arc::clone(&pool), 0);
+        let hnsw_result: Vec<(i64, f64)> = hnsw_be
+            .vector_search(&query, &FactFilter::default(), 2)
+            .await
+            .unwrap();
+        assert_eq!(hnsw_result.len(), 2, "HNSW must return 2 results");
+
+        // IDs and scores must match exactly (HNSW exact-rescores via load_embedding).
+        assert_eq!(
+            hnsw_result.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            oracle.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            "HNSW top-k ids must match brute-force"
+        );
+        for ((_, hs), (_, bs)) in hnsw_result.iter().zip(oracle.iter()) {
+            assert!(
+                (hs - bs).abs() < 1e-6,
+                "HNSW score {hs} must equal brute-force score {bs} (f32→f64 widening)"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // B2 — ann_threshold boundary: below ⇒ brute-force, at/above ⇒ HNSW
+    // -------------------------------------------------------------------------
+
+    /// With 3 active facts, threshold=4 ⇒ `active_count` (3) < 4 ⇒ brute-force.
+    /// Both paths must return the same results.
+    #[tokio::test]
+    async fn threshold_above_active_count_uses_brute_force() {
+        let facts = vec![
+            fact("a", [1.0, 0.0, 0.0, 0.0]),
+            fact("b", [0.9, 0.1, 0.0, 0.0]),
+            fact("c", [0.0, 1.0, 0.0, 0.0]),
+        ];
+        let pool = seeded(&facts);
+        // threshold=4 > active_count(3) → should_use_hnsw() = false → brute-force.
+        let be = backend_with_ann(Arc::clone(&pool), 4);
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let got = be
+            .vector_search(&query, &FactFilter::default(), 2)
+            .await
+            .unwrap();
+        // Must still return correct results via brute-force.
+        assert_eq!(got.len(), 2);
+        // First result must be the [1,0,0,0] fact (exact match).
+        let all_facts = {
+            let c = pool.read().unwrap();
+            FactStore::new(&c, DIM).list_all().unwrap()
+        };
+        let north_id = all_facts.iter().find(|f| f.content == "a").unwrap().id;
+        assert_eq!(
+            got[0].0, north_id,
+            "first result must be the exact-match fact"
+        );
+    }
+
+    /// With 3 facts, threshold=3 ⇒ `active_count` (3) >= 3 ⇒ HNSW activates.
+    #[tokio::test]
+    async fn threshold_equal_active_count_activates_hnsw() {
+        let facts = vec![
+            fact("a", [1.0, 0.0, 0.0, 0.0]),
+            fact("b", [0.9, 0.1, 0.0, 0.0]),
+            fact("c", [0.0, 1.0, 0.0, 0.0]),
+        ];
+        let pool = seeded(&facts);
+        // threshold=3, active_count=3 → 3 >= 3 → HNSW.
+        let be = backend_with_ann(Arc::clone(&pool), 3);
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let got = be
+            .vector_search(&query, &FactFilter::default(), 2)
+            .await
+            .unwrap();
+        assert_eq!(got.len(), 2, "HNSW at threshold must return 2 results");
+    }
+
+    // -------------------------------------------------------------------------
+    // B3 — search_config == None ⇒ never HNSW (always brute-force)
+    // -------------------------------------------------------------------------
+
+    /// A backend with no `search_config` must never activate HNSW, even with lots
+    /// of facts. This validates the `#630` edge case.
+    #[tokio::test]
+    async fn no_search_config_always_brute_force() {
+        let facts = vec![
+            fact("a", [1.0, 0.0, 0.0, 0.0]),
+            fact("b", [0.9, 0.1, 0.0, 0.0]),
+            fact("c", [0.0, 1.0, 0.0, 0.0]),
+        ];
+        let pool = seeded(&facts);
+        // No search config → should_use_hnsw() always false.
+        let be = backend_no_config(Arc::clone(&pool));
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let got = be
+            .vector_search(&query, &FactFilter::default(), 2)
+            .await
+            .unwrap();
+        // Must return correct results via brute-force.
+        assert_eq!(got.len(), 2);
+        let all_facts = {
+            let c = pool.read().unwrap();
+            FactStore::new(&c, DIM).list_all().unwrap()
+        };
+        let north_id = all_facts.iter().find(|f| f.content == "a").unwrap().id;
+        assert_eq!(
+            got[0].0, north_id,
+            "no-config backend must still rank correctly"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // B4 — index maintenance: insert/expire reflected in HNSW results
+    // -------------------------------------------------------------------------
+
+    /// After `insert_fact` the newly inserted fact must appear in HNSW results.
+    #[tokio::test]
+    async fn notify_insert_via_insert_fact_makes_fact_findable() {
+        let pool = seeded(&[
+            fact("a", [1.0, 0.0, 0.0, 0.0]),
+            fact("b", [0.0, 1.0, 0.0, 0.0]),
+        ]);
+        // threshold=0 so HNSW is always active.
+        let be = backend_with_ann(Arc::clone(&pool), 0);
+
+        // Insert a new fact close to [1,0,0,0] via the FactGraph write path.
+        let new_id = be
+            .insert_fact(&fact("new-close", [0.99, 0.01, 0.0, 0.0]))
+            .await
+            .unwrap();
+
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let results = be
+            .vector_search(&query, &FactFilter::default(), 3)
+            .await
+            .unwrap();
+        let found_ids: Vec<i64> = results.iter().map(|(id, _)| *id).collect();
+        assert!(
+            found_ids.contains(&new_id),
+            "newly inserted fact must appear in HNSW results; got {found_ids:?}"
+        );
+    }
+
+    /// After `expire_fact` the expired fact must NOT appear in HNSW results.
+    #[tokio::test]
+    async fn notify_expire_via_expire_fact_removes_fact_from_results() {
+        let pool = seeded(&[
+            fact("north", [1.0, 0.0, 0.0, 0.0]),
+            fact("near-north", [0.9, 0.1, 0.0, 0.0]),
+            fact("east", [0.0, 1.0, 0.0, 0.0]),
+        ]);
+        let be = backend_with_ann(Arc::clone(&pool), 0);
+
+        // Find the id of "north".
+        let north_id = be
+            .list_all_facts()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|f| f.content == "north")
+            .unwrap()
+            .id;
+
+        // Expire it.
+        be.expire_fact(north_id, Utc::now()).await.unwrap();
+
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let results = be
+            .vector_search(&query, &FactFilter::default(), 3)
+            .await
+            .unwrap();
+        assert!(
+            !results.iter().any(|(id, _)| *id == north_id),
+            "expired fact must not appear in HNSW results; got {results:?}"
+        );
+    }
+
+    /// After `insert_fact_atomic` the inserted fact must appear in HNSW results.
+    #[tokio::test]
+    async fn notify_insert_via_insert_fact_atomic() {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        let be = backend_with_ann(Arc::clone(&pool), 0);
+        let fp = EmbeddingFingerprint::new("test-model", "tei", DIM);
+
+        let new_id = be
+            .insert_fact_atomic(&fact("atomic", [0.95, 0.05, 0.0, 0.0]), &fp, DIM)
+            .await
+            .unwrap();
+
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let results = be
+            .vector_search(&query, &FactFilter::default(), 3)
+            .await
+            .unwrap();
+        let found_ids: Vec<i64> = results.iter().map(|(id, _)| *id).collect();
+        assert!(
+            found_ids.contains(&new_id),
+            "atomically inserted fact must appear in HNSW results; got {found_ids:?}"
+        );
+    }
+
+    /// After `insert_facts_batch_atomic` all inserted facts appear in HNSW results.
+    #[tokio::test]
+    async fn notify_insert_via_insert_facts_batch_atomic() {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        let be = backend_with_ann(Arc::clone(&pool), 0);
+        let fp = EmbeddingFingerprint::new("test-model", "tei", DIM);
+
+        let batch = vec![
+            fact("batch-a", [1.0, 0.0, 0.0, 0.0]),
+            fact("batch-b", [0.9, 0.1, 0.0, 0.0]),
+        ];
+        let paths: Vec<Option<String>> = vec![None, None];
+        let (ids, _) = be
+            .insert_facts_batch_atomic(&batch, &paths, &fp, DIM)
+            .await
+            .unwrap();
+
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let results = be
+            .vector_search(&query, &FactFilter::default(), 5)
+            .await
+            .unwrap();
+        let found_ids: Vec<i64> = results.iter().map(|(id, _)| *id).collect();
+        for id in &ids {
+            assert!(
+                found_ids.contains(id),
+                "batch-inserted fact {id} must appear in HNSW results; got {found_ids:?}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // B5 — non-Active filter falls through to brute-force
+    // -------------------------------------------------------------------------
+
+    /// A filter with extra dimensions (pinned / metadata / ids) must use brute-force
+    /// even when HNSW is otherwise active, so no result is incorrectly filtered.
+    #[tokio::test]
+    async fn rich_filter_falls_through_to_brute_force() {
+        let mut pinned_fact = fact("pinned-north", [1.0, 0.0, 0.0, 0.0]);
+        pinned_fact.is_pinned = true;
+        let pool = seeded(&[pinned_fact, fact("unpinned", [0.9, 0.1, 0.0, 0.0])]);
+
+        // HNSW active (threshold=0), but filter carries `pinned=true`.
+        let be = backend_with_ann(Arc::clone(&pool), 0);
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let got = be
+            .vector_search(&query, &FactFilter::new().pinned(true), 5)
+            .await
+            .unwrap();
+        // Must return only the pinned fact (brute-force path honours the filter).
+        assert_eq!(
+            got.len(),
+            1,
+            "pinned filter must restrict to the single pinned fact; got {got:?}"
+        );
+        let all_facts = {
+            let c = pool.read().unwrap();
+            FactStore::new(&c, DIM).list_all().unwrap()
+        };
+        let pinned_id = all_facts.iter().find(|f| f.is_pinned).unwrap().id;
+        assert_eq!(got[0].0, pinned_id, "result must be the pinned fact");
+    }
+
+    // -------------------------------------------------------------------------
+    // B6 — snapshot round-trip
+    // -------------------------------------------------------------------------
+
+    /// `hnsw_snapshot` + `load_hnsw_snapshot` must produce an index that gives the
+    /// same top-k results as the original (rebuilt from the same DB data).
+    #[tokio::test]
+    async fn snapshot_round_trip_preserves_search_results() {
+        let facts = vec![
+            fact("north", [1.0, 0.0, 0.0, 0.0]),
+            fact("near-north", [0.9, 0.1, 0.0, 0.0]),
+            fact("east", [0.0, 1.0, 0.0, 0.0]),
+        ];
+        let pool = seeded(&facts);
+        let cfg = SearchConfig { ann_threshold: 0 };
+
+        // Original backend.
+        let orig = backend_with_ann(Arc::clone(&pool), 0);
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        let original_results = orig
+            .vector_search(&query, &FactFilter::default(), 2)
+            .await
+            .unwrap();
+
+        // Take a snapshot.
+        let snap = orig.hnsw_snapshot().unwrap().expect("HNSW must be active");
+
+        // Build a fresh backend and load the snapshot.
+        let mut restored =
+            SqliteBackend::from_pool(Arc::clone(&pool), Arc::new(UpcasterRegistry::new()))
+                .with_search_config(cfg)
+                .unwrap();
+        restored.load_hnsw_snapshot(&snap).unwrap();
+
+        let restored_results = restored
+            .vector_search(&query, &FactFilter::default(), 2)
+            .await
+            .unwrap();
+
+        // Same ids in same order.
+        assert_eq!(
+            restored_results
+                .iter()
+                .map(|(id, _)| *id)
+                .collect::<Vec<_>>(),
+            original_results
+                .iter()
+                .map(|(id, _)| *id)
+                .collect::<Vec<_>>(),
+            "snapshot round-trip must preserve top-k result order"
         );
     }
 }


### PR DESCRIPTION
## Summary

**Stage B of #631** (epic #628) — additive prep, **engine byte-identical**. Moves HNSW vector-search ownership into `SqliteBackend` (completes #630's D3 deferral) so its `vector_search` keeps HNSW acceleration. The engine keeps its own `hnsw_strategy` until the Stage E cutover; this is a parallel, isolation-tested backend index.

## What

- **Struct + ctor:** `SqliteBackend` gains `search_config: Option<SearchConfig>` and `#[cfg(feature="ann")] hnsw: Option<Arc<HnswStrategy>>`; a `with_search_config` builder builds the index via `HnswStrategy::build_from_db` under `ann` + `ann_threshold < usize::MAX` (`from_pool` unchanged → brute-force, exactly #630).
- **Dispatch:** `vector_search` replicates the engine's `should_use_hnsw` predicate exactly (`active_count() >= ann_threshold`), plus a filter-compat gate — HNSW only for `Active` + `fact_type`/`scope_ids` (the dims `HnswStrategy::check_fact_filters` honors); richer `FactFilter` dims fall through to the brute path, which (post-#684) honors them via `build_filter_sql`. `f32→f64` widening at the seam boundary.
- **Maintenance:** `notify_insert`/`notify_expire` wired into the backend's owned write methods (insert / reinforce / atomic-insert / batch / expire / delete), post-commit. `notify_insert` is idempotent (tombstones the prior entry), so reinforce updates rather than duplicates. Cycle-apply returns `to_index` for the caller (Stage A contract).
- **Snapshot:** serialize/deserialize relocated to backend methods for Stage E to wire the engine snapshot/Drop.

## Verification

- `cargo test --all-features` — **1239 passed**; `cargo test --workspace` — **1533 passed**
- `cargo clippy --workspace --all-targets --all-features` + `--features async` (no-ann) — clean; `cargo build` (default) compiles
- `src/engine/` **byte-identical**; rebased onto current `main`.

## Fidelity

Self-conducted review (committed at `docs/plans/2026-06-21-stage-B-699-hnsw-fidelity-review.md`; the delegated reviewer hit the monthly subagent spend limit) verified: dispatch-predicate parity, the filter-compat gate composing correctly with #684's full-filter brute path, idempotent maintenance (reinforce-safe), `search_config==None`→never-HNSW, and engine byte-identity.

## Testing

10 `#[cfg(feature="ann")]` tests: HNSW-vs-brute recall+order parity; `ann_threshold` boundary sweep; `None`-config→brute; notify_insert/expire reflected in results (via `insert_fact`/`insert_fact_atomic`/`expire_fact`); rich-filter→brute fallthrough; snapshot round-trip.

Fixes #699
