### PR TITLE
fix(cli): isolate invalid records in batch ingest via partial-success path

### DIFF
--- a/memory-engine-cli/src/commands/batch_ingest.rs
+++ b/memory-engine-cli/src/commands/batch_ingest.rs
@@ -162,9 +162,12 @@ const MAX_LINE_BYTES: u64 = 8 << 20; // 8 MiB
 /// Each line must deserialize as a JSONL fact record. Malformed lines, lines
 /// that fail validation, and lines exceeding [`MAX_LINE_BYTES`] are skipped
 /// (counted in `total_skipped`) rather than aborting the run. Valid records are
-/// embedded and inserted in transactions of `batch_size`; a batch the engine
-/// rejects is counted as skipped plus one `failed_batches`, and ingestion
-/// continues. Progress is reported on stderr unless `format` is JSON.
+/// embedded and inserted in transactions of `batch_size` via the partial-success
+/// engine path (#663): a record the engine rejects (e.g. oversized content) is
+/// counted as skipped individually, leaving its batch-mates ingested. Only a
+/// **batch-level** failure (embedder error or atomic-insert rollback) skips the
+/// whole batch and bumps `failed_batches`. Ingestion continues either way.
+/// Progress is reported on stderr unless `format` is JSON.
 ///
 /// `default_scope` is applied to records that omit a `scope` field; a per-record
 /// `scope` in the JSONL always takes precedence.
