### PR TITLE
test(core): cargo-fuzz harnesses for untrusted parser entry-points (#254 wave5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ archive = ["compress-zstd"]
 
 [lints.rust]
 unsafe_code = "forbid"
+# `fuzzing` is set only by cargo-fuzz (`--cfg fuzzing`); it gates the
+# `fuzz_seam` module. Register it so the normal build does not warn on the
+# otherwise-unknown cfg name.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 [lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,81 @@
+# cargo-fuzz crate for memory-engine — DELIBERATELY OUTSIDE the main workspace.
+#
+# The empty `[workspace]` table below detaches this package from the parent
+# workspace so that `cargo build --workspace --all-features` at the repo root
+# never compiles it. The fuzz targets require the nightly-only libFuzzer
+# sanitizer runtime (`-Z sanitizer`, `--cfg fuzzing`); pulling them into the
+# default members would force nightly on the stable main build. Build/run with:
+#
+#     cargo +nightly fuzz build
+#     cargo +nightly fuzz run <target>
+#
+# The seam they drive (`fuzz_seam` in memory-engine / memory-engine-embed) is
+# `#[cfg(fuzzing)]`-gated, so it exists only under cargo-fuzz's `--cfg fuzzing`.
+[package]
+name = "memory-engine-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+rust-version = "1.88"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+tempfile = "3"
+
+# Exercise the compressed-snapshot and HNSW restore branches as well as the
+# plain path, so the snapshot/restore targets cover every deserialization route.
+memory-engine = { path = "..", features = ["ann", "compress-gzip", "compress-zstd", "archive"] }
+memory-engine-embed = { path = "../memory-engine-embed" }
+
+# Detach from the parent workspace: an empty `[workspace]` makes this its own
+# workspace root, so the repo-root `cargo build --workspace` ignores it.
+[workspace]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "snapshot_load"
+path = "fuzz_targets/snapshot_load.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_session_file"
+path = "fuzz_targets/parse_session_file.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_content_blocks"
+path = "fuzz_targets/parse_content_blocks.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fact_deserialize"
+path = "fuzz_targets/fact_deserialize.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "snapshot_restore"
+path = "fuzz_targets/snapshot_restore.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "embed_parse_response"
+path = "fuzz_targets/embed_parse_response.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/embed_parse_response.rs
+++ b/fuzz/fuzz_targets/embed_parse_response.rs
@@ -1,0 +1,35 @@
+//! Fuzz target for the HTTP embedding-response batch parsers (#449).
+//!
+//! `HttpEmbeddingProvider::{parse_openai_batch, parse_ollama_batch}` parse
+//! untrusted network JSON: each runs `serde_json::from_value::<Vec<f32>>` over an
+//! attacker-controlled `data` / `embeddings` array, then validates index
+//! continuity (OpenAI) or per-element shape (Ollama). A compromised or
+//! misconfigured endpoint could return adversarial bodies; the contract is that
+//! both parsers return `Ok`/`Err` and never panic.
+//!
+//! The parsers are private associated fns of `HttpEmbeddingProvider`; they are
+//! reached through the `#[cfg(fuzzing)]` `memory_engine_embed::fuzz_seam`
+//! re-export, so the shipped crate's API is unchanged.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(data) else {
+        return;
+    };
+
+    // OpenAI shape: { "data": [ { "index": .., "embedding": [..] }, .. ] }.
+    if let Some(items) = body.get("data").and_then(|v| v.as_array()) {
+        // Drive both the matching-count branch and a deliberately mismatched
+        // count so the count-guard and the continuity check are both exercised.
+        let _ = memory_engine_embed::fuzz_seam::parse_openai_batch(items, items.len());
+        let _ = memory_engine_embed::fuzz_seam::parse_openai_batch(items, items.len() + 1);
+    }
+
+    // Ollama shape: { "embeddings": [ [..], [..] ] }.
+    if let Some(rows) = body.get("embeddings").and_then(|v| v.as_array()) {
+        let _ = memory_engine_embed::fuzz_seam::parse_ollama_batch(rows, rows.len());
+        let _ = memory_engine_embed::fuzz_seam::parse_ollama_batch(rows, rows.len() + 1);
+    }
+});

