### PR TITLE
refactor(core)!: should_pin takes owned ClassifierInput, not synthetic Fact (#254 wave4)

### DIFF
--- a/src/bootstrap/memory_dir.rs
+++ b/src/bootstrap/memory_dir.rs
@@ -31,7 +31,7 @@ use rusqlite::Connection;
 use crate::error::Result;
 use crate::store::facts::FactStore;
 use crate::traits::{EmbeddingProvider, PersistenceClassifier};
-use crate::types::{FactType, NewFact};
+use crate::types::{ClassifierInput, FactType, NewFact};
 
 use super::BootstrapConfig;
 use super::metrics::BootstrapReport;
@@ -359,28 +359,17 @@ fn import_one_memory(
         redactions += redact::redact_json_strings(&mut metadata, &config.denylist);
     }
 
+    // Classifiers read only content/fact_type/importance/metadata — build the
+    // owned `ClassifierInput` view, not a 20-field synthetic `Fact` cloning the
+    // embedding (#118/#343/#388).
     let is_pinned = classifier.is_some_and(|c| {
-        let temp = crate::types::Fact {
-            id: 0,
+        let input = ClassifierInput {
             content: content.clone(),
-            content_hash: String::new(),
-            embedding: embedding.clone(),
             fact_type,
-            t_created: timestamp,
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
             importance: MEMORY_IMPORTANCE,
-            access_count: 0,
-            last_accessed: timestamp,
             metadata: metadata.clone(),
-            scope_id,
-            is_pinned: false,
-            importance_score: MEMORY_IMPORTANCE,
-            surfaced_at: None,
         };
-        c.should_pin(&temp)
+        c.should_pin(&input)
     });
 
     // Bi-temporal note (#521): t_created backdated to the file's date/mtime;

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -22,7 +22,7 @@ use crate::store::events::{EventFilter, EventStore};
 use crate::store::facts::FactStore;
 use crate::store::upcaster::UpcasterRegistry;
 use crate::traits::{EmbeddingProvider, PersistenceClassifier};
-use crate::types::{EventType, FactType, NewEvent, NewFact};
+use crate::types::{ClassifierInput, EventType, FactType, NewEvent, NewFact};
 
 pub use extract::{ExtractedFact, KeywordExtractor, SessionExtractor};
 pub use filter::{CandidateEpisode, ConversationTurn, EpisodeCategory, ToolCallRecord};
@@ -246,28 +246,17 @@ fn store_extracted_fact(
 
     let embedding = ctx.embedder.embed(&content)?;
 
+    // Classifiers read only content/fact_type/importance/metadata — build the
+    // owned `ClassifierInput` view, not a 20-field synthetic `Fact` cloning the
+    // embedding (#118/#343/#388).
     let is_pinned = ctx.classifier.is_some_and(|c| {
-        let temp = crate::types::Fact {
-            id: 0,
+        let input = ClassifierInput {
             content: content.clone(),
-            content_hash: String::new(),
-            embedding: embedding.clone(),
             fact_type: fact.fact_type,
-            t_created: effective_created,
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: Some(marker_event_id),
             importance: fact.importance,
-            access_count: 0,
-            last_accessed: effective_created,
             metadata: metadata.clone(),
-            scope_id: ctx.scope_id,
-            is_pinned: false,
-            importance_score: fact.importance,
-            surfaced_at: None,
         };
-        c.should_pin(&temp)
+        c.should_pin(&input)
     });
 
     // Bi-temporal note (#521): t_created is backdated to the historical turn

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 
 use crate::error::{ConflictError, MemoryError, Result};
 use crate::limits::{check_json_size, check_str_size};
 use crate::traits::{EmbeddingProvider, PersistenceClassifier};
-use crate::types::{AddFactRequest, EmbeddingFingerprint, Fact, NewEvent, NewFact};
+use crate::types::{AddFactRequest, ClassifierInput, EmbeddingFingerprint, NewEvent, NewFact};
 
 use super::{MemoryEngine, spawn_join_err};
 
@@ -144,36 +144,26 @@ impl MemoryEngine {
         let effective_last_accessed = opts.last_accessed.unwrap_or(now);
 
         // Classify off the async executor (a classifier may be a blocking LLM/HTTP
-        // call). scope_id=0 placeholder; classifiers rely on content/type/importance/metadata.
+        // call). Classifiers read only content/fact_type/importance/metadata.
         let is_pinned = match opts.pinned {
             Some(p) => p,
             None => match classifier {
                 None => false,
                 Some(c) => {
-                    let temp = Fact {
-                        id: 0,
+                    // Only the four classifier-authorised fields (no embedding
+                    // clone, no 20-field synthetic Fact — #118/#343/#388). Owned
+                    // so it moves into the blocking task that runs the (possibly
+                    // blocking) classifier off the async executor.
+                    let input = ClassifierInput {
                         content: req.content.clone(),
-                        content_hash: String::new(),
-                        embedding: embedding.clone(),
                         fact_type: req.fact_type,
-                        t_created: effective_created,
-                        t_expired: None,
-                        t_valid: opts.t_valid,
-                        t_invalid: opts.t_invalid,
-                        source_event_id: req.source_event_id,
                         importance: base_importance,
-                        access_count: 0,
-                        last_accessed: effective_last_accessed,
                         metadata: opts
                             .metadata
                             .clone()
                             .unwrap_or_else(|| serde_json::json!({})),
-                        scope_id: 0,
-                        is_pinned: false,
-                        importance_score: base_importance,
-                        surfaced_at: None,
                     };
-                    tokio::task::spawn_blocking(move || c.should_pin(&temp))
+                    tokio::task::spawn_blocking(move || c.should_pin(&input))
                         .await
                         .map_err(spawn_join_err)?
                 }
@@ -383,9 +373,7 @@ impl MemoryEngine {
 
         // --- Phase 2: Classify + prepare (auto-pin off the executor) ---
         let now = Utc::now();
-        let pins = self
-            .compute_batch_pins(entries, &embeddings, classifier, now)
-            .await?;
+        let pins = self.compute_batch_pins(entries, classifier).await?;
 
         // --- Phase 3: build NewFacts (+ scope paths) for the atomic batch insert ---
         // `scope_id` here is a placeholder; `insert_facts_batch_atomic` resolves
@@ -449,45 +437,30 @@ impl MemoryEngine {
     async fn compute_batch_pins(
         &self,
         entries: &[&AddFactRequest],
-        embeddings: &[Vec<f32>],
         classifier: Option<Arc<dyn PersistenceClassifier>>,
-        now: DateTime<Utc>,
     ) -> Result<Vec<bool>> {
         // Resolve the slots that need no classification inline (caller-`pinned` set,
-        // or no classifier → `false`); collect the temp facts that DO need it into
-        // `pending` so the whole subset is classified in ONE blocking task instead of
+        // or no classifier → `false`); collect a `ClassifierInput` for each entry that
+        // DOES need it into `pending` so the whole subset is classified in ONE blocking task instead of
         // one task per entry (a batch of up to MAX_BATCH_SIZE = 10k would otherwise
         // spawn 10k). A `None` slot consumes the next `pending` result, in order.
         let mut slots: Vec<Option<bool>> = Vec::with_capacity(entries.len());
-        let mut pending: Vec<Fact> = Vec::new();
-        for (entry, embedding) in entries.iter().zip(embeddings) {
+        let mut pending: Vec<ClassifierInput> = Vec::new();
+        for entry in entries {
             let opts = entry.opts.clone().unwrap_or_default();
             slots.push(match opts.pinned {
                 Some(p) => Some(p),
                 None if classifier.is_some() => {
-                    let base_importance = opts.importance.unwrap_or(0.5);
-                    pending.push(Fact {
-                        id: 0,
+                    // Only the four classifier-authorised fields — no embedding
+                    // clone, no synthetic Fact (#118/#343/#388).
+                    pending.push(ClassifierInput {
                         content: entry.content.clone(),
-                        content_hash: String::new(),
-                        embedding: embedding.clone(),
                         fact_type: entry.fact_type,
-                        t_created: opts.t_created.unwrap_or(now),
-                        t_expired: None,
-                        t_valid: opts.t_valid,
-                        t_invalid: opts.t_invalid,
-                        source_event_id: entry.source_event_id,
-                        importance: base_importance,
-                        access_count: 0,
-                        last_accessed: opts.last_accessed.unwrap_or(now),
+                        importance: opts.importance.unwrap_or(0.5),
                         metadata: opts
                             .metadata
                             .clone()
                             .unwrap_or_else(|| serde_json::json!({})),
-                        scope_id: 0,
-                        is_pinned: false,
-                        importance_score: base_importance,
-                        surfaced_at: None,
                     });
                     None
                 }
@@ -500,7 +473,7 @@ impl MemoryEngine {
             Some(c) if !pending.is_empty() => tokio::task::spawn_blocking(move || {
                 pending
                     .iter()
-                    .map(|f| c.should_pin(f))
+                    .map(|input| c.should_pin(input))
                     .collect::<Vec<bool>>()
             })
             .await

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -4180,6 +4180,98 @@ async fn add_facts_batch_with_classifier() {
     assert!(fact.is_pinned);
 }
 
+/// Multi-entry batch with a *discriminating* classifier, interleaving
+/// classifier-decided slots (`opts.pinned == None`) with caller-pinned slots
+/// (`Some(true)`/`Some(false)`).
+///
+/// This is the regression guard for the `compute_batch_pins` slot/pending
+/// stitching (`src/engine/ingest.rs`): each `None` slot must consume the *next*
+/// classifier result IN ORDER, and the `ClassifierInput` built per entry must
+/// carry *that* entry's own `fact_type`/`content` — not a neighbour's. A
+/// single-entry batch with a constant classifier (see the test above) cannot
+/// detect a mis-alignment: with one slot and one pending result, any ordering
+/// bug is invisible. Here the classifier verdict depends on `fact_type`
+/// (`Semantic` → pin, `Episodic` → no pin), and the `None`/`Some` slots are
+/// interleaved so an off-by-one in the stitch flips an observable `is_pinned`.
+#[tokio::test]
+async fn add_facts_batch_classifier_interleaved_slots_align() {
+    /// Pins iff the fact is `Semantic` — proves the per-entry `ClassifierInput`
+    /// carries the right `fact_type` (and that results map to the right slot).
+    struct PinSemantic;
+    impl PersistenceClassifier for PinSemantic {
+        fn should_pin(&self, input: &ClassifierInput) -> bool {
+            input.fact_type == FactType::Semantic
+        }
+    }
+
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let embedder: std::sync::Arc<dyn EmbeddingProvider> =
+        std::sync::Arc::new(MockEmbedder { dim: DIM });
+
+    // The classifier-decided slots (None) are deliberately NON-palindromic in
+    // their verdicts (slots 0/2/4 → pin/skip/skip), so a mis-ordered stitch
+    // (e.g. results applied in reverse) flips an observable `is_pinned` rather
+    // than merely shuffling equal values.
+    //
+    // (content, fact_type, opts.pinned, expected is_pinned)
+    //   slot 0: Semantic,  None       → classifier pins  → true
+    //   slot 1: Episodic,  Some(true) → caller override  → true  (classifier would say false)
+    //   slot 2: Episodic,  None       → classifier skips → false
+    //   slot 3: Semantic,  Some(false)→ caller override  → false (classifier would say true)
+    //   slot 4: Episodic,  None       → classifier skips → false
+    let cases: [(&str, FactType, Option<bool>, bool); 5] = [
+        ("auto-semantic-pinned", FactType::Semantic, None, true),
+        ("caller-pin-episodic", FactType::Episodic, Some(true), true),
+        ("auto-episodic-a", FactType::Episodic, None, false),
+        (
+            "caller-unpin-semantic",
+            FactType::Semantic,
+            Some(false),
+            false,
+        ),
+        ("auto-episodic-b", FactType::Episodic, None, false),
+    ];
+
+    let entries: Vec<AddFactRequest> = cases
+        .iter()
+        .map(|(content, fact_type, pinned, _)| AddFactRequest {
+            content: (*content).into(),
+            fact_type: *fact_type,
+            source_event_id: None,
+            scope: None,
+            opts: pinned.map(|p| AddFactOptions {
+                pinned: Some(p),
+                ..Default::default()
+            }),
+        })
+        .collect();
+
+    let ids = engine
+        .add_facts_batch(
+            &entries,
+            embedder.clone(),
+            Some(std::sync::Arc::new(PinSemantic) as std::sync::Arc<dyn PersistenceClassifier>),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ids.len(), cases.len());
+
+    for (id, (content, _, _, expected_pinned)) in ids.iter().zip(cases.iter()) {
+        let fact = engine.get_fact(*id).await.unwrap();
+        // The id-order must mirror the entry order, so each fact's content
+        // confirms we are asserting against the matching slot.
+        assert_eq!(
+            fact.content, *content,
+            "fact ids must preserve batch entry order"
+        );
+        assert_eq!(
+            fact.is_pinned, *expected_pinned,
+            "slot for {content:?} got is_pinned={} (expected {expected_pinned})",
+            fact.is_pinned
+        );
+    }
+}
+
 #[tokio::test]
 async fn add_facts_batch_rejects_embedding_count_mismatch() {
     /// Embedder that returns fewer embeddings than requested.

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -7,8 +7,8 @@ use crate::traits::{
     PersistenceClassifier, SummarizableContent, SummaryGenerator,
 };
 use crate::types::{
-    AddFactOptions, AddFactRequest, EmbeddingFingerprint, EventType, Fact, FactType, NewEvent,
-    NewFact,
+    AddFactOptions, AddFactRequest, ClassifierInput, EmbeddingFingerprint, EventType, Fact,
+    FactType, NewEvent, NewFact,
 };
 
 const DIM: usize = 4;
@@ -2057,8 +2057,8 @@ async fn add_fact_with_explicit_pin() {
 async fn add_fact_with_classifier() {
     struct PinSemantic;
     impl PersistenceClassifier for PinSemantic {
-        fn should_pin(&self, fact: &Fact) -> bool {
-            fact.fact_type == FactType::Semantic
+        fn should_pin(&self, input: &ClassifierInput) -> bool {
+            input.fact_type == FactType::Semantic
         }
     }
 
@@ -2104,7 +2104,7 @@ async fn add_fact_with_classifier() {
 async fn explicit_pin_overrides_classifier() {
     struct AlwaysPin;
     impl PersistenceClassifier for AlwaysPin {
-        fn should_pin(&self, _fact: &Fact) -> bool {
+        fn should_pin(&self, _input: &ClassifierInput) -> bool {
             true
         }
     }
@@ -4150,7 +4150,7 @@ async fn add_facts_batch_with_scopes() {
 async fn add_facts_batch_with_classifier() {
     struct AlwaysPin;
     impl PersistenceClassifier for AlwaysPin {
-        fn should_pin(&self, _fact: &Fact) -> bool {
+        fn should_pin(&self, _input: &ClassifierInput) -> bool {
             true
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub use traits::{
 // a representative subset, and `cargo build --workspace --all-features` proves
 // the whole list still satisfies every downstream consumer.
 pub use types::{
-    Activity, ActivityStatus, AddFactOptions, AddFactRequest, ConsolidationLevel,
+    Activity, ActivityStatus, AddFactOptions, AddFactRequest, ClassifierInput, ConsolidationLevel,
     ConsolidationProposal, DreamCycleConfig, Edge, EmbeddingFingerprint, Event, EventFilter,
     EventType, Fact, FactId, FactScoringRow, FactType, Insight, LineageId, LineageRecord,
     LineageSnapshotEntry, MergeGroup, NewActivity, NewEdge, NewEvent, NewFact, NewFactBuilder,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::error::Result;
 use crate::search::hybrid::SearchResult;
-use crate::types::{ConsolidationProposal, EmbeddingFingerprint, Fact};
+use crate::types::{ClassifierInput, ConsolidationProposal, EmbeddingFingerprint, Fact};
 
 // --- Phase 1: Embedding provider (fully used) ---
 
@@ -225,19 +225,21 @@ pub enum CrudDecision {
 ///
 /// Default implementation returns `false` — opt-in, zero behavior change.
 ///
-/// **Classifier input caveat:** The `Fact` passed to `should_pin()` during
-/// `add_fact()` is a pre-insert synthetic with `id=0`, `scope_id=0`,
-/// `importance_score` seeded from base `importance`, and no graph connectivity.
-/// Classifiers should only rely on `content`, `fact_type`, `importance`
-/// (caller hint), and `metadata` — not on `id`, `scope_id`,
-/// `importance_score`, or `access_count`.
+/// **Classifier input:** `should_pin` receives a [`ClassifierInput`] — an owned
+/// view of the *only* four fields a classifier is authorised to read at
+/// classification time: `content`, `fact_type`, `importance` (the caller hint),
+/// and `metadata`. The fact is pre-insert, so its `id`, `scope_id`,
+/// `importance_score`, graph connectivity, and timestamps are either unassigned
+/// or off-limits and are deliberately **not** exposed. This replaced an earlier
+/// `&Fact` signature whose callers built a 20-field synthetic `Fact` (cloning the
+/// embedding) purely to satisfy the parameter type (#118/#343/#388).
 ///
 /// Requires `Send + Sync`: classifiers are shared across the engine's worker
 /// threads alongside the other consumer providers.
 pub trait PersistenceClassifier: Send + Sync {
     /// Decide if a fact should be pinned (never forgotten).
-    fn should_pin(&self, fact: &Fact) -> bool {
-        let _ = fact;
+    fn should_pin(&self, input: &ClassifierInput) -> bool {
+        let _ = input;
         false
     }
 }
@@ -644,28 +646,13 @@ impl ForgetPolicy {
 mod tests {
     use super::*;
     use crate::types::FactType;
-    use chrono::Utc;
 
-    fn stub_fact() -> Fact {
-        Fact {
-            id: 0,
+    fn stub_classifier_input() -> ClassifierInput {
+        ClassifierInput {
             content: String::new(),
-            content_hash: String::new(),
-            embedding: vec![],
             fact_type: FactType::Semantic,
-            t_created: Utc::now(),
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
             importance: 0.5,
-            access_count: 0,
-            last_accessed: Utc::now(),
             metadata: serde_json::Value::Null,
-            scope_id: 0,
-            is_pinned: false,
-            importance_score: 0.5,
-            surfaced_at: None,
         }
     }
 
@@ -1076,7 +1063,7 @@ mod tests {
         impl PersistenceClassifier for Dummy {}
         let p: &dyn PersistenceClassifier = &Dummy;
         // Default impl returns false
-        assert!(!p.should_pin(&stub_fact()));
+        assert!(!p.should_pin(&stub_classifier_input()));
     }
 
     #[test]
@@ -1241,6 +1228,6 @@ mod tests {
     fn persistence_classifier_default_returns_false() {
         struct Blank;
         impl PersistenceClassifier for Blank {}
-        assert!(!Blank.should_pin(&stub_fact()));
+        assert!(!Blank.should_pin(&stub_classifier_input()));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -490,6 +490,39 @@ impl NewFact {
     }
 }
 
+/// The owned view a classifier receives at classification time.
+///
+/// Passed to [`PersistenceClassifier::should_pin`](crate::traits::PersistenceClassifier::should_pin),
+/// it carries the *only* fields a classifier is authorised to read: `content`,
+/// `fact_type`, `importance`, and `metadata`.
+///
+/// It deliberately carries **no** `embedding`, `id`, `scope_id`,
+/// `importance_score`, or timestamps: those are either not yet assigned at
+/// classification time (the fact is pre-insert) or off-limits per the trait
+/// contract. Dropping the embedding alone eliminates a per-fact `Vec<f32>` clone
+/// of 384–1536 dimensions (≈1.5–6 KB) that the previous synthetic-`Fact` shim
+/// cloned purely to satisfy the `&Fact` parameter (#388); collapsing the 20-field
+/// shim to these four removes the duplicated literal at every classify site
+/// (#118) and the confusion over which fields matter (#343).
+///
+/// Owned (not a borrowing view) so it can be moved into the
+/// `tokio::task::spawn_blocking` closure that runs a possibly-blocking classifier
+/// off the async executor without borrowing engine-local temporaries across the
+/// `move`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClassifierInput {
+    /// The fact's text content (post-redaction, as it will be stored).
+    pub content: String,
+    /// The fact's type tag.
+    pub fact_type: FactType,
+    /// The consumer-supplied base importance prior (the `add_fact` caller hint),
+    /// a finite value normally in `[0.0, 1.0]`. Mirrors [`Fact::importance`] /
+    /// [`NewFact::importance`], **not** the decayed `importance_score`.
+    pub importance: f64,
+    /// The fact's metadata object (post-redaction).
+    pub metadata: serde_json::Value,
+}
+
 /// Fluent builder for [`NewFact`], mirroring the ergonomics of
 /// [`MemoryEngineBuilder`](crate::MemoryEngineBuilder).
 ///

--- a/tests/bootstrap_dryrun.rs
+++ b/tests/bootstrap_dryrun.rs
@@ -22,8 +22,8 @@ use std::sync::{Arc, Mutex};
 use chrono::{DateTime, Datelike, Utc};
 use memory_engine::traits::PersistenceClassifier;
 use memory_engine::{
-    BootstrapConfig, EmbeddingFingerprint, EmbeddingProvider, Fact, KeywordExtractor, MemoryEngine,
-    MemoryError, SessionExtractor,
+    BootstrapConfig, ClassifierInput, EmbeddingFingerprint, EmbeddingProvider, Fact,
+    KeywordExtractor, MemoryEngine, MemoryError, SessionExtractor,
 };
 
 /// Zero-vector embedder (dim 4) — retrieval is irrelevant to this audit.
@@ -37,18 +37,26 @@ impl EmbeddingProvider for TestEmbedder {
     }
 }
 
-/// Records `(content, t_created)` for every fact the engine offers for pinning,
-/// i.e. every bootstrapped fact — with its (backdated) `t_created` intact.
+/// Records `(content, session_id)` for every fact the engine offers for pinning,
+/// i.e. every bootstrapped fact. The classifier sees only the four authorised
+/// fields (`ClassifierInput` — no `t_created`); the per-session discriminator is
+/// the `session_id` the `KeywordExtractor` stamps into each fact's `metadata`,
+/// which is sufficient to confirm the pre-dedup view spans distinct sessions.
+/// (The authoritative `t_created` backdating check is on the stored rows below.)
 #[derive(Default)]
 struct RecordingClassifier {
-    seen: Mutex<Vec<(String, DateTime<Utc>)>>,
+    seen: Mutex<Vec<(String, String)>>,
 }
 impl PersistenceClassifier for RecordingClassifier {
-    fn should_pin(&self, fact: &Fact) -> bool {
+    fn should_pin(&self, input: &ClassifierInput) -> bool {
+        let session_id = input.metadata["session_id"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
         self.seen
             .lock()
             .unwrap()
-            .push((fact.content.clone(), fact.t_created));
+            .push((input.content.clone(), session_id));
         false
     }
 }
@@ -221,9 +229,9 @@ async fn dryrun_yield_backdate_idempotency_dedup_reinforce() {
         total_reinforced += report.facts_reinforced;
     }
     println!("TOTAL facts (first pass) = {total_facts}");
-    for (content, t) in recorder.seen.lock().unwrap().iter() {
+    for (content, session_id) in recorder.seen.lock().unwrap().iter() {
         let snippet: String = content.chars().take(90).collect();
-        println!("  fact t_created={t} content={snippet:?}");
+        println!("  fact session_id={session_id} content={snippet:?}");
     }
     // Deterministic yield with dedup-with-reinforcement: sessions 1–4 → 1 created fact
     // each (4); session 5 → its bug turn is created (1) while its convention turn (identical
@@ -274,33 +282,29 @@ async fn dryrun_yield_backdate_idempotency_dedup_reinforce() {
         "skipped sessions must create no facts"
     );
 
-    // --- Backdating: every t_created is the historical session time (2024/2025),
-    //     never Utc::now() (2026+). ---
+    // --- Pre-dedup view: snapshot the recorder's captured facts once into an owned Vec.
     //
-    // Snapshot the recorder's captured facts once into an owned Vec; the
-    // `std::sync::MutexGuard` is released on this line, so nothing holds a thread-affine
-    // guard across the later engine `.await` calls (the engine API is async now). The
-    // owned clone stays in scope for the cross-session dedup checks below.
-    let seen: Vec<(String, DateTime<Utc>)> = recorder.seen.lock().unwrap().clone();
+    // Snapshot the recorder's captured `(content, session_id)` pairs once into an
+    // owned Vec; the `std::sync::MutexGuard` is released on this line, so nothing
+    // holds a thread-affine guard across the later engine `.await` calls (the
+    // engine API is async now). The owned clone stays in scope for the
+    // cross-session dedup checks below. (Backdating of `t_created` is no longer
+    // observable from the classifier — `ClassifierInput` carries only the four
+    // authorised fields — but it is asserted authoritatively on the stored rows
+    // further down.)
+    let seen: Vec<(String, String)> = recorder.seen.lock().unwrap().clone();
     assert!(!seen.is_empty(), "recorder should have captured facts");
-    let now = Utc::now();
-    for (content, t) in &seen {
-        assert!(
-            t.year() < now.year(),
-            "t_created not backdated (year >= current) ({t}) for {content:?}"
-        );
-        assert!(t < &now, "t_created must be historical, got {t}");
-    }
 
     // --- Cross-session dedup-with-reinforcement (#520): the IDENTICAL convention sentence
     //     appears verbatim in sessions 3 and 5. The classifier runs BEFORE the dedup
     //     decision, so it is offered both occurrences across two distinct backdated
-    //     sessions — that is the pre-dedup view, not the stored view. ---
+    //     sessions — that is the pre-dedup view, not the stored view. The per-fact
+    //     `session_id` (stamped into metadata by the extractor) discriminates them. ---
     let classifier_copies = seen.iter().filter(|(c, _)| c.contains(SHARED)).count();
-    let classifier_sessions: std::collections::BTreeSet<i64> = seen
+    let classifier_sessions: std::collections::BTreeSet<&str> = seen
         .iter()
         .filter(|(c, _)| c.contains(SHARED))
-        .map(|(_, t)| t.timestamp())
+        .map(|(_, sid)| sid.as_str())
         .collect();
     println!(
         "shared convention: classifier saw {classifier_copies} copies across {} distinct sessions",

--- a/tests/bootstrap_test.rs
+++ b/tests/bootstrap_test.rs
@@ -498,18 +498,18 @@ async fn bootstrap_pins_facts_when_classifier_returns_true() {
     // coverage existed only for should_pin == false (the dryrun recorder), so the
     // is_pinned == true PROPAGATION into a stored bootstrap row was untested.
     // Drive both poles and assert the stored flag follows the classifier.
-    use memory_engine::Fact;
+    use memory_engine::ClassifierInput;
     use memory_engine::traits::PersistenceClassifier;
 
     struct AlwaysPin;
     impl PersistenceClassifier for AlwaysPin {
-        fn should_pin(&self, _fact: &Fact) -> bool {
+        fn should_pin(&self, _input: &ClassifierInput) -> bool {
             true
         }
     }
     struct NeverPin;
     impl PersistenceClassifier for NeverPin {
-        fn should_pin(&self, _fact: &Fact) -> bool {
+        fn should_pin(&self, _input: &ClassifierInput) -> bool {
             false
         }
     }

--- a/tests/eval/helpers.rs
+++ b/tests/eval/helpers.rs
@@ -11,7 +11,7 @@ use memory_engine::traits::{
     ConflictArbiter, CrudDecision, EmbeddingProvider, ForgetPolicy, PersistenceClassifier,
     SummarizableContent, SummaryGenerator,
 };
-use memory_engine::types::{AddFactOptions, AddFactRequest, Fact, FactType};
+use memory_engine::types::{AddFactOptions, AddFactRequest, ClassifierInput, Fact, FactType};
 
 use crate::corpus::CorpusDefinition;
 
@@ -91,8 +91,8 @@ pub struct PinByType {
 }
 
 impl PersistenceClassifier for PinByType {
-    fn should_pin(&self, fact: &Fact) -> bool {
-        fact.fact_type == self.pinned_type
+    fn should_pin(&self, input: &ClassifierInput) -> bool {
+        input.fact_type == self.pinned_type
     }
 }
 

--- a/tests/phase3b_lifecycle_test.rs
+++ b/tests/phase3b_lifecycle_test.rs
@@ -10,7 +10,7 @@ use memory_engine::ResumeConfig;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
 use memory_engine::traits::{EmbeddingProvider, ForgetPolicy, PersistenceClassifier};
-use memory_engine::types::{AddFactOptions, AddFactRequest, Fact, FactType};
+use memory_engine::types::{AddFactOptions, AddFactRequest, ClassifierInput, FactType};
 
 const DIM: usize = 8;
 
@@ -164,8 +164,8 @@ async fn full_lifecycle_pinned_and_future_memory() {
 async fn classifier_auto_pins_semantic_facts() {
     struct PinSemantic;
     impl PersistenceClassifier for PinSemantic {
-        fn should_pin(&self, fact: &Fact) -> bool {
-            fact.fact_type == FactType::Semantic
+        fn should_pin(&self, input: &ClassifierInput) -> bool {
+            input.fact_type == FactType::Semantic
         }
     }
 


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 4, post-#631). Consolidates **one cluster** — #118, #343, #388 all describe the same antipattern.

## Findings closed (one cluster)
- **#118** (synthetic `Fact{id:0,…}` duplicated across sites), **#343** (full-struct scratch-pad to call `should_pin`), **#388** (embedding cloned per fact just to satisfy `should_pin`).

## Change
Introduced an owned `ClassifierInput { content, fact_type, importance, metadata }` (exactly the 4 fields the `PersistenceClassifier` doc authorizes a classifier to read — **no embedding**, which eliminates #388's clone). Changed `should_pin(&Fact)` → `should_pin(&ClassifierInput)`. Migrated all **4** construction sites (engine single-add + batch `compute_batch_pins`, bootstrap mod + memory_dir) and all test impls. Owned (not borrowed) per the post-#631 `spawn_blocking(move ||)` constraint.

## ⚠ Breaking
Public trait signature change (`should_pin` param type). Pre-1.0; no `PersistenceClassifier` impls exist in CLI/MCP/embed, so no consumer-crate changes.

## Review (internal diverse-lens subagents)
3 lenses: correctness clean; **1 major** (test-quality) — the batch path's only test was a single-entry/always-true tautology → **fixed** with a 5-entry discriminating + interleaved caller-pinned test, **verified by mutation testing** (reversing the slot/pending stitch makes it fail). 0 deferred.

## Gate
`cargo build/test/clippy --workspace --all-targets --all-features -D warnings` + `cargo fmt --check` — green (main @ 5c02133).

Fixes #118, fixes #343, fixes #388
