### PR TITLE
refactor(core)!: Send+Sync on InsightStream + de-stale (Phase 2) trait docs (#254 wave4)

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -294,7 +294,13 @@ pub trait Reranker: Send + Sync {
 /// typically just writing to a buffer or database.
 ///
 /// Passed as `&dyn InsightStream` per-call (not stored in the engine).
-pub trait InsightStream {
+///
+/// Requires `Send + Sync` for consistency with the other consumer traits
+/// (#386): although `record` is invoked synchronously and the trait object is
+/// never sent across an `.await`, carrying the same bound as every sibling
+/// provider keeps the consumer-facing API surface uniform — a downstream
+/// `Arc<dyn InsightStream>` behaves like every other `Arc<dyn …Provider>`.
+pub trait InsightStream: Send + Sync {
     /// Record a high-value insight.
     ///
     /// # Errors

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -96,9 +96,9 @@ pub trait EmbeddingProvider: Send + Sync {
     fn fingerprint(&self) -> EmbeddingFingerprint;
 }
 
-// --- Phase 2 placeholder traits and types ---
+// --- Phase 2: Consolidation traits and types (summary, conflict arbitration) ---
 
-/// Trait for generating a textual summary from a set of related items (Phase 2).
+/// Trait for generating a textual summary from a set of related items.
 ///
 /// Used by consolidation: the cluster-fusion pass summarizes related *facts*, and
 /// the global-integration pass summarizes the resulting *cluster summaries* — both
@@ -183,7 +183,7 @@ pub trait DeltaProposer: Send + Sync {
     fn propose(&self, window: &[Fact], prior_wisdom: &[Fact]) -> Result<ConsolidationProposal>;
 }
 
-/// Trait for arbitrating conflicts between contradicting facts (Phase 2).
+/// Trait for arbitrating conflicts between contradicting facts.
 ///
 /// Requires `Send + Sync`: arbiters are shared across the engine's worker
 /// threads alongside the other consumer providers.
@@ -244,7 +244,7 @@ pub trait PersistenceClassifier: Send + Sync {
 
 // --- Phase 4a: Reranker ---
 
-/// Trait for reranking search results after initial retrieval (Phase 4a).
+/// Trait for reranking search results after initial retrieval.
 ///
 /// Cross-encoder rerankers score (query, candidate) pairs precisely,
 /// improving nDCG@10 by 5-15% on top-K candidates after RRF merge.
@@ -363,7 +363,7 @@ pub trait DreamCycle: Send + Sync {
     ) -> Result<crate::engine::cycle::CycleReport>;
 }
 
-/// Configuration for the consolidation process (Phase 2).
+/// Configuration for the consolidation process.
 ///
 /// `#[non_exhaustive]` (#344): construct it from outside the crate via
 /// [`ConsolidationConfig::builder`] or [`ConsolidationConfig::default`], not a
@@ -495,7 +495,7 @@ impl ConsolidationConfigBuilder {
     }
 }
 
-/// Statistics returned by consolidation (Phase 2).
+/// Statistics returned by consolidation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConsolidationStats {
     pub duplicates_removed: usize,
@@ -503,14 +503,14 @@ pub struct ConsolidationStats {
     pub global_summaries: usize,
 }
 
-/// Statistics returned by the forget/prune operation (Phase 2).
+/// Statistics returned by the forget/prune operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PruneStats {
     pub facts_expired: usize,
     pub facts_evaluated: usize,
 }
 
-/// Result of a conflict resolution (Phase 2).
+/// Result of a conflict resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConflictResolution {
     pub decision: CrudDecision,


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 4, post-#631). Closes 2 findings.

## Findings closed
- **#122** [docs] — replaced stale `(Phase 2)` labels on completed/in-use traits & types (`SummaryGenerator`, `ConflictArbiter`, `ConsolidationConfig`, et al.) with accurate descriptions; left section dividers + genuinely-pending markers.
- **#386** [refactor] — added `Send + Sync` to `InsightStream` (the #631 cutover already added it to the other 5 consumer traits; this was the one-line residual).

## ⚠ Breaking (provably harmless)
`InsightStream: Send + Sync` is technically a supertrait tightening. In-workspace the sole impl (`RecordingStream`) is already `Send + Sync` and no external crate references the trait; object-safety (`&dyn InsightStream`) is unaffected. Recorded for the changelog/semver bump.

## Review (internal diverse-lens subagents)
3 lenses: **0 blocker, 0 major** (only the breaking-change note above).

## Gate
`cargo build/test/clippy --workspace --all-features` + `cargo fmt --check` — green.

Fixes #122, fixes #386