--- a/fuzz/fuzz_targets/fact_deserialize.rs
+++ b/fuzz/fuzz_targets/fact_deserialize.rs
@@ -1,0 +1,34 @@
+//! Fuzz target for core-type JSON deserialization over untrusted BYTES (#445).
+//!
+//! `Fact`, `Event`, and `Edge` all derive `Deserialize` and are the entry-points
+//! for untrusted JSON flowing in from the MCP server and the import path. This
+//! target fuzzes the **bytes** directly via `serde_json::from_slice` — it does
+//! NOT add `#[derive(Arbitrary)]` to the core types (that would mean editing
+//! `types.rs`). The contract is total: deserialization either returns `Ok` or a
+//! `serde_json::Error`, never a panic.
+//!
+//! Semantic note (the residual the #445 re-triage flags): serde accepts
+//! structurally valid but semantically extreme values — a non-finite
+//! `importance` (`Infinity`/`NaN` via the JSON `f64` path) or one outside
+//! `[0.0, 1.0]`. Per `Fact::importance`'s own docs, range enforcement lives in
+//! `add_fact` (#571), not in the type, and a few direct-insert paths still skip
+//! it (#584). So this is an *observation* of the validation seam, not a crash
+//! condition: we surface the extreme value (via `std::hint::black_box`) without
+//! asserting it away, so a future range-tightening can turn it into a guard.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use memory_engine::{Edge, Event, Fact};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(fact) = serde_json::from_slice::<Fact>(data) {
+        // Observe (do not assert) the semantic-validation seam: a parsed Fact may
+        // carry a non-finite or out-of-range importance, an arbitrarily long
+        // embedding, etc. The type accepts it; only `add_fact` rejects it.
+        std::hint::black_box(fact.importance.is_finite());
+        std::hint::black_box(fact.embedding.len());
+    }
+    let _ = serde_json::from_slice::<Event>(data);
+    let _ = serde_json::from_slice::<Edge>(data);
+});

--- a/fuzz/fuzz_targets/parse_content_blocks.rs
+++ b/fuzz/fuzz_targets/parse_content_blocks.rs
@@ -1,0 +1,19 @@
+//! Fuzz target for the content-block parser (#426).
+//!
+//! `bootstrap::parse::parse_content_blocks` maps an arbitrary `serde_json::Value`
+//! `content` array into `ContentBlock`s, dispatching `parse_single_block` on the
+//! per-element `type` string (`text` / `tool_use` / unrecognized fall-through).
+//! The fuzzer first parses bytes into a `Value`, then drives the block parser to
+//! prove the type-string match and the `.get(..)`/`as_str` chains never panic on
+//! adversarial shapes (wrong-typed fields, missing keys, deep nesting).
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(data) {
+        let blocks = memory_engine::fuzz_seam::parse_content_blocks(&value);
+        // A non-array `content` yields an empty vec; never a panic.
+        let _ = blocks.len();
+    }
+});

--- a/fuzz/fuzz_targets/parse_session_file.rs
+++ b/fuzz/fuzz_targets/parse_session_file.rs
@@ -1,0 +1,25 @@
+//! Fuzz target for the JSONL session-log parser (#426).
+//!
+//! `bootstrap::parse::parse_session_file` is the bootstrap pipeline's first
+//! touch on untrusted JSONL (real session logs, or files handed to the MCP
+//! bootstrap endpoint). It reads bounded lines, UTF-8-checks each, then
+//! `serde_json::from_str::<SessionEntry>`. The per-line / per-stream / per-entry
+//! caps are enforced; this drives the parser with adversarial bytes to prove it
+//! never panics and always returns a best-effort `(entries, malformed)` pair.
+//!
+//! The parser is `pub(crate)`; reached via the `#[cfg(fuzzing)]`
+//! `memory_engine::fuzz_seam` re-export.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::io::BufReader;
+
+fuzz_target!(|data: &[u8]| {
+    // Caps fuzzed at both ends: 0/0 = fully unbounded (worst case for the
+    // allocator), plus a small explicit cap to exercise the truncation branch.
+    let reader = BufReader::new(data);
+    let _ = memory_engine::fuzz_seam::parse_session_file(reader, 0, 0);
+
+    let reader = BufReader::new(data);
+    let (_entries, _malformed) = memory_engine::fuzz_seam::parse_session_file(reader, 4096, 16);
+});

