### PR TITLE
refactor(core)!: OutcomeClass enum + drop phantom lineage_id + serde proptests (#254 wave4)

### DIFF
--- a/memory-engine-mcp/src/tools/mod.rs
+++ b/memory-engine-mcp/src/tools/mod.rs
@@ -1636,7 +1636,13 @@ async fn handle_record_activity(
     let result_summary = get_str(args, "result");
     let timestamp = get_datetime(args, "timestamp")?.unwrap_or_else(Utc::now);
     let scope = get_str(args, "scope");
-    let outcome_class = get_str(args, "outcome_class");
+    // `OutcomeClass::from_str` is infallible (the open `Other` arm captures any
+    // value), so an arbitrary JSON string maps cleanly; `None` defers to the
+    // engine's `OutcomeClass::Success` default.
+    let outcome_class = get_str(args, "outcome_class").map(|s| {
+        let Ok(class) = s.parse::<memory_engine::OutcomeClass>();
+        class
+    });
 
     let req = memory_engine::RecordActivityRequest {
         tool_name,

--- a/src/engine/activity.rs
+++ b/src/engine/activity.rs
@@ -63,11 +63,8 @@ impl MemoryEngine {
 
         // Step 2: Compute args hash.
         let hash = args_hash(&req.args);
-        let outcome = req
-            .outcome_class
-            .as_deref()
-            .unwrap_or("success")
-            .to_string();
+        // `None` defaults to `OutcomeClass::Success` (the DB column default).
+        let outcome = req.outcome_class.clone().unwrap_or_default();
 
         // Steps 3+4: Resolve scope, then insert/dedup via the port.
         let scope_id = match req.scope_path.as_deref() {

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -342,9 +342,9 @@ impl MemoryEngine {
 
         // Normalize metadata to an object + inject the provenance envelope (pure
         // engine-side work; the atomic insert + identity guard live below the seam).
-        // `lineage_id` has `#[serde(skip_serializing)]` on PromotionProvenance, so only
-        // descriptive fields are stored — the lineage table is authoritative for the
-        // `lineage_id → source_fact_ids` mapping.
+        // `PromotionProvenance` carries only descriptive fields — the lineage table
+        // (keyed by its row PK) is authoritative for the `lineage_id →
+        // source_fact_ids` mapping, so no id leaks into the stored envelope.
         let mut metadata = match req.metadata.clone() {
             serde_json::Value::Object(map) => serde_json::Value::Object(map),
             _ => serde_json::json!({}),
@@ -462,7 +462,6 @@ mod tests {
             confidence: 0.85,
             method_version: "test-v1".into(),
             representative_ids: vec![1, 2, 3],
-            lineage_id: 0, // reconstructed from DB row PK on read
         }
     }
 

--- a/src/engine/cycle/apply.rs
+++ b/src/engine/cycle/apply.rs
@@ -197,7 +197,6 @@ mod tests {
             confidence: 0.9,
             method_version: "test".into(),
             representative_ids: vec![],
-            lineage_id: 0,
         }
     }
 

--- a/src/engine/cycle/default_impl.rs
+++ b/src/engine/cycle/default_impl.rs
@@ -165,7 +165,6 @@ fn cluster_provenance(cluster: &[FactId], by_id: &HashMap<FactId, &Fact>) -> Pro
         confidence,
         method_version: METHOD_VERSION.to_owned(),
         representative_ids,
-        lineage_id: 0,
     }
 }
 

--- a/src/engine/cycle/report.rs
+++ b/src/engine/cycle/report.rs
@@ -272,7 +272,6 @@ mod tests {
             confidence: 0.9,
             method_version: "dbscan-v1".into(),
             representative_ids: vec![1, 2],
-            lineage_id: 0,
         };
         let report = CycleReport {
             deltas: vec![

--- a/src/engine/lineage.rs
+++ b/src/engine/lineage.rs
@@ -95,7 +95,6 @@ mod tests {
             confidence: 0.85,
             method_version: "dreamcycle-v1".into(),
             representative_ids: vec![],
-            lineage_id: 0,
         }
     }
 
@@ -166,7 +165,8 @@ mod tests {
         assert_eq!(record.wisdom_fact_id, 1);
         assert_eq!(record.source_fact_ids, vec![2, 3]);
         assert_eq!(got_prov.source_count, 2);
-        assert_eq!(got_prov.lineage_id, lineage_id);
+        // The lineage_id is returned on the companion record, not the envelope.
+        assert_eq!(record.lineage_id, lineage_id);
     }
 
     #[tokio::test]

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -415,7 +415,6 @@ mod tests {
                 confidence: 0.9,
                 method_version: "v1".into(),
                 representative_ids: vec![1, 2],
-                lineage_id: 21,
             },
         }
     }
@@ -705,10 +704,10 @@ mod tests {
             fact_vectors: vec![],
             config,
         };
-        // EngineSnapshot is intentionally not `PartialEq`: `PromotionProvenance`
-        // carries a denormalized `lineage_id` re-derived from its parent entry on
-        // load, so serialize→deserialize is not value-identity. Assert JSON
-        // stability (re-serialization is byte-stable) instead.
+        // EngineSnapshot does not derive `PartialEq` (it nests `serde_json::Value`
+        // metadata and float scores, for which value-identity is ill-defined), so
+        // assert JSON stability (re-serialization is byte-stable) instead of
+        // structural equality.
         assert_roundtrip_json_stable(&snapshot);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,9 +151,10 @@ pub use types::{
     ConsolidationProposal, DreamCycleConfig, Edge, EmbeddingFingerprint, Event, EventFilter,
     EventType, Fact, FactId, FactScoringRow, FactType, Insight, LineageId, LineageRecord,
     LineageSnapshotEntry, MergeGroup, NewActivity, NewEdge, NewEvent, NewFact, NewFactBuilder,
-    NewLineageRecord, NewSummary, Outcome, OutcomeCounts, ParseActivityStatusError, ProjectContext,
-    PromoteOutcome, PromoteRequest, PromotionProvenance, PromotionResult, RecordActivityRequest,
-    RecordActivityResult, ScopeNode, ScopeQuery, SessionCheckpoint, SessionFact, Summary,
+    NewLineageRecord, NewSummary, Outcome, OutcomeClass, OutcomeCounts, ParseActivityStatusError,
+    ProjectContext, PromoteOutcome, PromoteRequest, PromotionProvenance, PromotionResult,
+    RecordActivityRequest, RecordActivityResult, ScopeNode, ScopeQuery, SessionCheckpoint,
+    SessionFact, Summary,
 };
 
 // Storage port — tight flat re-export of the umbrella + cross-cutting types only.

--- a/src/storage/sqlite/consolidation.rs
+++ b/src/storage/sqlite/consolidation.rs
@@ -526,7 +526,6 @@ impl ConsolidationStore for SqliteBackend {
                                 confidence: 1.0,
                                 method_version: "synthesize-v1".to_owned(),
                                 representative_ids: sources.iter().take(5).copied().collect(),
-                                lineage_id: 0,
                             };
                             LineageStore::new(&tx).insert(
                                 &NewLineageRecord {
@@ -744,7 +743,6 @@ mod tests {
             confidence: 0.9,
             method_version: "dreamcycle-v1".into(),
             representative_ids: vec![1, 2],
-            lineage_id: 0,
         }
     }
 

--- a/src/storage/sqlite/session.rs
+++ b/src/storage/sqlite/session.rs
@@ -131,7 +131,7 @@ mod tests {
     use crate::pool::ConnectionPool;
     use crate::storage::session::SessionStore;
     use crate::store::upcaster::UpcasterRegistry;
-    use crate::types::{ActivityStatus, NewActivity, SessionCheckpoint};
+    use crate::types::{ActivityStatus, NewActivity, OutcomeClass, SessionCheckpoint};
 
     const DIM: usize = 4;
 
@@ -147,7 +147,7 @@ mod tests {
             args_hash: format!("{tool:0<32}"),
             args: serde_json::json!({}),
             result_summary: None,
-            outcome_class: "success".into(),
+            outcome_class: OutcomeClass::Success,
             timestamp: Utc::now(),
             scope_id: 1,
         }

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -281,6 +281,48 @@ mod tests {
         assert_eq!(fetched.status, ActivityStatus::Recorded);
     }
 
+    /// Persist every [`OutcomeClass`] variant through the real `SQLite` `TEXT`
+    /// column and read it back, proving the `to_string()` -> column ->
+    /// `from_str()` round-trip in [`row_to_activity`] (the entire #347
+    /// back-compat justification) holds across the persistence seam — not just
+    /// in the isolated `Display`/`FromStr` unit tests.
+    #[test]
+    fn outcome_class_roundtrips_through_sqlite() {
+        let conn = setup();
+        let store = ActivityStore::new(&conn);
+
+        // One row per variant. `args_hash` is varied per variant so the dedup
+        // index never collapses two inserts (the round-trip, not dedup, is what
+        // we are exercising) — each insert is therefore a fresh row.
+        let cases = [
+            OutcomeClass::Success,
+            OutcomeClass::Error,
+            OutcomeClass::TestFailure,
+            OutcomeClass::Other("vendor-x".into()),
+        ];
+
+        for (i, expected) in cases.into_iter().enumerate() {
+            let activity = NewActivity {
+                session_id: "sess-roundtrip".into(),
+                tool_name: "Bash".into(),
+                args_hash: format!("hash{i:028}"),
+                args: serde_json::json!({"cmd": "cargo test"}),
+                result_summary: None,
+                outcome_class: expected.clone(),
+                timestamp: Utc::now(),
+                scope_id: 1,
+            };
+            let (id, deduped) = store.insert_or_dedup(&activity, 300).unwrap();
+            assert!(!deduped, "fresh args_hash must not dedup for {expected:?}");
+
+            let fetched = store.get(id).unwrap();
+            assert_eq!(
+                fetched.outcome_class, expected,
+                "outcome_class did not survive the SQLite round-trip"
+            );
+        }
+    }
+
     #[test]
     fn dedup_within_window() {
         let conn = setup();

--- a/src/store/activities.rs
+++ b/src/store/activities.rs
@@ -3,7 +3,7 @@
 use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::error::{MemoryError, Result};
-use crate::types::{Activity, ActivityStatus, NewActivity};
+use crate::types::{Activity, ActivityStatus, NewActivity, OutcomeClass};
 
 use super::parse_timestamp;
 
@@ -48,7 +48,7 @@ impl<'a> ActivityStore<'a> {
                     activity.session_id,
                     activity.tool_name,
                     activity.args_hash,
-                    activity.outcome_class,
+                    activity.outcome_class.to_string(),
                     activity.scope_id,
                     ts,
                     dedup_window_secs,
@@ -86,7 +86,7 @@ impl<'a> ActivityStore<'a> {
                     activity.args_hash,
                     activity.args.to_string(),
                     activity.result_summary,
-                    activity.outcome_class,
+                    activity.outcome_class.to_string(),
                     ts,
                     activity.scope_id,
                 ],
@@ -223,6 +223,10 @@ fn row_to_activity(row: &rusqlite::Row<'_>) -> rusqlite::Result<Activity> {
     })?;
     let first_seen_str: String = row.get("first_seen")?;
     let last_seen_str: String = row.get("last_seen")?;
+    // `OutcomeClass::from_str` is infallible (the open `Other` arm captures any
+    // stored string), so any historical `outcome_class` value round-trips losslessly.
+    let outcome_class_str: String = row.get("outcome_class")?;
+    let Ok(outcome_class) = outcome_class_str.parse::<OutcomeClass>();
 
     Ok(Activity {
         id: row.get("id")?,
@@ -231,7 +235,7 @@ fn row_to_activity(row: &rusqlite::Row<'_>) -> rusqlite::Result<Activity> {
         args_hash: row.get("args_hash")?,
         args,
         result_summary: row.get("result_summary")?,
-        outcome_class: row.get("outcome_class")?,
+        outcome_class,
         status,
         occurrence_count: row.get("occurrence_count")?,
         first_seen: parse_timestamp(&first_seen_str)?,
@@ -263,7 +267,7 @@ mod tests {
             args_hash: "abc123def456abc123def456abc123de".into(),
             args: serde_json::json!({"path": "/foo/bar.rs"}),
             result_summary: Some("200 lines".into()),
-            outcome_class: "success".into(),
+            outcome_class: OutcomeClass::Success,
             timestamp: Utc::now(),
             scope_id: 1,
         };
@@ -287,7 +291,7 @@ mod tests {
             args_hash: "abc123def456abc123def456abc123de".into(),
             args: serde_json::json!({"path": "/foo/bar.rs"}),
             result_summary: Some("200 lines".into()),
-            outcome_class: "success".into(),
+            outcome_class: OutcomeClass::Success,
             timestamp: Utc::now(),
             scope_id: 1,
         };
@@ -314,12 +318,12 @@ mod tests {
             args_hash: "abc123def456abc123def456abc123de".into(),
             args: serde_json::json!({"cmd": "cargo test"}),
             result_summary: Some("ok".into()),
-            outcome_class: "success".into(),
+            outcome_class: OutcomeClass::Success,
             timestamp: Utc::now(),
             scope_id: 1,
         };
         let failure = NewActivity {
-            outcome_class: "error".into(),
+            outcome_class: OutcomeClass::Error,
             result_summary: Some("FAILED".into()),
             ..success.clone()
         };
@@ -341,7 +345,7 @@ mod tests {
                 args_hash: format!("hash{i:032}"),
                 args: serde_json::json!({}),
                 result_summary: None,
-                outcome_class: "success".into(),
+                outcome_class: OutcomeClass::Success,
                 timestamp: Utc::now(),
                 scope_id: 1,
             };
@@ -365,7 +369,7 @@ mod tests {
                 args_hash: format!("hash{i:032}"),
                 args: serde_json::json!({}),
                 result_summary: None,
-                outcome_class: "success".into(),
+                outcome_class: OutcomeClass::Success,
                 timestamp: Utc::now(),
                 scope_id: 1,
             };
@@ -388,7 +392,7 @@ mod tests {
             args_hash: "abc123def456abc123def456abc123de".into(),
             args: serde_json::json!({"cmd": "git commit"}),
             result_summary: Some("committed".into()),
-            outcome_class: "success".into(),
+            outcome_class: OutcomeClass::Success,
             timestamp: Utc::now(),
             scope_id: 1,
         };

--- a/src/store/lineage.rs
+++ b/src/store/lineage.rs
@@ -22,8 +22,8 @@ impl<'a> LineageStore<'a> {
     /// Validates that the `wisdom_fact_id` references an **active** (non-expired)
     /// fact and that all `source_fact_ids` reference existing facts before
     /// inserting — so a lineage row can never be orphaned against a missing or
-    /// soft-deleted wisdom fact. The `provenance.lineage_id` field is not stored
-    /// in the JSON (`skip_serializing`) — the row PK is authoritative.
+    /// soft-deleted wisdom fact. The row PK is the authoritative `lineage_id`; the
+    /// provenance envelope no longer carries one (see [`PromotionProvenance`]).
     ///
     /// # Errors
     ///
@@ -134,8 +134,9 @@ impl<'a> LineageStore<'a> {
         match result {
             Ok((lineage_id, wfid, source_ids_json, prov_json)) => {
                 let source_fact_ids: Vec<i64> = serde_json::from_str(&source_ids_json)?;
-                let mut provenance: PromotionProvenance = serde_json::from_str(&prov_json)?;
-                provenance.lineage_id = lineage_id;
+                let provenance: PromotionProvenance = serde_json::from_str(&prov_json)?;
+                // The PK is the authoritative lineage_id; it lives on the
+                // companion record, not (re)written onto the envelope.
                 let record = LineageRecord {
                     lineage_id,
                     wisdom_fact_id: wfid,
@@ -224,8 +225,9 @@ impl<'a> LineageStore<'a> {
             let source_ids_json: String = row.get(2)?;
             let prov_json: String = row.get(3)?;
             let source_fact_ids: Vec<i64> = serde_json::from_str(&source_ids_json)?;
-            let mut provenance: PromotionProvenance = serde_json::from_str(&prov_json)?;
-            provenance.lineage_id = lineage_id;
+            let provenance: PromotionProvenance = serde_json::from_str(&prov_json)?;
+            // `lineage_id` lives on the snapshot entry (the row PK), not on the
+            // envelope — no reconstruction onto `provenance` needed.
             f(LineageSnapshotEntry {
                 lineage_id,
                 wisdom_fact_id,
@@ -277,7 +279,6 @@ mod tests {
             confidence: 0.85,
             method_version: "dreamcycle-v1".into(),
             representative_ids: vec![10, 20],
-            lineage_id: 0,
         }
     }
 
@@ -300,7 +301,9 @@ mod tests {
         assert_eq!(prov.source_count, 2);
         assert!((prov.confidence - 0.85).abs() < f64::EPSILON);
         assert_eq!(prov.method_version, "dreamcycle-v1");
-        assert_eq!(prov.lineage_id, lineage_id);
+        // The authoritative lineage_id now lives on the companion record (the row
+        // PK), not reconstructed onto the provenance envelope.
+        assert_eq!(record.lineage_id, lineage_id);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1779,6 +1779,103 @@ mod tests {
         assert!(back.merges.is_empty());
     }
 
+    /// Property-based serde round-trips for the core types whose invariants the
+    /// example tests above only spot-check at one or two fixed inputs (#444).
+    ///
+    /// The example tests pin specific shapes (one `PromotionProvenance`, two
+    /// `Fact` JSON blobs); these assert the round-trip and field-omission
+    /// invariants hold across the *whole* input space — arbitrary counts, scores,
+    /// timestamps, id vectors, and the `surfaced_at` `Some`/`None` axis.
+    mod proptest_serde_roundtrip {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Build a UTC timestamp from a second-offset proptest sample, clamped to a
+        /// representable range so the strategy never produces an out-of-range value.
+        fn ts_from_secs(secs: i64) -> DateTime<Utc> {
+            // chrono's representable range is enormous; this band is more than wide
+            // enough to exercise the serialization without flirting with overflow.
+            let clamped = secs.clamp(-62_135_596_800, 253_402_300_799);
+            DateTime::<Utc>::from_timestamp(clamped, 0).unwrap_or_else(Utc::now)
+        }
+
+        proptest! {
+            /// `PromotionProvenance` is a lossless serde round-trip over arbitrary
+            /// field values, and — post-#402 — no `lineage_id` token ever appears in
+            /// the serialized JSON (the field was removed; the row PK is the
+            /// authoritative id, carried on the companion record, not the envelope).
+            #[test]
+            fn promotion_provenance_roundtrips_and_omits_lineage_id(
+                source_count in any::<u32>(),
+                session_count in any::<u32>(),
+                start_secs in any::<i64>(),
+                end_secs in any::<i64>(),
+                // Confidence is a score in [0, 1] by construction (see
+                // `cluster_provenance`); this also keeps it clear of the
+                // extreme-exponent magnitudes where serde_json's f64 formatting is
+                // not bit-exact — a property of the encoder, not of the type.
+                confidence in 0.0_f64..=1.0,
+                method_version in ".*",
+                representative_ids in proptest::collection::vec(any::<i64>(), 0..8),
+            ) {
+                let prov = PromotionProvenance {
+                    source_count,
+                    session_count,
+                    date_range_start: ts_from_secs(start_secs),
+                    date_range_end: ts_from_secs(end_secs),
+                    confidence,
+                    method_version,
+                    representative_ids,
+                };
+                let value = serde_json::to_value(&prov).unwrap();
+                // The phantom field is gone for good: no `lineage_id` *key* may ever
+                // appear in the serialized object, for any input. Checked on the
+                // parsed object (not a substring of the raw text) so an arbitrary
+                // `method_version` that happens to contain the token cannot fool it.
+                prop_assert!(
+                    value.as_object().is_some_and(|o| !o.contains_key("lineage_id")),
+                    "lineage_id key leaked into serialized provenance"
+                );
+                let back: PromotionProvenance = serde_json::from_value(value).unwrap();
+                prop_assert_eq!(back, prov);
+            }
+
+            /// `Fact.surfaced_at` (a `#[serde(default)] Option<DateTime<Utc>>`)
+            /// round-trips for both the `Some` and `None` arms across arbitrary
+            /// timestamps — the field the example tests exercise with only two fixed
+            /// JSON strings.
+            #[test]
+            fn fact_surfaced_at_roundtrips_over_some_and_none(
+                surfaced_secs in proptest::option::of(any::<i64>()),
+            ) {
+                let surfaced_at = surfaced_secs.map(ts_from_secs);
+                let fact = Fact {
+                    id: 1,
+                    content: "p".into(),
+                    content_hash: "h".into(),
+                    embedding: vec![0.0_f32],
+                    fact_type: FactType::Semantic,
+                    t_created: ts_from_secs(0),
+                    t_expired: None,
+                    t_valid: None,
+                    t_invalid: None,
+                    source_event_id: None,
+                    importance: 0.5,
+                    access_count: 0,
+                    last_accessed: ts_from_secs(0),
+                    metadata: serde_json::json!({}),
+                    scope_id: 1,
+                    is_pinned: false,
+                    importance_score: 0.5,
+                    surfaced_at,
+                };
+                let json = serde_json::to_string(&fact).unwrap();
+                let back: Fact = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(back.surfaced_at, fact.surfaced_at);
+            }
+        }
+    }
+
     // --- EmbeddingFingerprint (#612) ---
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -896,6 +896,90 @@ pub struct PromotionResult {
 #[error("unknown activity status: {0}")]
 pub struct ParseActivityStatusError(pub String);
 
+/// Outcome class of a recorded tool activity.
+///
+/// Replaces the previously stringly-typed `outcome_class` field on [`Activity`],
+/// [`NewActivity`], and [`RecordActivityRequest`]. Encoding the known outcomes as
+/// variants makes the dedup-key invariant (the `(session_id, tool_name, args_hash,
+/// outcome_class, scope_id)` index keys off the *string*) misuse-resistant: a
+/// consumer can no longer accidentally pass an empty string that would silently
+/// corrupt deduplication.
+///
+/// # String representation (DB + JSON back-compat)
+///
+/// [`Display`](fmt::Display)/[`FromStr`] are a total round-trip with the on-disk
+/// `outcome_class TEXT` column and the MCP JSON boundary:
+/// `Success` ⇄ `"success"`, `Error` ⇄ `"error"`, `TestFailure` ⇄ `"test_failure"`.
+/// Any other stored string parses into the open [`Other`](Self::Other) variant and
+/// serializes back **verbatim**, so existing activity rows keep their exact value.
+/// [`Default`] is [`Success`](Self::Success), matching the DB column default.
+///
+/// The [`Other`](Self::Other) arm is an escape hatch for consumer-defined classes;
+/// it deliberately **bypasses** compile-time checking and should be reserved for
+/// values not covered by a named variant.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub enum OutcomeClass {
+    /// The tool invocation succeeded. Serializes as `"success"`. Default variant.
+    #[default]
+    Success,
+    /// The tool invocation failed. Serializes as `"error"`.
+    Error,
+    /// A test run reported failures. Serializes as `"test_failure"`.
+    TestFailure,
+    /// Any consumer-defined outcome class. Serializes as its inner string verbatim;
+    /// bypasses the compile-time invariant the named variants provide.
+    Other(String),
+}
+
+impl fmt::Display for OutcomeClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Success => f.write_str("success"),
+            Self::Error => f.write_str("error"),
+            Self::TestFailure => f.write_str("test_failure"),
+            Self::Other(s) => f.write_str(s),
+        }
+    }
+}
+
+impl FromStr for OutcomeClass {
+    type Err = std::convert::Infallible;
+
+    /// Total parse: every string maps to a variant, unknown ones into
+    /// [`Other`](Self::Other). The named arms match the exact lowercase strings the
+    /// store writes; parsing is therefore the inverse of [`Display`](fmt::Display)
+    /// and preserves stored values byte-for-byte on round-trip.
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(match s {
+            "success" => Self::Success,
+            "error" => Self::Error,
+            "test_failure" => Self::TestFailure,
+            other => Self::Other(other.to_owned()),
+        })
+    }
+}
+
+impl Serialize for OutcomeClass {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for OutcomeClass {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        // `FromStr` is infallible (`Other` captures the open set), so the `Err`
+        // arm is unreachable — destructure the `Infallible` `Ok` directly.
+        let Ok(class) = s.parse();
+        Ok(class)
+    }
+}
+
 impl std::str::FromStr for ActivityStatus {
     type Err = ParseActivityStatusError;
 
@@ -919,7 +1003,7 @@ pub struct Activity {
     pub args_hash: String,
     pub args: serde_json::Value,
     pub result_summary: Option<String>,
-    pub outcome_class: String,
+    pub outcome_class: OutcomeClass,
     pub status: ActivityStatus,
     pub occurrence_count: i64,
     pub first_seen: DateTime<Utc>,
@@ -936,7 +1020,7 @@ pub struct NewActivity {
     pub args_hash: String,
     pub args: serde_json::Value,
     pub result_summary: Option<String>,
-    pub outcome_class: String,
+    pub outcome_class: OutcomeClass,
     pub timestamp: DateTime<Utc>,
     pub scope_id: i64,
 }
@@ -961,8 +1045,9 @@ pub struct RecordActivityRequest {
     pub session_id: String,
     pub timestamp: DateTime<Utc>,
     pub scope_path: Option<String>,
-    /// Outcome class (e.g. "success", "error", "`test_failure`"). Defaults to "success".
-    pub outcome_class: Option<String>,
+    /// Outcome class of the activity. `None` defaults to
+    /// [`OutcomeClass::Success`] (the DB column default).
+    pub outcome_class: Option<OutcomeClass>,
 }
 
 /// Result of recording an activity.
@@ -1282,6 +1367,72 @@ mod tests {
         // Case-sensitivity: the matcher expects lowercase variants.
         assert!(ActivityStatus::from_str("Recorded").is_err());
         assert!(ActivityStatus::from_str("").is_err());
+    }
+
+    // --- OutcomeClass (#347) ---
+
+    #[test]
+    fn outcome_class_display_emits_db_strings() {
+        // The named variants render exactly the lowercase strings the store writes.
+        assert_eq!(OutcomeClass::Success.to_string(), "success");
+        assert_eq!(OutcomeClass::Error.to_string(), "error");
+        assert_eq!(OutcomeClass::TestFailure.to_string(), "test_failure");
+        assert_eq!(OutcomeClass::Other("flaky".into()).to_string(), "flaky");
+    }
+
+    #[test]
+    fn outcome_class_default_is_success() {
+        // Matches the `outcome_class TEXT NOT NULL DEFAULT 'success'` column default.
+        assert_eq!(OutcomeClass::default(), OutcomeClass::Success);
+    }
+
+    #[test]
+    fn outcome_class_from_str_maps_known_and_open_set() {
+        use std::str::FromStr;
+        let Ok(s) = OutcomeClass::from_str("success");
+        assert_eq!(s, OutcomeClass::Success);
+        let Ok(e) = OutcomeClass::from_str("error");
+        assert_eq!(e, OutcomeClass::Error);
+        let Ok(tf) = OutcomeClass::from_str("test_failure");
+        assert_eq!(tf, OutcomeClass::TestFailure);
+        // Any unrecognized string lands in the open `Other` arm verbatim — this is
+        // the back-compat guarantee for activity rows written before this enum.
+        let Ok(o) = OutcomeClass::from_str("custom-thing");
+        assert_eq!(o, OutcomeClass::Other("custom-thing".into()));
+        // Even the empty string round-trips (it is no longer a silent footgun: a
+        // consumer must spell `Other("")` to produce it).
+        let Ok(empty) = OutcomeClass::from_str("");
+        assert_eq!(empty, OutcomeClass::Other(String::new()));
+    }
+
+    #[test]
+    fn outcome_class_string_round_trip_is_lossless() {
+        use std::str::FromStr;
+        for class in [
+            OutcomeClass::Success,
+            OutcomeClass::Error,
+            OutcomeClass::TestFailure,
+            OutcomeClass::Other("vendor-specific".into()),
+        ] {
+            let rendered = class.to_string();
+            let Ok(parsed) = OutcomeClass::from_str(&rendered);
+            assert_eq!(parsed, class, "Display->from_str round-trip failed");
+        }
+    }
+
+    #[test]
+    fn outcome_class_serde_is_a_plain_string() {
+        // Wire format is a bare JSON string (back-compat with the prior `String`
+        // field + the MCP `"type": "string"` schema), not an externally-tagged enum.
+        assert_eq!(
+            serde_json::to_string(&OutcomeClass::TestFailure).unwrap(),
+            "\"test_failure\""
+        );
+        let back: OutcomeClass = serde_json::from_str("\"error\"").unwrap();
+        assert_eq!(back, OutcomeClass::Error);
+        // An unknown stored value deserializes into the open arm, never an error.
+        let open: OutcomeClass = serde_json::from_str("\"legacy_value\"").unwrap();
+        assert_eq!(open, OutcomeClass::Other("legacy_value".into()));
     }
 
     // --- Phase 5a type tests ---

--- a/src/types.rs
+++ b/src/types.rs
@@ -321,11 +321,17 @@ pub enum ScopeQuery {
 /// Lightweight provenance envelope attached to promoted wisdom facts.
 ///
 /// Carries summary statistics about the promotion (how many source facts,
-/// across how many sessions, confidence score). The full source chain lives
-/// in the sidecar `lineage` table, loaded on demand via `lineage_id`.
+/// across how many sessions, confidence score). It is the **serialized envelope**:
+/// every field round-trips through the `lineage.provenance` JSON column and the
+/// promoted fact's `metadata.promotion_provenance` key.
 ///
-/// `lineage_id` is reconstructed from the DB row PK on read and is
-/// **not** persisted in the JSON column (skipped during serialization).
+/// The owning `lineage_id` (DB row PK) is **not** part of this envelope — it is a
+/// property of the row, not of the provenance. Read paths return it alongside the
+/// envelope in the companion [`LineageRecord`] / [`LineageSnapshotEntry`], and the
+/// write path returns it in [`PromotionResult`]. Previously this struct carried a
+/// phantom `lineage_id: i64` with `#[serde(skip_serializing, default)]` that was
+/// always `0` on deserialization and reconstructed from the PK on read — a lying
+/// field with an invisible "0 means not-yet-persisted" invariant. It is removed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PromotionProvenance {
     pub source_count: u32,
@@ -336,10 +342,6 @@ pub struct PromotionProvenance {
     pub method_version: String,
     /// 3-5 most representative source fact IDs (for quick human review).
     pub representative_ids: Vec<i64>,
-    /// Foreign key to the `lineage` table for the full source chain.
-    /// Reconstructed from the row PK on read — not stored in the provenance JSON.
-    #[serde(skip_serializing, default)]
-    pub lineage_id: i64,
 }
 
 /// A row in the `lineage` sidecar table (full source chain).
@@ -1716,16 +1718,14 @@ mod tests {
             confidence: 0.87,
             method_version: "dreamcycle-v1".into(),
             representative_ids: vec![10, 20, 30],
-            lineage_id: 42,
         };
         let json = serde_json::to_string(&prov).unwrap();
-        // lineage_id is skip_serializing — should not appear in JSON
+        // The owning lineage_id is no longer a field — it belongs to the row, not
+        // the envelope — so it must never leak into the serialized provenance.
         assert!(!json.contains("lineage_id"));
         let back: PromotionProvenance = serde_json::from_str(&json).unwrap();
-        // lineage_id defaults to 0 on deserialization (not round-tripped)
-        assert_eq!(back.lineage_id, 0);
-        assert_eq!(back.source_count, prov.source_count);
-        assert_eq!(back.method_version, prov.method_version);
+        // Every remaining field is a true, lossless round-trip.
+        assert_eq!(back, prov);
     }
 
     #[test]


### PR DESCRIPTION
Part of the **#254** super-qa `area:core` sweep (Wave 4, post-#631). Closes 3 findings.

## Findings closed
- **#347** — replaced the stringly-typed `outcome_class` with an `OutcomeClass` enum `{Success, Error, TestFailure, Other(String)}` across the 3 activity types + store + engine + MCP. **Back-compat verified**: serializes to the identical lowercase strings, so stored `outcome_class TEXT` rows and the MCP wire shape are byte-identical (no data migration).
- **#402** — removed the phantom `PromotionProvenance.lineage_id` field (`skip_serializing`, always 0 on read); the row PK is already carried by the companion `LineageRecord`/`LineageSnapshotEntry`/`PromotionResult`. The type identity is unchanged → no `StorageBackend` trait change.
- **#444** — serde-roundtrip proptests for `PromotionProvenance` (post-#402 shape, asserting no `lineage_id` key leaks) and `Fact.surfaced_at`.

## ⚠ Breaking
`OutcomeClass` enum replaces `String` on the public activity types (serde value unchanged). `PromotionProvenance.lineage_id` removed. Pre-1.0.

## Review (internal diverse-lens subagents)
3 lenses: **1 major** (test-quality) — the OutcomeClass String↔DB round-trip wasn't exercised end-to-end → **fixed** with a store-level test inserting+reading back each variant. Minors/nits (OutcomeClass::Other-vs-named shadowing; pre-existing non-`--all-features` clippy-1.96 warnings) noted/deferred to collateral. 0 deferred blockers.

## Gate
`cargo build/test/clippy --workspace --all-targets --all-features -D warnings` + `cargo fmt --check` — green (rebased on current main 1f235aa, incl. #623).

Fixes #347, fixes #402, fixes #444
