### PR TITLE
refactor(core)!: push resume-tier SQL LIMIT/exclude into StorageBackend + shared due-predicate (#254 wave4)

### DIFF
--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -292,8 +292,10 @@ impl MemoryEngine {
     /// window `[last_dream_cycle_at, now)`.
     async fn build_cycle_context(&self) -> Result<CycleContext<'_>> {
         let now = Utc::now();
-        // Prior wisdom = active pinned facts (port read).
-        let prior_wisdom = self.storage.list_pinned_facts(&[]).await?;
+        // Prior wisdom = ALL active pinned facts (port read). The dream cycle
+        // genuinely wants the full pinned set as prior wisdom, so it passes
+        // `usize::MAX` (no cap) — the #395 cap is a resume-tier concern only.
+        let prior_wisdom = self.storage.list_pinned_facts(&[], usize::MAX).await?;
         // Watermark: the default window start.
         let start = match self.storage.get_config("last_dream_cycle_at").await? {
             Some(s) => DateTime::parse_from_rfc3339(&s)

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -295,7 +295,7 @@ impl MemoryEngine {
         // Prior wisdom = ALL active pinned facts (port read). The dream cycle
         // genuinely wants the full pinned set as prior wisdom, so it passes
         // `usize::MAX` (no cap) — the #395 cap is a resume-tier concern only.
-        let prior_wisdom = self.storage.list_pinned_facts(&[], usize::MAX).await?;
+        let prior_wisdom = self.storage.list_pinned_facts(&[], None).await?;
         // Watermark: the default window start.
         let start = match self.storage.get_config("last_dream_cycle_at").await? {
             Some(s) => DateTime::parse_from_rfc3339(&s)

--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -80,13 +80,17 @@ impl MemoryEngine {
             .await?;
         seen.extend(high_importance.iter().map(|f| f.id));
 
-        // Tier 3: Due facts (future memory now surfacing)
-        let due_all = self.storage.list_due_facts(now, &scope_ids).await?;
-        let due: Vec<Fact> = due_all
-            .into_iter()
-            .filter(|f| !seen.contains(&f.id))
-            .take(config.due_cap)
-            .collect();
+        // Tier 3: Due facts (future memory now surfacing). The exclude(seen) set
+        // and the cap are pushed to SQL (#396) — the DB no longer materializes (and
+        // decodes the embedding BLOB of) every due fact only to drop the already-seen
+        // ones and truncate to `due_cap` in Rust. json_each exclusion is
+        // order-independent, and `ORDER BY t_valid ASC LIMIT` yields the identical
+        // set the old `.filter(!seen).take(due_cap)` produced.
+        let exclude: Vec<i64> = seen.iter().copied().collect();
+        let due = self
+            .storage
+            .list_due_facts(now, &scope_ids, &exclude, Some(config.due_cap))
+            .await?;
         seen.extend(due.iter().map(|f| f.id));
 
         // Tier 4: Scope-filtered recent

--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -64,7 +64,7 @@ impl MemoryEngine {
         // of pinned facts beyond `pinned_cap` only to discard them in Rust.
         let pinned = self
             .storage
-            .list_pinned_facts(&[], config.pinned_cap)
+            .list_pinned_facts(&[], Some(config.pinned_cap))
             .await?;
         seen.extend(pinned.iter().map(|f| f.id));
 

--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -100,13 +100,14 @@ impl MemoryEngine {
 
         // Step 3: Stamp surfaced_at on ALL due facts across ALL tiers (#93).
         // A fact is "due" if t_valid <= now AND not bi-temporally invalidated,
-        // regardless of which tier claimed it. Matches FactStore::list_due() predicate.
+        // regardless of which tier claimed it. The valid-time test is the shared
+        // `Fact::is_temporally_due` predicate (#477) — the single source of truth
+        // the SQL `list_due` and `explain`'s FactState::Due both mirror, so they
+        // cannot silently drift. Here we additionally require the fact to be
+        // *unsurfaced* (the surfacing concern stays at the call site).
         // Must use write_conn — read connections have query_only = ON.
-        let is_unsurfaced_due = |f: &Fact| -> bool {
-            f.surfaced_at.is_none()
-                && f.t_valid.is_some_and(|tv| tv <= now)
-                && f.t_invalid.is_none_or(|ti| ti > now)
-        };
+        let is_unsurfaced_due =
+            |f: &Fact| -> bool { f.surfaced_at.is_none() && f.is_temporally_due(now) };
         let unsurfaced_ids: Vec<i64> = ctx
             .pinned
             .iter()

--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -59,9 +59,13 @@ impl MemoryEngine {
         // ordering, dedup (`seen`), and caps are preserved verbatim.
         let mut seen: HashSet<i64> = HashSet::new();
 
-        // Tier 1: Pinned facts (always present, cross-scope)
-        let pinned_all = self.storage.list_pinned_facts(&[]).await?;
-        let pinned: Vec<Fact> = pinned_all.into_iter().take(config.pinned_cap).collect();
+        // Tier 1: Pinned facts (always present, cross-scope). The cap is pushed to
+        // SQL (#395) — the DB no longer transmits/deserializes the embedding BLOBs
+        // of pinned facts beyond `pinned_cap` only to discard them in Rust.
+        let pinned = self
+            .storage
+            .list_pinned_facts(&[], config.pinned_cap)
+            .await?;
         seen.extend(pinned.iter().map(|f| f.id));
 
         // Tier 2: High-importance by materialized score

--- a/src/engine/scheduling.rs
+++ b/src/engine/scheduling.rs
@@ -20,7 +20,12 @@ impl MemoryEngine {
     /// surfaced-at stamping fails.
     pub async fn list_due(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>> {
         let scope_ids = self.resolve_scope_ids(scope)?;
-        let mut facts = self.storage.list_due_facts(now, &scope_ids).await?;
+        // Scheduling contract: ALL due facts, uncapped and unfiltered (#396 made
+        // the exclude/limit params optional precisely so this path stays uncapped).
+        let mut facts = self
+            .storage
+            .list_due_facts(now, &scope_ids, &[], None)
+            .await?;
 
         // Stamp surfaced_at for newly-surfaced facts
         let unsurfaced_ids: Vec<i64> = facts

--- a/src/inspect/explain.rs
+++ b/src/inspect/explain.rs
@@ -108,14 +108,17 @@ pub(crate) fn determine_state(fact: &Fact, now: DateTime<Utc>) -> FactState {
     if fact.is_pinned {
         return FactState::Pinned;
     }
-    if let Some(t_valid) = fact.t_valid {
-        let not_yet_invalid = fact.t_invalid.is_none_or(|t_inv| t_inv > now);
-        if t_valid <= now && not_yet_invalid {
-            return FactState::Due {
-                t_valid,
-                surfaced_at: fact.surfaced_at,
-            };
-        }
+    // Shared valid-time predicate (#477): same `Fact::is_temporally_due` the resume
+    // walk and the SQL `list_due` use, so the classifier cannot drift from them.
+    // (The earlier `t_invalid <= now` early-return already split off Invalidated, so
+    // reaching here with `is_temporally_due` true means a genuinely-due active fact.)
+    if let Some(t_valid) = fact.t_valid
+        && fact.is_temporally_due(now)
+    {
+        return FactState::Due {
+            t_valid,
+            surfaced_at: fact.surfaced_at,
+        };
     }
     FactState::Active
 }

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -119,9 +119,12 @@ pub trait FactGraph: Send + Sync {
     ) -> Result<Vec<Fact>>;
     /// List active pinned facts, ordered by `importance_score` DESC, capped at
     /// `limit` (pushed to the backend so embedding BLOBs past the cap are never
-    /// materialized — #395). Pass `usize::MAX` for `limit` to retrieve all pinned
-    /// facts. `scope_ids` empty = **all scopes** (see the trait-level contract).
-    async fn list_pinned_facts(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Fact>>;
+    /// materialized — #395). `None` retrieves all pinned facts — consistent with
+    /// [`list_due_facts`](Self::list_due_facts) and
+    /// [`list_active_facts`](Self::list_active_facts). `scope_ids` empty = **all
+    /// scopes** (see the trait-level contract).
+    async fn list_pinned_facts(&self, scope_ids: &[i64], limit: Option<usize>)
+    -> Result<Vec<Fact>>;
     /// List active facts "due now" (`t_valid <= now`, not bi-temporally
     /// invalidated), ordered by `t_valid` ASC. `exclude` is an id set removed in
     /// the backend (empty = no exclusion); `limit` caps the result in the backend

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -122,7 +122,19 @@ pub trait FactGraph: Send + Sync {
     /// materialized — #395). Pass `usize::MAX` for `limit` to retrieve all pinned
     /// facts. `scope_ids` empty = **all scopes** (see the trait-level contract).
     async fn list_pinned_facts(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Fact>>;
-    async fn list_due_facts(&self, now: DateTime<Utc>, scope_ids: &[i64]) -> Result<Vec<Fact>>;
+    /// List active facts "due now" (`t_valid <= now`, not bi-temporally
+    /// invalidated), ordered by `t_valid` ASC. `exclude` is an id set removed in
+    /// the backend (empty = no exclusion); `limit` caps the result in the backend
+    /// (`None` = uncapped, the scheduling contract). Pushing both down (#396)
+    /// avoids materializing and decoding embedding BLOBs the caller would discard.
+    /// `scope_ids` empty = **all scopes** (see the trait-level contract).
+    async fn list_due_facts(
+        &self,
+        now: DateTime<Utc>,
+        scope_ids: &[i64],
+        exclude: &[i64],
+        limit: Option<usize>,
+    ) -> Result<Vec<Fact>>;
     async fn next_due_time(
         &self,
         now: DateTime<Utc>,

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -117,7 +117,11 @@ pub trait FactGraph: Send + Sync {
         limit: usize,
         exclude: &HashSet<i64>,
     ) -> Result<Vec<Fact>>;
-    async fn list_pinned_facts(&self, scope_ids: &[i64]) -> Result<Vec<Fact>>;
+    /// List active pinned facts, ordered by `importance_score` DESC, capped at
+    /// `limit` (pushed to the backend so embedding BLOBs past the cap are never
+    /// materialized — #395). Pass `usize::MAX` for `limit` to retrieve all pinned
+    /// facts. `scope_ids` empty = **all scopes** (see the trait-level contract).
+    async fn list_pinned_facts(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Fact>>;
     async fn list_due_facts(&self, now: DateTime<Utc>, scope_ids: &[i64]) -> Result<Vec<Fact>>;
     async fn next_due_time(
         &self,

--- a/src/storage/sqlite/graph.rs
+++ b/src/storage/sqlite/graph.rs
@@ -401,10 +401,15 @@ impl FactGraph for SqliteBackend {
     }
 
     // READ
-    async fn list_pinned_facts(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Fact>> {
+    async fn list_pinned_facts(
+        &self,
+        scope_ids: &[i64],
+        limit: Option<usize>,
+    ) -> Result<Vec<Fact>> {
         let scope_ids = scope_ids.to_vec();
         let dim = self.embed_dim;
-        self.block_read(move |c| FactStore::new(c, dim).list_pinned(&scope_ids, limit))
+        let cap = limit.unwrap_or(usize::MAX);
+        self.block_read(move |c| FactStore::new(c, dim).list_pinned(&scope_ids, cap))
             .await
     }
 
@@ -1189,7 +1194,7 @@ mod tests {
                 .unwrap()
         };
         let be = backend(Arc::clone(&pool));
-        let got = be.list_pinned_facts(&[], usize::MAX).await.unwrap();
+        let got = be.list_pinned_facts(&[], None).await.unwrap();
         // Both should return the same 2 rows (empty = ALL scopes).
         assert_eq!(
             got.len(),
@@ -1201,7 +1206,7 @@ mod tests {
             oracle.iter().map(|f| f.id).collect::<HashSet<_>>(),
         );
         // #395: the limit is honored through the port — a cap of 1 returns 1 row.
-        let capped = be.list_pinned_facts(&[], 1).await.unwrap();
+        let capped = be.list_pinned_facts(&[], Some(1)).await.unwrap();
         assert_eq!(capped.len(), 1, "limit=1 must cap at one pinned fact");
     }
 

--- a/src/storage/sqlite/graph.rs
+++ b/src/storage/sqlite/graph.rs
@@ -311,10 +311,17 @@ impl FactGraph for SqliteBackend {
     }
 
     // READ
-    async fn list_due_facts(&self, now: DateTime<Utc>, scope_ids: &[i64]) -> Result<Vec<Fact>> {
+    async fn list_due_facts(
+        &self,
+        now: DateTime<Utc>,
+        scope_ids: &[i64],
+        exclude: &[i64],
+        limit: Option<usize>,
+    ) -> Result<Vec<Fact>> {
         let scope_ids = scope_ids.to_vec();
+        let exclude = exclude.to_vec();
         let dim = self.embed_dim;
-        self.block_read(move |c| FactStore::new(c, dim).list_due(now, &scope_ids))
+        self.block_read(move |c| FactStore::new(c, dim).list_due(now, &scope_ids, &exclude, limit))
             .await
     }
 
@@ -1145,6 +1152,59 @@ mod tests {
         // #395: the limit is honored through the port — a cap of 1 returns 1 row.
         let capped = be.list_pinned_facts(&[], 1).await.unwrap();
         assert_eq!(capped.len(), 1, "limit=1 must cap at one pinned fact");
+    }
+
+    /// #396: `list_due_facts` honors `exclude` + `limit` through the port, and the
+    /// uncapped scheduling shape (`exclude=[]`, `limit=None`) returns every due
+    /// fact — matching the direct `FactStore` oracle.
+    #[tokio::test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "write guard is intentionally held across the seed block"
+    )]
+    async fn list_due_facts_exclude_and_limit_through_port() {
+        use chrono::TimeDelta;
+
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        let now = Utc::now();
+        let mut seeded_ids = Vec::new();
+        {
+            let conn = pool.write();
+            let store = FactStore::new(&conn, DIM);
+            // Four due facts (ascending t_valid) + one future (never due).
+            for i in 0..4 {
+                let mut f = fact(&format!("due {i}"), [0.1; DIM]);
+                f.t_valid = Some(now - TimeDelta::hours(i64::from(4 - i)));
+                seeded_ids.push(store.insert(&f).unwrap());
+            }
+            let mut future = fact("future", [0.2; DIM]);
+            future.t_valid = Some(now + TimeDelta::hours(1));
+            store.insert(&future).unwrap();
+        }
+        let be = backend(Arc::clone(&pool));
+
+        // Uncapped scheduling shape through the port.
+        let all_due = be.list_due_facts(now, &[], &[], None).await.unwrap();
+        assert_eq!(all_due.len(), 4, "uncapped port returns all due facts");
+
+        // Exclude the earliest, cap at 2 → the next two in t_valid ASC order.
+        let exclude = vec![seeded_ids[0]];
+        let got = be
+            .list_due_facts(now, &[], &exclude, Some(2))
+            .await
+            .unwrap();
+        let got_ids: Vec<i64> = got.iter().map(|f| f.id).collect();
+        let oracle: Vec<i64> = all_due
+            .iter()
+            .filter(|f| f.id != seeded_ids[0])
+            .take(2)
+            .map(|f| f.id)
+            .collect();
+        assert_eq!(got_ids, oracle, "port exclude+limit must match filter+take");
+        assert!(
+            !got_ids.contains(&seeded_ids[0]),
+            "excluded id must not appear"
+        );
     }
 
     /// `scope_ids=[]` on `list_facts_by_scopes_recent` means NO scopes (empty=NONE).

--- a/src/storage/sqlite/graph.rs
+++ b/src/storage/sqlite/graph.rs
@@ -303,10 +303,10 @@ impl FactGraph for SqliteBackend {
     }
 
     // READ
-    async fn list_pinned_facts(&self, scope_ids: &[i64]) -> Result<Vec<Fact>> {
+    async fn list_pinned_facts(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Fact>> {
         let scope_ids = scope_ids.to_vec();
         let dim = self.embed_dim;
-        self.block_read(move |c| FactStore::new(c, dim).list_pinned(&scope_ids))
+        self.block_read(move |c| FactStore::new(c, dim).list_pinned(&scope_ids, limit))
             .await
     }
 
@@ -1126,10 +1126,12 @@ mod tests {
         // Oracle: direct FactStore call with empty slice.
         let oracle: Vec<Fact> = {
             let conn = pool.read().unwrap();
-            FactStore::new(&conn, DIM).list_pinned(&[]).unwrap()
+            FactStore::new(&conn, DIM)
+                .list_pinned(&[], usize::MAX)
+                .unwrap()
         };
         let be = backend(Arc::clone(&pool));
-        let got = be.list_pinned_facts(&[]).await.unwrap();
+        let got = be.list_pinned_facts(&[], usize::MAX).await.unwrap();
         // Both should return the same 2 rows (empty = ALL scopes).
         assert_eq!(
             got.len(),
@@ -1140,6 +1142,9 @@ mod tests {
             got.iter().map(|f| f.id).collect::<HashSet<_>>(),
             oracle.iter().map(|f| f.id).collect::<HashSet<_>>(),
         );
+        // #395: the limit is honored through the port — a cap of 1 returns 1 row.
+        let capped = be.list_pinned_facts(&[], 1).await.unwrap();
+        assert_eq!(capped.len(), 1, "limit=1 must cap at one pinned fact");
     }
 
     /// `scope_ids=[]` on `list_facts_by_scopes_recent` means NO scopes (empty=NONE).

--- a/src/storage/sqlite/graph.rs
+++ b/src/storage/sqlite/graph.rs
@@ -29,6 +29,104 @@ use crate::types::{
     SessionFact,
 };
 
+/// `(fact_ids, scope_ids_to_cache, embeddings)` — the result of the batch-insert
+/// savepoint. `embeddings` is aligned with `fact_ids` (ann only; empty otherwise).
+type BatchInsertResult = (Vec<i64>, Vec<i64>, Vec<Vec<f32>>);
+
+impl SqliteBackend {
+    /// Savepoint body for [`insert_facts_batch_atomic`](FactGraph::insert_facts_batch_atomic):
+    /// stamp identity, resolve scopes, and insert each fact, all-or-nothing.
+    ///
+    /// Takes `facts` **by value** so it can patch `scope_id` in place (no per-fact
+    /// clone in the insert loop) and then move the embeddings out of the consumed
+    /// vec for the caller's post-commit HNSW notify — neither path clones the
+    /// embedding (#391). Under `not(feature = "ann")` the returned embeddings vec
+    /// is empty (the sidecar is absent, so the move is skipped entirely).
+    ///
+    /// # Returns
+    ///
+    /// `(fact_ids, scope_ids_to_cache, embeddings)` — `fact_ids` in `facts` order;
+    /// `scope_ids_to_cache` the deduplicated new scope ids; `embeddings` aligned
+    /// with `fact_ids` (ann only, else empty).
+    fn batch_insert_savepoint(
+        conn: &rusqlite::Connection,
+        facts: Vec<NewFact>,
+        scope_paths: &[Option<String>],
+        fingerprint: &EmbeddingFingerprint,
+        expected_dim: usize,
+        dim: usize,
+    ) -> Result<BatchInsertResult> {
+        // Verbatim body of ingest.rs:397-476: savepoint wrapping stamp +
+        // scope-resolve + per-fact insert.
+        conn.execute_batch("SAVEPOINT batch_insert")?;
+
+        let result: Result<BatchInsertResult> = (|| {
+            // Record the embedding identity on first write (#613), inside the
+            // savepoint so it commits atomically with the batch.
+            crate::store::embedding_meta::record_if_absent(conn, fingerprint, expected_dim)?;
+
+            let scope_store = ScopeStore::new(conn);
+            let store = FactStore::new(conn, dim);
+
+            // Resolve scopes INSIDE the savepoint so they roll back on error.
+            // Deduplicate by path to avoid N redundant DB lookups.
+            let mut scope_cache: std::collections::HashMap<String, i64> =
+                std::collections::HashMap::new();
+            let mut per_entry_scope_ids = Vec::with_capacity(facts.len());
+            for path_opt in scope_paths {
+                let scope_id = match path_opt {
+                    Some(path) => {
+                        if let Some(&cached) = scope_cache.get(path) {
+                            cached
+                        } else {
+                            let id = scope_store.ensure_path(path)?;
+                            scope_cache.insert(path.clone(), id);
+                            id
+                        }
+                    }
+                    None => 1, // root scope
+                };
+                per_entry_scope_ids.push(scope_id);
+            }
+            let scope_ids_to_cache: Vec<i64> = scope_cache.into_values().collect();
+
+            // Patch scope_id in place and insert by reference — no per-fact clone
+            // (the NewFact coming in may have a placeholder; we honor the resolved
+            // scope_id from the savepoint).
+            let mut facts = facts;
+            let mut ids = Vec::with_capacity(facts.len());
+            for (i, fact) in facts.iter_mut().enumerate() {
+                fact.scope_id = per_entry_scope_ids[i];
+                ids.push(store.insert(fact)?);
+            }
+
+            // Move the embeddings out of the now-consumed facts for the post-commit
+            // HNSW notify (ann only; otherwise the sidecar is absent so skip it).
+            #[cfg(feature = "ann")]
+            let embeddings: Vec<Vec<f32>> = facts.into_iter().map(|f| f.embedding).collect();
+            #[cfg(not(feature = "ann"))]
+            let embeddings: Vec<Vec<f32>> = {
+                drop(facts);
+                Vec::new()
+            };
+
+            Ok((ids, scope_ids_to_cache, embeddings))
+        })();
+
+        match result {
+            Ok(triple) => {
+                conn.execute_batch("RELEASE batch_insert")?;
+                Ok(triple)
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK TO batch_insert");
+                let _ = conn.execute_batch("RELEASE batch_insert");
+                Err(e)
+            }
+        }
+    }
+}
+
 #[async_trait]
 impl FactGraph for SqliteBackend {
     // -------------------------------------------------------------------------
@@ -625,78 +723,29 @@ impl FactGraph for SqliteBackend {
         fingerprint: &EmbeddingFingerprint,
         expected_dim: usize,
     ) -> Result<(Vec<i64>, Vec<i64>)> {
-        // Capture embeddings before moving `facts` into the closure.
-        #[cfg(feature = "ann")]
-        let embeddings: Vec<Vec<f32>> = facts.iter().map(|f| f.embedding.clone()).collect();
+        // One owning copy of the batch is unavoidable: the `block_write` closure is
+        // `'static + Send`, so it must own its data and the engine keeps the
+        // borrowed originals. The owned `facts` vec is moved into the helper, which
+        // patches scope_id in place (no per-fact clone inside the insert loop) and
+        // then moves the embeddings out of it (no embedding clone) — #391.
         let facts = facts.to_vec();
         let scope_paths = scope_paths.to_vec();
         let fingerprint = fingerprint.clone();
         let dim = self.embed_dim;
-        let (ids, scope_ids_to_cache) = self
+        // The savepoint helper moves the owned embeddings OUT of `facts` after the
+        // inserts (the post-commit HNSW notify needs them, fired outside the
+        // closure) — moved, not cloned, since `facts` is dropped at the closure's
+        // end anyway (#391). Under `not(ann)` the helper returns them empty.
+        let (ids, scope_ids_to_cache, embeddings) = self
             .block_write(move |conn| {
-                // Verbatim body of ingest.rs:397-476: savepoint wrapping stamp +
-                // scope-resolve + per-fact insert.
-                conn.execute_batch("SAVEPOINT batch_insert")?;
-
-                let result: Result<(Vec<i64>, Vec<i64>)> = (|| {
-                    // Record the embedding identity on first write (#613), inside the
-                    // savepoint so it commits atomically with the batch.
-                    crate::store::embedding_meta::record_if_absent(
-                        conn,
-                        &fingerprint,
-                        expected_dim,
-                    )?;
-
-                    let scope_store = ScopeStore::new(conn);
-                    let store = FactStore::new(conn, dim);
-
-                    // Resolve scopes INSIDE the savepoint so they roll back on error.
-                    // Deduplicate by path to avoid N redundant DB lookups.
-                    let mut scope_cache: std::collections::HashMap<String, i64> =
-                        std::collections::HashMap::new();
-                    let mut per_entry_scope_ids = Vec::with_capacity(facts.len());
-                    for path_opt in &scope_paths {
-                        let scope_id = match path_opt {
-                            Some(path) => {
-                                if let Some(&cached) = scope_cache.get(path) {
-                                    cached
-                                } else {
-                                    let id = scope_store.ensure_path(path)?;
-                                    scope_cache.insert(path.clone(), id);
-                                    id
-                                }
-                            }
-                            None => 1, // root scope
-                        };
-                        per_entry_scope_ids.push(scope_id);
-                    }
-                    let scope_ids_to_cache: Vec<i64> = scope_cache.into_values().collect();
-
-                    let mut ids = Vec::with_capacity(facts.len());
-                    for (i, fact) in facts.iter().enumerate() {
-                        // Patch scope_id from the resolved value (the NewFact coming in
-                        // may have a placeholder 0; in practice the engine already sets it,
-                        // but we honor the resolved scope_id from the savepoint).
-                        let mut f = fact.clone();
-                        f.scope_id = per_entry_scope_ids[i];
-                        let fact_id = store.insert(&f)?;
-                        ids.push(fact_id);
-                    }
-
-                    Ok((ids, scope_ids_to_cache))
-                })();
-
-                match result {
-                    Ok(pair) => {
-                        conn.execute_batch("RELEASE batch_insert")?;
-                        Ok(pair)
-                    }
-                    Err(e) => {
-                        let _ = conn.execute_batch("ROLLBACK TO batch_insert");
-                        let _ = conn.execute_batch("RELEASE batch_insert");
-                        Err(e)
-                    }
-                }
+                Self::batch_insert_savepoint(
+                    conn,
+                    facts,
+                    &scope_paths,
+                    &fingerprint,
+                    expected_dim,
+                    dim,
+                )
             })
             .await?;
         // Post-commit HNSW notifications (mirrors engine/ingest.rs batch path).
@@ -704,6 +753,8 @@ impl FactGraph for SqliteBackend {
         for (id, embedding) in ids.iter().zip(embeddings.iter()) {
             self.hnsw_notify_insert(*id, embedding);
         }
+        #[cfg(not(feature = "ann"))]
+        let _ = embeddings; // unused without the HNSW sidecar
         Ok((ids, scope_ids_to_cache))
     }
 

--- a/src/storage/sqlite/graph.rs
+++ b/src/storage/sqlite/graph.rs
@@ -56,6 +56,18 @@ impl SqliteBackend {
         expected_dim: usize,
         dim: usize,
     ) -> Result<BatchInsertResult> {
+        // Defensive precondition: the insert loop indexes `per_entry_scope_ids`
+        // (built 1:1 from `scope_paths`) by fact position, so the two MUST be the
+        // same length. Reject a mismatch with a typed error rather than panicking
+        // on an out-of-bounds index (or silently dropping facts via a zip).
+        if facts.len() != scope_paths.len() {
+            return Err(crate::error::MemoryError::Internal(format!(
+                "batch insert: facts ({}) and scope_paths ({}) length mismatch",
+                facts.len(),
+                scope_paths.len()
+            )));
+        }
+
         // Verbatim body of ingest.rs:397-476: savepoint wrapping stamp +
         // scope-resolve + per-fact insert.
         conn.execute_batch("SAVEPOINT batch_insert")?;
@@ -1652,6 +1664,23 @@ mod tests {
             let expected_content = ["a", "b", "c"][i];
             assert_eq!(got.content, expected_content);
         }
+    }
+
+    /// Mismatched `facts` / `scope_paths` lengths must return a typed error, not
+    /// panic on an out-of-bounds scope-id index inside the savepoint loop.
+    #[tokio::test]
+    async fn insert_facts_batch_atomic_rejects_length_mismatch() {
+        let be = backend(Arc::new(ConnectionPool::open_memory(DIM).unwrap()));
+        let facts = vec![fact("a", [0.1; DIM]), fact("b", [0.2; DIM])];
+        let paths: Vec<Option<String>> = vec![None]; // one short
+        let err = be
+            .insert_facts_batch_atomic(&facts, &paths, &fp(), DIM)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Internal(ref m) if m.contains("length mismatch")),
+            "expected a length-mismatch Internal error, got {err:?}"
+        );
     }
 
     /// Scope split: a named scope path is resolved inside the savepoint and its id

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -604,29 +604,70 @@ impl<'a> FactStore<'a> {
 
     /// List active, valid facts where `t_valid <= now` and `t_valid IS NOT NULL`.
     /// Excludes facts where `t_invalid <= now` (bi-temporally invalidated).
-    pub fn list_due(&self, now: DateTime<Utc>, scope_ids: &[i64]) -> Result<Vec<Fact>> {
+    ///
+    /// `exclude` is an id set removed in SQL (`id NOT IN (json_each(?))`); pass an
+    /// empty slice for no exclusion. `limit` caps the result in SQL (`LIMIT ?`);
+    /// pass `None` for the uncapped scheduling contract (`MemoryEngine::list_due`
+    /// returns ALL due facts). Pushing both down (#396) keeps the resume Tier-3
+    /// path from materializing — and decoding the embedding BLOB of — every due
+    /// fact only to filter+cap it in Rust, matching `list_by_importance_score`.
+    pub fn list_due(
+        &self,
+        now: DateTime<Utc>,
+        scope_ids: &[i64],
+        exclude: &[i64],
+        limit: Option<usize>,
+    ) -> Result<Vec<Fact>> {
         let now_str = now.to_rfc3339();
         let base = format!(
             "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL AND t_valid IS NOT NULL AND t_valid <= ?1
              AND (t_invalid IS NULL OR t_invalid > ?1)"
         );
-        let sql = if scope_ids.is_empty() {
-            format!("{base} ORDER BY t_valid ASC")
+
+        // Build the dynamic clauses and the matching positional params together so
+        // the `?N` indices stay in lock-step. `?1` is always `now`; subsequent
+        // indices are assigned in append order.
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(now_str)];
+        let mut next_idx = 2;
+
+        let scope_clause = if scope_ids.is_empty() {
+            String::new()
         } else {
             let placeholders: String = scope_ids
                 .iter()
-                .enumerate()
-                .map(|(i, _)| format!("?{}", i + 2))
+                .map(|_| {
+                    let p = format!("?{next_idx}");
+                    next_idx += 1;
+                    p
+                })
                 .collect::<Vec<_>>()
                 .join(",");
-            format!("{base} AND scope_id IN ({placeholders}) ORDER BY t_valid ASC")
+            for id in scope_ids {
+                params.push(Box::new(*id));
+            }
+            format!(" AND scope_id IN ({placeholders})")
         };
+
+        let exclude_clause = if exclude.is_empty() {
+            String::new()
+        } else {
+            let exclude_json = serde_json::to_string(exclude).expect("serialize exclude_ids");
+            let clause = format!(" AND id NOT IN (SELECT value FROM json_each(?{next_idx}))");
+            next_idx += 1;
+            params.push(Box::new(exclude_json));
+            clause
+        };
+
+        let limit_clause = limit.map_or_else(String::new, |n| {
+            let clause = format!(" LIMIT ?{next_idx}");
+            params.push(Box::new(i64::try_from(n).unwrap_or(i64::MAX)));
+            clause
+        });
+
+        let sql =
+            format!("{base}{scope_clause}{exclude_clause} ORDER BY t_valid ASC{limit_clause}");
         let mut stmt = self.conn.prepare(&sql)?;
-        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(now_str)];
-        for id in scope_ids {
-            params.push(Box::new(*id));
-        }
         let dim = self.embed_dim;
         let rows = stmt.query_map(rusqlite::params_from_iter(params), |row| {
             row_to_fact(row, dim)
@@ -2175,9 +2216,60 @@ mod tests {
         fs.insert(&make_fact("regular fact", vec![0.3; DIM]))
             .unwrap();
 
-        let result = fs.list_due(now, &[]).unwrap();
+        let result = fs.list_due(now, &[], &[], None).unwrap();
         assert_eq!(result.len(), 1);
         assert!(result[0].content.contains("past"));
+    }
+
+    /// #396: the SQL `exclude` + `LIMIT` returns the SAME set the old resume Tier-3
+    /// Rust path did — `list_due(now, scope).filter(|f| !seen.contains).take(cap)` —
+    /// and the uncapped scheduling shape (`exclude=[]`, `limit=None`) is unaffected.
+    #[test]
+    fn list_due_exclude_and_limit_match_rust_filter_take() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+        let now = Utc::now();
+
+        // Six due facts, all in the past so all are due; ascending t_valid so the
+        // `ORDER BY t_valid ASC` selection (and thus what LIMIT keeps) is unambiguous.
+        let mut ids = Vec::new();
+        for i in 0..6 {
+            let mut f = make_fact(&format!("due {i}"), vec![0.1; DIM]);
+            f.t_valid = Some(now - TimeDelta::hours(i64::from(6 - i)));
+            ids.push(fs.insert(&f).unwrap());
+        }
+        // One future fact that must never be due.
+        let mut future = make_fact("future", vec![0.2; DIM]);
+        future.t_valid = Some(now + TimeDelta::hours(1));
+        fs.insert(&future).unwrap();
+
+        // Uncapped scheduling shape: ALL six due, none excluded.
+        let all_due = fs.list_due(now, &[], &[], None).unwrap();
+        assert_eq!(all_due.len(), 6, "scheduling shape returns ALL due facts");
+
+        // Exclude the two earliest (the first two in t_valid ASC order) and cap.
+        let seen: std::collections::HashSet<i64> = [ids[0], ids[1]].into_iter().collect();
+        for cap in [0_usize, 1, 2, 4, 99] {
+            // Oracle: the pre-#396 Rust path over the uncapped query.
+            let rust: Vec<i64> = all_due
+                .iter()
+                .filter(|f| !seen.contains(&f.id))
+                .take(cap)
+                .map(|f| f.id)
+                .collect();
+            // SQL pushdown.
+            let exclude: Vec<i64> = seen.iter().copied().collect();
+            let sql: Vec<i64> = fs
+                .list_due(now, &[], &exclude, Some(cap))
+                .unwrap()
+                .iter()
+                .map(|f| f.id)
+                .collect();
+            assert_eq!(
+                sql, rust,
+                "SQL exclude+LIMIT {cap} must equal Rust .filter(!seen).take({cap})"
+            );
+        }
     }
 
     /// #477: the SQL `list_due` predicate and the shared in-Rust
@@ -2228,9 +2320,9 @@ mod tests {
         let expired_id = fs.insert(&expired).unwrap();
         fs.expire(expired_id, now).unwrap();
 
-        // SQL truth set.
+        // SQL truth set (uncapped, unfiltered — the scheduling shape).
         let sql_ids: std::collections::HashSet<i64> = fs
-            .list_due(now, &[])
+            .list_due(now, &[], &[], None)
             .unwrap()
             .into_iter()
             .map(|f| f.id)

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -2139,6 +2139,83 @@ mod tests {
         assert!(result[0].content.contains("past"));
     }
 
+    /// #477: the SQL `list_due` predicate and the shared in-Rust
+    /// `Fact::is_temporally_due` predicate MUST agree on the same active fact
+    /// population, over a corpus with varied `t_valid`/`t_invalid` combinations.
+    /// This pins the two against silent drift (the resume walk and `explain`'s
+    /// `FactState::Due` both route through `is_temporally_due`).
+    #[test]
+    fn list_due_membership_equals_is_temporally_due_predicate() {
+        // Item-before-statements (clippy::items_after_statements): the alias keeps
+        // the `cases` corpus type readable.
+        type Ts = Option<chrono::DateTime<Utc>>;
+
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+        let now = Utc::now();
+        let past = now - TimeDelta::hours(1);
+        let future = now + TimeDelta::hours(1);
+
+        // A corpus spanning every meaningful (t_valid, t_invalid) combination,
+        // including the boundary instants (== now) the predicate hinges on.
+        let cases: &[(&str, Ts, Ts)] = &[
+            ("no_tvalid", None, None), // t_valid None → never due
+            ("no_tvalid_invalidated", None, Some(future)),
+            ("past_tvalid", Some(past), None),     // due
+            ("tvalid_eq_now", Some(now), None),    // due (boundary: t_valid <= now)
+            ("future_tvalid", Some(future), None), // not yet valid
+            ("past_then_invalid_future", Some(past), Some(future)), // due (invalid still ahead)
+            ("past_then_invalid_past", Some(past), Some(past)), // invalidated
+            ("invalid_eq_now", Some(past), Some(now)), // invalidated (boundary: t_invalid > now is false)
+        ];
+
+        let mut active_facts = Vec::new();
+        for (label, t_valid, t_invalid) in cases {
+            let mut f = make_fact(label, vec![0.1; DIM]);
+            f.t_valid = *t_valid;
+            f.t_invalid = *t_invalid;
+            let id = fs.insert(&f).unwrap();
+            active_facts.push(fs.get(id).unwrap());
+        }
+
+        // Also seed an EXPIRED-but-otherwise-due fact: it must NOT appear in
+        // list_due (system-time filter), and is excluded from the predicate oracle
+        // because is_temporally_due deliberately does not test t_expired (its
+        // documented scope — the caller's active-only read owns that).
+        let mut expired = make_fact("expired_due", vec![0.2; DIM]);
+        expired.t_valid = Some(past);
+        let expired_id = fs.insert(&expired).unwrap();
+        fs.expire(expired_id, now).unwrap();
+
+        // SQL truth set.
+        let sql_ids: std::collections::HashSet<i64> = fs
+            .list_due(now, &[])
+            .unwrap()
+            .into_iter()
+            .map(|f| f.id)
+            .collect();
+
+        // Predicate truth set over the ACTIVE corpus only (matches the predicate's
+        // documented scope: valid-time only, system-time liveness owned by caller).
+        let pred_ids: std::collections::HashSet<i64> = active_facts
+            .iter()
+            .filter(|f| f.is_temporally_due(now))
+            .map(|f| f.id)
+            .collect();
+
+        assert_eq!(
+            sql_ids, pred_ids,
+            "SQL list_due and Fact::is_temporally_due must agree on the active corpus"
+        );
+        // The expired-but-due fact must be in NEITHER (SQL filters it, oracle omits it).
+        assert!(
+            !sql_ids.contains(&expired_id),
+            "expired fact must not be due"
+        );
+        // Sanity: the due set is non-empty (3 due cases above).
+        assert_eq!(sql_ids.len(), 3, "exactly the three due cases");
+    }
+
     #[test]
     fn next_due_time_returns_earliest_future_t_valid() {
         let conn = setup();

--- a/src/store/facts.rs
+++ b/src/store/facts.rs
@@ -569,26 +569,34 @@ impl<'a> FactStore<'a> {
             .map_err(MemoryError::Database)
     }
 
-    /// List active pinned (unforgettable) facts, optionally filtered by scope.
-    /// Pass empty slice to get all pinned facts across all scopes.
-    pub fn list_pinned(&self, scope_ids: &[i64]) -> Result<Vec<Fact>> {
+    /// List active pinned (unforgettable) facts, optionally filtered by scope,
+    /// ordered by `importance_score` DESC and capped at `limit`.
+    ///
+    /// Pass empty `scope_ids` to get pinned facts across all scopes. Pass
+    /// `usize::MAX` for `limit` to retrieve every pinned fact (no cap). The cap is
+    /// pushed down to SQL (`LIMIT ?`) so the DB never transmits or deserializes the
+    /// embedding BLOBs of facts beyond the cap (#395) — matching the pattern of
+    /// `list_by_importance_score`.
+    pub fn list_pinned(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Fact>> {
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         let base =
             format!("SELECT {FACT_COLUMNS} FROM facts WHERE t_expired IS NULL AND is_pinned = 1");
         let dim = self.embed_dim;
         if scope_ids.is_empty() {
-            let sql = format!("{base} ORDER BY importance_score DESC");
+            let sql = format!("{base} ORDER BY importance_score DESC LIMIT ?1");
             let mut stmt = self.conn.prepare(&sql)?;
-            let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
+            let rows = stmt.query_map(rusqlite::params![limit_i64], |row| row_to_fact(row, dim))?;
             rows.collect::<std::result::Result<Vec<_>, _>>()
                 .map_err(Into::into)
         } else {
             let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
             let sql = format!(
-                "{base} AND scope_id IN (SELECT value FROM json_each(?1)) ORDER BY importance_score DESC"
+                "{base} AND scope_id IN (SELECT value FROM json_each(?1)) ORDER BY importance_score DESC LIMIT ?2"
             );
             let mut stmt = self.conn.prepare(&sql)?;
-            let rows =
-                stmt.query_map(rusqlite::params![scope_json], |row| row_to_fact(row, dim))?;
+            let rows = stmt.query_map(rusqlite::params![scope_json, limit_i64], |row| {
+                row_to_fact(row, dim)
+            })?;
             rows.collect::<std::result::Result<Vec<_>, _>>()
                 .map_err(Into::into)
         }
@@ -2107,9 +2115,42 @@ mod tests {
         fs.insert(&make_fact("normal fact", vec![0.2; DIM]))
             .unwrap();
 
-        let result = fs.list_pinned(&[]).unwrap();
+        let result = fs.list_pinned(&[], usize::MAX).unwrap();
         assert_eq!(result.len(), 1);
         assert!(result[0].is_pinned);
+    }
+
+    /// #395: the SQL `LIMIT` returns the SAME set the old Rust
+    /// `list_pinned(..).take(cap)` did — the top-`cap` pinned facts by
+    /// `importance_score` DESC — and `usize::MAX` retrieves all of them.
+    #[test]
+    fn list_pinned_sql_limit_matches_rust_take() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+        // Seed five pinned facts with strictly increasing importance_score so the
+        // DESC ordering (and thus the top-N selected by LIMIT) is unambiguous.
+        for i in 0..5 {
+            let mut f = make_fact(&format!("pinned {i}"), vec![0.1; DIM]);
+            f.is_pinned = true;
+            let id = fs.insert(&f).unwrap();
+            fs.update_importance_score(id, f64::from(i) / 10.0).unwrap();
+        }
+        // Oracle: fetch all, then take(cap) in Rust (the pre-#395 behavior).
+        let all = fs.list_pinned(&[], usize::MAX).unwrap();
+        assert_eq!(all.len(), 5, "usize::MAX = no cap");
+        for cap in [0_usize, 1, 3, 5, 99] {
+            let rust_take: Vec<i64> = all.iter().take(cap).map(|f| f.id).collect();
+            let sql_limit: Vec<i64> = fs
+                .list_pinned(&[], cap)
+                .unwrap()
+                .iter()
+                .map(|f| f.id)
+                .collect();
+            assert_eq!(
+                sql_limit, rust_take,
+                "SQL LIMIT {cap} must equal Rust .take({cap}) (same order)"
+            );
+        }
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -237,6 +237,32 @@ impl Fact {
     /// `0.5` literal. Arbiter implementations may compare against it to detect an
     /// unscored candidate.
     pub const UNSCORED_IMPORTANCE: f64 = 0.5;
+
+    /// Whether this fact is **temporally due** at `now`: it has a concrete
+    /// valid-time start that has arrived (`t_valid` is `Some` and `<= now`) and is
+    /// not yet bi-temporally invalidated (`t_invalid` is `None` or strictly after
+    /// `now`).
+    ///
+    /// This is the single source of truth for the in-Rust due predicate, shared by
+    /// the resume surfacing walk and the `explain` `FactState::Due` classifier so
+    /// the two cannot silently drift (#477). It is the Rust mirror of the SQL
+    /// `WHERE` clause in `FactStore::list_due` / `SchemaManager::statistics` and of
+    /// [`TemporalFilter::ValidDue`](crate::storage::TemporalFilter::ValidDue).
+    ///
+    /// # Scope (what this predicate does NOT cover)
+    ///
+    /// It is purely the *valid-time* test. Callers retain responsibility for the
+    /// orthogonal concerns the SQL bundles in:
+    /// - **System-time liveness** (`t_expired IS NULL`): the resume/explain callers
+    ///   only ever evaluate facts drawn from active-only reads, so the row is
+    ///   already known live. The SQL spells it out because it scans the raw table.
+    /// - **Surfacing state** (`surfaced_at`): the resume walk additionally requires
+    ///   `surfaced_at.is_none()` to pick the *unsurfaced* subset; that is a
+    ///   surfacing concern, not a due concern, and stays at the call site.
+    #[must_use]
+    pub fn is_temporally_due(&self, now: DateTime<Utc>) -> bool {
+        self.t_valid.is_some_and(|tv| tv <= now) && self.t_invalid.is_none_or(|ti| ti > now)
+    }
 }
 
 /// A graph edge between two facts.


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 4, post-#631 async-native). Resume read-path perf + shared predicate. Closes 4 findings.

## Findings closed
- **#477** — extracted a shared `Fact::is_temporally_due` predicate so `list_due` SQL and the `is_unsurfaced_due` closure can't drift.
- **#395** — `list_pinned` pushes the cap into SQL (LIMIT) instead of fetching all pinned facts (incl embedding BLOBs) and truncating in Rust; threaded through the `StorageBackend` trait + `SqliteBackend`.
- **#396** — `list_due` pushes `exclude(seen)` + LIMIT into SQL for resume Tier-3; the uncapped `scheduling` path stays uncapped (`exclude=&[]`, `limit=None`).
- **#391** — (partially-valid: the original double-clone was already fixed by #631) implemented the real relocated residual — `batch_insert_savepoint` takes facts by value, patches `scope_id` via `iter_mut`, and moves embeddings out for the HNSW notify (no per-iteration `NewFact`+embedding clone).

## ⚠ Breaking (StorageBackend trait)
`list_pinned_facts` / `list_due_facts` gained cap/exclude params (`Option<usize>` for consistency). The future `PgBackend` (#633) must adopt them; the #632 conformance suite covers them.

## Review (internal diverse-lens subagents)
3 lenses: **0 blocker, 0 major**. TDD parity oracles (SQL LIMIT/exclude == old Rust `.filter().take()` across caps; `is_temporally_due` membership cross-check; uncapped-scheduling-unaffected). Addressed the `Option<usize>` consistency minor. Pre-existing non-ann build warnings noted for collateral (#706).

## Gate
`cargo build/test/clippy --workspace --all-targets --all-features -D warnings` + `cargo fmt --check` — green (main @ 025bddd; 1569 tests).

Fixes #477, fixes #395, fixes #396, fixes #391