--- a/fuzz/fuzz_targets/parse_session_file.rs
+++ b/fuzz/fuzz_targets/parse_session_file.rs
@@ -7,7 +7,7 @@
 //! caps are enforced; this drives the parser with adversarial bytes to prove it
 //! never panics and always returns a best-effort `(entries, malformed)` pair.
 //!
-//! The parser is `pub(crate)`; reached via the `#[cfg(fuzzing)]`
+//! The parser is crate-internal; reached via the `#[cfg(fuzzing)]`
 //! `memory_engine::fuzz_seam` re-export.
 #![no_main]
 
@@ -15,8 +15,9 @@ use libfuzzer_sys::fuzz_target;
 use std::io::BufReader;
 
 fuzz_target!(|data: &[u8]| {
-    // Caps fuzzed at both ends: 0/0 = fully unbounded (worst case for the
-    // allocator), plus a small explicit cap to exercise the truncation branch.
+    // Caps fuzzed at both ends: 0/0 disables the per-stream and per-entry caps
+    // (the per-line MAX_JSONL_LINE_BYTES cap stays fixed at 8 MiB inside the
+    // parser), plus a small explicit cap to exercise the truncation branch.
     let reader = BufReader::new(data);
     let _ = memory_engine::fuzz_seam::parse_session_file(reader, 0, 0);
 

--- a/fuzz/fuzz_targets/snapshot_load.rs
+++ b/fuzz/fuzz_targets/snapshot_load.rs
@@ -32,14 +32,25 @@ fuzz_target!(|data: &[u8]| {
             *slot = Some(t);
         }
         let path = slot.as_ref().unwrap().path();
+
+        // (1) Raw bytes: exercises the OUTER envelope parse — size gate,
+        // header_len bounds, header MessagePack deserialize, and the
+        // checksum-reject path. `embed_dim` fuzzed implicitly (768 vs a
+        // mismatching 0). Both None and Some(..) are fine; only a panic fails.
         // fs::write truncates, so each iteration fully replaces the contents.
-        if std::fs::write(path, data).is_err() {
-            return;
+        if std::fs::write(path, data).is_ok() {
+            let _ = memory_engine::fuzz_seam::load_from_file(path, 768);
+            let _ = memory_engine::fuzz_seam::load_from_file(path, 0);
         }
-        // `embed_dim` is fuzzed implicitly: try the common 768 and a mismatching
-        // 0 so both the dimension-accept and dimension-reject branches run. Both
-        // `None` and `Some(..)` are acceptable; the only failure is a panic.
-        let _ = memory_engine::fuzz_seam::load_from_file(path, 768);
-        let _ = memory_engine::fuzz_seam::load_from_file(path, 0);
+
+        // (2) Wrapped bytes: a valid header + a blake3 recomputed over `data`,
+        // so the checksum gate PASSES and `data` reaches the payload MessagePack
+        // deserializer (the deep-nesting / large-allocation paths #311 targets,
+        // which the raw path can never reach — guessing a 256-bit hash is
+        // infeasible). embed_dim 768 matches the header the wrapper writes.
+        let envelope = memory_engine::fuzz_seam::fuzz_wrap_payload(data, 768);
+        if std::fs::write(path, &envelope).is_ok() {
+            let _ = memory_engine::fuzz_seam::load_from_file(path, 768);
+        }
     });
 });

