### PR TITLE
test(storage): restore raw-SQL-injection tests via a test-only raw_exec seam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,12 @@ ann = ["dep:hnsw", "dep:space", "dep:rand"]
 compress-gzip = ["dep:flate2"]
 compress-zstd = ["dep:zstd"]
 archive = ["compress-zstd"]
+# Exposes test-only escape hatches on the storage port (e.g.
+# `SchemaManager::raw_exec`) for cross-crate tests — notably the #632 conformance
+# suite, where every backend must provide the seam for the failure-injection
+# tests to run. Always active for this crate's own `#[cfg(test)]` builds; not part
+# of the public API surface and never enabled in release builds.
+test-util = []
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/engine/archive.rs
+++ b/src/engine/archive.rs
@@ -361,9 +361,6 @@ mod tests {
     /// The `.pak` is written before the commit transaction; without on-error
     /// cleanup it would be a permanent disk leak with no manifest row (CWE-459).
     #[tokio::test]
-    #[ignore = "#727: assertions are disabled — needs a #[cfg(test)] StorageBackend exec \
-                seam to DROP the manifest table below the port and inject the commit failure; \
-                ignored so its green status does not imply the CWE-459 cleanup guard is live"]
     async fn archive_cleans_up_pak_when_commit_fails() {
         let dir = tempfile::tempdir().unwrap();
         let engine = MemoryEngine::builder(DIM)
@@ -382,44 +379,43 @@ mod tests {
                 .unwrap();
         }
         // Force `commit_archive` to fail: drop the manifest table so its INSERT
-        // errors out *after* the `.pak` has already been written to disk.
-        // TODO(#631-test): raw SQL needs a port escape — `DROP TABLE
-        // archive_manifest` (the commit-failure injection) has no `StorageBackend`
-        // method, and `engine.write_conn()` is gone post-cutover. Without it the
-        // archive commit succeeds, so the failure-path assertions below cannot be
-        // exercised; they are commented out until a test-only raw-exec seam exists.
+        // errors out *after* the `.pak` has already been written to disk. The
+        // test-only `raw_exec` seam (#727) injects the failure below the port now
+        // that `engine.write_conn()` is gone post-#631.
+        engine
+            .storage()
+            .raw_exec("DROP TABLE archive_manifest")
+            .await
+            .unwrap();
 
         let policy = ArchivePolicy {
             expired_before: Utc::now() + Duration::hours(1),
             min_facts: 1,
         };
 
-        let _result = engine.archive(&policy).await;
-        // TODO(#631-test): without the DROP-TABLE injection above, `archive` now
-        // succeeds; the original commit-failure + orphan-cleanup assertions are
-        // disabled until the raw-exec port escape lands.
-        // assert!(
-        //     _result.is_err(),
-        //     "archive must propagate the commit failure, got {_result:?}"
-        // );
-        //
-        // // The archive directory must contain no orphan `.pak` file.
-        // let archive_dir = dir.path().join("archives");
-        // let orphans: Vec<_> = std::fs::read_dir(&archive_dir)
-        //     .map(|rd| {
-        //         rd.filter_map(std::result::Result::ok)
-        //             .filter(|e| {
-        //                 e.path()
-        //                     .extension()
-        //                     .is_some_and(|ext| ext.eq_ignore_ascii_case("pak"))
-        //             })
-        //             .map(|e| e.path())
-        //             .collect()
-        //     })
-        //     .unwrap_or_default();
-        // assert!(
-        //     orphans.is_empty(),
-        //     "commit_archive failure left orphan .pak file(s): {orphans:?}"
-        // );
+        let result = engine.archive(&policy).await;
+        assert!(
+            result.is_err(),
+            "archive must propagate the commit failure, got {result:?}"
+        );
+
+        // The archive directory must contain no orphan `.pak` file (CWE-459).
+        let archive_dir = dir.path().join("archives");
+        let orphans: Vec<_> = std::fs::read_dir(&archive_dir)
+            .map(|rd| {
+                rd.filter_map(std::result::Result::ok)
+                    .filter(|e| {
+                        e.path()
+                            .extension()
+                            .is_some_and(|ext| ext.eq_ignore_ascii_case("pak"))
+                    })
+                    .map(|e| e.path())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            orphans.is_empty(),
+            "commit_archive failure left orphan .pak file(s): {orphans:?}"
+        );
     }
 }

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -4640,10 +4640,6 @@ async fn builder_wires_search_config() {
 }
 
 #[tokio::test]
-#[ignore = "#727: the #543-regression assertion is disabled — needs a #[cfg(test)] \
-            StorageBackend raw-conn seam to insert a revision-1 event through an empty \
-            upcaster registry; ignored so its green status does not imply the guard is live"]
-#[allow(clippy::significant_drop_tightening)]
 async fn builder_threads_upcaster_registry_in_memory() {
     // Regression for #543: `.upcaster_registry(custom).build()` with NO `.path()`
     // must HONOR the custom registry. Before the fix, `build()`'s in-memory branch
@@ -4665,33 +4661,34 @@ async fn builder_threads_upcaster_registry_in_memory() {
         .build()
         .unwrap();
 
-    // Insert an event stamped at revision 1 using an *empty* registry, bypassing
-    // the engine's ingest (which would stamp at the engine registry's latest).
-    //
-    // TODO(#631-test): raw SQL needs a port escape. This site requires inserting an
-    // event through an EventStore built with an *empty* upcaster registry (revision 1)
-    // to exercise replay-time upcasting. `StorageBackend::insert_event` necessarily
-    // uses the backend's own (engine) registry, which would stamp at revision 2 and
-    // defeat the test premise. No object-safe raw-connection escape exists on
-    // `Arc<dyn StorageBackend>`. Body disabled pending a test-only raw-conn port.
-    /*
-    {
-        let conn = engine.pool.write();
-        let empty = crate::store::upcaster::UpcasterRegistry::new();
-        let store = crate::store::events::EventStore::new(&conn, &empty);
-        let event = NewEvent {
+    // Ingest an Interaction event (the threaded registry stamps it at its latest
+    // revision = 2), then downgrade its stored revision to 1 via the test-only
+    // `raw_exec` seam (#727) so replay must upcast it back through the engine's
+    // 1->2 upcaster. If the custom registry had been dropped (the #543 bug), the
+    // engine's empty registry would stamp at revision 1, the UPDATE would be a
+    // no-op, and replay would leave `upcasted` absent.
+    let id = engine
+        .ingest(&NewEvent {
             timestamp: chrono::Utc::now(),
             event_type: EventType::Interaction,
-            payload: serde_json::json!({"msg": "hello"}),
+            payload: serde_json::json!({ "msg": "hello" }),
             source: "test".into(),
             session_id: Some("s1".into()),
             scope_id: 1,
             origin_node_id: "local".into(),
             sequence_id: 0,
             created_at: None,
-        };
-        store.insert(&event).unwrap();
-    }
+        })
+        .await
+        .unwrap();
+
+    engine
+        .storage()
+        .raw_exec(&format!(
+            "UPDATE events SET event_revision = 1 WHERE id = {id}"
+        ))
+        .await
+        .unwrap();
 
     let filter = crate::inspect::ReplayFilter {
         upcast: true,
@@ -4707,8 +4704,6 @@ async fn builder_threads_upcaster_registry_in_memory() {
         "custom upcaster_registry must be honored in-memory and applied on replay"
     );
     assert_eq!(events[0].event_revision, 2, "payload upcast to revision 2");
-    */
-    let _ = &engine;
 }
 
 #[tokio::test]

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -155,4 +155,23 @@ pub trait SchemaManager: Send + Sync {
     /// if an identity is recorded and `candidate` differs from it, or
     /// [`MemoryError::Storage`](crate::error::MemoryError::Storage) on a backend failure.
     async fn check_embedding_compatible(&self, candidate: &EmbeddingFingerprint) -> Result<()>;
+
+    /// Execute a raw SQL statement or batch against the backend — no parameter
+    /// binding, no result. A **test-only** escape hatch (#727) for failure
+    /// injection and fixture setup the typed port cannot express: e.g.
+    /// `DROP TABLE archive_manifest` to force a commit failure (the CWE-459
+    /// orphan-`.pak` cleanup guard), or an `UPDATE` that downgrades an event's
+    /// stored revision to exercise replay-time upcasting (#543).
+    ///
+    /// Gated to `cfg(test)` / the `test-util` feature so it never reaches the
+    /// public API. The #632 conformance suite requires every backend to provide
+    /// it (in its own SQL dialect) so the failure-injection tests can run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Storage`](crate::error::MemoryError::Storage) on a
+    /// SQL or backend failure, or [`MemoryError::ReadOnly`](crate::error::MemoryError::ReadOnly)
+    /// on a read-only backend.
+    #[cfg(any(test, feature = "test-util"))]
+    async fn raw_exec(&self, sql: &str) -> Result<()>;
 }

--- a/src/storage/sqlite/schema.rs
+++ b/src/storage/sqlite/schema.rs
@@ -224,6 +224,16 @@ impl SchemaManager for SqliteBackend {
         self.block_read(move |c| embedding_meta::check_compatible(c, &candidate))
             .await
     }
+
+    // TEST-ONLY raw SQL escape (#727) — `execute_batch` on the write connection, so
+    // a read-only pool rejects it with `MemoryError::ReadOnly` and a driver error
+    // is mapped to `Storage(Backend)` by the seam.
+    #[cfg(any(test, feature = "test-util"))]
+    async fn raw_exec(&self, sql: &str) -> Result<()> {
+        let sql = sql.to_owned();
+        self.block_write(move |c| c.execute_batch(&sql).map_err(Into::into))
+            .await
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #727 (coverage regression from the #631 cutover).

The cutover removed the engine's direct `write_conn()`/pool access, so 3 tests that injected failures or bypassed the registry via a raw connection were left `#[ignore]`d (their green status no longer implied a live guard).

## Seam
A `#[cfg(any(test, feature = "test-util"))]`, object-safe `SchemaManager::raw_exec(&self, sql)` — callable through `Arc<dyn StorageBackend>`; `SqliteBackend` execs on the **write** connection (read-only pool → `ReadOnly`), driver errors map to `Storage(Backend)`. The `test-util` feature lets the future #632 conformance suite exercise it on every backend; a release build confirms it never leaks to the public API.

## Re-enabled
- `archive_cleans_up_pak_when_commit_fails` — `DROP TABLE archive_manifest` forces `commit_archive` to fail after the `.pak` is written → asserts error propagation **+ CWE-459 orphan-`.pak` cleanup`** (the highest-value gap).
- `builder_threads_upcaster_registry_in_memory` (#543) — ingest an Interaction event, `UPDATE` its revision to 1 via `raw_exec`, then replay-upcast; fails if the custom registry is dropped.

## Site 3
`builder_wires_search_config` keeps `build()`-success coverage (no public getter post-cutover); a raw seam adds nothing.

Diverse-lens internal review (seam object-safety/leak + test-validity): **0 findings**. Full gate green; rebased on latest main + re-gated.