### PR TITLE
fix(consolidation): run consumer summarize/embed off the write lock (read→compute→write)

### DIFF
--- a/docs/advanced/consolidation.md
+++ b/docs/advanced/consolidation.md
@@ -2,7 +2,9 @@
 
 **Status: Implemented**
 
-Consolidation compresses the fact store by removing duplicates and generating hierarchical summaries. It runs as a three-pass pipeline within a single SQLite transaction: dedup, cluster fusion, global integration. This taxonomy follows the Memory Survey's consolidation framework.
+Consolidation compresses the fact store by removing duplicates and generating hierarchical summaries via a three-pass pipeline: dedup, cluster fusion, global integration. This taxonomy follows the Memory Survey's consolidation framework.
+
+Each run is structured **read → compute → write** so the engine's single write lock is _not_ held across the consumer `SummaryGenerator`/`EmbeddingProvider` calls, which are unbounded network IO (#409): a brief locked read snapshots the active set, the three passes (including all consumer IO) then run lock-free against that snapshot to produce a plan, and a final brief locked transaction applies the plan. This keeps other writers — and, for an in-memory pool, readers — from being starved for the IO duration, while preserving atomicity (below).
 
 ## Three-Pass Pipeline
 
@@ -12,7 +14,7 @@ Pass 1: Local Dedup       Pass 2: Cluster Fusion       Pass 3: Global Integratio
   expire duplicates         generate cluster summaries     into one global summary
 ```
 
-All three passes execute atomically. If any pass fails (including errors from the `SummaryGenerator`), the entire consolidation rolls back.
+Atomicity is preserved end-to-end. The compute phase produces a plan without touching the store, so a failure there (including errors from the `SummaryGenerator`/`EmbeddingProvider`) aborts the run before any write. The write phase applies the whole plan — expirations, cluster + global summaries, embedding identity, watermark — in a **single SQLite transaction**, so a failure there rolls everything back. Either way the store is never left half-consolidated.
 
 ### Pass 1: Local Dedup
 

--- a/src/consolidation/cluster.rs
+++ b/src/consolidation/cluster.rs
@@ -6,63 +6,74 @@ use crate::store::summaries::SummaryStore;
 use crate::traits::{EmbeddingProvider, SummarizableContent, SummaryGenerator};
 use crate::types::{ConsolidationLevel, Fact, NewSummary};
 
-/// Cluster fusion pass.
+/// Parameters for the cluster-fusion pass, bundled so the [`compute_clusters`] and
+/// apply halves share one descriptor — and so each fits under clippy's argument limit
+/// now that the pass is split read→compute→write (#409).
+pub(super) struct ClusterParams {
+    /// Fact/summary embedding dimension (validated by `summarize_and_embed`).
+    pub(super) embed_dim: usize,
+    /// Minimum cluster size to summarize.
+    pub(super) min_cluster_size: usize,
+    /// Cosine threshold for greedy single-linkage clustering (looser than dedup).
+    pub(super) cluster_threshold: f32,
+    /// Safety cap: above this many facts the O(N²) pass is skipped (#345).
+    pub(super) max_facts: usize,
+    /// Single run-level timestamp shared by all summaries from this run (#495).
+    pub(super) now: chrono::DateTime<chrono::Utc>,
+}
+
+/// Result of the pure cluster computation: the new cluster summaries to write, plus
+/// whether the pass actually ran (vs. skipped over the safety cap).
+pub(super) struct ClusterComputed {
+    /// `false` when `facts.len()` exceeded the cap and clustering was skipped. The
+    /// caller must then NOT delete the existing cluster/global summaries (there are no
+    /// replacements), so this flag gates the apply-side delete+insert (#345).
+    pub(super) ran: bool,
+    /// The cluster summaries to insert (already summarized + embedded).
+    pub(super) summaries: Vec<NewSummary>,
+}
+
+/// Compute cluster summaries **without touching the store** (#409).
 ///
-/// Clears prior cluster-level summaries before creating new ones (idempotent).
-/// Groups active facts by similarity (greedy single-linkage clustering) at
-/// `cluster_threshold` (cosine; lower than the dedup threshold so clustering is
-/// looser than dedup). For each cluster >= `min_cluster_size`, calls
-/// `SummaryGenerator` to create a summary, then `EmbeddingProvider` to embed it
-/// into the fact vector space. Stores summaries via `SummaryStore` with
-/// `level=Cluster`.
+/// Greedy single-linkage clustering at `params.cluster_threshold` (cosine; lower than
+/// the dedup threshold so clustering is looser than dedup), then the consumer
+/// `summarize`/`embed` IO for each cluster ≥ `params.min_cluster_size`. Returns the
+/// summaries as data for [`apply_clusters`] to write — no store IO happens here, so it
+/// is safe to run while the engine holds no lock.
 ///
-/// Returns number of clusters created.
+/// `facts` is the post-dedup active set, borrowed (no clone — #679/#389). The safety
+/// cap (`params.max_facts`, #345) is checked first: over it, `ran = false` and no
+/// summaries (and no consumer IO) are produced, so the caller preserves any existing
+/// summaries rather than wiping them without replacements.
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on SQL failure, or propagates errors from
-/// the `SummaryGenerator` or `EmbeddingProvider`.
-/// Returns `MemoryError::EmbeddingDimension` if the embedder returns an embedding
-/// whose length does not match `embed_dim`.
-/// Returns `MemoryError::Serialization` on JSON serialization failure.
-// Interim arity: the run-level `now` (#495) pushed this to 8 params. Wave 5b's
-// read→compute→write restructure collapses these passes behind a plan type, which
-// removes the bloat; allow until then rather than introduce a throwaway params struct.
-#[allow(clippy::too_many_arguments)]
-pub fn cluster_fusion(
-    conn: &Connection,
+/// Propagates errors from the `SummaryGenerator` or `EmbeddingProvider`.
+/// Returns `MemoryError::EmbeddingDimension` if an embedding length != `embed_dim`.
+pub(super) fn compute_clusters(
     facts: &[&Fact],
     generator: &dyn SummaryGenerator,
     embedder: &dyn EmbeddingProvider,
-    embed_dim: usize,
-    min_cluster_size: usize,
-    cluster_threshold: f32,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<usize> {
-    // `facts` is the post-dedup active set, loaded once by the caller and shared
-    // with the dedup pass (#389). Safety cap (`super::MAX_FACTS_FOR_CLUSTERING`,
-    // #345) checked BEFORE deleting existing summaries so we never wipe them
-    // without producing replacements.
-    if facts.len() > super::MAX_FACTS_FOR_CLUSTERING {
+    params: &ClusterParams,
+) -> Result<ClusterComputed> {
+    if facts.len() > params.max_facts {
         tracing::warn!(
             count = facts.len(),
-            max = super::MAX_FACTS_FOR_CLUSTERING,
+            max = params.max_facts,
             "clustering skipped: too many active facts for O(N^2) comparison"
         );
-        return Ok(0);
+        return Ok(ClusterComputed {
+            ran: false,
+            summaries: Vec::new(),
+        });
     }
 
-    let summary_store = SummaryStore::new(conn, embed_dim);
+    // Greedy single-linkage clustering.
+    let clusters = greedy_cluster(facts, params.cluster_threshold);
 
-    // Idempotent: clear previous cluster summaries (safe — we know we'll rebuild them)
-    summary_store.delete_by_level(&ConsolidationLevel::Cluster)?;
-
-    // Greedy single-linkage clustering
-    let clusters = greedy_cluster(facts, cluster_threshold);
-
-    let mut clusters_created = 0;
+    let mut summaries = Vec::new();
     for cluster in &clusters {
-        if cluster.len() < min_cluster_size {
+        if cluster.len() < params.min_cluster_size {
             continue;
         }
 
@@ -75,7 +86,7 @@ pub fn cluster_fusion(
             .map(|&idx| SummarizableContent::new(&facts[idx].content, &facts[idx].embedding))
             .collect();
         let (summary_text, summary_embedding) =
-            super::summarize_and_embed(generator, embedder, &items, embed_dim)?;
+            super::summarize_and_embed(generator, embedder, &items, params.embed_dim)?;
 
         // Determine scope_id from majority vote of source facts.
         // Deterministic tie-break: lowest scope_id wins on equal counts.
@@ -91,19 +102,65 @@ pub fn cluster_fusion(
                 .map_or(1, |(id, _)| id)
         };
 
-        summary_store.insert(&NewSummary {
+        summaries.push(NewSummary {
             content: summary_text,
             embedding: summary_embedding,
             level: ConsolidationLevel::Cluster,
             source_fact_ids: source_ids,
             scope_id,
-            created_at: now,
-        })?;
-
-        clusters_created += 1;
+            created_at: params.now,
+        });
     }
 
-    Ok(clusters_created)
+    Ok(ClusterComputed {
+        ran: true,
+        summaries,
+    })
+}
+
+/// Apply computed cluster summaries inside the caller's write context (#409): clear the
+/// prior cluster-level summaries (idempotent), then insert the new ones. Call this only
+/// when the pass actually ran ([`ClusterComputed::ran`]) — over the cap, existing
+/// summaries must be preserved because there are no replacements.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure, or `MemoryError::Serialization` on
+/// JSON serialization failure.
+pub(super) fn apply_clusters(
+    conn: &Connection,
+    embed_dim: usize,
+    summaries: &[NewSummary],
+) -> Result<()> {
+    let summary_store = SummaryStore::new(conn, embed_dim);
+    summary_store.delete_by_level(&ConsolidationLevel::Cluster)?;
+    for summary in summaries {
+        summary_store.insert(summary)?;
+    }
+    Ok(())
+}
+
+/// Cluster fusion pass — compute + apply on a single connection.
+///
+/// Thin wrapper over [`compute_clusters`] + [`apply_clusters`], kept as the per-pass
+/// entry point exercised by this module's unit tests (hence `#[cfg(test)]`). Returns the
+/// number of clusters created. The engine no longer calls this — it runs
+/// [`compute_clusters`] lock-free and applies the writes inside the final transaction
+/// (#409) — but the behavior is identical: existing summaries are cleared and rebuilt
+/// only when the pass runs (never over the cap).
+#[cfg(test)]
+fn cluster_fusion(
+    conn: &Connection,
+    facts: &[&Fact],
+    generator: &dyn SummaryGenerator,
+    embedder: &dyn EmbeddingProvider,
+    params: &ClusterParams,
+) -> Result<usize> {
+    let computed = compute_clusters(facts, generator, embedder, params)?;
+    if computed.ran {
+        apply_clusters(conn, params.embed_dim, &computed.summaries)?;
+    }
+    Ok(computed.summaries.len())
 }
 
 /// Greedy single-linkage clustering.