--- a/fuzz/fuzz_targets/snapshot_load.rs
+++ b/fuzz/fuzz_targets/snapshot_load.rs
@@ -13,17 +13,33 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use std::cell::RefCell;
+
+thread_local! {
+    // Reuse one temp file across iterations and overwrite its contents:
+    // creating + deleting a NamedTempFile every run is heavy disk I/O that
+    // throttles fuzz throughput.
+    static TMP: RefCell<Option<tempfile::NamedTempFile>> = const { RefCell::new(None) };
+}
 
 fuzz_target!(|data: &[u8]| {
-    let Ok(tmp) = tempfile::NamedTempFile::new() else {
-        return;
-    };
-    if std::fs::write(tmp.path(), data).is_err() {
-        return;
-    }
-    // `embed_dim` is fuzzed implicitly: try the common 768 and a mismatching 0
-    // so both the dimension-accept and dimension-reject branches are exercised.
-    // Both `None` and `Some(..)` are acceptable; the only failure is a panic.
-    let _ = memory_engine::fuzz_seam::load_from_file(tmp.path(), 768);
-    let _ = memory_engine::fuzz_seam::load_from_file(tmp.path(), 0);
+    TMP.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if slot.is_none() {
+            let Ok(t) = tempfile::NamedTempFile::new() else {
+                return;
+            };
+            *slot = Some(t);
+        }
+        let path = slot.as_ref().unwrap().path();
+        // fs::write truncates, so each iteration fully replaces the contents.
+        if std::fs::write(path, data).is_err() {
+            return;
+        }
+        // `embed_dim` is fuzzed implicitly: try the common 768 and a mismatching
+        // 0 so both the dimension-accept and dimension-reject branches run. Both
+        // `None` and `Some(..)` are acceptable; the only failure is a panic.
+        let _ = memory_engine::fuzz_seam::load_from_file(path, 768);
+        let _ = memory_engine::fuzz_seam::load_from_file(path, 0);
+    });
 });

--- a/fuzz/fuzz_targets/snapshot_load.rs
+++ b/fuzz/fuzz_targets/snapshot_load.rs
@@ -1,0 +1,29 @@
+//! Fuzz target for the binary snapshot reader (#311).
+//!
+//! `engine::snapshot::load_from_file` ingests an untrusted sidecar file: it
+//! parses a `u32` LE `header_len`, slices `data[4..header_end]`, then runs two
+//! `rmp_serde::from_slice` passes (header, then payload) plus a blake3 verify.
+//! The on-disk size and in-band bounds are guarded, but the MessagePack
+//! deep-nesting / large-allocation paths were never fuzzed. The contract is
+//! total: every malformed input must return `None`, never panic.
+//!
+//! The reader is `pub(crate)`; it is reached through the `#[cfg(fuzzing)]`
+//! `memory_engine::fuzz_seam` re-export so this harness does not widen the
+//! shipped public API.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(tmp) = tempfile::NamedTempFile::new() else {
+        return;
+    };
+    if std::fs::write(tmp.path(), data).is_err() {
+        return;
+    }
+    // `embed_dim` is fuzzed implicitly: try the common 768 and a mismatching 0
+    // so both the dimension-accept and dimension-reject branches are exercised.
+    // Both `None` and `Some(..)` are acceptable; the only failure is a panic.
+    let _ = memory_engine::fuzz_seam::load_from_file(tmp.path(), 768);
+    let _ = memory_engine::fuzz_seam::load_from_file(tmp.path(), 0);
+});

--- a/fuzz/fuzz_targets/snapshot_load.rs
+++ b/fuzz/fuzz_targets/snapshot_load.rs
@@ -7,7 +7,7 @@
 //! deep-nesting / large-allocation paths were never fuzzed. The contract is
 //! total: every malformed input must return `None`, never panic.
 //!
-//! The reader is `pub(crate)`; it is reached through the `#[cfg(fuzzing)]`
+//! The reader is crate-internal; it is reached through the `#[cfg(fuzzing)]`
 //! `memory_engine::fuzz_seam` re-export so this harness does not widen the
 //! shipped public API.
 #![no_main]

