### PR TITLE
docs(core): repoint ResumeConfig doc-links to the public resume_context entry

### DIFF
--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -7,7 +7,7 @@ use crate::error::Result;
 use crate::store::facts::FactStore;
 use crate::types::Fact;
 
-/// Configuration for [`resume_context`].
+/// Configuration for [`MemoryEngine::resume_context`](crate::MemoryEngine::resume_context).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResumeConfig {
     /// Scope path to resume from. None = root only.
@@ -90,7 +90,7 @@ impl ResumeConfig {
     }
 }
 
-/// Result of [`resume_context`].
+/// Result of [`MemoryEngine::resume_context`](crate::MemoryEngine::resume_context).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResumeContext {
     /// Pinned (unforgettable) facts — agent identity, core beliefs.


### PR DESCRIPTION
## What

`ResumeConfig`'s doc (`/// Configuration for [`resume_context`]`) and the result-type doc (`/// Result of [`resume_context`]`) linked the free `resume_context` fn. It's `pub` but lives in a non-public module, so rustdoc treats it as private and errors under `-D rustdoc::broken_intra_doc_links` ("public documentation ... links to private item"). Both are repointed to the public entry point `MemoryEngine::resume_context`, matching the existing pattern at `context.rs:130`.

The third `[`resume_context`]` (in a `#[cfg(test)]` test-module doc) is intentionally left — rustdoc doesn't process cfg(test) items and the symbol is in scope there.

## Verification

`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` no longer reports the two `resume_context` link errors. `cargo fmt --check` clean. Doc-comment-only change (no code logic), so no test impact.

## Out of scope (surfaced, not folded in)

`cargo doc -D warnings` revealed **other, pre-existing** broken intra-doc links unrelated to this issue: `MemoryError::Embedding` (×3, likely meant `EmbeddingDimension`), `EpisodeCategory::from_str`, and `max_session_bytes` → private `DEFAULT_MAX_SESSION_BYTES`. These are a broader doc-link cleanup; recommend a separate follow-up (or a small `area:docs` sweep). Not folded in to keep this fix scoped to #720.

Closes #720.
