### PR TITLE
refactor(core)!: purify ResumeConfig::Default + drop kb_stubs placeholder (#254 wave4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ src/
   conflict/           # Bi-temporal conflict resolution
   pool/               # ConnectionPool (N readers + 1 writer)
   scope/              # Hierarchical scope tree
-  resume/             # 5-tier cognitive boot (pinned → importance → due → recent → kb_stubs)
+  resume/             # 4-tier cognitive boot (pinned → importance → due → recent)
   bootstrap/          # Claude Code JSONL session import
   inspect/            # Debugging APIs (explain, replay, dump, restore, statistics)
   async_engine.rs     # AsyncMemoryEngine (tokio, feature-gated)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -48,7 +48,7 @@ Source lives in `src/`. Each module owns its domain:
 - `conflict/` — Bi-temporal conflict resolution via `ConflictArbiter` trait.
 - `pool/` — `ConnectionPool`: N readers + 1 writer, `parking_lot::Mutex`.
 - `scope/` — `ScopeTree` hierarchical cache. Paths like `"user:michael/project:demo"`.
-- `resume/` — 5-tier cognitive boot: pinned → high_importance → due → recent → kb_stubs.
+- `resume/` — 4-tier cognitive boot: pinned → high_importance → due → recent.
 - `bootstrap/` — Parse Claude Code JSONL session logs into historical facts.
 - `inspect/` — Debugging APIs: `explain_fact`, `fact_history`, `replay_events`, `dump_state`, `statistics`.
 - `async_engine.rs` — `AsyncMemoryEngine` via `tokio::spawn_blocking` (feature-gated).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fn main() -> Result<(), MemoryError> {
 - **Trait-based extensibility** — `EmbeddingProvider`, `SummaryGenerator`, `ConflictArbiter`, `PersistenceClassifier`, `Reranker`
 - **Hierarchical scoping** — isolate facts by context (e.g., `"user:alice/project:demo"`)
 - **Pinned facts** — exempt critical facts from decay and deduplication
-- **5-tier resume** — `resume_context()` bootstraps agent sessions with graduated detail levels
+- **4-tier resume** — `resume_context()` bootstraps agent sessions with graduated detail levels
 - **Introspection** — `explain_fact()`, `replay_events()`, `statistics()`, import/export (JSON + SQLite, gzip/zstd compression)
 - **MCP server** — `memory-engine-mcp` crate exposes engine operations as MCP tools
 - **CLI inspector** — `memory-engine-cli` for terminal-based inspection and debugging

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -90,7 +90,7 @@ The crate is organized into modules with clear responsibilities:
 | `search/`          | Query layer. FTS5 (BM25), vector (cosine similarity, brute-force or HNSW via `ann` feature), strategy dispatch, and hybrid (RRF) search.                                                                                                                                                     |
 | `graph/`           | `MemoryGraph` wrapper around `petgraph::DiGraph`. Loaded from SQLite on startup, kept in sync on mutations.                                                                                                                                                                                  |
 | `scope/`           | `ScopeTree` for hierarchical isolation. In-memory tree structure, backed by `ScopeStore` in SQLite.                                                                                                                                                                                          |
-| `resume/`          | Session bootstrapping. `MemoryEngine::resume_context()` (an `async` engine method) implements 5-tier retrieval (pinned → high_importance → due → recent → kb_stubs).                                                                                                                         |
+| `resume/`          | Session bootstrapping. `MemoryEngine::resume_context()` (an `async` engine method) implements 4-tier retrieval (pinned → high_importance → due → recent).                                                                                                                                     |
 | `consolidation/`   | Three-pass memory compression: local dedup, cluster fusion, global integration.                                                                                                                                                                                                              |
 | `forgetting/`      | Ebbinghaus decay with multi-signal importance scoring.                                                                                                                                                                                                                                       |
 | `engine::conflict` | Bi-temporal conflict resolution (`MemoryEngine::resolve_conflict`) delegated to the consumer `ConflictArbiter`.                                                                                                                                                                              |
@@ -155,7 +155,7 @@ The core data flow follows an event-sourced pattern:
 
 ### Resume Context
 
-Session bootstrapping uses 5-tier retrieval to populate the agent's context window:
+Session bootstrapping uses 4-tier retrieval to populate the agent's context window:
 
 | Tier                | Source          | Selection Criteria                                                           |
 | ------------------- | --------------- | ---------------------------------------------------------------------------- |
@@ -163,9 +163,8 @@ Session bootstrapping uses 5-tier retrieval to populate the agent's context wind
 | **High-importance** | Scope ancestors | Facts with materialized `importance_score` above a configurable threshold.   |
 | **Due**             | Scope ancestors | Future-memory facts whose `t_valid` has arrived (`t_valid <= now`).          |
 | **Recent**          | Scope ancestors | Most recently created facts. Current working context.                        |
-| **KB stubs**        | —               | Placeholder for Phase 5 knowledge-base references.                           |
 
-The five tiers are mutually exclusive (a fact appears in at most one tier). The consumer controls tier sizes and thresholds via `ResumeConfig`.
+The four tiers are mutually exclusive (a fact appears in at most one tier). The consumer controls tier sizes and thresholds via `ResumeConfig`.
 
 ## Prospective Memory
 

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -131,7 +131,7 @@ Scope queries control visibility:
 | **Forget**      | `forget()`                      | Decay and prune low-importance facts (skips pinned) |
 | **Resolve**     | `resolve_conflict()`            | Arbitrate contradicting facts                       |
 | **Schedule**    | `list_due()`, `next_due_time()` | Surface future-memory facts and poll timing         |
-| **Resume**      | `resume_context()`              | 5-tier session bootstrapping                        |
+| **Resume**      | `resume_context()`              | 4-tier session bootstrapping                        |
 
 ## Threading
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -153,25 +153,24 @@ This page summarizes the public API surface of the `memory-engine` crate.
 
 | Method           | Signature                                                 | Description                                                                                                     |
 | ---------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `resume_context` | `(&self, config: &ResumeConfig) -> Result<ResumeContext>` | 5-tier fact retrieval for session bootstrapping. Returns `NotFound` if the requested scope path does not exist. |
+| `resume_context` | `(&self, config: &ResumeConfig) -> Result<ResumeContext>` | 4-tier fact retrieval for session bootstrapping. Returns `NotFound` if the requested scope path does not exist. |
 
 `ResumeConfig` fields:
 
 - `scope_path: Option<String>` -- scope to resume from (ancestors are included).
-- `now: DateTime<Utc>` -- current time for due-fact evaluation.
+- `now: Option<DateTime<Utc>>` -- evaluation instant for due facts. `None` (the default) defers to `resume_context`, which resolves `Utc::now()` once at call time; `Some(_)` pins a specific instant.
 - `pinned_cap: usize` -- max pinned facts (default: 50).
 - `high_importance_cap: usize` -- max high-importance facts (default: 20).
 - `high_importance_min: f64` -- minimum `importance_score` for tier 2 (default: 0.7).
 - `due_cap: usize` -- max due facts (default: 10).
 - `recent_cap: usize` -- max recent facts (default: 10).
 
-`ResumeContext` fields (5 tiers, mutually exclusive):
+`ResumeContext` fields (4 tiers, mutually exclusive):
 
 - `pinned: Vec<Fact>` -- tier 1: unforgettable facts, cross-scope, sorted by `importance_score` descending.
 - `high_importance: Vec<Fact>` -- tier 2: top facts by materialized `importance_score`.
 - `due: Vec<Fact>` -- tier 3: future-memory facts whose `t_valid` has arrived.
 - `recent: Vec<Fact>` -- tier 4: most recent facts from scope ancestors.
-- `kb_stubs: Vec<String>` -- tier 5: placeholder for Phase 5 knowledge-base references.
 
 ### Bootstrap
 

--- a/docs/reference/crate-layout.md
+++ b/docs/reference/crate-layout.md
@@ -18,7 +18,7 @@ memory_engine (lib.rs)
   +-- pool          Connection pool (N readers + 1 writer)
   +-- scope         Hierarchical scope tree cache
   +-- bootstrap     Session log bootstrap pipeline
-  +-- resume        Session bootstrapping (5-tier retrieval)
+  +-- resume        Session bootstrapping (4-tier retrieval)
   +-- inspect       Debugging and observability APIs
 ```
 
@@ -94,13 +94,12 @@ memory_engine (lib.rs)
 : Session log bootstrap pipeline. Parses Claude Code JSONL session logs and imports noteworthy episodes (bug fixes, decisions, conventions, learnings) as historical facts. Sub-modules handle each pipeline stage: `parse` (JSONL deserialization), `filter` (turn reconstruction and keyword pre-filter), `outcome` (heuristic session outcome classification), `extract` (fact extraction via the `SessionExtractor` trait), and `metrics` (configuration, reporting, and prewarm quality metrics). Uses savepoint transactions for crash safety and event-based idempotency to prevent duplicate imports.
 
 `resume`
-: Session bootstrapping via `ResumeConfig` and `ResumeContext`. Implements 5-tier retrieval:
+: Session bootstrapping via `ResumeConfig` and `ResumeContext`. Implements 4-tier retrieval:
 
 1. **Pinned** -- unforgettable facts (`is_pinned = true`), cross-scope, sorted by `importance_score` descending.
 2. **High-importance** -- facts with materialized `importance_score` above a configurable threshold.
 3. **Due** -- future-memory facts whose `t_valid` has arrived (`t_valid <= now`).
 4. **Recent** -- most recent facts from scope ancestors.
-5. **KB stubs** -- placeholder for Phase 5 knowledge-base references.
    Tiers are mutually exclusive (a fact appears in at most one tier).
 
 `inspect`

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -63,7 +63,7 @@ Global summary invariant
 : Global-level summaries (consolidation pass 3) are always placed at `scope_id=1` (root scope), regardless of the scopes of the underlying facts. Cluster-level summaries use majority-vote scope assignment.
 
 Resume context
-: Five-tier fact retrieval for bootstrapping a new agent session. Tier 1 (pinned): unforgettable facts, cross-scope. Tier 2 (high-importance): facts above a materialized `importance_score` threshold. Tier 3 (due): future-memory facts whose `t_valid` has arrived. Tier 4 (recent): most recent facts from scope ancestors. Tier 5 (kb_stubs): placeholder for Phase 5 knowledge-base references. Tiers are mutually exclusive.
+: Four-tier fact retrieval for bootstrapping a new agent session. Tier 1 (pinned): unforgettable facts, cross-scope. Tier 2 (high-importance): facts above a materialized `importance_score` threshold. Tier 3 (due): future-memory facts whose `t_valid` has arrived. Tier 4 (recent): most recent facts from scope ancestors. Tiers are mutually exclusive.
 
 WAL (Write-Ahead Logging)
 : SQLite journaling mode used by the connection pool. Enables concurrent readers while a single writer commits. The engine opens all connections in WAL mode to maximize read throughput without blocking on writes.

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -98,7 +98,7 @@ Add to `.claude/settings.json`:
 | `memory_ingest`              | P0        | Append event to log                    | —                    |
 | `memory_add_fact`            | P0        | Add fact with embedding                | —                    |
 | `memory_query`               | P0        | Hybrid FTS + vector search             | sparse/standard/full |
-| `memory_resume_context`      | P0        | 5-tier cognitive boot                  | sparse/standard/full |
+| `memory_resume_context`      | P0        | 4-tier cognitive boot                  | sparse/standard/full |
 | `memory_list_due`            | P0        | Scheduled fact surfacing               | sparse/standard/full |
 | `memory_next_due_time`       | P0        | Next scheduled time                    | —                    |
 | `memory_explain_fact`        | P0        | Fact provenance                        | sparse/standard/full |

--- a/memory-engine-mcp/src/depth.rs
+++ b/memory-engine-mcp/src/depth.rs
@@ -158,7 +158,6 @@ pub fn shape_resume_context(ctx: &ResumeContext, depth: Depth) -> Value {
         "high_importance": shape_vec(&ctx.high_importance),
         "due": shape_vec(&ctx.due),
         "recent": shape_vec(&ctx.recent),
-        "kb_stubs": ctx.kb_stubs,
     })
 }
 

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -103,7 +103,7 @@ pub fn all_tool_definitions() -> Vec<Tool> {
         ),
         tool_def(
             "memory_resume_context",
-            "Retrieve tiered cognitive boot context (5-tier: pinned → high-importance → due → recent → kb_stubs).",
+            "Retrieve tiered cognitive boot context (4-tier: pinned → high-importance → due → recent).",
             json!({
                 "type": "object",
                 "properties": {

--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -942,7 +942,7 @@ async fn handle_resume_context(
 
     let config = ResumeConfig {
         scope_path: get_str(args, "scope"),
-        now: Utc::now(),
+        now: Some(Utc::now()),
         pinned_cap: get_usize(args, "pinned_cap").unwrap_or(50),
         high_importance_cap: get_usize(args, "high_importance_cap").unwrap_or(20),
         high_importance_min: get_f64(args, "high_importance_min").unwrap_or(0.7),

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_full.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_full.snap
@@ -5,7 +5,6 @@ expression: body
 ---
 due: []
 high_importance: []
-kb_stubs: []
 pinned:
   - access_count: 0
     content: Critical pinned fact

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_sparse.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_sparse.snap
@@ -5,7 +5,6 @@ expression: body
 ---
 due: []
 high_importance: []
-kb_stubs: []
 pinned:
   - content: Critical pinned fact
     id: 1

--- a/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_standard.snap
+++ b/memory-engine-mcp/tests/snapshots/depth_shaping__resume_context_standard.snap
@@ -5,7 +5,6 @@ expression: body
 ---
 due: []
 high_importance: []
-kb_stubs: []
 pinned:
   - access_count: 0
     content: Critical pinned fact

--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -13,12 +13,11 @@ impl MemoryEngine {
 
     /// Retrieve tiered context for resuming a session.
     ///
-    /// Returns five tiers of facts (mutually exclusive):
+    /// Returns four tiers of facts (mutually exclusive):
     /// 1. **Pinned** — all pinned facts (cross-scope)
     /// 2. **High-importance** — top-N by materialized `importance_score`
     /// 3. **Due** — facts with `t_valid` <= now
     /// 4. **Recent** — most recent, from scope ancestors
-    /// 5. **KB stubs** — placeholder for Phase 5
     ///
     /// # Errors
     ///
@@ -54,7 +53,7 @@ impl MemoryEngine {
             }
         }; // scope_tree read lock dropped here
 
-        // Step 2: Assemble the five tiers via the async storage port. This inlines
+        // Step 2: Assemble the four tiers via the async storage port. This inlines
         // the former `resume::resume_context(conn, ...)` helper — the backend now
         // owns embed_dim, so the per-tier port calls drop it. Control flow, tier
         // ordering, dedup (`seen`), and caps are preserved verbatim.
@@ -92,15 +91,11 @@ impl MemoryEngine {
             .list_facts_by_scopes_recent(&scope_ids, config.recent_cap, &seen)
             .await?;
 
-        // Tier 5: KB stubs (Phase 5 placeholder)
-        let kb_stubs = Vec::new();
-
         let mut ctx = ResumeContext {
             pinned,
             high_importance,
             due,
             recent,
-            kb_stubs,
         };
 
         // Step 3: Stamp surfaced_at on ALL due facts across ALL tiers (#93).

--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use chrono::Utc;
+
 use crate::error::{MemoryError, Result};
 use crate::resume::context::{ResumeConfig, ResumeContext};
 use crate::types::Fact;
@@ -28,6 +30,12 @@ impl MemoryEngine {
         // acquiring the scope_tree lock or touching the DB (#359). The internal
         // tier walk below trusts its already-validated input.
         config.validate()?;
+
+        // Resolve the evaluation instant ONCE, before the tier walk. `ResumeConfig`
+        // defaults `now` to `None` (a pure `Default`); the wall-clock fallback lives
+        // here so every tier read below — due-fact filtering, the bi-temporal
+        // surfaced_at predicate, and the stamp — sees a single, consistent `now`.
+        let now = config.now.unwrap_or_else(Utc::now);
 
         // Step 1: Resolve scope IDs from cache (short-lived read lock).
         // The scope_tree guard is taken and dropped entirely within this block —
@@ -70,7 +78,7 @@ impl MemoryEngine {
         seen.extend(high_importance.iter().map(|f| f.id));
 
         // Tier 3: Due facts (future memory now surfacing)
-        let due_all = self.storage.list_due_facts(config.now, &scope_ids).await?;
+        let due_all = self.storage.list_due_facts(now, &scope_ids).await?;
         let due: Vec<Fact> = due_all
             .into_iter()
             .filter(|f| !seen.contains(&f.id))
@@ -101,8 +109,8 @@ impl MemoryEngine {
         // Must use write_conn — read connections have query_only = ON.
         let is_unsurfaced_due = |f: &Fact| -> bool {
             f.surfaced_at.is_none()
-                && f.t_valid.is_some_and(|tv| tv <= config.now)
-                && f.t_invalid.is_none_or(|ti| ti > config.now)
+                && f.t_valid.is_some_and(|tv| tv <= now)
+                && f.t_invalid.is_none_or(|ti| ti > now)
         };
         let unsurfaced_ids: Vec<i64> = ctx
             .pinned
@@ -115,9 +123,7 @@ impl MemoryEngine {
             .collect();
 
         if !unsurfaced_ids.is_empty() {
-            let stamped = self
-                .stamp_surfaced_facts(&unsurfaced_ids, config.now)
-                .await?;
+            let stamped = self.stamp_surfaced_facts(&unsurfaced_ids, now).await?;
             apply_surfaced_stamps(
                 ctx.pinned
                     .iter_mut()

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -1454,6 +1454,17 @@ async fn resume_rejects_invalid_config() {
     assert!(matches!(err, MemoryError::Conflict(_)), "got {err:?}");
 }
 
+// --- Issue #279: ResumeConfig::default() is pure (no wall-clock capture) ---
+
+/// `ResumeConfig::default()` must not capture `Utc::now()` at construction — the
+/// `now` field defaults to `None`, and the engine resolves the wall-clock instant
+/// once at call time. This makes `Default` deterministic and stops stored configs
+/// from operating on a stale timestamp.
+#[test]
+fn resume_config_default_now_is_none() {
+    assert_eq!(ResumeConfig::default().now, None);
+}
+
 // --- Issue #93: surfaced_at for due facts in non-due tiers ---
 
 #[tokio::test]
@@ -1487,7 +1498,7 @@ async fn resume_stamps_surfaced_at_on_pinned_due_fact() {
         .unwrap();
 
     let config = ResumeConfig {
-        now,
+        now: Some(now),
         ..ResumeConfig::default()
     };
     let ctx = engine.resume_context(&config).await.unwrap();
@@ -1535,7 +1546,7 @@ async fn resume_stamps_surfaced_at_on_high_importance_due_fact() {
         .unwrap();
 
     let config = ResumeConfig {
-        now,
+        now: Some(now),
         high_importance_min: 0.7,
         ..ResumeConfig::default()
     };
@@ -1585,7 +1596,7 @@ async fn resume_does_not_stamp_invalidated_pinned_due_fact() {
         .unwrap();
 
     let config = ResumeConfig {
-        now,
+        now: Some(now),
         ..ResumeConfig::default()
     };
     let ctx = engine.resume_context(&config).await.unwrap();
@@ -1643,7 +1654,7 @@ async fn resume_surfaced_at_is_idempotent() {
 
     let ctx1 = engine
         .resume_context(&ResumeConfig {
-            now,
+            now: Some(now),
             ..ResumeConfig::default()
         })
         .await
@@ -1656,7 +1667,7 @@ async fn resume_surfaced_at_is_idempotent() {
     // Second call at a strictly later `now`. surfaced_at must be unchanged.
     let ctx2 = engine
         .resume_context(&ResumeConfig {
-            now: later,
+            now: Some(later),
             ..ResumeConfig::default()
         })
         .await

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -44,7 +44,7 @@ impl ResumeConfig {
     /// Validate configuration parameters.
     ///
     /// `high_importance_min` is a materialized-score threshold that flows
-    /// directly into [`FactStore::list_by_importance_score`]'s `min_score`
+    /// directly into `FactStore::list_by_importance_score`'s `min_score`
     /// comparison; it must be finite and within `[0.0, 1.0]` — a value like
     /// `2.0` would silently yield an empty high-importance tier with no
     /// diagnostic. The four tier caps must each be non-zero, since a `0` cap

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -101,6 +101,4 @@ pub struct ResumeContext {
     pub due: Vec<Fact>,
     /// Most recent facts from active scopes.
     pub recent: Vec<Fact>,
-    /// Placeholder: KB reference URIs for Phase 5.
-    pub kb_stubs: Vec<String>,
 }

--- a/src/resume/context.rs
+++ b/src/resume/context.rs
@@ -8,8 +8,12 @@ use crate::types::Fact;
 pub struct ResumeConfig {
     /// Scope path to resume from. None = root only.
     pub scope_path: Option<String>,
-    /// Current time for due-fact evaluation.
-    pub now: DateTime<Utc>,
+    /// Current time for due-fact evaluation. `None` (the [`Default`]) defers
+    /// resolution to [`MemoryEngine::resume_context`](crate::MemoryEngine::resume_context),
+    /// which resolves it once to `Utc::now()` at call time — keeping the `Default`
+    /// impl pure (no wall-clock capture at construction). Set `Some(_)` to pin a
+    /// specific evaluation instant (e.g. for deterministic tests or replay).
+    pub now: Option<DateTime<Utc>>,
     /// Max pinned facts. Default: 50.
     pub pinned_cap: usize,
     /// Max high-importance facts (by materialized score). Default: 20.
@@ -26,7 +30,7 @@ impl Default for ResumeConfig {
     fn default() -> Self {
         Self {
             scope_path: None,
-            now: Utc::now(),
+            now: None,
             pinned_cap: 50,
             high_importance_cap: 20,
             high_importance_min: 0.7,

--- a/src/resume/mod.rs
+++ b/src/resume/mod.rs
@@ -1,5 +1,5 @@
-//! Session bootstrapping: 5-tier context retrieval (pinned, high-importance,
-//! due, scope-filtered recent, KB stubs).
+//! Session bootstrapping: 4-tier context retrieval (pinned, high-importance,
+//! due, scope-filtered recent).
 
 pub mod context;
 

--- a/tests/phase3b_lifecycle_test.rs
+++ b/tests/phase3b_lifecycle_test.rs
@@ -105,7 +105,7 @@ async fn full_lifecycle_pinned_and_future_memory() {
     // 4. resume_context at current time — future fact should NOT appear in due tier
     let ctx = engine
         .resume_context(&ResumeConfig {
-            now,
+            now: Some(now),
             ..Default::default()
         })
         .await
@@ -294,7 +294,7 @@ async fn resume_context_5_tier_integration() {
         .unwrap();
 
     let config = ResumeConfig {
-        now,
+        now: Some(now),
         ..ResumeConfig::default()
     };
     let ctx = engine.resume_context(&config).await.unwrap();

--- a/tests/phase3b_lifecycle_test.rs
+++ b/tests/phase3b_lifecycle_test.rs
@@ -230,7 +230,7 @@ async fn classifier_auto_pins_semantic_facts() {
 }
 
 #[tokio::test]
-async fn resume_context_5_tier_integration() {
+async fn resume_context_4_tier_integration() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: Arc<dyn EmbeddingProvider> = Arc::new(TestEmbedder);
     let now = Utc::now();
@@ -302,10 +302,6 @@ async fn resume_context_5_tier_integration() {
     assert_eq!(ctx.pinned.len(), 1, "should have 1 pinned fact");
     assert_eq!(ctx.due.len(), 1, "should have 1 due fact");
     assert!(!ctx.recent.is_empty(), "should have recent facts");
-    assert!(
-        ctx.kb_stubs.is_empty(),
-        "kb_stubs placeholder should be empty"
-    );
 
     // Verify mutual exclusivity — no fact ID appears in multiple tiers
     let all_ids: Vec<i64> = ctx


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 4, post-#631). Closes 2 findings.

## Findings closed
- **#279** [refactor] — `ResumeConfig::Default` captured `Utc::now()` (impure, stale-prone). `now` is now `Option<DateTime<Utc>>` (default `None`), resolved once at the top of the async `MemoryEngine::resume_context` so all tier reads see one consistent timestamp.
- **#358** [refactor] — removed the always-empty `kb_stubs` placeholder field from `ResumeContext` (dead since Phase-2; Phase-5 landed without it). Updated the MCP depth shaping, regenerated the 3 insta snapshots, and the integration assertion.

## ⚠ Breaking
Public **serde-shape change**: `ResumeContext` no longer emits `kb_stubs`; `ResumeConfig.now` field type changed (`Option`). Pre-1.0; MCP/CLI consumers updated in-tree.

## Review (internal diverse-lens subagents)
3 lenses (correctness / api-surface & consumers / test-quality & docs): **0 blocker, 0 major**. Nits: fixed a pre-existing broken intra-doc link in `validate()`; out-of-scope doc nits filed as #739; ROADMAP left per the frozen-doc convention.

## Gate
`cargo build/test/clippy --workspace --all-features` + `cargo fmt --check` — green (main @ 0e55cd2).

Fixes #279, fixes #358