@@ -190,6 +193,9 @@ pub async fn ingest_from_reader(
     let mut total_skipped: usize = 0;
     let mut failed_batches: usize = 0;
     let mut batch: Vec<AddFactRequest> = Vec::with_capacity(batch_size);
+    // Parallel to `batch`: the source JSONL line of each batched record, so a
+    // per-record skip warning can name the offending line (#663 / #727 review).
+    let mut batch_lines: Vec<usize> = Vec::with_capacity(batch_size);
     let mut line_no: usize = 0;
     let mut line = String::new();
 
@@ -250,11 +256,13 @@ pub async fn ingest_from_reader(
         }
 
         batch.push(jsonl_to_request(fact, default_scope));
+        batch_lines.push(line_no);
 
         if batch.len() >= batch_size {
             let flushed = flush_batch(
                 engine,
                 &mut batch,
+                &mut batch_lines,
                 &embedder,
                 &format!("batch at line {line_no}"),
                 &mut total_ingested,
@@ -272,6 +280,7 @@ pub async fn ingest_from_reader(
     flush_batch(
         engine,
         &mut batch,
+        &mut batch_lines,
         &embedder,
         "final batch",
         &mut total_ingested,
@@ -314,6 +323,7 @@ fn eprint_progress(ingested: usize, skipped: usize, start: &Instant, format: Out
 async fn flush_batch(
     engine: &MemoryEngine,
     batch: &mut Vec<AddFactRequest>,
+    batch_lines: &mut Vec<usize>,
     embedder: &std::sync::Arc<dyn EmbeddingProvider>,
     context: &str,
     total_ingested: &mut usize,
@@ -324,15 +334,31 @@ async fn flush_batch(
         return true;
     }
     let chunk_size = batch.len();
-    let ingested = match engine
-        .add_facts_batch(batch.as_slice(), embedder.clone(), None)
+    // Partial-success ingest (#663): a single invalid record (e.g. content in the
+    // 1–8 MiB band that passes the CLI line cap but exceeds the engine's payload
+    // limit) is skipped individually instead of poisoning its whole batch.
+    let progressed = match engine
+        .add_facts_batch_partial(batch.as_slice(), embedder.clone(), None)
         .await
     {
-        Ok(ids) => {
-            *total_ingested += ids.len();
+        Ok(results) => {
+            // `results` is positional with `batch` (hence `batch_lines`), so each
+            // rejection is reported against its own source JSONL line, matching the
+            // CLI's other `warning: line N: …` diagnostics.
+            let mut inserted = 0usize;
+            for (src_line, result) in batch_lines.iter().zip(&results) {
+                match result {
+                    Ok(_) => inserted += 1,
+                    Err(err) => eprintln!("warning: line {src_line}: skipped (engine): {err}"),
+                }
+            }
+            *total_ingested += inserted;
+            *total_skipped += chunk_size - inserted;
             true
         }
         Err(e) => {
+            // Batch-level failure (embedder error or atomic-insert rollback): the
+            // whole batch could not be persisted.
             eprintln!("warning: {context}: {e}");
             *total_skipped += chunk_size;
             *failed_batches += 1;
@@ -340,7 +366,8 @@ async fn flush_batch(
         }
     };
     batch.clear();
-    ingested
+    batch_lines.clear();
+    progressed
 }
 
 // ---------------------------------------------------------------------------

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -253,16 +253,113 @@ impl MemoryEngine {
         // single invalid importance or oversized content/metadata rejects the
         // whole call before any entry is embedded or persisted.
         for entry in entries {
-            Self::validate_importance(entry.opts.as_ref().and_then(|o| o.importance))?;
-            check_str_size(&entry.content, "fact content")?;
-            if let Some(metadata) = entry.opts.as_ref().and_then(|o| o.metadata.as_ref()) {
-                check_json_size(metadata, "fact metadata")?;
+            Self::validate_add_fact_request(entry)?;
+        }
+
+        let refs: Vec<&AddFactRequest> = entries.iter().collect();
+        self.insert_validated_batch(&refs, &embedder, classifier)
+            .await
+    }
+
+    /// Partial-success variant of [`add_facts_batch`](Self::add_facts_batch):
+    /// returns a per-record result so a single invalid record no longer poisons
+    /// its whole batch (#663).
+    ///
+    /// Each input entry maps positionally to one `Result<i64, MemoryError>`:
+    /// `Ok(id)` if it was embedded and inserted, `Err(e)` if it was rejected by
+    /// per-record validation (importance range, oversized content/metadata). The
+    /// **valid** partition is embedded and inserted in one atomic batch, so the
+    /// invalid records are simply skipped rather than failing their neighbours.
+    ///
+    /// # Errors
+    ///
+    /// Returns an **outer** `Err` for batch-level failures that prevent the valid
+    /// partition from being persisted at all: a consumer-`embedder` failure, an
+    /// `embed_batch` count mismatch, a rollback of the atomic insert itself
+    /// (a rare DB-constraint failure rolls the whole valid set back together —
+    /// per-record isolation covers *validation* rejection, the realistic poison,
+    /// not a mid-insert constraint violation), or a backend that returns a
+    /// different number of ids than valid entries (a contract violation). Every
+    /// internal-invariant breach surfaces as the outer `Err`; the returned `Vec`
+    /// carries **only** per-record validation failures, never an outer-`Err` cause.
+    pub async fn add_facts_batch_partial(
+        &self,
+        entries: &[AddFactRequest],
+        embedder: Arc<dyn EmbeddingProvider>,
+        classifier: Option<Arc<dyn PersistenceClassifier>>,
+    ) -> Result<Vec<std::result::Result<i64, MemoryError>>> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Partition: `validation[i] == None` ⇒ entry i is valid and contributes
+        // to `valid` (in input order); `Some(e)` ⇒ entry i is rejected.
+        let mut validation: Vec<Option<MemoryError>> = Vec::with_capacity(entries.len());
+        let mut valid: Vec<&AddFactRequest> = Vec::new();
+        for entry in entries {
+            match Self::validate_add_fact_request(entry) {
+                Ok(()) => {
+                    valid.push(entry);
+                    validation.push(None);
+                }
+                Err(e) => validation.push(Some(e)),
             }
         }
 
+        // Insert only the valid partition atomically (skipped entirely when all
+        // records were rejected). A systemic embed failure or an atomic-insert
+        // rollback propagates as the outer `Err`.
+        let ids = if valid.is_empty() {
+            Vec::new()
+        } else {
+            self.insert_validated_batch(&valid, &embedder, classifier)
+                .await?
+        };
+
+        // Invariant: the atomic insert returns exactly one id per valid entry (or
+        // an outer `Err`, rolled back). A short id vector is a backend-contract
+        // violation — surface it as an outer `Err`, not scattered in-band — which
+        // also makes the positional re-thread below total.
+        if ids.len() != valid.len() {
+            return Err(MemoryError::Internal(format!(
+                "batch insert returned {} ids for {} valid entries",
+                ids.len(),
+                valid.len()
+            )));
+        }
+
+        // Re-thread results positionally: each valid (`None`) slot consumes the
+        // next inserted id; each invalid slot keeps its validation error.
+        let mut ids_iter = ids.into_iter();
+        let results = validation
+            .into_iter()
+            .map(|v| {
+                v.map_or_else(
+                    || {
+                        Ok(ids_iter
+                            .next()
+                            .expect("one id per valid entry (checked above)"))
+                    },
+                    Err,
+                )
+            })
+            .collect();
+        Ok(results)
+    }
+
+    /// Embed, classify, and atomically insert a **pre-validated** set of entries
+    /// (the shared core of [`add_facts_batch`](Self::add_facts_batch) and
+    /// [`add_facts_batch_partial`](Self::add_facts_batch_partial)). Returns the
+    /// assigned ids in `entries` order. Callers are responsible for validation.
+    async fn insert_validated_batch(
+        &self,
+        entries: &[&AddFactRequest],
+        embedder: &Arc<dyn EmbeddingProvider>,
+        classifier: Option<Arc<dyn PersistenceClassifier>>,
+    ) -> Result<Vec<i64>> {
         // --- Phase 1: Batch embed off the executor (one blocking call) ---
         let texts: Vec<String> = entries.iter().map(|e| e.content.clone()).collect();
-        let provider = Arc::clone(&embedder);
+        let provider = Arc::clone(embedder);
         let embeddings = tokio::task::spawn_blocking(move || {
             let refs: Vec<&str> = texts.iter().map(String::as_str).collect();
             provider.embed_batch(&refs)
@@ -345,7 +442,7 @@ impl MemoryEngine {
     /// `prepare_batch_entries` pin logic exactly.
     async fn compute_batch_pins(
         &self,
-        entries: &[AddFactRequest],
+        entries: &[&AddFactRequest],
         embeddings: &[Vec<f32>],
         classifier: Option<Arc<dyn PersistenceClassifier>>,
         now: DateTime<Utc>,
@@ -525,5 +622,81 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    /// #663: one oversized-content record is skipped **per-record** by
+    /// `add_facts_batch_partial`; its valid batch-mates are still ingested
+    /// (the all-or-nothing `add_facts_batch` would have lost all of them).
+    #[tokio::test]
+    async fn add_facts_batch_partial_isolates_invalid_record() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let mk = |content: String| AddFactRequest {
+            content,
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        };
+        let entries = vec![
+            mk("good-1".to_string()),
+            mk("x".repeat(MAX_PAYLOAD_BYTES + 1)), // poison: oversized content
+            mk("good-2".to_string()),
+            mk("good-3".to_string()),
+        ];
+
+        let results = engine
+            .add_facts_batch_partial(
+                &entries,
+                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 4, "one result per input, positionally");
+        assert!(results[0].is_ok(), "good-1 ingested");
+        match &results[1] {
+            Err(MemoryError::Conflict(ConflictError::PayloadTooLarge { kind, .. })) => {
+                assert_eq!(*kind, "fact content");
+            }
+            other => panic!("expected per-record PayloadTooLarge at [1], got {other:?}"),
+        }
+        assert!(results[2].is_ok(), "good-2 ingested");
+        assert!(results[3].is_ok(), "good-3 ingested");
+
+        // The 3 valid neighbours are persisted — the bad record did NOT poison them.
+        let active = engine.list_active_facts(None).await.unwrap();
+        assert_eq!(active.len(), 3, "3 valid records survived the poison");
+    }
+
+    /// #663 edge case: an all-invalid batch returns all `Err` and persists nothing
+    /// (no spurious insert, no outer error).
+    #[tokio::test]
+    async fn add_facts_batch_partial_all_invalid_persists_nothing() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let entries = vec![AddFactRequest {
+            content: "x".repeat(MAX_PAYLOAD_BYTES + 1),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        }];
+
+        let results = engine
+            .add_facts_batch_partial(
+                &entries,
+                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_err(), "the only record is rejected");
+        assert_eq!(
+            engine.list_active_facts(None).await.unwrap().len(),
+            0,
+            "nothing persisted"
+        );
     }
 }


### PR DESCRIPTION
Fixes #663 (unblocked by the #631 cutover).

## Problem
`batch-ingest`'s 8 MiB per-line cap admits a record whose `content` is in the 1–8 MiB band; the engine's 1 MiB `MAX_PAYLOAD_BYTES` then rejects it, and because `add_facts_batch` is all-or-nothing, that one record failed its whole batch — silently discarding up to `batch_size − 1` valid neighbours.

## Fix (locked design from the issue)
- `MemoryEngine::add_facts_batch_partial` → `Vec<Result<i64, MemoryError>>`, one per input positionally: pre-validate + partition, insert only the valid set atomically (shared `insert_validated_batch` core), re-thread results by position. Validation rejections are isolated per-record; systemic embed failure / atomic-insert rollback / backend id-count mismatch surface as the outer `Err`.
- `add_facts_batch` keeps all-or-nothing semantics (delegates the shared core).
- CLI `flush_batch` uses the partial path — per-record skips counted + reported against their source JSONL line (matching the CLI's other `warning: line N: …` diagnostics); only batch-level failures bump `failed_batches`.

## Tests
- `add_facts_batch_partial_isolates_invalid_record` (the repro: 1 oversized + 3 valid → 3 ingested, 1 per-record `Err`).
- `add_facts_batch_partial_all_invalid_persists_nothing`.
- Full CLI suite (131) green.

Diverse-lens internal review applied (3 findings: a CI-reddening `option_if_let_else` lint, the in-band vs outer-`Err` contract for a backend id-count mismatch, and line-anchored per-record warnings).