--- a/fuzz/fuzz_targets/snapshot_restore.rs
+++ b/fuzz/fuzz_targets/snapshot_restore.rs
@@ -15,13 +15,28 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use std::cell::RefCell;
+
+thread_local! {
+    // Reuse one temp file across iterations (overwrite contents) — per-run
+    // file create/delete is heavy disk I/O that throttles fuzz throughput.
+    static TMP: RefCell<Option<tempfile::NamedTempFile>> = const { RefCell::new(None) };
+}
 
 fuzz_target!(|data: &[u8]| {
-    let Ok(tmp) = tempfile::NamedTempFile::new() else {
-        return;
-    };
-    if std::fs::write(tmp.path(), data).is_err() {
-        return;
-    }
-    let _ = memory_engine::inspect::restore::read_snapshot(tmp.path());
+    TMP.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if slot.is_none() {
+            let Ok(t) = tempfile::NamedTempFile::new() else {
+                return;
+            };
+            *slot = Some(t);
+        }
+        let path = slot.as_ref().unwrap().path();
+        // fs::write truncates, so each iteration fully replaces the contents.
+        if std::fs::write(path, data).is_err() {
+            return;
+        }
+        let _ = memory_engine::inspect::restore::read_snapshot(path);
+    });
 });

--- a/fuzz/fuzz_targets/snapshot_restore.rs
+++ b/fuzz/fuzz_targets/snapshot_restore.rs
@@ -1,0 +1,27 @@
+//! Fuzz target for the JSON snapshot import path (#445).
+//!
+//! `inspect::restore::read_snapshot` is the real untrusted-FILE ingest for the
+//! `Deserialize` core types: it size-guards the file, sniffs compression from
+//! magic bytes (plain / gzip / zstd), then `serde_json::from_reader::<
+//! EngineSnapshot>`. `EngineSnapshot` transitively contains `Vec<Fact>` /
+//! `Vec<Event>` / `Vec<Edge>` / etc, so this exercises the whole graph of core
+//! deserializers through the genuine entry point (the #445 re-triage's
+//! higher-value anchor than a bare `from_str::<Fact>`). `read_snapshot` is
+//! already `pub`, so no seam is needed.
+//!
+//! Built with `compress-gzip` + `compress-zstd`, so a fuzzer-discovered gzip or
+//! zstd magic prefix routes through the decoder branches as well as the plain
+//! path. The contract: every input yields `Ok` or `Err`, never a panic.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(tmp) = tempfile::NamedTempFile::new() else {
+        return;
+    };
+    if std::fs::write(tmp.path(), data).is_err() {
+        return;
+    }
+    let _ = memory_engine::inspect::restore::read_snapshot(tmp.path());
+});

--- a/memory-engine-embed/Cargo.toml
+++ b/memory-engine-embed/Cargo.toml
@@ -20,6 +20,10 @@ proptest = "1"
 
 [lints.rust]
 unsafe_code = "forbid"
+# `fuzzing` is set only by cargo-fuzz (`--cfg fuzzing`); it gates the
+# `fuzz_seam` module. Register it so the normal build does not warn on the
+# otherwise-unknown cfg name.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 [lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/memory-engine-embed/src/http.rs
+++ b/memory-engine-embed/src/http.rs
@@ -635,6 +635,38 @@ fn truncate_on_char_boundary(s: &str, max: usize) -> String {
     format!("{}... (truncated)", &s[..end])
 }
 
