### PR TITLE
refactor(core): ResumeConfig::validate + resume tier/idempotency tests (#254 wave3)

### DIFF
--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -18,7 +18,9 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::NotFound` if the requested scope path doesn't exist.
+    /// Returns `MemoryError::NotFound` if the requested scope path doesn't exist,
+    /// or `MemoryError::Conflict` if [`ResumeConfig::validate`] rejects the config
+    /// (out-of-range `high_importance_min` or a zero tier cap).
     pub fn resume_context(&self, config: &ResumeConfig) -> Result<ResumeContext> {
         // Step 1: Resolve scope IDs from cache (short-lived read lock)
         let scope_ids = {

--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -22,6 +22,11 @@ impl MemoryEngine {
     /// or `MemoryError::Conflict` if [`ResumeConfig::validate`] rejects the config
     /// (out-of-range `high_importance_min` or a zero tier cap).
     pub fn resume_context(&self, config: &ResumeConfig) -> Result<ResumeContext> {
+        // Fail fast at the public boundary: reject an invalid config before
+        // acquiring the scope_tree lock or touching the DB (#359). The internal
+        // `resume::resume_context` helper trusts its already-validated input.
+        config.validate()?;
+
         // Step 1: Resolve scope IDs from cache (short-lived read lock)
         let scope_ids = {
             let tree = self.scope_tree.read();

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -1241,6 +1241,20 @@ fn resume_nonexistent_scope_returns_not_found() {
     assert!(matches!(err, MemoryError::NotFound(_)));
 }
 
+#[test]
+fn resume_rejects_invalid_config() {
+    // #359: ResumeConfig::validate() is enforced at the public boundary
+    // (fail-fast, before the scope lock / DB), so an out-of-range config is a
+    // Conflict — not a silently-empty tier.
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let config = ResumeConfig {
+        high_importance_min: 5.0,
+        ..ResumeConfig::default()
+    };
+    let err = engine.resume_context(&config).unwrap_err();
+    assert!(matches!(err, MemoryError::Conflict(_)), "got {err:?}");
+}
+
 // --- Issue #93: surfaced_at for due facts in non-due tiers ---
 
 #[test]

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -1382,6 +1382,119 @@ fn resume_does_not_stamp_invalidated_pinned_due_fact() {
     );
 }
 
+// --- Issue #476: surfaced_at stamping is idempotent across calls ---
+
+/// A second `resume_context` call on the same due fact must NOT re-stamp
+/// `surfaced_at`: the timestamp from the first surfacing is the authoritative
+/// record and must stay stable. Both the closure guard in `engine/resume.rs`
+/// (`f.surfaced_at.is_none()`) and the SQL guard in `FactStore::stamp_surfaced`
+/// (`AND surfaced_at IS NULL`) protect against re-stamping; this test fails if
+/// either drifts.
+///
+/// The two calls pass *different* `now` values (`now` then `later`). If
+/// re-stamping leaked, the second call would overwrite the timestamp with
+/// `later`, so the equality assertion discriminates the regression.
+#[test]
+fn resume_surfaced_at_is_idempotent() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let embedder = MockEmbedder { dim: DIM };
+    let now = Utc::now();
+    let past = now - chrono::Duration::hours(1);
+    let later = now + chrono::Duration::hours(2);
+
+    // A plain due fact (t_valid in the past) — lands in the `due` tier.
+    engine
+        .add_fact(
+            &AddFactRequest {
+                content: "deploy the staging build".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(AddFactOptions {
+                    t_valid: Some(past),
+                    ..Default::default()
+                }),
+            },
+            &embedder,
+            None,
+        )
+        .unwrap();
+
+    let ctx1 = engine
+        .resume_context(&ResumeConfig {
+            now,
+            ..ResumeConfig::default()
+        })
+        .unwrap();
+    assert_eq!(ctx1.due.len(), 1);
+    let first_stamp = ctx1.due[0]
+        .surfaced_at
+        .expect("due fact must be surfaced on first resume_context");
+
+    // Second call at a strictly later `now`. surfaced_at must be unchanged.
+    let ctx2 = engine
+        .resume_context(&ResumeConfig {
+            now: later,
+            ..ResumeConfig::default()
+        })
+        .unwrap();
+    assert_eq!(ctx2.due.len(), 1);
+    let second_stamp = ctx2.due[0]
+        .surfaced_at
+        .expect("due fact must still carry its surfaced_at on the second call");
+
+    assert_eq!(
+        second_stamp, first_stamp,
+        "surfaced_at must not be re-stamped on a second resume_context call"
+    );
+}
+
+/// The same idempotency guarantee on the public `list_due()` path, which shares
+/// the `surfaced_at.is_none()` guard (`engine/scheduling.rs`). A second
+/// `list_due()` call must return the original `surfaced_at`, not a fresh stamp.
+#[test]
+fn list_due_surfaced_at_is_idempotent() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let embedder = MockEmbedder { dim: DIM };
+    let now = Utc::now();
+    let past = now - chrono::Duration::hours(1);
+    let later = now + chrono::Duration::hours(2);
+
+    engine
+        .add_fact(
+            &AddFactRequest {
+                content: "rotate the API key".into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: Some(AddFactOptions {
+                    t_valid: Some(past),
+                    ..Default::default()
+                }),
+            },
+            &embedder,
+            None,
+        )
+        .unwrap();
+
+    let due1 = engine.list_due(now, None).unwrap();
+    assert_eq!(due1.len(), 1);
+    let first_stamp = due1[0]
+        .surfaced_at
+        .expect("due fact must be surfaced on first list_due");
+
+    let due2 = engine.list_due(later, None).unwrap();
+    assert_eq!(due2.len(), 1);
+    let second_stamp = due2[0]
+        .surfaced_at
+        .expect("due fact must still carry its surfaced_at on the second call");
+
+    assert_eq!(
+        second_stamp, first_stamp,
+        "surfaced_at must not be re-stamped on a second list_due call"
+    );
+}
+
 // --- Issue #474: resume_context scope ancestor-chain filtering ---
 
 /// `resume_context` with `scope_path = Some(<existing child>)` must scope the

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -432,3 +432,121 @@ mod tests {
         assert!(ctx.high_importance[0].importance_score >= 0.7);
     }
 }
+
+/// Property-based tests for the tier mutual-exclusivity invariant (#475).
+///
+/// The single example test `resume_tiers_mutually_exclusive` covers exactly one
+/// fact arrangement (one pinned, one scored, one due, one recent). The invariant
+/// — *no fact appears in more than one tier* — is enforced by the `seen`
+/// `HashSet` accumulated across tiers in [`resume_context`], so it is most
+/// stressed by facts that qualify for several tiers at once (e.g. pinned AND
+/// high-scored AND due). These proptests vary fact attributes, fact counts, and
+/// tier caps to exercise that overlap broadly.
+///
+/// Placed in its own module after `mod tests` so no non-test items follow a
+/// `#[cfg(test)]` module (`clippy::items_after_test_module`).
+#[cfg(test)]
+mod proptest_tiers {
+    use std::collections::HashSet;
+
+    use chrono::{Duration, Utc};
+    use proptest::prelude::*;
+    use rusqlite::Connection;
+
+    use super::{ResumeConfig, resume_context};
+    use crate::store::facts::FactStore;
+    use crate::store::schema::{init_schema, migrate, open_memory};
+    use crate::types::{FactType, NewFact};
+
+    const DIM: usize = 4;
+
+    fn setup() -> Connection {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        migrate(&conn, None).unwrap();
+        conn
+    }
+
+    /// One generated fact: its tier-relevant attributes.
+    #[derive(Debug, Clone)]
+    struct FactSpec {
+        pinned: bool,
+        /// Materialized importance score, applied after insert.
+        score: f64,
+        /// `t_valid` offset in hours relative to `now`; negative = in the past
+        /// (due), positive = in the future (not yet due).
+        t_valid_offset_h: i64,
+    }
+
+    prop_compose! {
+        fn arb_fact_spec()(
+            pinned in any::<bool>(),
+            score in 0.0f64..=1.0,
+            t_valid_offset_h in -48i64..=48,
+        ) -> FactSpec {
+            FactSpec { pinned, score, t_valid_offset_h }
+        }
+    }
+
+    proptest! {
+        /// The four tiers returned by `resume_context` are always pairwise
+        /// disjoint: a fact's id never appears in more than one tier, for any
+        /// combination of fact attributes and (non-zero) tier caps.
+        #[test]
+        fn tiers_always_mutually_exclusive(
+            specs in proptest::collection::vec(arb_fact_spec(), 0..12),
+            pinned_cap in 1usize..8,
+            high_importance_cap in 1usize..8,
+            high_importance_min in 0.0f64..=1.0,
+            due_cap in 1usize..8,
+            recent_cap in 1usize..8,
+        ) {
+            let conn = setup();
+            let fs = FactStore::new(&conn, DIM);
+            let now = Utc::now();
+
+            for (i, spec) in specs.iter().enumerate() {
+                // Distinct content per fact (`fact-{i}`) so the content-hash
+                // dedup in FactStore::insert never collapses two specs into one
+                // row.
+                let new_fact = NewFact::builder(
+                    format!("fact-{i}"),
+                    vec![0.1; DIM],
+                    FactType::Semantic,
+                )
+                .scope_id(1)
+                .is_pinned(spec.pinned)
+                .t_valid(now + Duration::hours(spec.t_valid_offset_h))
+                .build();
+                let id = fs.insert(&new_fact).unwrap();
+                fs.update_importance_score(id, spec.score).unwrap();
+            }
+
+            let config = ResumeConfig {
+                now,
+                pinned_cap,
+                high_importance_cap,
+                high_importance_min,
+                due_cap,
+                recent_cap,
+                ..ResumeConfig::default()
+            };
+            let ctx = resume_context(&conn, &[1], DIM, &config).unwrap();
+
+            let all_ids: Vec<i64> = ctx
+                .pinned
+                .iter()
+                .chain(ctx.high_importance.iter())
+                .chain(ctx.due.iter())
+                .chain(ctx.recent.iter())
+                .map(|f| f.id)
+                .collect();
+            let unique: HashSet<i64> = all_ids.iter().copied().collect();
+            prop_assert_eq!(
+                all_ids.len(),
+                unique.len(),
+                "a fact appeared in more than one tier"
+            );
+        }
+    }
+}

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -40,6 +40,56 @@ impl Default for ResumeConfig {
     }
 }
 