@@ -157,6 +214,7 @@ mod tests {
 
     /// Load the active facts and run `cluster_fusion` over borrowed references —
     /// the orchestrator now owns the single load (#389), so tests mirror that here.
+    /// `max_facts` is `usize::MAX` so the cluster cap never trips in these tests.
     fn cluster(
         conn: &Connection,
         generator: &dyn SummaryGenerator,
@@ -167,16 +225,14 @@ mod tests {
     ) -> Result<usize> {
         let active = FactStore::new(conn, dim).list_active(None)?;
         let refs: Vec<&Fact> = active.iter().collect();
-        cluster_fusion(
-            conn,
-            &refs,
-            generator,
-            embedder,
-            dim,
+        let params = ClusterParams {
+            embed_dim: dim,
             min_cluster_size,
             cluster_threshold,
-            Utc::now(),
-        )
+            max_facts: usize::MAX,
+            now: Utc::now(),
+        };
+        cluster_fusion(conn, &refs, generator, embedder, &params)
     }
 
     /// Mock generator that concatenates fact contents.

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -42,8 +42,24 @@ enum DedupOutcome {
     },
 }
 
-/// Result of the pure dedup computation: which facts to expire and which importance
-/// values the survivors inherit, expressed as **data** rather than DB writes.
+/// One planned expiry: the `loser` to expire, folded into its `survivor`.
+///
+/// The pairing is what lets [`apply_dedup`] honor the #409 read→write gap: if the
+/// `survivor` was concurrently expired between the lock-free snapshot and the write, the
+/// merge decision is void and the `loser` must be kept (not expired), so the duplicate
+/// group is never left without an active representative. `survivor` is the **immediate**
+/// survivor of the pairwise decision; chain correctness comes from snapshotting every
+/// survivor's liveness in `apply_dedup` *before* any expiry (see there).
+pub(super) struct Expiry {
+    /// The lower-importance fact to expire.
+    pub(super) loser: i64,
+    /// The fact `loser` was folded into (the higher-importance member of the pair).
+    pub(super) survivor: i64,
+}
+
+/// Result of the pure dedup computation: which facts to expire (with their survivors) and
+/// which importance values the survivors inherit, expressed as **data** rather than DB
+/// writes.
 ///
 /// Produced by [`compute_dedup`] (no `Connection`, so it runs lock-free during the
 /// engine's compute phase, #409) and applied by [`apply_dedup`] inside the final
@@ -56,10 +72,9 @@ pub(super) struct DedupComputed {
     /// The corpus exceeded the cap, so the pass was skipped: no writes, and the
     /// caller must NOT advance the watermark.
     pub(super) skipped: bool,
-    /// Number of near-duplicates chosen for expiry.
-    pub(super) removed: usize,
-    /// Ids to expire (the lower-importance member of each duplicate pair).
-    pub(super) expirations: Vec<i64>,
+    /// Planned expiries (loser + its survivor), the lower-importance member of each
+    /// duplicate pair paired with the fact it merges into.
+    pub(super) expirations: Vec<Expiry>,
     /// Base-`importance` inheritances `(survivor_id, importance)` — empty under the
     /// current expiry rule (kept for write-set fidelity; see the struct docs).
     pub(super) importance_updates: Vec<(i64, f64)>,
@@ -73,7 +88,6 @@ impl DedupComputed {
     pub(super) const fn skipped() -> Self {
         Self {
             skipped: true,
-            removed: 0,
             expirations: Vec::new(),
             importance_updates: Vec::new(),
             importance_score_updates: Vec::new(),
@@ -121,8 +135,10 @@ pub(super) fn compute_dedup(
         },
     );
 
+    // `expired_ids` is the loop's skip set (a loser is never re-compared); `expiries` is
+    // the ordered plan (loser + its survivor) handed to `apply_dedup`.
     let mut expired_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
-    let mut removed = 0;
+    let mut expiries: Vec<Expiry> = Vec::new();
     let mut importance_updates: Vec<(i64, f64)> = Vec::new();
     // Running maximum `importance_score` per surviving fact id (#264). The in-memory
     // `active_facts` slice is never mutated, so within a multi-duplicate chain a
@@ -162,15 +178,17 @@ pub(super) fn compute_dedup(
                     candidate.importance,
                     candidate.id,
                 );
-                expired_ids.insert(expire_id);
-                removed += 1;
-
                 // Survivor inherits the max importance values from the merged pair.
                 let (survivor, loser): (&Fact, &Fact) = if expire_id == new_fact.id {
                     (candidate, new_fact)
                 } else {
                     (new_fact, candidate)
                 };
+                expired_ids.insert(expire_id);
+                expiries.push(Expiry {
+                    loser: expire_id,
+                    survivor: survivor.id,
+                });
                 inherit_max_importance(
                     survivor,
                     loser,
@@ -188,8 +206,7 @@ pub(super) fn compute_dedup(
 
     DedupComputed {
         skipped: false,
-        removed,
-        expirations: expired_ids.into_iter().collect(),
+        expirations: expiries,
         importance_updates,
         importance_score_updates: running_scores.into_iter().collect(),
     }
@@ -197,15 +214,29 @@ pub(super) fn compute_dedup(
 
 /// Apply a computed dedup plan inside the caller's write context (#409): the base- and
 /// score-importance inheritances first (while every fact is still active), then the
-/// expirations and their edge cascades.
+/// expirations and their edge cascades. Returns the ids actually expired by **this**
+/// call, so the engine can drive its vector-index `notify_expire` and stats off what
+/// truly changed rather than the (possibly stale) plan.
 ///
-/// Tolerant of a concurrent expiry: because the engine now releases the write lock
-/// between snapshotting the active set and applying the plan, another writer (e.g.
-/// `prune` or conflict resolution) may already have expired a planned-for fact. A
-/// resulting [`MemoryError::NotFound`] from [`FactStore::expire`] is therefore treated
-/// as "already done", not an error — the desired end state (the fact is expired) still
-/// holds. In the single-connection wrapper/test path no concurrent writer exists, so
-/// that branch is never taken there.
+/// # Concurrency — the read→write gap (#409)
+///
+/// The engine releases the write lock between snapshotting the active set and applying
+/// the plan, so another writer (`prune`, conflict resolution, the dream cycle) may have
+/// expired a planned-for fact in between. Two cases are handled:
+///
+/// - **Loser concurrently expired:** [`FactStore::expire`] returns
+///   [`MemoryError::NotFound`]; tolerated as "already done" (the end state holds) and not
+///   counted as expired-by-us.
+/// - **Survivor concurrently expired:** the merge decision is void — expiring the loser
+///   too would leave the duplicate group with no active representative. So liveness of
+///   every survivor is **snapshotted up front** (before any expiry), and a loser is
+///   expired only if its survivor was still active at that point; otherwise the loser is
+///   kept. Snapshotting first (rather than checking at expiry time) is what keeps chains
+///   correct: an intermediate survivor that this call legitimately expires must not be
+///   mistaken for a concurrently-expired one.
+///
+/// The single-connection wrapper/test path has no concurrent writer, so every survivor is
+/// live and every planned loser is expired — behavior identical to the old pass.
 ///
 /// # Errors
 ///
@@ -217,7 +248,7 @@ pub(super) fn apply_dedup(
     embed_dim: usize,
     computed: &DedupComputed,
     now: DateTime<Utc>,
-) -> Result<()> {
+) -> Result<Vec<i64>> {
     let fact_store = FactStore::new(conn, embed_dim);
     let edge_store = EdgeStore::new(conn);
 
@@ -227,17 +258,37 @@ pub(super) fn apply_dedup(
     for &(id, score) in &computed.importance_score_updates {
         fact_store.update_importance_score(id, score)?;
     }
-    for &id in &computed.expirations {
-        match fact_store.expire(id, now) {
-            // `Ok` is the normal path; a `NotFound` means the fact was concurrently
-            // expired between the snapshot and this apply — the desired end state already
-            // holds, so it is a no-op, not a failure (#409).
-            Ok(()) | Err(MemoryError::NotFound(_)) => {}
-            Err(e) => return Err(e),
+
+    // Snapshot each distinct survivor's liveness BEFORE expiring anything, so a survivor
+    // this call itself expires (it may also be a loser in a merge chain) is not confused
+    // with one a concurrent writer expired (#409, survivor case).
+    let mut survivor_live: std::collections::HashMap<i64, bool> = std::collections::HashMap::new();
+    for e in &computed.expirations {
+        if let std::collections::hash_map::Entry::Vacant(slot) = survivor_live.entry(e.survivor) {
+            slot.insert(fact_store.is_active(e.survivor)?);
         }
-        edge_store.expire_by_fact(id, now)?;
     }
-    Ok(())
+
+    let mut expired = Vec::with_capacity(computed.expirations.len());
+    for e in &computed.expirations {
+        // Survivor concurrently expired → the merge is void; keep the loser as the
+        // group's representative instead of orphaning the cluster.
+        if !survivor_live[&e.survivor] {
+            continue;
+        }
+        match fact_store.expire(e.loser, now) {
+            Ok(()) => {
+                edge_store.expire_by_fact(e.loser, now)?;
+                expired.push(e.loser);
+            }
+            // Loser concurrently expired between snapshot and apply — the desired end
+            // state already holds, so it is a no-op, not a failure, and not counted as
+            // expired by this call (#409, loser case).
+            Err(MemoryError::NotFound(_)) => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(expired)
 }
 
 /// Local deduplication pass — compute + apply on a single connection.
@@ -265,10 +316,10 @@ fn local_dedup(
             active_count: active_facts.len(),
         });
     }
-    apply_dedup(conn, embed_dim, &computed, now)?;
+    let expired_ids = apply_dedup(conn, embed_dim, &computed, now)?;
     Ok(DedupOutcome::Ran {
-        removed: computed.removed,
-        expired_ids: computed.expirations,
+        removed: expired_ids.len(),
+        expired_ids,
     })
 }
 

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
-use crate::error::Result;
+use crate::error::{MemoryError, Result};
 use crate::search::vector::cosine_similarity;
 use crate::store::edges::EdgeStore;
 use crate::store::facts::FactStore;
@@ -16,23 +16,16 @@ use crate::types::Fact;
 /// staying far tighter than any gap between genuinely distinct facts.
 const DEDUP_SIMILARITY_EPSILON: f32 = 1e-6;
 
-/// Outcome of a [`local_dedup`] pass.
+/// Outcome of the single-connection [`local_dedup`] wrapper.
 ///
-/// Replaces the former `(usize, Vec<i64>)` return whose `usize::MAX` first element
-/// was an in-band "skipped" sentinel (#272). The flaw was not collision odds — a
-/// real removed-count of `usize::MAX` is physically impossible — but that the
-/// signal was *in-band*: every caller had to know the magic value and decode it
-/// before use, and the value was self-documenting-hostile. The skip state now lives
-/// in the type, so the over-cap case is matched explicitly and can never be read as
-/// a count.
-///
-/// Deliberately **not** `#[non_exhaustive]`: `consolidation` is `pub(crate)`, so
-/// this is crate-internal and matched exhaustively at its single call site (mirrors
-/// the `CycleOutcome` convention). Adding a variant is an in-crate change, not a
-/// semver break.
+/// Retained as the return shape exercised by this module's unit tests (hence
+/// `#[cfg(test)]`): the production path is [`compute_dedup`] → [`apply_dedup`], which
+/// carries the skip state in [`DedupComputed::skipped`] instead. This enum still encodes
+/// the #272 contract — the skip is in the type, never an in-band `usize::MAX` count.
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use = "a DedupOutcome must be inspected — a Skipped pass must suppress the watermark advance"]
-pub enum DedupOutcome {
+enum DedupOutcome {
     /// The pass ran to completion.
     Ran {
         /// Number of near-duplicate facts expired.
@@ -49,39 +42,64 @@ pub enum DedupOutcome {
     },
 }
 
-/// Local deduplication pass.
+/// Result of the pure dedup computation: which facts to expire and which importance
+/// values the survivors inherit, expressed as **data** rather than DB writes.
+///
+/// Produced by [`compute_dedup`] (no `Connection`, so it runs lock-free during the
+/// engine's compute phase, #409) and applied by [`apply_dedup`] inside the final
+/// write transaction. Base-`importance` inheritance is carried separately from
+/// `importance_score`: under the current expiry rule (always expire the
+/// lower-importance fact) the base list is always empty, but it is materialized
+/// through the same guard so the applied write set is provably identical to the old
+/// inline pass.
+pub(super) struct DedupComputed {
+    /// The corpus exceeded the cap, so the pass was skipped: no writes, and the
+    /// caller must NOT advance the watermark.
+    pub(super) skipped: bool,
+    /// Number of near-duplicates chosen for expiry.
+    pub(super) removed: usize,
+    /// Ids to expire (the lower-importance member of each duplicate pair).
+    pub(super) expirations: Vec<i64>,
+    /// Base-`importance` inheritances `(survivor_id, importance)` — empty under the
+    /// current expiry rule (kept for write-set fidelity; see the struct docs).
+    pub(super) importance_updates: Vec<(i64, f64)>,
+    /// `importance_score` inheritances `(survivor_id, score)` — the #264 running-max,
+    /// one final entry per survivor that absorbed a strictly-higher score.
+    pub(super) importance_score_updates: Vec<(i64, f64)>,
+}
+
+impl DedupComputed {
+    /// The skipped (over-cap) result: no writes, watermark held.
+    pub(super) const fn skipped() -> Self {
+        Self {
+            skipped: true,
+            removed: 0,
+            expirations: Vec::new(),
+            importance_updates: Vec::new(),
+            importance_score_updates: Vec::new(),
+        }
+    }
+}
+
+/// Compute the local-dedup plan **without touching the store** (#409).
 ///
 /// Compares facts created since `since` (or all if `None`) against all active facts.
-/// Duplicates (cosine ≥ threshold) are resolved by expiring the lower-importance
-/// fact. Deterministic tie-break: on equal importance, the newer fact (higher id) is
-/// expired. A `threshold` of 1.0 therefore merges only exact duplicates.
+/// Duplicates (cosine ≥ `threshold`, within [`DEDUP_SIMILARITY_EPSILON`]) are resolved
+/// by expiring the lower-importance fact ([`choose_expiry`]); the survivor inherits the
+/// chain-wide maximum `importance_score` (#264, tracked in a running-max map so a stale
+/// in-memory score is never read). Returns the expirations and inherited scores as data
+/// for [`apply_dedup`] to write — no IO happens here, so it is safe to run while the
+/// engine holds no lock.
 ///
-/// `active_facts` is the current active set, loaded once by the caller and shared
-/// with the cluster pass (#389) — `local_dedup` reads it for comparison and writes
-/// expirations through `conn`, but does not re-query the store.
-///
-/// When `active_facts.len()` exceeds `max_facts` the O(N*M) pairwise comparison is
-/// skipped and [`DedupOutcome::Skipped`] is returned (the orchestrator then leaves
-/// the watermark unadvanced); otherwise [`DedupOutcome::Ran`] carries the removed
-/// count and the expired ids. The cap is injected so callers own the policy and
-/// tests can exercise the skip path without a 50 000-fact corpus.
-///
-/// # Errors
-///
-/// Returns `MemoryError::Database` on SQL failure.
-/// Returns `MemoryError::NotFound` if a fact to expire or update no longer exists.
-pub fn local_dedup(
-    conn: &Connection,
-    embed_dim: usize,
+/// When `active_facts.len()` exceeds `max_facts` the O(N·M) pass is skipped
+/// ([`DedupComputed::skipped`]) so the caller leaves the watermark unadvanced and the
+/// over-cap facts are retried once the corpus shrinks.
+pub(super) fn compute_dedup(
     active_facts: &[Fact],
     threshold: f32,
     max_facts: usize,
     since: Option<DateTime<Utc>>,
-    now: DateTime<Utc>,
-) -> Result<DedupOutcome> {
-    let fact_store = FactStore::new(conn, embed_dim);
-    let edge_store = EdgeStore::new(conn);
-
+) -> DedupComputed {
     if active_facts.len() > max_facts {
         tracing::warn!(
             count = active_facts.len(),
@@ -89,13 +107,11 @@ pub fn local_dedup(
             "dedup skipped: too many active facts for O(N*M) comparison; \
              watermark will NOT advance so skipped facts are retried when corpus shrinks"
         );
-        return Ok(DedupOutcome::Skipped {
-            active_count: active_facts.len(),
-        });
+        return DedupComputed::skipped();
     }
 
-    // Split into "new" (to compare) and "all active" (to compare against)
-    let new_facts: Vec<_> = since.map_or_else(
+    // Split into "new" (to compare) and "all active" (to compare against).
+    let new_facts: Vec<&Fact> = since.map_or_else(
         || active_facts.iter().collect(),
         |since_dt| {
             active_facts
@@ -105,16 +121,17 @@ pub fn local_dedup(
         },
     );
 
-    let mut expired_ids = std::collections::HashSet::new();
-    let mut duplicates_removed = 0;
-    // Running maximum `importance_score` per surviving fact id (#264). The
-    // in-memory `active_facts` Vec is never updated after a DB write, so within a
-    // multi-duplicate chain a survivor's in-memory score goes stale once an earlier
-    // merge has already written a higher value. This map is the live source of
-    // truth consulted by `inherit_max_importance`.
+    let mut expired_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
+    let mut removed = 0;
+    let mut importance_updates: Vec<(i64, f64)> = Vec::new();
+    // Running maximum `importance_score` per surviving fact id (#264). The in-memory
+    // `active_facts` slice is never mutated, so within a multi-duplicate chain a
+    // survivor's in-memory score goes stale once an earlier merge inherited a higher
+    // value. This map is the live source of truth; its final state is the set of
+    // score writes [`apply_dedup`] later applies.
     let mut running_scores: std::collections::HashMap<i64, f64> = std::collections::HashMap::new();
 
-    for new_fact in &new_facts {
+    for &new_fact in &new_facts {
         if expired_ids.contains(&new_fact.id) || new_fact.is_pinned {
             continue; // pinned facts are never dedup candidates
         }
@@ -145,21 +162,23 @@ pub fn local_dedup(
                     candidate.importance,
                     candidate.id,
                 );
-
-                fact_store.expire(expire_id, now)?;
-                edge_store.expire_by_fact(expire_id, now)?;
                 expired_ids.insert(expire_id);
-                duplicates_removed += 1;
+                removed += 1;
 
-                // Update survivor's importance: inherit max from merged pair
-                let (survivor, loser) = if expire_id == new_fact.id {
-                    (&candidate, new_fact)
+                // Survivor inherits the max importance values from the merged pair.
+                let (survivor, loser): (&Fact, &Fact) = if expire_id == new_fact.id {
+                    (candidate, new_fact)
                 } else {
-                    (new_fact, &candidate)
+                    (new_fact, candidate)
                 };
-                inherit_max_importance(&fact_store, survivor, loser, &mut running_scores)?;
+                inherit_max_importance(
+                    survivor,
+                    loser,
+                    &mut importance_updates,
+                    &mut running_scores,
+                );
 
-                // If the new_fact itself was expired, stop comparing it
+                // If the new_fact itself was expired, stop comparing it.
                 if expire_id == new_fact.id {
                     break;
                 }
@@ -167,10 +186,89 @@ pub fn local_dedup(
         }
     }
 
-    let expired_vec: Vec<i64> = expired_ids.into_iter().collect();
+    DedupComputed {
+        skipped: false,
+        removed,
+        expirations: expired_ids.into_iter().collect(),
+        importance_updates,
+        importance_score_updates: running_scores.into_iter().collect(),
+    }
+}
+
+/// Apply a computed dedup plan inside the caller's write context (#409): the base- and
+/// score-importance inheritances first (while every fact is still active), then the
+/// expirations and their edge cascades.
+///
+/// Tolerant of a concurrent expiry: because the engine now releases the write lock
+/// between snapshotting the active set and applying the plan, another writer (e.g.
+/// `prune` or conflict resolution) may already have expired a planned-for fact. A
+/// resulting [`MemoryError::NotFound`] from [`FactStore::expire`] is therefore treated
+/// as "already done", not an error — the desired end state (the fact is expired) still
+/// holds. In the single-connection wrapper/test path no concurrent writer exists, so
+/// that branch is never taken there.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure, or `MemoryError::NotFound` from an
+/// importance update if a fact row is missing (facts are soft-deleted, so this does not
+/// fire for a merely-expired row).
+pub(super) fn apply_dedup(
+    conn: &Connection,
+    embed_dim: usize,
+    computed: &DedupComputed,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    let fact_store = FactStore::new(conn, embed_dim);
+    let edge_store = EdgeStore::new(conn);
+
+    for &(id, importance) in &computed.importance_updates {
+        fact_store.update_importance(id, importance)?;
+    }
+    for &(id, score) in &computed.importance_score_updates {
+        fact_store.update_importance_score(id, score)?;
+    }
+    for &id in &computed.expirations {
+        match fact_store.expire(id, now) {
+            // `Ok` is the normal path; a `NotFound` means the fact was concurrently
+            // expired between the snapshot and this apply — the desired end state already
+            // holds, so it is a no-op, not a failure (#409).
+            Ok(()) | Err(MemoryError::NotFound(_)) => {}
+            Err(e) => return Err(e),
+        }
+        edge_store.expire_by_fact(id, now)?;
+    }
+    Ok(())
+}
+
+/// Local deduplication pass — compute + apply on a single connection.
+///
+/// A thin wrapper over [`compute_dedup`] + [`apply_dedup`], kept as the per-pass entry
+/// point exercised by this module's unit tests (hence `#[cfg(test)]`). The engine no
+/// longer calls this: it runs [`compute_dedup`] lock-free and defers the writes to a
+/// single final transaction (#409). The behavior is identical.
+///
+/// `active_facts` is the current active set, loaded once by the caller and shared with
+/// the cluster pass (#389). A `threshold` of 1.0 merges only exact duplicates.
+#[cfg(test)]
+fn local_dedup(
+    conn: &Connection,
+    embed_dim: usize,
+    active_facts: &[Fact],
+    threshold: f32,
+    max_facts: usize,
+    since: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Result<DedupOutcome> {
+    let computed = compute_dedup(active_facts, threshold, max_facts, since);
+    if computed.skipped {
+        return Ok(DedupOutcome::Skipped {
+            active_count: active_facts.len(),
+        });
+    }
+    apply_dedup(conn, embed_dim, &computed, now)?;
     Ok(DedupOutcome::Ran {
-        removed: duplicates_removed,
-        expired_ids: expired_vec,
+        removed: computed.removed,
+        expired_ids: computed.expirations,
     })
 }
 
@@ -190,32 +288,33 @@ fn choose_expiry(a_importance: f64, a_id: i64, b_importance: f64, b_id: i64) -> 
     }
 }
 
-/// Inherit the higher importance values from the loser into the survivor.
+/// Record the higher importance values from the loser into the survivor — as **data**,
+/// not DB writes (#409): base `importance` into `importance_updates`, `importance_score`
+/// into the `running_scores` running-max map (#264).
 ///
-/// Called after a dedup merge to ensure the surviving fact retains the maximum
-/// base `importance` and `importance_score` across the merged pair — and,
-/// crucially, across an entire chain of merges onto the same survivor.
+/// Called after a dedup merge so the survivor ends up with the maximum base `importance`
+/// and `importance_score` across the merged pair — and, crucially, across an entire
+/// chain of merges onto the same survivor.
 ///
 /// `running_scores` tracks the live maximum `importance_score` per fact id so the
-/// decision never reads a stale in-memory value (#264): the in-memory `Fact` is
-/// not updated after a DB write, so an earlier merge's higher inherited score
-/// would otherwise be invisible — and overwritten — by a later, lower one. A fact
-/// absent from the map has never been written, so its in-memory score equals the
-/// DB value and is a safe fallback. The `loser` is consulted through the map too,
-/// so a fact that absorbed a high score before itself being expired passes that
-/// score on to its own survivor.
+/// decision never reads a stale in-memory value (#264): the in-memory `Fact` is not
+/// mutated, so an earlier merge's higher inherited score would otherwise be invisible —
+/// and overwritten — by a later, lower one. A fact absent from the map has never
+/// inherited, so its in-memory score equals the snapshot value and is a safe fallback.
+/// The `loser` is consulted through the map too, so a fact that absorbed a high score
+/// before itself being expired passes that score on to its own survivor.
 fn inherit_max_importance(
-    fact_store: &FactStore<'_>,
     survivor: &Fact,
     loser: &Fact,
+    importance_updates: &mut Vec<(i64, f64)>,
     running_scores: &mut std::collections::HashMap<i64, f64>,
-) -> Result<()> {
+) {
     // Base `importance` inheritance is a structural no-op under the current expiry
-    // rule: dedup always expires the lower-importance fact (ties broken by id), so
-    // the survivor's `importance` is always >= the loser's and the guard below can
-    // never fire. It is kept as a defensive symmetric guard; the assert documents
-    // and enforces the invariant so a future change to the expiry rule that breaks
-    // it (re-introducing the #264 staleness for this field) fails loudly in tests.
+    // rule: dedup always expires the lower-importance fact (ties broken by id), so the
+    // survivor's `importance` is always >= the loser's and the guard below can never
+    // fire. It is kept as a defensive symmetric guard; the assert documents and enforces
+    // the invariant so a future change to the expiry rule that breaks it (re-introducing
+    // the #264 staleness for this field) fails loudly in tests.
     debug_assert!(
         loser.importance <= survivor.importance,
         "expiry invariant violated: loser.importance ({}) > survivor.importance ({}); \
@@ -224,7 +323,7 @@ fn inherit_max_importance(
         survivor.importance
     );
     if loser.importance > survivor.importance {
-        fact_store.update_importance(survivor.id, loser.importance)?;
+        importance_updates.push((survivor.id, loser.importance));
     }
 
     // `importance_score`: compare live (not in-memory) maxima for both facts.
@@ -237,10 +336,8 @@ fn inherit_max_importance(
         .copied()
         .unwrap_or(loser.importance_score);
     if loser_score > survivor_score {
-        fact_store.update_importance_score(survivor.id, loser_score)?;
         running_scores.insert(survivor.id, loser_score);
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/consolidation/dedup.rs
+++ b/src/consolidation/dedup.rs
@@ -214,9 +214,10 @@ pub(super) fn compute_dedup(
 
 /// Apply a computed dedup plan inside the caller's write context (#409): the base- and
 /// score-importance inheritances first (while every fact is still active), then the
-/// expirations and their edge cascades. Returns the ids actually expired by **this**
-/// call, so the engine can drive its vector-index `notify_expire` and stats off what
-/// truly changed rather than the (possibly stale) plan.
+/// expirations and their edge cascades. Returns a [`DedupApplied`] — the ids actually
+/// expired by **this** call (so the engine drives `notify_expire`/stats off what truly
+/// changed, not the stale plan) plus whether a survivor was lost in the gap (so the
+/// caller can skip the now-stale summary writes).
 ///
 /// # Concurrency — the read→write gap (#409)
 ///
@@ -248,7 +249,7 @@ pub(super) fn apply_dedup(
     embed_dim: usize,
     computed: &DedupComputed,
     now: DateTime<Utc>,
-) -> Result<Vec<i64>> {
+) -> Result<DedupApplied> {
     let fact_store = FactStore::new(conn, embed_dim);
     let edge_store = EdgeStore::new(conn);
 
@@ -270,10 +271,13 @@ pub(super) fn apply_dedup(
     }
 
     let mut expired = Vec::with_capacity(computed.expirations.len());
+    let mut survivor_lost = false;
     for e in &computed.expirations {
-        // Survivor concurrently expired → the merge is void; keep the loser as the
-        // group's representative instead of orphaning the cluster.
+        // Survivor concurrently expired → the merge is void; keep the loser as the group's
+        // representative instead of orphaning the cluster. Flag it so the caller skips the
+        // now-stale summary writes (the plan clustered the survivors *without* this loser).
         if !survivor_live[&e.survivor] {
+            survivor_lost = true;
             continue;
         }
         match fact_store.expire(e.loser, now) {
@@ -283,12 +287,29 @@ pub(super) fn apply_dedup(
             }
             // Loser concurrently expired between snapshot and apply — the desired end
             // state already holds, so it is a no-op, not a failure, and not counted as
-            // expired by this call (#409, loser case).
+            // expired by this call (#409, loser case). Summaries stay valid: the loser was
+            // going to be removed from the cluster set anyway, just by another writer.
             Err(MemoryError::NotFound(_)) => {}
             Err(err) => return Err(err),
         }
     }
-    Ok(expired)
+    Ok(DedupApplied {
+        expired,
+        survivor_lost,
+    })
+}
+
+/// Outcome of [`apply_dedup`]: the ids actually expired by this call, and whether any
+/// planned loser was **kept** because its survivor was concurrently expired (#409). The
+/// latter signals that the cluster/global summaries in the plan are stale — they were
+/// computed over the survivors with that loser removed — so the caller should skip the
+/// summary writes and let the next consolidation rebuild them.
+pub(super) struct DedupApplied {
+    /// Ids the call actually expired (excludes concurrently-expired or kept losers).
+    pub(super) expired: Vec<i64>,
+    /// A survivor disappeared in the read→write gap, so a planned loser was kept and the
+    /// plan's summaries no longer match the store.
+    pub(super) survivor_lost: bool,
 }
 
 /// Local deduplication pass — compute + apply on a single connection.
@@ -316,7 +337,7 @@ fn local_dedup(
             active_count: active_facts.len(),
         });
     }
-    let expired_ids = apply_dedup(conn, embed_dim, &computed, now)?;
+    let expired_ids = apply_dedup(conn, embed_dim, &computed, now)?.expired;
     Ok(DedupOutcome::Ran {
         removed: expired_ids.len(),
         expired_ids,

--- a/src/consolidation/global.rs
+++ b/src/consolidation/global.rs
@@ -5,35 +5,28 @@ use crate::store::summaries::SummaryStore;
 use crate::traits::{EmbeddingProvider, SummarizableContent, SummaryGenerator};
 use crate::types::{ConsolidationLevel, NewSummary};
 
-/// Global integration pass.
+/// Compute the global summary from the **in-memory** cluster summaries, touching no
+/// store (#409). Returns `None` when there are no cluster summaries to integrate.
 ///
-/// Summarizes all cluster-level summaries into a single global summary.
-/// Deletes prior global summaries first (idempotent).
-///
-/// Returns 1 if a global summary was created, 0 if no clusters exist.
+/// The engine passes the cluster summaries it just computed this run (#409: not a store
+/// re-read), so the consumer `summarize`/`embed` IO here runs lock-free. Semantically
+/// identical to re-reading them: the global summary aggregates exactly the clusters this
+/// run produced.
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on SQL failure, or propagates errors from
-/// the `SummaryGenerator` or `EmbeddingProvider`.
-/// Returns `MemoryError::EmbeddingDimension` if the embedder returns an embedding
-/// whose length does not match `embed_dim`.
-/// Returns `MemoryError::Serialization` on JSON serialization failure.
-pub fn global_integration(
-    conn: &Connection,
+/// Propagates errors from the `SummaryGenerator` or `EmbeddingProvider`.
+/// Returns `MemoryError::EmbeddingDimension` if the embedder returns an embedding whose
+/// length does not match `embed_dim`.
+pub(super) fn compute_global(
+    cluster_summaries: &[NewSummary],
     generator: &dyn SummaryGenerator,
     embedder: &dyn EmbeddingProvider,
     embed_dim: usize,
     now: chrono::DateTime<chrono::Utc>,
-) -> Result<usize> {
-    let summary_store = SummaryStore::new(conn, embed_dim);
-
-    // Idempotent: clear previous global summaries
-    summary_store.delete_by_level(&ConsolidationLevel::Global)?;
-
-    let cluster_summaries = summary_store.list_by_level(&ConsolidationLevel::Cluster)?;
+) -> Result<Option<NewSummary>> {
     if cluster_summaries.is_empty() {
-        return Ok(0);
+        return Ok(None);
     }
 
     // Summarize the cluster summaries directly — borrow each summary's text and
@@ -53,23 +46,77 @@ pub fn global_integration(
         .map(|s| s.source_fact_ids.len())
         .sum();
     let mut all_source_ids: Vec<i64> = Vec::with_capacity(total_source_ids);
-    for s in &cluster_summaries {
+    for s in cluster_summaries {
         all_source_ids.extend_from_slice(&s.source_fact_ids);
     }
 
-    // Global summaries are intentionally root-scoped (scope_id=1).
-    // They aggregate across all cluster-level summaries regardless of
-    // individual cluster scopes.
-    summary_store.insert(&NewSummary {
+    // Global summaries are intentionally root-scoped (scope_id=1). They aggregate
+    // across all cluster-level summaries regardless of individual cluster scopes.
+    Ok(Some(NewSummary {
         content: global_text,
         embedding: global_embedding,
         level: ConsolidationLevel::Global,
         source_fact_ids: all_source_ids,
         scope_id: 1,
         created_at: now,
-    })?;
+    }))
+}
 
-    Ok(1)
+/// Apply the computed global summary inside the caller's write context (#409): clear the
+/// prior global summary (idempotent), then insert the new one if present. `None` leaves
+/// the store with no global summary (the cleared state).
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure, or `MemoryError::Serialization` on
+/// JSON serialization failure.
+pub(super) fn apply_global(
+    conn: &Connection,
+    embed_dim: usize,
+    summary: Option<&NewSummary>,
+) -> Result<()> {
+    let summary_store = SummaryStore::new(conn, embed_dim);
+    summary_store.delete_by_level(&ConsolidationLevel::Global)?;
+    if let Some(s) = summary {
+        summary_store.insert(s)?;
+    }
+    Ok(())
+}
+
+/// Global integration pass — compute + apply on a single connection.
+///
+/// Thin wrapper over [`compute_global`] + [`apply_global`], kept as the per-pass entry
+/// point exercised by this module's unit tests (hence `#[cfg(test)]`). Reads the current
+/// cluster summaries from the store, summarizes them, and applies the result. Returns 1
+/// if a global summary was created, 0 if no clusters exist. The engine no longer calls
+/// this — it runs [`compute_global`] over the in-memory cluster summaries it just
+/// produced and applies inside the final transaction (#409) — but the behavior is
+/// identical.
+#[cfg(test)]
+fn global_integration(
+    conn: &Connection,
+    generator: &dyn SummaryGenerator,
+    embedder: &dyn EmbeddingProvider,
+    embed_dim: usize,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<usize> {
+    // The store hands back `Summary` (with ids); `compute_global` consumes the id-less
+    // `NewSummary` the engine path produces, so bridge the stored rows into that shape.
+    let cluster_summaries: Vec<NewSummary> = SummaryStore::new(conn, embed_dim)
+        .list_by_level(&ConsolidationLevel::Cluster)?
+        .into_iter()
+        .map(|s| NewSummary {
+            content: s.content,
+            embedding: s.embedding,
+            level: s.level,
+            source_fact_ids: s.source_fact_ids,
+            scope_id: s.scope_id,
+            created_at: s.created_at,
+        })
+        .collect();
+    let global = compute_global(&cluster_summaries, generator, embedder, embed_dim, now)?;
+    apply_global(conn, embed_dim, global.as_ref())?;
+    Ok(usize::from(global.is_some()))
 }
 
 #[cfg(test)]

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -1,33 +1,45 @@
 //! Three-pass consolidation pipeline: dedup, cluster fusion, global integration.
 //!
-//! All passes run atomically in a single `SQLite` transaction.
+//! **Lock-free compute, atomic apply (#409).** The pipeline is split into three phases
+//! so the engine can release its single write lock across the unbounded consumer
+//! `summarize`/`embed` IO:
+//!
+//! 1. [`load_snapshot`] — a brief read: count + `last_consolidated_at` + the active set,
+//!    loaded once (#389) and short-circuited entirely when over both safety caps (#659).
+//! 2. [`compute_plan`] — **no `Connection`, no lock**: the dedup decision, the cluster
+//!    summaries, and the global summary are all computed (the consumer IO lives here) and
+//!    returned as a [`ConsolidationPlan`] of pure data.
+//! 3. [`apply_plan`] — all writes in a **single transaction**, preserving atomicity
+//!    exactly as before (D3): a consumer failure aborts in phase 2 before any write, and
+//!    a write failure rolls the whole transaction back.
+//!
+//! A single-connection `consolidate` entry composes all three on one connection for the
+//! unit tests; the engine calls the phases separately so it can drop the lock between the
+//! read and the compute.
 
 mod cluster;
 mod dedup;
 mod global;
 
-pub use cluster::cluster_fusion;
-pub use dedup::{DedupOutcome, local_dedup};
-pub use global::global_integration;
-
 use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
 use crate::error::Result;
+use crate::store::facts::FactStore;
 use crate::store::schema::{get_config, set_config};
 use crate::traits::{
     ConsolidationConfig, ConsolidationStats, EmbeddingProvider, SummarizableContent,
     SummaryGenerator,
 };
-use crate::types::Fact;
+use crate::types::{EmbeddingFingerprint, Fact, NewSummary};
 
-/// Safety cap for the O(N·M) [`local_dedup`] pass. Beyond this many active facts
+/// Safety cap for the O(N·M) dedup pass (`compute_dedup`). Beyond this many active facts
 /// the pass is **skipped and the consolidation watermark is NOT advanced**, so the
 /// skipped facts are retried on a later run once the corpus shrinks
-/// ([`DedupOutcome::Skipped`]).
+/// (`DedupComputed::skipped`).
 const MAX_FACTS_FOR_DEDUP: usize = 50_000;
 
-/// Safety cap for the O(N²) [`cluster_fusion`] pass. Beyond this many active facts
+/// Safety cap for the O(N²) cluster pass (`compute_clusters`). Beyond this many active facts
 /// clustering is **silently skipped, preserving any existing cluster summaries**
 /// (the cap is checked before they would be deleted).
 ///
@@ -64,31 +76,306 @@ pub fn summarize_and_embed(
     Ok((text, embedding))
 }
 
-/// Orchestrate all 3 consolidation passes atomically.
+/// An immutable read-phase snapshot of everything [`compute_plan`] needs, captured
+/// under a brief lock and then released so the compute phase runs lock-free (#409).
+pub struct Snapshot {
+    /// The active set, loaded once (#389). Empty when `over_both_caps` (the load was
+    /// short-circuited, #659) — distinguished from a genuinely empty store by the flag.
+    active_facts: Vec<Fact>,
+    /// `last_consolidated_at` watermark scoping the dedup "new facts" set.
+    last: Option<DateTime<Utc>>,
+    /// Single run-level timestamp; the watermark advances to this on success.
+    now: DateTime<Utc>,
+    /// The corpus exceeded BOTH safety caps, so the (expensive) `list_active` load was
+    /// skipped (#659): the plan is a complete no-op (dedup skipped, clustering skipped).
+    over_both_caps: bool,
+}
+
+/// The fully-computed plan for one consolidation run — pure data produced lock-free by
+/// [`compute_plan`] and applied atomically by [`apply_plan`] (#409). Holds no borrow of
+/// the store, so it survives the gap between releasing the read lock and acquiring the
+/// write lock.
+pub struct ConsolidationPlan {
+    /// Dedup decision (expirations + importance inheritances) as data.
+    dedup: dedup::DedupComputed,
+    /// Whether clustering ran (vs. skipped over the cap). Gates the summary writes so
+    /// existing summaries are preserved when the pass could not run (#345).
+    cluster_ran: bool,
+    /// New cluster summaries to write (already summarized + embedded).
+    cluster_summaries: Vec<NewSummary>,
+    /// New global summary to write, if any.
+    global_summary: Option<NewSummary>,
+    /// The embedder's fingerprint to stamp, set **iff** a summary vector was produced
+    /// (#643). Captured during compute so `apply_plan` needs no embedder.
+    embedding_fingerprint: Option<EmbeddingFingerprint>,
+    /// Run-level timestamp (expiry stamp + watermark).
+    now: DateTime<Utc>,
+}
+
+impl ConsolidationPlan {
+    /// Ids the plan will expire — the engine forwards these to its vector index
+    /// (`notify_expire`) after the write commits.
+    pub fn expirations(&self) -> &[i64] {
+        &self.dedup.expirations
+    }
+
+    /// Number of near-duplicates the plan removes — the engine rebuilds its graph when
+    /// this is `> 0`.
+    pub const fn duplicates_removed(&self) -> usize {
+        self.dedup.removed
+    }
+}
+
+/// Phase 1 — load the read snapshot under a brief lock (engine: production caps).
 ///
-/// 1. Local dedup — expire near-duplicate facts
-/// 2. Cluster fusion — group related facts, generate cluster summaries
-/// 3. Global integration — summarize all clusters into one global summary
+/// # Errors
 ///
-/// All passes run within a single transaction. On any failure (including
-/// `SummaryGenerator` or `EmbeddingProvider` errors), the entire consolidation
-/// is rolled back.
+/// Returns `MemoryError::Conflict` if `config` fails validation, `MemoryError::Migration`
+/// if `last_consolidated_at` cannot be parsed, or `MemoryError::Database` on read failure.
+pub fn load_snapshot(
+    conn: &Connection,
+    embed_dim: usize,
+    config: &ConsolidationConfig,
+) -> Result<Snapshot> {
+    load_snapshot_capped(
+        conn,
+        embed_dim,
+        config,
+        MAX_FACTS_FOR_DEDUP,
+        MAX_FACTS_FOR_CLUSTERING,
+    )
+}
+
+/// Cap-injecting core of [`load_snapshot`]; tests pass small caps to exercise the skip
+/// paths without a 50 000-fact corpus.
+fn load_snapshot_capped(
+    conn: &Connection,
+    embed_dim: usize,
+    config: &ConsolidationConfig,
+    max_dedup_facts: usize,
+    max_cluster_facts: usize,
+) -> Result<Snapshot> {
+    // Validate up front, before any read — mirrors `prune()` rejecting an invalid
+    // `ForgetPolicy` at the forget entry point. In the cap-injecting core so the test
+    // cap-path validates too.
+    config.validate()?;
+
+    let last = get_config(conn, "last_consolidated_at")?
+        .map(|s| DateTime::parse_from_rfc3339(&s))
+        .transpose()
+        .map_err(|e| {
+            crate::error::MigrationError::Incompatible(format!("invalid last_consolidated_at: {e}"))
+        })?
+        .map(|dt| dt.with_timezone(&Utc));
+    let now = Utc::now();
+
+    let fact_store = FactStore::new(conn, embed_dim);
+    let active_count = fact_store.count_active()?;
+
+    // #659: if the corpus is over BOTH caps, the dedup pass would skip AND the cluster
+    // pass would skip — so neither needs the materialized active set. Short-circuit the
+    // expensive `list_active` load (which deserializes every embedding BLOB) and return
+    // a no-op marker instead. A genuinely empty store (count 0) is NOT over the caps, so
+    // it still loads (and consolidates to a watermark-advancing no-op).
+    if active_count > max_dedup_facts && active_count > max_cluster_facts {
+        return Ok(Snapshot {
+            active_facts: Vec::new(),
+            last,
+            now,
+            over_both_caps: true,
+        });
+    }
+
+    // #389: load the active set ONCE and share it across the dedup and cluster passes,
+    // instead of each pass re-querying the store (and re-deserializing every embedding
+    // BLOB — ~147 MB for 50k×768-dim, previously paid twice).
+    let active_facts = fact_store.list_active(None)?;
+    Ok(Snapshot {
+        active_facts,
+        last,
+        now,
+        over_both_caps: false,
+    })
+}
+
+/// Phase 2 — compute the plan **without any lock or store access** (engine: production
+/// caps). The consumer `summarize`/`embed` IO happens here, off the write lock (#409).
 ///
-/// Reads `last_consolidated_at` from config to scope dedup.
-/// Updates `last_consolidated_at` after successful completion.
+/// # Errors
 ///
-/// `generator` produces the summary text; `embedder` projects that text into
-/// the fact vector space (issue #116 — embedding is no longer duplicated on the
-/// generator trait).
+/// Propagates errors from the `SummaryGenerator` or `EmbeddingProvider`, or
+/// `MemoryError::EmbeddingDimension` on a mismatched embedding length. A failure here
+/// aborts before any write, so the store is untouched (atomicity, D3).
+pub fn compute_plan(
+    snapshot: &Snapshot,
+    generator: &dyn SummaryGenerator,
+    embedder: &dyn EmbeddingProvider,
+    embed_dim: usize,
+    config: &ConsolidationConfig,
+) -> Result<ConsolidationPlan> {
+    compute_plan_capped(
+        snapshot,
+        generator,
+        embedder,
+        embed_dim,
+        config,
+        MAX_FACTS_FOR_DEDUP,
+        MAX_FACTS_FOR_CLUSTERING,
+    )
+}
+
+/// Cap-injecting core of [`compute_plan`].
+fn compute_plan_capped(
+    snapshot: &Snapshot,
+    generator: &dyn SummaryGenerator,
+    embedder: &dyn EmbeddingProvider,
+    embed_dim: usize,
+    config: &ConsolidationConfig,
+    max_dedup_facts: usize,
+    max_cluster_facts: usize,
+) -> Result<ConsolidationPlan> {
+    // Over both caps (#659): a complete no-op — dedup skipped (so the watermark is held)
+    // and clustering skipped (so existing summaries are preserved). No consumer IO.
+    if snapshot.over_both_caps {
+        return Ok(ConsolidationPlan {
+            dedup: dedup::DedupComputed::skipped(),
+            cluster_ran: false,
+            cluster_summaries: Vec::new(),
+            global_summary: None,
+            embedding_fingerprint: None,
+            now: snapshot.now,
+        });
+    }
+
+    // Pass 1 — dedup (pure): expirations + importance inheritances as data (#272/#264).
+    let dedup = dedup::compute_dedup(
+        &snapshot.active_facts,
+        config.dedup_threshold,
+        max_dedup_facts,
+        snapshot.last,
+    );
+
+    // Survivors = the loaded active set minus the dedup expirations (no re-query, borrowed
+    // so no clone — #679/#389). They carry the PRE-dedup `importance`/`importance_score`;
+    // inert today, since clustering reads only `id`/`content`/`embedding`/`scope_id`.
+    let expired_set: std::collections::HashSet<i64> = dedup.expirations.iter().copied().collect();
+    let survivors: Vec<&Fact> = snapshot
+        .active_facts
+        .iter()
+        .filter(|f| !expired_set.contains(&f.id))
+        .collect();
+
+    // Pass 2 — cluster (consumer IO, no store): summarize/embed each qualifying cluster.
+    // The single run-level `now` flows through so all summaries share a created_at (#495).
+    let params = cluster::ClusterParams {
+        embed_dim,
+        min_cluster_size: config.min_cluster_size,
+        cluster_threshold: config.cluster_threshold,
+        max_facts: max_cluster_facts,
+        now: snapshot.now,
+    };
+    let cluster = cluster::compute_clusters(&survivors, generator, embedder, &params)?;
+
+    // Pass 3 — global (consumer IO, no store): summarize THIS run's in-memory cluster
+    // summaries. Gated on `cluster.ran`: when clustering is skipped over the cap, the
+    // existing cluster/global summaries are left untouched, so global never re-summarizes
+    // stale clusters it could not refresh.
+    let global_summary = if cluster.ran {
+        global::compute_global(
+            &cluster.summaries,
+            generator,
+            embedder,
+            embed_dim,
+            snapshot.now,
+        )?
+    } else {
+        None
+    };
+
+    // Stamp the embedding identity only if a summary vector was actually produced (#643);
+    // capture the fingerprint now so `apply_plan` needs no embedder.
+    let stamp = !cluster.summaries.is_empty() || global_summary.is_some();
+    let embedding_fingerprint = stamp.then(|| embedder.fingerprint());
+
+    Ok(ConsolidationPlan {
+        dedup,
+        cluster_ran: cluster.ran,
+        cluster_summaries: cluster.summaries,
+        global_summary,
+        embedding_fingerprint,
+        now: snapshot.now,
+    })
+}
+
+/// Phase 3 — apply the plan in a **single transaction** (#409, D3 atomicity).
+///
+/// All-or-nothing: a failure here rolls back every write; a consumer failure has already
+/// aborted in [`compute_plan`], before this transaction opens. Idempotent and tolerant of
+/// a fact concurrently expired between the snapshot and this apply (see [`dedup::apply_dedup`]).
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on SQL failure, or `MemoryError::Serialization` on a
+/// summary serialization failure.
+pub fn apply_plan(
+    conn: &Connection,
+    plan: &ConsolidationPlan,
+    embed_dim: usize,
+) -> Result<ConsolidationStats> {
+    let tx = conn.unchecked_transaction()?;
+
+    // Dedup writes: importance inheritances + expirations (NotFound-tolerant, #409).
+    dedup::apply_dedup(&tx, embed_dim, &plan.dedup, plan.now)?;
+
+    // Summary writes — only when clustering actually ran (#345): over the cap we must not
+    // delete existing summaries without replacements. Cluster + global move together so
+    // global never re-summarizes stale clusters.
+    if plan.cluster_ran {
+        cluster::apply_clusters(&tx, embed_dim, &plan.cluster_summaries)?;
+        global::apply_global(&tx, embed_dim, plan.global_summary.as_ref())?;
+    }
+
+    // Record the embedding identity on first vector write only (#613/#643, ADR 0015 §2),
+    // atomically inside `tx` with the summaries it describes. A vector-less run leaves the
+    // store unstamped, so a later real first write with a different embedder establishes
+    // the true identity instead of inheriting a stale one (the #614-enforcement landmine).
+    if let Some(fingerprint) = &plan.embedding_fingerprint {
+        crate::store::embedding_meta::record_if_absent(&tx, fingerprint, embed_dim)?;
+    }
+
+    // Advance the watermark only if dedup actually ran (#439/#306). When skipped, facts
+    // ingested during the over-cap period must be retried on the next run.
+    if !plan.dedup.skipped {
+        set_config(&tx, "last_consolidated_at", &plan.now.to_rfc3339())?;
+    }
+
+    tx.commit()?;
+
+    Ok(ConsolidationStats {
+        duplicates_removed: plan.dedup.removed,
+        clusters_created: plan.cluster_summaries.len(),
+        global_summaries: usize::from(plan.global_summary.is_some()),
+    })
+}
+
+/// Orchestrate all 3 consolidation passes on a single connection (load → compute →
+/// apply). The convenience entry for non-engine callers and the unit tests; the engine
+/// instead calls the three phases separately so it can drop its write lock across the
+/// lock-free [`compute_plan`] (#409).
+///
+/// Reads `last_consolidated_at` to scope dedup and updates it after a successful run.
+/// `generator` produces the summary text; `embedder` projects it into the fact vector
+/// space (#116). Returns the stats and the ids expired (so the engine can update vector
+/// indexes).
 ///
 /// # Errors
 ///
 /// Returns `MemoryError::Conflict` if `config` fails validation
-/// ([`ConsolidationConfig::validate`]).
-/// Propagates errors from any pass, the `SummaryGenerator`, or the
+/// ([`ConsolidationConfig::validate`]), `MemoryError::Migration` if `last_consolidated_at`
+/// cannot be parsed, or propagates errors from any pass, the `SummaryGenerator`, or the
 /// `EmbeddingProvider`.
-/// Returns `MemoryError::Migration` if `last_consolidated_at` in config cannot be parsed.
-pub fn consolidate(
+#[cfg(test)]
+fn consolidate(
     conn: &Connection,
     generator: &dyn SummaryGenerator,
     embedder: &dyn EmbeddingProvider,
@@ -102,17 +389,18 @@ pub fn consolidate(
         embed_dim,
         config,
         MAX_FACTS_FOR_DEDUP,
+        MAX_FACTS_FOR_CLUSTERING,
     )
 }
 
-/// Cap-injecting core of [`consolidate`]. The public entry point passes the
-/// production [`MAX_FACTS_FOR_DEDUP`]; tests pass a small `max_dedup_facts` to
-/// exercise the dedup-skip / watermark-suppression path without a 50 000-fact
-/// corpus.
+/// Cap-injecting core of [`consolidate`]; tests pass small caps to exercise the dedup-skip
+/// / watermark-suppression (#439/#306) and the over-both-caps load short-circuit (#659)
+/// without a 50 000-fact corpus.
 ///
 /// # Errors
 ///
-/// Same as [`consolidate`].
+/// Same as `consolidate`.
+#[cfg(test)]
 fn consolidate_with_caps(
     conn: &Connection,
     generator: &dyn SummaryGenerator,
@@ -120,108 +408,21 @@ fn consolidate_with_caps(
     embed_dim: usize,
     config: &ConsolidationConfig,
     max_dedup_facts: usize,
+    max_cluster_facts: usize,
 ) -> Result<(ConsolidationStats, Vec<i64>)> {
-    // Validate up front, before touching the store — mirrors `prune()` rejecting
-    // an invalid `ForgetPolicy` at the forget entry point. Placed here (the shared
-    // core), not in the public wrapper, so the test cap-path validates too.
-    config.validate()?;
-
-    let last = get_config(conn, "last_consolidated_at")?
-        .map(|s| DateTime::parse_from_rfc3339(&s))
-        .transpose()
-        .map_err(|e| {
-            crate::error::MigrationError::Incompatible(format!("invalid last_consolidated_at: {e}"))
-        })?
-        .map(|dt| dt.with_timezone(&Utc));
-    let now = Utc::now();
-
-    let tx = conn.unchecked_transaction()?;
-
-    // #389: load the active set ONCE and share it across the dedup and cluster
-    // passes, instead of each pass re-querying the store (and re-deserializing
-    // every embedding BLOB — ~147 MB for 50k×768-dim, previously paid twice).
-    let active_facts = crate::store::facts::FactStore::new(&tx, embed_dim).list_active(None)?;
-
-    // The dedup-skip state is carried in the return type ([`DedupOutcome`]), not an
-    // in-band `usize::MAX` sentinel (#272). A `Skipped` pass contributes no
-    // removals and leaves the watermark unadvanced so the over-cap facts are
-    // retried on the next run.
-    let (duplicates_removed, expired_ids, dedup_skipped) = match local_dedup(
-        &tx,
-        embed_dim,
-        &active_facts,
-        config.dedup_threshold,
-        max_dedup_facts,
-        last,
-        now,
-    )? {
-        DedupOutcome::Ran {
-            removed,
-            expired_ids,
-        } => (removed, expired_ids, false),
-        DedupOutcome::Skipped { .. } => (0, Vec::new(), true),
-    };
-
-    // Cluster operates on the post-dedup survivors: the loaded facts minus the ones
-    // dedup just expired (no re-query, borrowed so no clone — #679/#389). On the
-    // dedup-skip path `expired_ids` is empty, so this is the full loaded set, which
-    // `cluster_fusion`'s own cap then skips (the two caps are equal).
-    //
-    // These survivors carry the PRE-dedup `importance`/`importance_score` — dedup
-    // mutates those columns in the DB but not the in-memory `Fact`s. Inert today:
-    // `cluster_fusion` reads only `id`/`content`/`embedding`/`scope_id`. A future
-    // cluster pass that reads importance would need a re-read (or #264's running-max
-    // treatment) here.
-    let expired_set: std::collections::HashSet<i64> = expired_ids.iter().copied().collect();
-    let survivors: Vec<&Fact> = active_facts
-        .iter()
-        .filter(|f| !expired_set.contains(&f.id))
-        .collect();
-
-    // #495: thread the single run-level `now` through both summary-writing passes
-    // so all summaries from one consolidation share a created_at, instead of each
-    // pass calling `Utc::now()` independently.
-    let clusters_created = cluster_fusion(
-        &tx,
-        &survivors,
+    let snapshot =
+        load_snapshot_capped(conn, embed_dim, config, max_dedup_facts, max_cluster_facts)?;
+    let plan = compute_plan_capped(
+        &snapshot,
         generator,
         embedder,
         embed_dim,
-        config.min_cluster_size,
-        config.cluster_threshold,
-        now,
+        config,
+        max_dedup_facts,
+        max_cluster_facts,
     )?;
-    let global_summaries = global_integration(&tx, generator, embedder, embed_dim, now)?;
-
-    // Record the embedding identity on first write (#613, ADR 0015 §2) — but only
-    // once a summary vector has actually been written (#643). `local_dedup` only
-    // expires rows; `cluster_fusion`/`global_integration` are the sole vector
-    // writers here, so gating on their counts defers the stamp past a vector-less
-    // run (dedup-only, or a no-op on a sparse store). Done inside `tx`, so the
-    // identity still commits atomically with the summaries it describes. A no-op
-    // run leaves the store unstamped, so a later real first write with a different
-    // embedder establishes the true identity instead of inheriting a stale one
-    // (the #614-enforcement landmine).
-    if clusters_created > 0 || global_summaries > 0 {
-        crate::store::embedding_meta::record_if_absent(&tx, &embedder.fingerprint(), embed_dim)?;
-    }
-
-    // Only advance the watermark if dedup actually ran. When skipped, facts
-    // ingested during the over-cap period must be retried on the next run.
-    if !dedup_skipped {
-        set_config(&tx, "last_consolidated_at", &now.to_rfc3339())?;
-    }
-
-    tx.commit()?;
-
-    Ok((
-        ConsolidationStats {
-            duplicates_removed,
-            clusters_created,
-            global_summaries,
-        },
-        expired_ids,
-    ))
+    let stats = apply_plan(conn, &plan, embed_dim)?;
+    Ok((stats, plan.dedup.expirations))
 }
 
 #[cfg(test)]
@@ -661,7 +862,8 @@ mod tests {
             "precondition: no watermark before the run"
         );
 
-        // Dedup cap of 1 vs a 3-fact corpus → dedup is skipped.
+        // Dedup cap of 1 vs a 3-fact corpus → dedup is skipped. The cluster cap stays
+        // large (`MAX_FACTS_FOR_CLUSTERING`) so only the dedup pass skips, not clustering.
         let (stats, expired) = consolidate_with_caps(
             &conn,
             &MockGenerator,
@@ -669,6 +871,7 @@ mod tests {
             DIM,
             &ConsolidationConfig::default(),
             1,
+            MAX_FACTS_FOR_CLUSTERING,
         )
         .unwrap();
 
@@ -697,6 +900,95 @@ mod tests {
         assert!(
             get_config(&conn, "last_consolidated_at").unwrap().is_none(),
             "watermark must NOT advance when dedup is skipped (over cap)"
+        );
+    }
+
+    /// #659: when the corpus is over BOTH caps, [`load_snapshot_capped`] short-circuits
+    /// the expensive `list_active` load and [`compute_plan_capped`] returns a complete
+    /// no-op plan — nothing expired, no summaries written, watermark held. Driven with
+    /// both caps at 1 vs a 3-fact corpus so the over-both-caps branch is reachable without
+    /// a 50 000-fact corpus.
+    #[test]
+    fn over_both_caps_skips_load_and_is_noop() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        seed_cluster(&conn); // 3 near-duplicates that would normally dedup + cluster
+
+        // Sanity: the snapshot took the short-circuit (no facts materialized).
+        let snapshot =
+            load_snapshot_capped(&conn, DIM, &ConsolidationConfig::default(), 1, 1).unwrap();
+        assert!(
+            snapshot.over_both_caps,
+            "over both caps must short-circuit the load"
+        );
+        assert!(
+            snapshot.active_facts.is_empty(),
+            "the active set must not be materialized when over both caps"
+        );
+
+        let (stats, expired) = consolidate_with_caps(
+            &conn,
+            &MockGenerator,
+            &MockEmbedder,
+            DIM,
+            &ConsolidationConfig::default(),
+            1,
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(stats.duplicates_removed, 0);
+        assert_eq!(stats.clusters_created, 0);
+        assert_eq!(stats.global_summaries, 0);
+        assert!(expired.is_empty());
+
+        // Nothing expired; both passes skipped, so the watermark is held for retry.
+        assert_eq!(
+            FactStore::new(&conn, DIM).list_active(None).unwrap().len(),
+            3,
+            "no fact is expired when over both caps"
+        );
+        assert!(
+            get_config(&conn, "last_consolidated_at").unwrap().is_none(),
+            "watermark must NOT advance when over both caps"
+        );
+    }
+
+    /// #409 read→write gap: because the engine releases the write lock between the
+    /// snapshot and the apply, another writer may expire a planned-for fact in between.
+    /// [`apply_plan`] must tolerate that — a `NotFound` from `expire` is a no-op (the
+    /// desired end state already holds), not a failure. Simulated here by expiring the
+    /// dedup victim between [`compute_plan`] and [`apply_plan`].
+    #[test]
+    fn apply_plan_tolerates_concurrently_expired_fact() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        // Two near-duplicates → dedup plans to expire the lower-importance one.
+        insert_fact(&conn, "keep", vec![1.0, 0.0, 0.0, 0.0], 0.9);
+        insert_fact(&conn, "drop", vec![0.99, 0.01, 0.0, 0.0], 0.5);
+
+        let config = ConsolidationConfig::default();
+        let snapshot = load_snapshot(&conn, DIM, &config).unwrap();
+        let plan = compute_plan(&snapshot, &MockGenerator, &MockEmbedder, DIM, &config).unwrap();
+        assert_eq!(
+            plan.expirations().len(),
+            1,
+            "dedup must plan exactly one expiry"
+        );
+        let victim = plan.expirations()[0];
+
+        // Simulate a concurrent writer expiring the victim between snapshot and apply.
+        FactStore::new(&conn, DIM)
+            .expire(victim, Utc::now())
+            .unwrap();
+
+        // apply_plan must NOT error on the already-expired victim (NotFound → no-op).
+        let stats = apply_plan(&conn, &plan, DIM).unwrap();
+        assert_eq!(stats.duplicates_removed, 1);
+        assert_eq!(
+            FactStore::new(&conn, DIM).list_active(None).unwrap().len(),
+            1,
+            "exactly the survivor remains"
         );
     }
 }

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -317,27 +317,36 @@ pub fn apply_plan(
     let tx = conn.unchecked_transaction()?;
 
     // Dedup writes: importance inheritances + expirations (concurrency-tolerant, #409).
-    // Returns the ids actually expired by this call.
-    let expired = dedup::apply_dedup(&tx, embed_dim, &plan.dedup, plan.now)?;
+    // Returns the ids actually expired plus whether a survivor disappeared in the gap.
+    let applied = dedup::apply_dedup(&tx, embed_dim, &plan.dedup, plan.now)?;
 
-    // Summary writes — only when clustering actually ran (#345): over the cap we must not
-    // delete existing summaries without replacements. Cluster + global move together so
-    // global never re-summarizes stale clusters.
-    if plan.cluster_ran {
+    // Summary writes are gated on TWO conditions:
+    //  - clustering actually ran (#345): over the cap we must not delete existing summaries
+    //    without replacements;
+    //  - the dedup applied without a survivor disappearing in the read→write gap (#409): if
+    //    a concurrent writer expired a survivor, a planned loser was kept, so the plan's
+    //    summaries — clustered over the survivors *without* that loser — are stale. Skip
+    //    them and let the next consolidation rebuild from the corrected active set.
+    // Cluster + global move together so global never re-summarizes stale clusters.
+    let wrote_summaries = plan.cluster_ran && !applied.survivor_lost;
+    if wrote_summaries {
         cluster::apply_clusters(&tx, embed_dim, &plan.cluster_summaries)?;
         global::apply_global(&tx, embed_dim, plan.global_summary.as_ref())?;
-    }
 
-    // Record the embedding identity on first vector write only (#613/#643, ADR 0015 §2),
-    // atomically inside `tx` with the summaries it describes. A vector-less run leaves the
-    // store unstamped, so a later real first write with a different embedder establishes
-    // the true identity instead of inheriting a stale one (the #614-enforcement landmine).
-    if let Some(fingerprint) = &plan.embedding_fingerprint {
-        crate::store::embedding_meta::record_if_absent(&tx, fingerprint, embed_dim)?;
+        // Record the embedding identity on first vector write only (#613/#643, ADR 0015 §2),
+        // atomically inside `tx` with the summaries it describes. A vector-less run leaves
+        // the store unstamped, so a later real first write with a different embedder
+        // establishes the true identity instead of inheriting a stale one (the
+        // #614-enforcement landmine).
+        if let Some(fingerprint) = &plan.embedding_fingerprint {
+            crate::store::embedding_meta::record_if_absent(&tx, fingerprint, embed_dim)?;
+        }
     }
 
     // Advance the watermark only if dedup actually ran (#439/#306). When skipped, facts
-    // ingested during the over-cap period must be retried on the next run.
+    // ingested during the over-cap period must be retried on the next run. A survivor loss
+    // is a divergence, not a skip: the dedup that *did* apply is committed, so the
+    // watermark advances and the kept loser is reconsidered next run.
     if !plan.dedup.skipped {
         set_config(&tx, "last_consolidated_at", &plan.now.to_rfc3339())?;
     }
@@ -345,11 +354,15 @@ pub fn apply_plan(
     tx.commit()?;
 
     let stats = ConsolidationStats {
-        duplicates_removed: expired.len(),
-        clusters_created: plan.cluster_summaries.len(),
-        global_summaries: usize::from(plan.global_summary.is_some()),
+        duplicates_removed: applied.expired.len(),
+        clusters_created: if wrote_summaries {
+            plan.cluster_summaries.len()
+        } else {
+            0
+        },
+        global_summaries: usize::from(wrote_summaries && plan.global_summary.is_some()),
     };
-    Ok((stats, expired))
+    Ok((stats, applied.expired))
 }
 
 /// Orchestrate all 3 consolidation passes on a single connection (load → compute →
@@ -1028,5 +1041,62 @@ mod tests {
         );
         assert_eq!(active[0].id, loser);
         assert_eq!(active[0].content, "drop");
+    }
+
+    /// #409 read→write gap (codex review): when a survivor disappears, the plan's
+    /// cluster/global summaries were computed over the survivors WITHOUT the now-kept
+    /// loser, so they are stale. `apply_plan` must NOT write them — it leaves the existing
+    /// summaries in place for the next consolidation to rebuild. Seeds a cluster summary,
+    /// forces a survivor loss, and asserts the seeded summary survives (a normal run would
+    /// clear it).
+    #[test]
+    fn apply_plan_skips_stale_summary_writes_when_survivor_lost() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        // A pre-existing cluster summary from an earlier run.
+        let summary_store = SummaryStore::new(&conn, DIM);
+        summary_store
+            .insert(&NewSummary {
+                content: "prior cluster".into(),
+                embedding: vec![0.25; DIM],
+                level: ConsolidationLevel::Cluster,
+                source_fact_ids: vec![1, 2],
+                scope_id: 1,
+                created_at: Utc::now(),
+            })
+            .unwrap();
+
+        // Two near-duplicates → dedup plans to expire `drop`, survivor `keep`.
+        insert_fact(&conn, "keep", vec![1.0, 0.0, 0.0, 0.0], 0.9);
+        insert_fact(&conn, "drop", vec![0.99, 0.01, 0.0, 0.0], 0.5);
+
+        let config = ConsolidationConfig::default();
+        let snapshot = load_snapshot(&conn, DIM, &config).unwrap();
+        let plan = compute_plan(&snapshot, &MockGenerator, &MockEmbedder, DIM, &config).unwrap();
+        let survivor = plan.dedup.expirations[0].survivor;
+
+        // Concurrently expire the survivor → the plan's summary view is now stale.
+        FactStore::new(&conn, DIM)
+            .expire(survivor, Utc::now())
+            .unwrap();
+
+        let (stats, _) = apply_plan(&conn, &plan, DIM).unwrap();
+        assert_eq!(
+            stats.clusters_created, 0,
+            "no summaries are (re)written when a survivor was lost"
+        );
+
+        // The seeded cluster summary is preserved — a normal (non-lost) run would have
+        // cleared it via apply_clusters' delete_by_level.
+        let clusters = SummaryStore::new(&conn, DIM)
+            .list_by_level(&ConsolidationLevel::Cluster)
+            .unwrap();
+        assert_eq!(
+            clusters.len(),
+            1,
+            "stale-plan summary writes must be skipped"
+        );
+        assert_eq!(clusters[0].content, "prior cluster");
     }
 }

--- a/src/consolidation/mod.rs
+++ b/src/consolidation/mod.rs
@@ -59,7 +59,7 @@ const MAX_FACTS_FOR_CLUSTERING: usize = 50_000;
 ///
 /// Propagates `SummaryGenerator` / `EmbeddingProvider` errors; returns
 /// `MemoryError::EmbeddingDimension` when the embedding length != `embed_dim`.
-pub fn summarize_and_embed(
+fn summarize_and_embed(
     generator: &dyn SummaryGenerator,
     embedder: &dyn EmbeddingProvider,
     items: &[SummarizableContent<'_>],
@@ -110,20 +110,6 @@ pub struct ConsolidationPlan {
     embedding_fingerprint: Option<EmbeddingFingerprint>,
     /// Run-level timestamp (expiry stamp + watermark).
     now: DateTime<Utc>,
-}
-
-impl ConsolidationPlan {
-    /// Ids the plan will expire — the engine forwards these to its vector index
-    /// (`notify_expire`) after the write commits.
-    pub fn expirations(&self) -> &[i64] {
-        &self.dedup.expirations
-    }
-
-    /// Number of near-duplicates the plan removes — the engine rebuilds its graph when
-    /// this is `> 0`.
-    pub const fn duplicates_removed(&self) -> usize {
-        self.dedup.removed
-    }
 }
 
 /// Phase 1 — load the read snapshot under a brief lock (engine: production caps).
@@ -258,7 +244,8 @@ fn compute_plan_capped(
     // Survivors = the loaded active set minus the dedup expirations (no re-query, borrowed
     // so no clone — #679/#389). They carry the PRE-dedup `importance`/`importance_score`;
     // inert today, since clustering reads only `id`/`content`/`embedding`/`scope_id`.
-    let expired_set: std::collections::HashSet<i64> = dedup.expirations.iter().copied().collect();
+    let expired_set: std::collections::HashSet<i64> =
+        dedup.expirations.iter().map(|e| e.loser).collect();
     let survivors: Vec<&Fact> = snapshot
         .active_facts
         .iter()
@@ -310,8 +297,13 @@ fn compute_plan_capped(
 /// Phase 3 — apply the plan in a **single transaction** (#409, D3 atomicity).
 ///
 /// All-or-nothing: a failure here rolls back every write; a consumer failure has already
-/// aborted in [`compute_plan`], before this transaction opens. Idempotent and tolerant of
-/// a fact concurrently expired between the snapshot and this apply (see [`dedup::apply_dedup`]).
+/// aborted in [`compute_plan`], before this transaction opens. Tolerant of a fact
+/// concurrently expired between the snapshot and this apply (see [`dedup::apply_dedup`]).
+///
+/// Returns the stats plus the ids **actually** expired by this call — which may be fewer
+/// than the plan proposed if a concurrent writer expired a survivor (then its loser is
+/// kept) or a loser (then it is not counted). The engine drives `notify_expire` and the
+/// graph rebuild off this real set, not the stale plan.
 ///
 /// # Errors
 ///
@@ -321,11 +313,12 @@ pub fn apply_plan(
     conn: &Connection,
     plan: &ConsolidationPlan,
     embed_dim: usize,
-) -> Result<ConsolidationStats> {
+) -> Result<(ConsolidationStats, Vec<i64>)> {
     let tx = conn.unchecked_transaction()?;
 
-    // Dedup writes: importance inheritances + expirations (NotFound-tolerant, #409).
-    dedup::apply_dedup(&tx, embed_dim, &plan.dedup, plan.now)?;
+    // Dedup writes: importance inheritances + expirations (concurrency-tolerant, #409).
+    // Returns the ids actually expired by this call.
+    let expired = dedup::apply_dedup(&tx, embed_dim, &plan.dedup, plan.now)?;
 
     // Summary writes — only when clustering actually ran (#345): over the cap we must not
     // delete existing summaries without replacements. Cluster + global move together so
@@ -351,11 +344,12 @@ pub fn apply_plan(
 
     tx.commit()?;
 
-    Ok(ConsolidationStats {
-        duplicates_removed: plan.dedup.removed,
+    let stats = ConsolidationStats {
+        duplicates_removed: expired.len(),
         clusters_created: plan.cluster_summaries.len(),
         global_summaries: usize::from(plan.global_summary.is_some()),
-    })
+    };
+    Ok((stats, expired))
 }
 
 /// Orchestrate all 3 consolidation passes on a single connection (load → compute →
@@ -421,8 +415,7 @@ fn consolidate_with_caps(
         max_dedup_facts,
         max_cluster_facts,
     )?;
-    let stats = apply_plan(conn, &plan, embed_dim)?;
-    Ok((stats, plan.dedup.expirations))
+    apply_plan(conn, &plan, embed_dim)
 }
 
 #[cfg(test)]
@@ -954,16 +947,16 @@ mod tests {
         );
     }
 
-    /// #409 read→write gap: because the engine releases the write lock between the
-    /// snapshot and the apply, another writer may expire a planned-for fact in between.
-    /// [`apply_plan`] must tolerate that — a `NotFound` from `expire` is a no-op (the
-    /// desired end state already holds), not a failure. Simulated here by expiring the
-    /// dedup victim between [`compute_plan`] and [`apply_plan`].
+    /// #409 read→write gap (loser case): the engine releases the write lock between the
+    /// snapshot and the apply, so another writer may expire the *loser* a dedup merge was
+    /// about to expire. [`apply_plan`] must tolerate that — `expire` returns `NotFound`,
+    /// which is a no-op (the end state already holds), not a failure, and is not counted
+    /// as expired by this run.
     #[test]
-    fn apply_plan_tolerates_concurrently_expired_fact() {
+    fn apply_plan_tolerates_concurrently_expired_loser() {
         let conn = open_memory().unwrap();
         init_schema(&conn).unwrap();
-        // Two near-duplicates → dedup plans to expire the lower-importance one.
+        // Two near-duplicates → dedup plans to expire the lower-importance one (drop).
         insert_fact(&conn, "keep", vec![1.0, 0.0, 0.0, 0.0], 0.9);
         insert_fact(&conn, "drop", vec![0.99, 0.01, 0.0, 0.0], 0.5);
 
@@ -971,24 +964,69 @@ mod tests {
         let snapshot = load_snapshot(&conn, DIM, &config).unwrap();
         let plan = compute_plan(&snapshot, &MockGenerator, &MockEmbedder, DIM, &config).unwrap();
         assert_eq!(
-            plan.expirations().len(),
+            plan.dedup.expirations.len(),
             1,
             "dedup must plan exactly one expiry"
         );
-        let victim = plan.expirations()[0];
+        let loser = plan.dedup.expirations[0].loser;
 
-        // Simulate a concurrent writer expiring the victim between snapshot and apply.
+        // Simulate a concurrent writer expiring the loser between snapshot and apply.
         FactStore::new(&conn, DIM)
-            .expire(victim, Utc::now())
+            .expire(loser, Utc::now())
             .unwrap();
 
-        // apply_plan must NOT error on the already-expired victim (NotFound → no-op).
-        let stats = apply_plan(&conn, &plan, DIM).unwrap();
-        assert_eq!(stats.duplicates_removed, 1);
+        // apply_plan must NOT error; the loser is already gone, so this run expires
+        // nothing (it is not double-counted) and only the survivor remains.
+        let (stats, expired) = apply_plan(&conn, &plan, DIM).unwrap();
         assert_eq!(
-            FactStore::new(&conn, DIM).list_active(None).unwrap().len(),
-            1,
-            "exactly the survivor remains"
+            stats.duplicates_removed, 0,
+            "the loser was already expired concurrently; this run expired nothing"
         );
+        assert!(expired.is_empty());
+        let active = FactStore::new(&conn, DIM).list_active(None).unwrap();
+        assert_eq!(active.len(), 1, "exactly the survivor remains");
+        assert_eq!(active[0].content, "keep");
+    }
+
+    /// #409 read→write gap (survivor case): if the *survivor* a dedup merge folds a loser
+    /// into is concurrently expired in the snapshot→apply gap, the merge decision is void.
+    /// [`apply_plan`] must then KEEP the loser as the group's representative rather than
+    /// expiring it too and orphaning the duplicate cluster.
+    #[test]
+    fn apply_plan_keeps_loser_when_survivor_concurrently_expired() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        // keep (higher importance) is the survivor; drop (lower) is the planned loser.
+        insert_fact(&conn, "keep", vec![1.0, 0.0, 0.0, 0.0], 0.9);
+        insert_fact(&conn, "drop", vec![0.99, 0.01, 0.0, 0.0], 0.5);
+
+        let config = ConsolidationConfig::default();
+        let snapshot = load_snapshot(&conn, DIM, &config).unwrap();
+        let plan = compute_plan(&snapshot, &MockGenerator, &MockEmbedder, DIM, &config).unwrap();
+        assert_eq!(plan.dedup.expirations.len(), 1);
+        let survivor = plan.dedup.expirations[0].survivor;
+        let loser = plan.dedup.expirations[0].loser;
+
+        // Concurrently expire the SURVIVOR between snapshot and apply.
+        FactStore::new(&conn, DIM)
+            .expire(survivor, Utc::now())
+            .unwrap();
+
+        let (stats, expired) = apply_plan(&conn, &plan, DIM).unwrap();
+        assert_eq!(
+            stats.duplicates_removed, 0,
+            "survivor gone → the merge is void, so the loser is NOT expired"
+        );
+        assert!(expired.is_empty());
+
+        // The loser survives as the group's representative — the cluster is not orphaned.
+        let active = FactStore::new(&conn, DIM).list_active(None).unwrap();
+        assert_eq!(
+            active.len(),
+            1,
+            "the loser is kept (survivor was expired elsewhere)"
+        );
+        assert_eq!(active[0].id, loser);
+        assert_eq!(active[0].content, "drop");
     }
 }

--- a/src/engine/consolidation.rs
+++ b/src/engine/consolidation.rs
@@ -21,13 +21,18 @@ impl MemoryEngine {
     ///
     /// 1. **Read** (brief lock): snapshot the active set + watermark.
     /// 2. **Compute** (no lock): run dedup/cluster/global, including all consumer IO,
-    ///    against the snapshot — producing a [`ConsolidationPlan`](crate::consolidation::ConsolidationPlan).
+    ///    against the snapshot — producing a `ConsolidationPlan` of pure data.
     /// 3. **Write** (brief lock, one transaction): apply the plan atomically, then
     ///    rebuild the graph if dedup expired anything.
     ///
     /// Atomicity is preserved (a consumer failure aborts in the compute phase, before any
     /// write; the apply is all-or-nothing), but other engine writers — and, for an
-    /// in-memory pool, readers — are no longer starved for the IO duration.
+    /// in-memory pool, readers — are no longer starved for the IO duration. Because the
+    /// lock is released across the compute phase, a concurrent writer (`prune`, conflict
+    /// resolution) may expire a planned-for fact in the gap; the apply phase tolerates
+    /// that. This method is **not** designed to be invoked concurrently *with itself* —
+    /// the per-phase lock no longer serializes whole runs, so two overlapping runs are a
+    /// benign last-writer-wins on derived summaries, not a supported pattern.
     ///
     /// # Errors
     ///
@@ -59,16 +64,19 @@ impl MemoryEngine {
 
         // Phase 3 — WRITE (brief lock, one transaction): apply atomically, then rebuild
         // the graph inside the same lock if dedup expired facts (and their edges).
+        // `apply_plan` returns the ids it *actually* expired (a concurrent writer may have
+        // pre-empted some in the read→compute gap), so the graph rebuild and the vector
+        // index notify below key off real changes, not the stale plan.
         let conn = self.write_conn()?;
-        let stats = crate::consolidation::apply_plan(&conn, &plan, self.embed_dim)?;
-        if plan.duplicates_removed() > 0 {
+        let (stats, expired_ids) = crate::consolidation::apply_plan(&conn, &plan, self.embed_dim)?;
+        if !expired_ids.is_empty() {
             *self.graph.write() = MemoryGraph::load_from_db(&conn)?;
         }
         drop(conn); // release the write lock before notifying the vector index
 
         #[cfg(feature = "ann")]
         if let Some(ref hnsw) = self.hnsw_strategy {
-            for &id in plan.expirations() {
+            for &id in &expired_ids {
                 hnsw.notify_expire(id);
             }
         }

--- a/src/engine/consolidation.rs
+++ b/src/engine/consolidation.rs
@@ -10,49 +10,68 @@ use super::MemoryEngine;
 impl MemoryEngine {
     /// Run three-pass consolidation: local dedup, cluster fusion, global integration.
     ///
-    /// `generator` produces the summary text for each cluster and the global
-    /// pass; `embedder` projects that text into the fact vector space. Embedding
-    /// is no longer duplicated on the `SummaryGenerator` trait (issue #116).
+    /// `generator` produces the summary text for each cluster and the global pass;
+    /// `embedder` projects that text into the fact vector space (issue #116 — embedding
+    /// is no longer duplicated on the `SummaryGenerator` trait).
+    ///
+    /// # Lock discipline (#409)
+    ///
+    /// Structured as **read → compute → write** so the engine's single write lock is
+    /// NOT held across the consumer `summarize`/`embed` calls (unbounded network IO):
+    ///
+    /// 1. **Read** (brief lock): snapshot the active set + watermark.
+    /// 2. **Compute** (no lock): run dedup/cluster/global, including all consumer IO,
+    ///    against the snapshot — producing a [`ConsolidationPlan`](crate::consolidation::ConsolidationPlan).
+    /// 3. **Write** (brief lock, one transaction): apply the plan atomically, then
+    ///    rebuild the graph if dedup expired anything.
+    ///
+    /// Atomicity is preserved (a consumer failure aborts in the compute phase, before any
+    /// write; the apply is all-or-nothing), but other engine writers — and, for an
+    /// in-memory pool, readers — are no longer starved for the IO duration.
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Propagates errors from any consolidation pass, the `SummaryGenerator`, or
-    /// the `EmbeddingProvider`.
+    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only. Propagates
+    /// errors from any consolidation pass, the `SummaryGenerator`, or the
+    /// `EmbeddingProvider`.
     pub fn consolidate(
         &self,
         generator: &dyn SummaryGenerator,
         embedder: &dyn EmbeddingProvider,
         config: &ConsolidationConfig,
     ) -> Result<ConsolidationStats> {
-        let (stats, expired_ids) = {
+        // Phase 1 — READ (brief lock): snapshot the active set + watermark, then release.
+        let snapshot = {
             let conn = self.write_conn()?;
-            let (stats, expired_ids) = crate::consolidation::consolidate(
-                &conn,
-                generator,
-                embedder,
-                self.embed_dim,
-                config,
-            )?;
+            crate::consolidation::load_snapshot(&conn, self.embed_dim, config)?
+        };
 
-            // Rebuild graph inside write lock — dedup may have expired facts and their edges
-            if stats.duplicates_removed > 0 {
-                *self.graph.write() = MemoryGraph::load_from_db(&conn)?;
-            }
+        // Phase 2 — COMPUTE (NO lock): dedup decision + cluster/global summaries, including
+        // the consumer `summarize`/`embed` network IO. This is the work that used to run
+        // under the write lock and starve every other writer (#409).
+        let plan = crate::consolidation::compute_plan(
+            &snapshot,
+            generator,
+            embedder,
+            self.embed_dim,
+            config,
+        )?;
 
-            (stats, expired_ids)
-        }; // DB lock released
+        // Phase 3 — WRITE (brief lock, one transaction): apply atomically, then rebuild
+        // the graph inside the same lock if dedup expired facts (and their edges).
+        let conn = self.write_conn()?;
+        let stats = crate::consolidation::apply_plan(&conn, &plan, self.embed_dim)?;
+        if plan.duplicates_removed() > 0 {
+            *self.graph.write() = MemoryGraph::load_from_db(&conn)?;
+        }
+        drop(conn); // release the write lock before notifying the vector index
 
         #[cfg(feature = "ann")]
         if let Some(ref hnsw) = self.hnsw_strategy {
-            for &id in &expired_ids {
+            for &id in plan.expirations() {
                 hnsw.notify_expire(id);
             }
         }
-
-        // Suppress unused variable warning when ann feature is disabled
-        #[cfg(not(feature = "ann"))]
-        let _ = expired_ids;
 
         Ok(stats)
     }

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -831,6 +831,77 @@ fn consolidate_is_idempotent() {
     assert_eq!(engine.list_active_facts(None).unwrap().len(), 2);
 }
 
+/// A `SummaryGenerator` that performs an engine WRITE from inside `summarize`.
+/// Used to prove the consumer callbacks run without the engine holding its write
+/// lock (#409): the write only succeeds if `consolidate` is *not* holding
+/// `write_conn` across the summarize/embed phase.
+struct LockProbingGenerator {
+    engine: std::sync::Arc<MemoryEngine>,
+}
+impl SummaryGenerator for LockProbingGenerator {
+    fn summarize(&self, items: &[SummarizableContent<'_>]) -> Result<String> {
+        // A real engine write reached from within the consumer callback. If
+        // `consolidate` still held the single write lock across this phase, this
+        // same-thread re-lock would trip the pool's non-reentrant guard
+        // (`parking_lot::Mutex` + the debug reentrancy assertion) and panic
+        // instead of completing — the deterministic signal that the lock is held.
+        self.engine
+            .set_config("consolidate_compute_was_lock_free", "yes")?;
+        Ok(items.iter().map(|i| i.text).collect::<Vec<_>>().join("; "))
+    }
+}
+
+/// #409 (denial-of-service / lock starvation): the consumer `SummaryGenerator` /
+/// `EmbeddingProvider` callbacks must run **without** the engine holding its `write_conn` lock.
+/// Before the read→compute→write split, `MemoryEngine::consolidate` held that guard
+/// across the entire pipeline — including the unbounded `summarize`/`embed` network
+/// IO — starving every other engine writer (and, on an in-memory pool, every reader,
+/// since reads serialize through the same `Mutex`) for the full duration.
+///
+/// The probe is deterministic and thread-free: a generator that writes through the
+/// engine from inside `summarize` succeeds only if the compute phase is lock-free.
+/// With the lock still held this same-thread re-lock would panic ("reentrant")
+/// rather than complete (see [`LockProbingGenerator`]); after the fix the marker
+/// write lands and we assert it persisted.
+#[test]
+fn consolidate_runs_consumer_callbacks_without_holding_write_lock() {
+    use std::sync::Arc;
+    let engine = Arc::new(MemoryEngine::builder(DIM).build().unwrap());
+
+    // A single-linkage chain that forms exactly one cluster (so `summarize` is
+    // actually invoked) with no near-duplicate expiry: adjacent cosines ~0.883
+    // sit between the 0.85 cluster and 0.90 dedup thresholds.
+    insert_raw_fact(&engine, &make_new_fact("a", vec![1.0, 0.0, 0.0, 0.0]));
+    insert_raw_fact(&engine, &make_new_fact("b", vec![0.8829, 0.4695, 0.0, 0.0]));
+    insert_raw_fact(&engine, &make_new_fact("c", vec![0.5592, 0.829, 0.0, 0.0]));
+
+    let generator = LockProbingGenerator {
+        engine: Arc::clone(&engine),
+    };
+    let config = ConsolidationConfig::builder()
+        .dedup_threshold(0.90)
+        .cluster_threshold(0.85)
+        .min_cluster_size(2)
+        .build();
+
+    let stats = engine
+        .consolidate(&generator, &MockEmbedder { dim: DIM }, &config)
+        .unwrap();
+    assert_eq!(
+        stats.clusters_created, 1,
+        "fixture must form exactly one cluster so `summarize` runs"
+    );
+
+    // The callback's write landed → the compute phase did not hold the write lock.
+    assert_eq!(
+        engine
+            .get_config("consolidate_compute_was_lock_free")
+            .unwrap(),
+        Some("yes".to_string()),
+        "a consumer callback must be able to write during consolidation (#409)"
+    );
+}
+
 #[test]
 fn forget_prunes_stale_facts() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -310,6 +310,25 @@ impl<'a> FactStore<'a> {
         Ok(usize::try_from(count).unwrap_or(0))
     }
 
+    /// Whether a fact is currently active (`t_expired IS NULL`).
+    ///
+    /// A point liveness probe used by the consolidation apply phase to detect a fact
+    /// that was concurrently expired between the lock-free snapshot and the write — so a
+    /// dedup survivor removed in that gap does not cause its loser to be expired too,
+    /// orphaning the duplicate group (#409 read→write gap).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn is_active(&self, id: i64) -> Result<bool> {
+        let active: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM facts WHERE id = ?1 AND t_expired IS NULL)",
+            params![id],
+            |row| row.get(0),
+        )?;
+        Ok(active)
+    }
+
     /// List the importance-scoring projection of all active facts
     /// (`t_expired IS NULL`).
     ///

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -290,6 +290,26 @@ impl<'a> FactStore<'a> {
         Ok(facts)
     }
 
+    /// Count active facts (`t_expired IS NULL`) without materializing any rows.
+    ///
+    /// A `COUNT(*)` companion to [`list_active`](Self::list_active): consolidation
+    /// uses it to test its O(N·M) / O(N²) safety caps **before** the expensive
+    /// `list_active` load — which would otherwise deserialize every embedding BLOB
+    /// (~147 MB for 50k×768-dim) only to discover the corpus is over the cap and
+    /// skip both passes (#659).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
+    pub fn count_active(&self) -> Result<usize> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM facts WHERE t_expired IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(usize::try_from(count).unwrap_or(0))
+    }
+
     /// List the importance-scoring projection of all active facts
     /// (`t_expired IS NULL`).
     ///
@@ -1291,6 +1311,28 @@ mod tests {
             scope_id: 1,
             is_pinned: false,
         }
+    }
+
+    /// #659: `count_active` counts exactly the rows `list_active` would return
+    /// (`t_expired IS NULL`) without materializing them, and tracks expiry.
+    #[test]
+    fn count_active_matches_list_active_and_tracks_expiry() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        assert_eq!(store.count_active().unwrap(), 0, "empty table → 0");
+
+        let a = store.insert(&make_fact("a", vec![0.1; DIM])).unwrap();
+        store.insert(&make_fact("b", vec![0.2; DIM])).unwrap();
+        assert_eq!(store.count_active().unwrap(), 2);
+        assert_eq!(
+            store.count_active().unwrap(),
+            store.list_active(None).unwrap().len(),
+            "count must agree with list_active's row count"
+        );
+
+        // Expiring a fact drops it from the active count (soft delete).
+        store.expire(a, Utc::now()).unwrap();
+        assert_eq!(store.count_active().unwrap(), 1, "expired fact not counted");
     }
 
     /// #209 cursor probe: `max_caller_written_fact_id` returns the highest id among

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -401,7 +401,7 @@ impl ConsolidationConfig {
     /// Validate configuration parameters.
     ///
     /// Enforced at the consolidation entry point
-    /// ([`crate::consolidation::consolidate`]), mirroring
+    /// ([`MemoryEngine::consolidate`](crate::MemoryEngine::consolidate)), mirroring
     /// [`ForgetPolicy::validate`] at the forget entry point.
     ///
     /// # Errors


### PR DESCRIPTION
## What & why

`MemoryEngine::consolidate` held the engine's single `write_conn` mutex across the **entire** 3-pass consolidation pipeline — including the consumer `SummaryGenerator::summarize` / `EmbeddingProvider::embed` calls, which are unbounded network IO. While held, every other engine writer — and, for an in-memory pool, every *reader* (reads serialize through the same mutex) — is starved for the full IO duration: a denial-of-service / lock-starvation surface (**#409**, `type:security`, `severity:medium`).

## Approach — read → compute → write (locked decision D3: preserve atomicity)

The pipeline is split so the lock is never held across consumer IO, while keeping all-or-nothing atomicity:

1. **`load_snapshot`** (brief lock): `COUNT` active (#659 short-circuit) + `last_consolidated_at` watermark + `list_active` once (#389).
2. **`compute_plan`** (NO lock): the dedup decision + cluster/global summaries — *all the consumer IO* — computed against the snapshot into a pure `ConsolidationPlan`.
3. **`apply_plan`** (brief lock, ONE transaction): every write applied atomically.

A consumer failure now aborts in the lock-free compute phase, **before any write** — strictly stronger than the prior tx-rollback (`failing_pass_rolls_back_entire_transaction` still holds). The single-connection `consolidate`/per-pass wrappers are retained as `#[cfg(test)]` helpers; the production path is compute + apply.

## Folds in #659

`FactStore::count_active` lets `load_snapshot` short-circuit the expensive `list_active` load (which deserializes every embedding BLOB) when the corpus is over **both** safety caps — both passes would skip anyway.

## Concurrency robustness (read→write gap)

Releasing the lock between snapshot and apply lets a concurrent writer (`prune`, conflict resolution, dream cycle) expire a planned-for fact in the gap. `apply_dedup` handles both cases and returns the ids it **actually** expired (so `notify_expire`/graph-rebuild/stats key off reality, not the stale plan):
- **loser concurrently expired** → tolerated (`NotFound` no-op), not counted;
- **survivor concurrently expired** → the merge is void, so the loser is **kept** rather than expired-too (no orphaned duplicate group). Survivor liveness is snapshotted *before* any expiry so merge **chains** stay correct.

## Intentional behavior change (surfaced, not buried)

When the **cluster** pass is skipped over its cap, global integration no longer re-summarizes the *stale* store clusters — summary writes are gated on `cluster_ran`, so cluster + global are only rewritten when clustering actually runs. Cleaner invariant; this edge case was untested (the cluster cap is 50k and not test-injectable on the old path).

## Test plan

- [x] `cargo build --workspace --all-features`
- [x] `cargo test --workspace` (1538 passed, 9 ignored)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --check`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok)
- [x] New tests: deterministic lock-free probe (a generator that writes through the engine from inside `summarize` — pre-fix it tripped the pool's non-reentrant guard); `count_active`; over-both-caps no-op; concurrent-loser tolerance; concurrent-survivor keeps-loser.

## Review

3 adversarial-lens subagent review (behavior-preservation / concurrency-atomicity / API-blast-radius). Behavior-preservation: LGTM. The substantive concurrency finding (survivor-liveness) is fixed here; the API findings (broken doc-link, stale narrative doc, over-visible helper) are addressed.

Closes #409.
Closes #659.