+/// Fuzz-only seam exposing the otherwise-private batch parsers.
+///
+/// [`HttpEmbeddingProvider::parse_openai_batch`] /
+/// [`HttpEmbeddingProvider::parse_ollama_batch`] are private associated fns:
+/// they parse untrusted network JSON (`serde_json::from_value::<Vec<f32>>` over
+/// attacker-controlled `data`/`embeddings` arrays) yet have no external call
+/// site a fuzz harness can reach. These thin wrappers live in the same module
+/// as the `impl`, so they can call the private fns, and are gated on `--cfg
+/// fuzzing` (set only by `cargo fuzz`) so they add nothing to the shipped crate.
+#[cfg(fuzzing)]
+pub mod fuzz_seam {
+    use super::HttpEmbeddingProvider;
+
+    /// Parse an `OpenAI`-shaped `data` array (untrusted). Returns `Err` on any
+    /// malformed item; the contract is "must not panic".
+    pub fn parse_openai_batch(
+        data: &[serde_json::Value],
+        expected_count: usize,
+    ) -> Result<Vec<Vec<f32>>, memory_engine::error::MemoryError> {
+        HttpEmbeddingProvider::parse_openai_batch(data, expected_count)
+    }
+
+    /// Parse an Ollama-shaped `embeddings` array (untrusted). Returns `Err` on
+    /// any malformed item; the contract is "must not panic".
+    pub fn parse_ollama_batch(
+        embeddings: &[serde_json::Value],
+        expected_count: usize,
+    ) -> Result<Vec<Vec<f32>>, memory_engine::error::MemoryError> {
+        HttpEmbeddingProvider::parse_ollama_batch(embeddings, expected_count)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/memory-engine-embed/src/lib.rs
+++ b/memory-engine-embed/src/lib.rs
@@ -29,3 +29,12 @@ mod proposer;
 
 pub use http::HttpEmbeddingProvider;
 pub use proposer::{HttpDeltaProposer, ProposerStats};
+
+/// Fuzz-only seam (`--cfg fuzzing`, set only by `cargo fuzz`).
+///
+/// Re-exports the otherwise-private batch response parsers so cargo-fuzz targets
+/// can drive them directly. Compiles to nothing on a normal build, so it adds no
+/// public API to the shipped crate. See [`http::fuzz_seam`].
+#[cfg(fuzzing)]
+#[doc(hidden)]
+pub use http::fuzz_seam;

--- a/src/engine/snapshot.rs
+++ b/src/engine/snapshot.rs
@@ -276,6 +276,41 @@ pub fn write_to_file(
     Ok(())
 }
 
+/// Wrap arbitrary fuzzer bytes as the **payload** of an otherwise-valid
+/// snapshot envelope: a correct header (current [`FORMAT_VERSION`] +
+/// `embed_dim`) and a blake3 recomputed over `payload`. Without this the
+/// fuzzer's bytes would be rejected at the checksum gate in
+/// [`load_from_file`] before ever reaching the payload MessagePack
+/// deserializer (the deep-nesting / large-allocation paths #311 targets).
+///
+/// `#[cfg(fuzzing)]` only — compiled solely under `cargo fuzz`, never shipped.
+#[cfg(fuzzing)]
+#[doc(hidden)]
+#[must_use]
+pub fn fuzz_wrap_payload(payload: &[u8], embed_dim: usize) -> Vec<u8> {
+    let header = SnapshotHeader {
+        format_version: FORMAT_VERSION,
+        fingerprint: DbFingerprint {
+            max_fact_id: 0,
+            active_fact_count: 0,
+            max_edge_id: 0,
+            active_edge_count: 0,
+            max_scope_id: 0,
+            scope_count: 0,
+        },
+        embed_dim,
+        engine_version: String::new(),
+    };
+    let header_bytes = rmp_serde::to_vec_named(&header).expect("fuzz header serialize");
+    let header_len = u32::try_from(header_bytes.len()).expect("fuzz header len fits u32");
+    let mut out = Vec::with_capacity(4 + header_bytes.len() + payload.len() + BLAKE3_LEN);
+    out.extend_from_slice(&header_len.to_le_bytes());
+    out.extend_from_slice(&header_bytes);
+    out.extend_from_slice(payload);
+    out.extend_from_slice(blake3::hash(payload).as_bytes());
+    out
+}
+
 /// Load and validate a snapshot from disk.
 ///
 /// Returns `None` on any failure (missing file, corrupt data, version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,29 @@ pub use engine::cycle::{
     TimeWindow,
 };
 
+/// Fuzz-only seam (`--cfg fuzzing`, set only by `cargo fuzz`).
+///
+/// Re-exports the otherwise crate-internal parser entry points so cargo-fuzz
+/// targets can drive untrusted-byte ingest directly:
+///
+/// - [`engine::snapshot::load_from_file`] — the `pub(crate)` binary snapshot
+///   reader (u32 LE header + msgpack header/payload + blake3).
+/// - [`bootstrap::parse::parse_session_file`] /
+///   [`bootstrap::parse::parse_content_blocks`] — the `pub(crate)` JSONL session
+///   parsers.
+///
+/// `inspect::restore::read_snapshot` (the JSON import path) is already public, so
+/// it is fuzzed directly without going through this seam.
+///
+/// This module compiles to nothing on a normal build, so it adds no public API
+/// to the shipped crate.
+#[cfg(fuzzing)]
+#[doc(hidden)]
+pub mod fuzz_seam {
+    pub use crate::bootstrap::parse::{parse_content_blocks, parse_session_file};
+    pub use crate::engine::snapshot::{SnapshotHeader, SnapshotPayload, load_from_file};
+}
+
 #[cfg(test)]
 mod tests {
     /// Smoke-test: verify that re-exported types are reachable from the crate root.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ pub use engine::cycle::{
 #[doc(hidden)]
 pub mod fuzz_seam {
     pub use crate::bootstrap::parse::{parse_content_blocks, parse_session_file};
-    pub use crate::engine::snapshot::load_from_file;
+    pub use crate::engine::snapshot::{fuzz_wrap_payload, load_from_file};
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,11 +167,11 @@ pub use engine::cycle::{
 /// Re-exports the otherwise crate-internal parser entry points so cargo-fuzz
 /// targets can drive untrusted-byte ingest directly:
 ///
-/// - [`engine::snapshot::load_from_file`] — the `pub(crate)` binary snapshot
+/// - [`engine::snapshot::load_from_file`] — the crate-internal binary snapshot
 ///   reader (u32 LE header + msgpack header/payload + blake3).
 /// - [`bootstrap::parse::parse_session_file`] /
-///   [`bootstrap::parse::parse_content_blocks`] — the `pub(crate)` JSONL session
-///   parsers.
+///   [`bootstrap::parse::parse_content_blocks`] — the crate-internal JSONL session
+///   parsers (`pub fn` inside a `pub(crate) mod`, so not reachable downstream).
 ///
 /// `inspect::restore::read_snapshot` (the JSON import path) is already public, so
 /// it is fuzzed directly without going through this seam.
@@ -182,7 +182,7 @@ pub use engine::cycle::{
 #[doc(hidden)]
 pub mod fuzz_seam {
     pub use crate::bootstrap::parse::{parse_content_blocks, parse_session_file};
-    pub use crate::engine::snapshot::{SnapshotHeader, SnapshotPayload, load_from_file};
+    pub use crate::engine::snapshot::load_from_file;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 5). Adds a cargo-fuzz crate for the untrusted-input parsers. Closes 4 findings.

## Findings closed
- **#311** — fuzz target for the binary snapshot reader (`load_from_file`).
- **#426** — fuzz target for `parse_session_file` (adversarial JSONL) + `parse_content_blocks`.
- **#445** — fuzz targets for core deserialization entry points (Fact/Event/Edge from untrusted JSON via `serde_json::from_slice` on the **bytes** — no `#[derive(Arbitrary)]`, so `types.rs` is untouched).
- **#449** — fuzz target for the embedding response parsers (`parse_openai_batch` / `parse_ollama_batch`).

## Design
- `fuzz/` is a **separate cargo-fuzz crate** with its own `[workspace]` — `cargo build --workspace` does NOT pull it in (no nightly/libfuzzer forced on the main build; `cargo metadata` confirms members = the 4 real crates).
- The crate-internal parsers are reached via a `#[cfg(fuzzing)] #[doc(hidden)] pub mod fuzz_seam` in `src/lib.rs` + `memory-engine-embed/src/lib.rs`. `cfg(fuzzing)` is only set under cargo-fuzz, so the seam **compiles to nothing in normal builds** — adds no shipped public API. `check-cfg` wired so normal builds don't warn on `cfg(fuzzing)`.

## Verification
- `cargo +nightly fuzz build`: all 6 targets compile (cargo-fuzz 0.13.2).
- Bounded smoke run of all targets (`-runs=2000 -max_total_time=8`): no crash/panic/leak.
- Main `cargo build/test/clippy --workspace --all-features` stays green (rebased on c62fa83).

## Review (internal diverse-lens subagents — no external models)
3 clean-slate reviewers (correctness / security & soundness / api-surface & build): **0 blocker, 0 major** — 4 doc/tidiness nits, all fixed (reworded `pub(crate)`→crate-internal, dropped 2 unused seam re-exports, corrected the cap comment).

Fixes #311, fixes #426, fixes #445, fixes #449