+impl ResumeConfig {
+    /// Validate configuration parameters.
+    ///
+    /// `high_importance_min` is a materialized-score threshold that flows
+    /// directly into [`FactStore::list_by_importance_score`]'s `min_score`
+    /// comparison; it must be finite and within `[0.0, 1.0]` — a value like
+    /// `2.0` would silently yield an empty high-importance tier with no
+    /// diagnostic. The four tier caps must each be non-zero, since a `0` cap
+    /// silently empties that tier.
+    ///
+    /// Mirrors the [`DreamCycleConfig::validate`](crate::types::DreamCycleConfig::validate)
+    /// precedent and uses the same
+    /// [`ConflictError::PolicyParameter`](crate::error::ConflictError::PolicyParameter)
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Conflict`](crate::error::MemoryError::Conflict)
+    /// wrapping [`ConflictError::PolicyParameter`](crate::error::ConflictError::PolicyParameter)
+    /// if `high_importance_min` is non-finite or outside `[0.0, 1.0]`, or if any
+    /// of the tier caps (`pinned_cap`, `high_importance_cap`, `due_cap`,
+    /// `recent_cap`) is zero.
+    pub fn validate(&self) -> Result<()> {
+        use crate::error::{ConflictError, MemoryError};
+
+        if !self.high_importance_min.is_finite() || !(0.0..=1.0).contains(&self.high_importance_min)
+        {
+            return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                format!(
+                    "high_importance_min must be in [0.0, 1.0], got {}",
+                    self.high_importance_min
+                ),
+            )));
+        }
+        for (name, cap) in [
+            ("pinned_cap", self.pinned_cap),
+            ("high_importance_cap", self.high_importance_cap),
+            ("due_cap", self.due_cap),
+            ("recent_cap", self.recent_cap),
+        ] {
+            if cap == 0 {
+                return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
+                    format!("{name} must be greater than 0, got 0"),
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Result of [`resume_context`].
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResumeContext {
@@ -70,7 +120,9 @@ pub struct ResumeContext {
 ///
 /// # Errors
 ///
-/// Returns [`crate::error::MemoryError`] if any underlying store query fails.
+/// Returns [`crate::error::MemoryError`] if [`ResumeConfig::validate`] rejects
+/// the config (out-of-range `high_importance_min` or a zero tier cap), or if any
+/// underlying store query fails.
 ///
 /// # Examples
 ///
@@ -92,6 +144,8 @@ pub fn resume_context(
     embed_dim: usize,
     config: &ResumeConfig,
 ) -> Result<ResumeContext> {
+    config.validate()?;
+
     let fact_store = FactStore::new(conn, embed_dim);
     let mut seen: HashSet<i64> = HashSet::new();
 
@@ -281,6 +335,79 @@ mod tests {
             .collect();
         let unique: HashSet<i64> = all_ids.iter().copied().collect();
         assert_eq!(all_ids.len(), unique.len(), "no duplicates across tiers");
+    }
+
+    #[test]
+    fn validate_accepts_default_config() {
+        assert!(ResumeConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_high_importance_min() {
+        use crate::error::{ConflictError, MemoryError};
+
+        for bad in [2.0_f64, -0.1, f64::NAN, f64::INFINITY] {
+            let config = ResumeConfig {
+                high_importance_min: bad,
+                ..ResumeConfig::default()
+            };
+            let err = config.validate().unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    MemoryError::Conflict(ConflictError::PolicyParameter(_))
+                ),
+                "expected PolicyParameter conflict for high_importance_min={bad}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_accepts_boundary_high_importance_min() {
+        for ok in [0.0_f64, 1.0] {
+            let config = ResumeConfig {
+                high_importance_min: ok,
+                ..ResumeConfig::default()
+            };
+            assert!(
+                config.validate().is_ok(),
+                "boundary high_importance_min={ok} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_zero_caps() {
+        use crate::error::{ConflictError, MemoryError};
+
+        let zero_setters: [fn(&mut ResumeConfig); 4] = [
+            |c| c.pinned_cap = 0,
+            |c| c.high_importance_cap = 0,
+            |c| c.due_cap = 0,
+            |c| c.recent_cap = 0,
+        ];
+        for set_zero in zero_setters {
+            let mut config = ResumeConfig::default();
+            set_zero(&mut config);
+            let err = config.validate().unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    MemoryError::Conflict(ConflictError::PolicyParameter(_))
+                ),
+                "expected PolicyParameter conflict for a zero cap, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn resume_context_propagates_invalid_config() {
+        let conn = setup();
+        let config = ResumeConfig {
+            high_importance_min: 5.0,
+            ..ResumeConfig::default()
+        };
+        assert!(resume_context(&conn, &[1], DIM, &config).is_err());
     }
 
     #[test]

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -144,8 +144,8 @@ pub fn resume_context(
     embed_dim: usize,
     config: &ResumeConfig,
 ) -> Result<ResumeContext> {
-    config.validate()?;
-
+    // Config is validated by the caller (MemoryEngine::resume_context) at the
+    // public boundary; this internal helper trusts its input (#359).
     let fact_store = FactStore::new(conn, embed_dim);
     let mut seen: HashSet<i64> = HashSet::new();
 
@@ -398,16 +398,6 @@ mod tests {
                 "expected PolicyParameter conflict for a zero cap, got {err:?}"
             );
         }
-    }
-
-    #[test]
-    fn resume_context_propagates_invalid_config() {
-        let conn = setup();
-        let config = ResumeConfig {
-            high_importance_min: 5.0,
-            ..ResumeConfig::default()
-        };
-        assert!(resume_context(&conn, &[1], DIM, &config).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 3 — collision-free subset; the store/StorageBackend-trait resume findings #395/#396/#477 are deferred behind storage epic #631). Closes 3 findings.

## Findings closed
- **#359** [refactor/medium] — `ResumeConfig` had no `validate()`; unconstrained `high_importance_min` (f64) and zero tier-caps silently produced empty tiers. Adds `ResumeConfig::validate()` (finite + in-range checks via `MemoryError::Conflict(ConflictError::PolicyParameter(..))`), enforced at the top of `resume_context`. **Additive / non-breaking** (all in-tree constructors use `default()` or in-range values).
- **#475** [test/medium] — tier mutual-exclusivity was covered by one hand-built example; adds a proptest generating facts whose attributes deliberately overlap tier predicates, stressing the `seen`-HashSet exclusion.
- **#476** [test/medium] — adds tests that a second `resume_context` call (and the `list_due` path) does not re-stamp `surfaced_at` (idempotency), asserted with a strictly-later `now` so a regression would visibly advance the timestamp.

## Review (internal diverse-lens subagents — no external models)
3 clean-slate reviewers (correctness / security & soundness / api-surface & test-quality): **0 blocker, 0 major** (1 nit: optionally advertise the cap `minimum` in the MCP tool JSON schema — the runtime guard is sound).

## Gate
`cargo build/test/clippy --workspace --all-features` + `cargo fmt --check` — green (rebased on current main c62fa83).

Fixes #359, fixes #475, fixes #476
