### PR TITLE
chore(build): make async default-on + CLI tokio dependency (#631 Stage D)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,11 @@ harness = false
 name = "lifecycle_bench"
 harness = false
 
+# `async` is default-on (#631 Stage D): the engine becomes async-native in the
+# Stage E cutover, where a backend cannot exist without a tokio runtime, so the
+# flag is on its way to vacuous. Opt out (pre-cutover) with --no-default-features.
 [features]
-default = []
+default = ["async"]
 async = ["dep:tokio"]
 ann = ["dep:hnsw", "dep:space", "dep:rand"]
 compress-gzip = ["dep:flate2"]

--- a/memory-engine-cli/Cargo.toml
+++ b/memory-engine-cli/Cargo.toml
@@ -20,6 +20,10 @@ anyhow = "1"
 tabled = "0.20"
 chrono = { version = "0.4", features = ["serde"] }
 rusqlite = { version = "0.34", features = ["bundled"] }
+# Direct runtime dep for the Stage E cutover (`#[tokio::main]`/`block_on` at the
+# command boundary). Already present transitively via memory-engine's default
+# `async`; named here so the cutover can use it directly. (#631 Stage D)
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 assert_cmd = "2"


### PR DESCRIPTION
## Summary

**Stage D of #631** (epic #628) — the last additive prep before the big-bang cutover (E). Two manifest changes:

1. **`default = ["async"]`** (root `Cargo.toml`) — the engine's async surface (the `SqliteBackend` + `AsyncMemoryEngine`) now compiles by default. The Stage E cutover makes `async` mandatory (a backend needs a tokio runtime), so this is the build-graph step on that path, isolated so any default-feature fallout surfaces here rather than buried in the cutover.
2. **`tokio` in `memory-engine-cli` `[dependencies]`** — direct dep for the cutover's `#[tokio::main]`/`block_on` at the command boundary (already present transitively via memory-engine's default `async`; named directly so the cutover can use it).

## Why it's safe / additive

- No `cfg(not(feature = "async"))` paths exist anywhere — flipping the default drops nothing from the build.
- The engine is still sync (the cutover is Stage E); this only changes which features compile by default. Behavior unchanged.
- **Side effect:** resolves the #706/#712 default-lib `dead_code` warnings — the `async`-gated `SessionStore` impl that uses those `store/{activities,checkpoints}` reads now compiles by default, so they're no longer dead.

## Verification

- `cargo build --workspace` (now default-async) — clean, **no dead_code warnings**
- `cargo test --workspace` — **1534 passed**; `cargo clippy --workspace --all-targets --all-features` clean; fmt clean; `cargo deny` ok
- Opt-out (pre-cutover) still works: `--no-default-features`.

Fixes #701
