### PR TITLE
feat(core): different-dimension reconstruction (reopen-at-D′) (#742)

### DIFF
--- a/docs/advanced/reconstruction.md
+++ b/docs/advanced/reconstruction.md
@@ -9,10 +9,17 @@ rollback. It is the only legitimate way to change a store's embedding identity (
 identity tuple and the vectors swap together, so retrieval is never served from a mixed vector
 space.
 
-Today's scope is **same-dimension**. A different-dimension swap (a new `embed_dim`) needs the
-engine effective-dimension transition (pool / dim-validation / vector index at the new dim) and is
-the [#742](https://github.com/dutiona/memory-engine/issues/742) follow-up; the storage layer here
-is already dimension-agnostic.
+Two flavors:
+
+- **Same-dimension** (#623) — a model/quantization swap at the same `embed_dim`. Zero downtime:
+  the engine keeps serving across the promote.
+- **Different-dimension** (#742) — a swap to a new `embed_dim`. Also supported, but because the
+  engine's `embed_dim` is consumer-passed and cached immutably at open, a different-dim promote
+  cannot take effect on the live handle. The promote **fences** the handle, and the consumer
+  **reopens the engine at the new dimension** (a brief downtime — see
+  [Different-dimension reconstruction](#different-dimension-reconstruction-reopen-at-d) below). A
+  truly in-place, no-reopen dimension transition is a separate, larger effort (it would need
+  `embed_dim` interior-mutable across the engine + an in-place vector-index swap) and is deferred.
 
 ## Why content is the source of truth
 
@@ -89,7 +96,10 @@ re-embedding expired facts is the cheap price.
 The promote is a **single** `block_write` transaction, never decomposed (any `?` before `commit`
 drops the transaction and rolls back, so a mid-promote failure cannot leave partial state):
 
-0. **Same-dim guard** — `populating.dim == active.dim`, else error (different-dim → #742).
+0. **Resolve** the active + populating spaces. No dim guard — a promote is dimension-agnostic at the
+   storage layer (the copy-swap is a blob-level `UPDATE`), so `populating.dim` may differ from
+   `active.dim` (#742). The width invariant is the engine-side per-vector backfill check; a
+   different-dim promote fences the handle (below).
 1. **Completeness gate _inside_ the tx** — every fact must already have a populating vector. This
    runs inside the transaction (not before it), so a straggler that lands after the catch-up pass
    is caught here rather than silently dropped (no TOCTOU).
@@ -117,7 +127,44 @@ Because the promote **retains** the previous active vectors in `fact_vectors[old
 ones back into `facts.embedding`, and flip the status. This is the mechanism #689 surfaces as
 operator UX.
 
-## (PromoteOutcome)
+## Different-dimension reconstruction (reopen-at-D′)
+
+A different-dimension reconstruction (a new `embed_dim`, D→D′) runs the same lifecycle — the storage
+layer is dimension-agnostic — but the engine's `embed_dim` is consumer-passed and **frozen at open**,
+threaded immutably into the connection pool, the vector index, and every `deserialize_embedding` read
+site. So once the promote makes `facts.embedding` D′-wide, the live handle (still holding D) cannot
+serve it.
+
+The handle is therefore **fenced** at the promote: `MemoryEngine.reopen_required` is set to D′, and
+every embedding-touching method returns `MemoryError::EmbeddingReopenRequired { new_dim }` (the push
+channel) while `MemoryEngine::reopen_required()` reports `Some(D′)` (the pull channel). A read on a
+fenced handle never deserializes a D′ blob at D — and even if a gated method were missed, the checked
+`deserialize_embedding` returns a loud `EmbeddingDimension`, never silent corruption. The fence
+upgrades that to an actionable error.
+
+The consumer then **reopens at D′**:
+
+```text
+let outcome = engine.reconstruct(&new_fp /* dim D′ */, &embedder_at_Dprime).await?;
+// engine.reopen_required() == Some(D′); embedding-touching reads now refuse.
+engine.flush_snapshot().await?;                      // fenced → clean no-op (no stale-dim sidecar)
+drop(engine);
+let engine = MemoryEngine::open(EngineConfig::new(path, Dprime) …)?;  // validates clean, rebuilds @ D′
+```
+
+Reopen re-runs the open path: `validate_embed_dim_against_meta` passes because the active identity is
+now D′, and the vector index is rebuilt at D′ from the freshly-promoted `facts.embedding` — so #624's
+live in-process rebuild is **not** needed for the different-dim path (the reopen rebuilds for free).
+The brief window between promote-commit and reopen is the accepted downtime; a truly in-place,
+no-reopen transition (interior-mutable `embed_dim` + a live index swap) is deferred.
+
+**In-memory engines** have no file to reopen, so a different-dim reconstruction leaves an in-memory
+handle permanently fenced (build a fresh engine and re-ingest). **Crash recovery:** if a crash leaves
+the DB promoted at D′ but the consumer reopens with the old-D config, the open is rejected with
+`EmbedDimMismatch { stored: D′, requested: D }` — the consumer updates its config to D′ (no engine
+self-heal, to avoid silent-identity-adoption, per #614).
+
+## PromoteOutcome and index rebuild
 
 `rebuild_index` is always `true`: a promote changes every active vector, so a downstream vector
 index (HNSW) must rebuild. The **live in-process rebuild is #624**; until then, a SQLite+`ann`
@@ -133,15 +180,22 @@ Restore writes them after `embedding_spaces` and `facts` (foreign-key order). A 
 no `fact_vectors` field and defaults to empty; `facts[].embedding` is unchanged, so an old snapshot
 loses nothing.
 
+After a **different-dimension** reconstruction (#742) the active space is D′ while a retained
+`deprecated` space is still D-wide, so a single engine `embed_dim` cannot decode every row. The dump
+therefore decodes each `fact_vectors` row at **its own space's recorded dimension** (read from
+`embedding_spaces`), and restore re-serializes dimension-agnostically — so a reconstructed store
+round-trips with its deprecated rollback vectors intact, no data loss.
+
 ## Scope and dependencies
 
-| Concern                                                | Where       |
-| ------------------------------------------------------ | ----------- |
-| Same-dim reconstruction (this page)                    | **#623** ✅ |
-| Different-dim transition (new `embed_dim`)             | #742        |
-| Live in-process HNSW / similarity-edge rebuild         | #624        |
-| Live-write race during the promote window              | #625        |
-| Operator UX (CLI/MCP) + query-across-spaces / rollback | #689        |
+| Concern                                                      | Where       |
+| ------------------------------------------------------------ | ----------- |
+| Same-dim reconstruction                                      | **#623** ✅ |
+| Different-dim transition (new `embed_dim`, via reopen-at-D′) | **#742** ✅ |
+| In-place (no-reopen) live dimension transition               | deferred    |
+| Live in-process HNSW / similarity-edge rebuild (same-dim)    | #624        |
+| Live-write race during the promote window                    | #625        |
+| Operator UX (CLI/MCP) + query-across-spaces / rollback       | #689        |
 
 ## See also
 

--- a/docs/design/adr/0015-cross-layer-embedding-identity-policy.md
+++ b/docs/design/adr/0015-cross-layer-embedding-identity-policy.md
@@ -97,10 +97,12 @@ transaction — a completeness gate _inside_ the tx, retain-old, an O(N) copy-sw
 new vectors into `facts.embedding`, then a demote-then-activate registry flip. **The
 status flip _is_ the identity swap** (`embedding_meta::load` reads the active row's
 fingerprint), so the identity and vectors swap atomically, satisfying this section. The
-post-promote vector-index (HNSW) rebuild is tracked separately (#624); a same-dim swap
-still changes every vector, so a rebuild is required. **Different-dim** reconstruction
-(the engine effective-`embed_dim` transition) is the #742 follow-up — the storage layer is
-already dim-agnostic and the promote surfaces the new dim in its outcome.
+post-promote vector-index (HNSW) rebuild for a **same-dim** swap is tracked separately
+(#624; the swap still changes every vector). **Different-dim** reconstruction (a new
+`embed_dim`) is also implemented (#742): the storage layer is dim-agnostic, but because
+the engine's `embed_dim` is frozen at open, a different-dim promote **fences** the handle
+and the consumer reopens the engine at the new dim (which re-validates and rebuilds the
+index at the new dim). A truly in-place, no-reopen dimension transition is deferred.
 
 > **Cross-repo parity (ADR 0015 is shared verbatim with `knowledge-base`).** This section
 > was updated for the Memory-layer implementation only. The Knowledge layer uses per-space

--- a/docs/design/embedding-identity-and-tei-qwen-migration.md
+++ b/docs/design/embedding-identity-and-tei-qwen-migration.md
@@ -49,9 +49,11 @@ existing shape cleanly.
 - Background embedding reconstruction (shadow space → backfill → atomic promote). _(**Same-dim
   reconstruction landed in #623** — schema v13→v14 adds `fact_vectors` (non-active spaces),
   `MemoryEngine::reconstruct` drives a resumable backfill + an atomic copy-swap promote that keeps
-  `facts.embedding` as the active store. **Different-dim** (engine effective-`embed_dim` transition)
-  is the #742 follow-up; the live HNSW rebuild is #624; operator UX + query-across-spaces is #689.
-  See `docs/advanced/reconstruction.md` and §Design.7.)_
+  `facts.embedding` as the active store. **Different-dim landed in #742** (reopen-at-D′: a different-
+  dimension promote fences the handle, the consumer reopens at the new dim — the engine `embed_dim`
+  is frozen at open). The live in-process HNSW rebuild (same-dim) is #624; a truly in-place no-reopen
+  dim transition is deferred; operator UX + query-across-spaces is #689. See
+  `docs/advanced/reconstruction.md` and §Design.7.)_
 - Weight-hash identity (slug-level identity only for now).
 - TEI `/info` authoritative-identity probe.
 
@@ -172,8 +174,9 @@ vector — `facts.content` is source-of-truth, `facts.embedding` is derived) **l
 as reusable tooling for future **same-dim** model swaps: `MemoryEngine::reconstruct` re-embeds
 `facts.content` under the new identity into a `populating` space (schema v13→v14's `fact_vectors`
 table), then atomically copy-swaps it into `facts.embedding` and flips the registry identity in
-one transaction, with the old vectors retained for rollback. Different-dim swaps (a new
-`embed_dim`) are #742. See `docs/advanced/reconstruction.md`.
+one transaction, with the old vectors retained for rollback. **Different-dim swaps (a new
+`embed_dim`) landed in #742** via reopen-at-D′ (the promote fences the handle; the consumer reopens
+the engine at the new dim, since `embed_dim` is frozen at open). See `docs/advanced/reconstruction.md`.
 
 ## Wave 0 — validation gate (smoke test)
 

--- a/src/engine/archive.rs
+++ b/src/engine/archive.rs
@@ -39,6 +39,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::Database` on SQL failure.
     /// Returns `MemoryError::ReadOnly` if the engine is read-only.
     pub async fn archive(&self, policy: &ArchivePolicy) -> Result<Option<ArchiveStats>> {
+        self.ensure_open()?;
         // Fail fast on read-only engines before any filesystem I/O — the atomic
         // commit below the seam checks this too, but we want to avoid writing an
         // orphan .pak file that would never be committed.

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -54,6 +54,7 @@ impl MemoryEngine {
         config: &crate::bootstrap::BootstrapConfig,
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
+        self.ensure_open()?;
         let scope_id = self
             .resolve_bootstrap_scope(config.scope.as_deref())
             .await?;
@@ -86,6 +87,7 @@ impl MemoryEngine {
         config: &crate::bootstrap::BootstrapConfig,
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
+        self.ensure_open()?;
         let scope_id = self
             .resolve_bootstrap_scope(config.scope.as_deref())
             .await?;
@@ -132,6 +134,7 @@ impl MemoryEngine {
         config: &crate::bootstrap::BootstrapConfig,
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
+        self.ensure_open()?;
         let scope_id = self
             .resolve_bootstrap_scope(config.scope.as_deref())
             .await?;

--- a/src/engine/cognitive.rs
+++ b/src/engine/cognitive.rs
@@ -194,6 +194,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine is read-only.
     /// Returns an error if context construction or the cycle's `run()` fails.
     pub async fn run_dream_cycle(&self, cycle: &dyn DreamCycle) -> Result<CycleReport> {
+        self.ensure_open()?;
         // Verify write access up front (apply happens separately).
         if self.read_only {
             return Err(MemoryError::ReadOnly);
@@ -232,6 +233,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine is read-only, or a store/cycle error.
     #[must_use = "the CycleOutcome carries the skip/run decision — a dropped Skipped silently loses the deferral"]
     pub async fn run_dream_cycle_guarded(&self, cycle: &dyn DreamCycle) -> Result<CycleOutcome> {
+        self.ensure_open()?;
         // Cursor read + max-id read + (skip-only) advance via the port. These are
         // separate port calls rather than one lock-held critical section: per the
         // deferral contract this is benign — a caller write landing between the reads

--- a/src/engine/conflict.rs
+++ b/src/engine/conflict.rs
@@ -37,6 +37,7 @@ impl MemoryEngine {
         old_id: i64,
         new_fact: &NewFact,
     ) -> Result<ConflictResolution> {
+        self.ensure_open()?;
         // The candidate fact is persisted verbatim on an Add/Update decision, so
         // it is a consumer ingest path and must respect the same size bound as
         // `add_fact` (issue #572 / L10).

--- a/src/engine/consolidation.rs
+++ b/src/engine/consolidation.rs
@@ -44,6 +44,7 @@ impl MemoryEngine {
         embedder: Arc<dyn EmbeddingProvider>,
         config: &ConsolidationConfig,
     ) -> Result<ConsolidationStats> {
+        self.ensure_open()?;
         // Phase 1 — READ: snapshot the active set + watermark below the seam.
         let snapshot = self
             .storage

--- a/src/engine/cycle/apply.rs
+++ b/src/engine/cycle/apply.rs
@@ -41,6 +41,7 @@ impl MemoryEngine {
     ///   `AddFact`/`Promote`/`Synthesize` embedding does not match the engine dimension.
     /// - [`MemoryError::Storage`](crate::error::MemoryError::Storage) on a backend failure.
     pub async fn apply_cycle_report(&self, report: &CycleReport) -> Result<ApplyResult> {
+        self.ensure_open()?;
         let (result, supersede_edges, _expired_ids, _to_index) = self
             .storage
             .apply_cycle_deltas_atomic(report, self.embed_dim, &self.upcaster_registry)

--- a/src/engine/dormant.rs
+++ b/src/engine/dormant.rs
@@ -32,6 +32,7 @@ impl MemoryEngine {
         context: &[f32],
         scope_ids: Option<&[i64]>,
     ) -> Result<Vec<Fact>> {
+        self.ensure_open()?;
         if context.len() != self.embed_dim {
             return Err(MemoryError::EmbeddingDimension {
                 expected: self.embed_dim,

--- a/src/engine/forgetting.rs
+++ b/src/engine/forgetting.rs
@@ -18,6 +18,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::Conflict` if the policy is invalid.
     /// Returns `MemoryError::Database` on SQL failure.
     pub async fn forget(&self, policy: &ForgetPolicy) -> Result<PruneStats> {
+        self.ensure_open()?;
         // The prune walk reads the in-memory graph (degree per fact) *before* any
         // port write and mutates it (`remove_edges_by_fact`) *after* the expiries
         // commit. To keep the future `Send`, the graph guards live entirely inside

--- a/src/engine/ingest.rs
+++ b/src/engine/ingest.rs
@@ -19,6 +19,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Database` on insert failure.
     pub async fn ingest(&self, event: &NewEvent) -> Result<i64> {
+        self.ensure_open()?;
         check_json_size(&event.payload, "event payload")?;
         self.storage.insert_event(event).await
     }
@@ -60,6 +61,7 @@ impl MemoryEngine {
         embedder: Arc<dyn EmbeddingProvider>,
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<i64> {
+        self.ensure_open()?;
         Self::validate_add_fact_request(req)?;
         // Embed off the async executor (the provider call may be a blocking HTTP
         // round-trip; running it inline would park the runtime thread, and a
@@ -101,6 +103,7 @@ impl MemoryEngine {
         declared: &EmbeddingFingerprint,
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<i64> {
+        self.ensure_open()?;
         Self::validate_add_fact_request(req)?;
         // The caller's declared fingerprint is treated exactly like a live
         // provider's: the atomic insert records-if-absent (and #614-rejects a
@@ -235,6 +238,7 @@ impl MemoryEngine {
         embedder: Arc<dyn EmbeddingProvider>,
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<Vec<i64>> {
+        self.ensure_open()?;
         if entries.is_empty() {
             return Ok(Vec::new());
         }
@@ -278,6 +282,7 @@ impl MemoryEngine {
         embedder: Arc<dyn EmbeddingProvider>,
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<Vec<std::result::Result<i64, MemoryError>>> {
+        self.ensure_open()?;
         if entries.is_empty() {
             return Ok(Vec::new());
         }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -14,6 +14,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::Database` on SQL failure.
     pub async fn statistics(&self) -> Result<crate::inspect::EngineStatistics> {
+        self.ensure_open()?;
         self.storage.statistics().await
     }
 
@@ -104,6 +105,8 @@ impl MemoryEngine {
         use crate::inspect::explain;
         use crate::inspect::types::FactProvenance;
 
+        self.ensure_open()?;
+
         // Snapshot graph context under the graph lock, then release it (the guard is
         // dropped at the end of this block, before any `.await`).
         let graph_context = {
@@ -155,6 +158,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::NotFound` if the fact doesn't exist.
     /// Returns `MemoryError::Database` on SQL failure.
     pub async fn fact_history(&self, id: i64) -> Result<crate::inspect::FactHistory> {
+        self.ensure_open()?;
         // The bi-temporal timeline is pure over a single fact's timestamps: fetch via
         // the port, then derive it with no `&Connection` needed.
         let fact = self.storage.get_fact(id).await?;
@@ -185,6 +189,7 @@ impl MemoryEngine {
     /// Returns [`MemoryError::ReadOnly`] for the `Sqlite` format if the engine
     /// was opened read-only (the `VACUUM INTO` backup acquires the write lock).
     pub async fn dump_state(&self, format: &crate::inspect::DumpFormat) -> Result<()> {
+        self.ensure_open()?;
         // The whole format dispatch (including the feature-gated `NotImplemented`
         // arms and the read-vs-write connection choice) lives below the seam in
         // [`SchemaManager::dump_state`](crate::storage::SchemaManager::dump_state).

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -638,7 +638,7 @@ impl MemoryEngine {
     /// net (#742 Phase 1) can be exercised without driving a full different-dim
     /// reconstruction. Production code arms it only inside [`reconstruct`](Self::reconstruct).
     #[cfg(test)]
-    pub(crate) fn force_reopen_fence(&self, new_dim: usize) {
+    fn force_reopen_fence(&self, new_dim: usize) {
         self.reopen_required.store(new_dim, Ordering::Release);
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
@@ -206,6 +206,16 @@ pub struct MemoryEngine {
     /// `AtomicBool` so a shared owner (`Arc<MemoryEngine>`, e.g. the MCP server) can
     /// flush + mark via `&self` without unwrapping the `Arc`.
     closed: AtomicBool,
+    /// The reconstruction **dimension fence** (#742). `0` = not fenced. Set to the
+    /// new dimension `D′` after a *different-dimension* [`reconstruct`](Self::reconstruct)
+    /// promotes a new embedding space: this handle's cached `embed_dim` is now stale
+    /// (its `facts.embedding` blobs are `D′`-wide), so [`ensure_open`](Self::ensure_open)
+    /// refuses every embedding-touching read/write with
+    /// [`MemoryError::EmbeddingReopenRequired`] until the consumer reopens at `D′`.
+    /// `AtomicUsize` keeps the engine `Send + Sync` with `&self` methods and adds no
+    /// lock contention. Same-dimension reconstruction never sets it (the cached dim
+    /// stays valid — #623 behavior preserved exactly).
+    reopen_required: AtomicUsize,
 }
 
 impl std::fmt::Debug for MemoryEngine {
@@ -327,6 +337,7 @@ impl MemoryEngine {
             read_only,
             db_path,
             closed: AtomicBool::new(false),
+            reopen_required: AtomicUsize::new(0),
         })
     }
 
@@ -470,11 +481,26 @@ impl MemoryEngine {
     /// No-op for in-memory or read-only engines (`Ok(false)`). `Ok(true)` when a
     /// snapshot was written.
     ///
+    /// Also a no-op (`Ok(false)`) when the handle is **fenced** by a different-dim
+    /// reconstruction (#742): the in-memory HNSW it would serialize was built at the
+    /// old dimension, while the DB (and thus the sidecar's fingerprint/`embed_dim`
+    /// header) is now `D′`. The reopen at `D′` rebuilds the index from the DB anyway
+    /// (the `embed_dim` header gate at [`snapshot::load_from_file`] already rejects a
+    /// stale-dim sidecar), and under `ann` the assembly would otherwise *fail*
+    /// re-reading the now-`D′` `facts.embedding` at the old dim. Short-circuiting
+    /// avoids that spurious error and the wasted work. The consumer can still flush +
+    /// drop a fenced engine cleanly.
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Storage` if the fingerprint read or sidecar write
     /// fails.
     pub async fn flush_snapshot(&self) -> Result<bool> {
+        // Fenced by a different-dim reconstruction → no sidecar (see doc above).
+        if self.reopen_required.load(Ordering::Acquire) != 0 {
+            self.closed.store(true, Ordering::Release);
+            return Ok(false);
+        }
         // Build the owned snapshots, then await — the read guards are temporaries
         // dropped at the end of each statement, so none is held across `.await`.
         let graph_snap = self.graph.read().to_snapshot();
@@ -581,6 +607,41 @@ impl MemoryEngine {
         self.embed_dim
     }
 
+    /// The new dimension a different-dimension reconstruction (#742) promoted to,
+    /// if this handle is **fenced** — `Some(new_dim)` means the engine refuses
+    /// embedding-touching operations until reopened at `new_dim`; `None` means it
+    /// is serving normally. The pull-side companion to the push-side
+    /// [`MemoryError::EmbeddingReopenRequired`] the gated methods return; a consumer
+    /// can poll this after a [`reconstruct`](Self::reconstruct) instead of catching
+    /// the error.
+    #[must_use]
+    pub fn reopen_required(&self) -> Option<usize> {
+        match self.reopen_required.load(Ordering::Acquire) {
+            0 => None,
+            new_dim => Some(new_dim),
+        }
+    }
+
+    /// Read-fence guard (#742): `Err(EmbeddingReopenRequired)` once a different-dim
+    /// reconstruction has fenced this handle, else `Ok(())`. Called at the entry of
+    /// every embedding-touching public method so a stale-dimension read surfaces an
+    /// actionable error rather than a low-level `EmbeddingDimension` from a blob of
+    /// the wrong width.
+    fn ensure_open(&self) -> Result<()> {
+        match self.reopen_required.load(Ordering::Acquire) {
+            0 => Ok(()),
+            new_dim => Err(MemoryError::EmbeddingReopenRequired { new_dim }),
+        }
+    }
+
+    /// Test-only: arm the reconstruction dimension fence directly, so the read-safety
+    /// net (#742 Phase 1) can be exercised without driving a full different-dim
+    /// reconstruction. Production code arms it only inside [`reconstruct`](Self::reconstruct).
+    #[cfg(test)]
+    pub(crate) fn force_reopen_fence(&self, new_dim: usize) {
+        self.reopen_required.store(new_dim, Ordering::Release);
+    }
+
     /// Whether this engine is file-backed (vs in-memory).
     #[must_use]
     pub const fn is_file_backed(&self) -> bool {
@@ -624,6 +685,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::NotFound` if the fact doesn't exist.
     pub async fn get_fact(&self, id: i64) -> Result<Fact> {
+        self.ensure_open()?;
         self.storage.get_fact(id).await
     }
 
@@ -636,6 +698,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::Database` on query failure.
     pub async fn list_active_facts(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
+        self.ensure_open()?;
         self.storage.list_active_facts(limit).await
     }
 
@@ -648,6 +711,7 @@ impl MemoryEngine {
         &self,
         level: &ConsolidationLevel,
     ) -> Result<Vec<crate::types::Summary>> {
+        self.ensure_open()?;
         self.storage.list_summaries_by_level(level).await
     }
 

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -62,6 +62,7 @@ impl MemoryEngine {
     /// Panics if internal candidate de-duplication yields an inconsistent
     /// index — an invariant that should never be violated in practice.
     pub async fn query(&self, query: &SearchQuery) -> Result<Vec<SearchResult>> {
+        self.ensure_open()?;
         // Resolve scope. A provided-but-missing scope yields no results rather than
         // an unscoped search (#117).
         let Some(scope_ids) = self.resolve_query_scope_ids(query.scope.as_ref()) else {
@@ -124,6 +125,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::Database` on query failure.
     pub async fn execute_query(&self, query: &MemoryQuery) -> Result<QueryResponse> {
+        self.ensure_open()?;
         // --- Validation ---
         Self::validate_memory_query(query)?;
 

--- a/src/engine/reconstruct.rs
+++ b/src/engine/reconstruct.rs
@@ -181,7 +181,7 @@ impl MemoryEngine {
     /// embed task, an [`EmbeddingProvider::embed_batch`] contract violation
     /// (length mismatch), an [`MemoryError::EmbeddingDimension`] if a produced
     /// vector is not `target_dim`-wide, or any storage-port failure.
-    pub(crate) async fn backfill_space(
+    async fn backfill_space(
         &self,
         space_name: &str,
         embedder: &Arc<dyn EmbeddingProvider>,

--- a/src/engine/reconstruct.rs
+++ b/src/engine/reconstruct.rs
@@ -1,7 +1,7 @@
-//! Background reconstruction (#623): re-embed stored fact **content** (the
-//! lossless source of truth) under a new same-dimension embedding identity in the
-//! background, staging the vectors in a `populating` space's `fact_vectors`, then
-//! atomically promoting them as the active serving vectors.
+//! Background reconstruction (#623, #742): re-embed stored fact **content** (the
+//! lossless source of truth) under a new embedding identity in the background,
+//! staging the vectors in a `populating` space's `fact_vectors`, then atomically
+//! promoting them as the active serving vectors.
 //!
 //! This module owns the **engine-side orchestration** ([`MemoryEngine::reconstruct`]):
 //! it drives the embedding — off the write lock, under
@@ -19,12 +19,17 @@
 //! and re-running [`reconstruct`](MemoryEngine::reconstruct) resumes the same
 //! `populating` space (`begin_populating_space` is idempotent).
 //!
-//! **Scope: same-dim only.** A different-dim transition needs the engine
-//! effective-`embed_dim` rebuild (pool / dim-validation / HNSW at the new dim) and
-//! is the #742 follow-up; the storage layer here is already dim-agnostic and
-//! [`PromoteOutcome::new_fingerprint`] carries the new dim for it.
+//! **Same-dim vs different-dim.** A same-dim reconstruction (#623) swaps with no
+//! downtime — the engine keeps serving. A **different-dim** reconstruction (#742)
+//! also succeeds, but because the engine's `embed_dim` is cached immutably at open,
+//! the promote **fences** the handle ([`MemoryEngine::reopen_required`]): every
+//! embedding-touching op then returns [`MemoryError::EmbeddingReopenRequired`] until
+//! the consumer drops the handle and reopens the engine at the new dimension (which
+//! re-validates cleanly and rebuilds the index at the new dim). A truly in-place,
+//! no-reopen dimension transition is deferred (see the issue).
 
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use super::spawn_join_err;
 use crate::engine::MemoryEngine;
@@ -58,10 +63,10 @@ fn space_name_for(fp: &EmbeddingFingerprint) -> String {
 }
 
 impl MemoryEngine {
-    /// Reconstruct the active embedding space under a new **same-dimension**
-    /// identity, with no downtime: open a shadow space, backfill it in the
-    /// background, then atomically promote it (the served vectors swap in one
-    /// transaction; the old vectors are retained for an instant rollback).
+    /// Reconstruct the active embedding space under a new `new_fingerprint`
+    /// identity: open a shadow space, backfill it in the background, then atomically
+    /// promote it (the served vectors swap in one transaction; the old vectors are
+    /// retained for an instant rollback).
     ///
     /// Sequence: open (or resume) the `populating` space → backfill → a second
     /// **catch-up** pass (facts ingested during the first pass — live
@@ -71,38 +76,48 @@ impl MemoryEngine {
     /// Returns the [`PromoteOutcome`], with `stragglers_caught` set from the
     /// catch-up pass.
     ///
-    /// `new_fingerprint.dim` must equal the engine's [`embed_dim`](Self::embed_dim)
-    /// (same-dim only — see the module docs; different-dim is #742). The atomic
-    /// promote re-checks the dim against the active space.
+    /// **Dimension change → fence.** `new_fingerprint.dim` may differ from the
+    /// engine's current [`embed_dim`](Self::embed_dim) — that is a different-dimension
+    /// reconstruction (#742). It succeeds, but since `embed_dim` is cached immutably
+    /// at open, a different-dim promote leaves this handle stale, so it is **fenced**:
+    /// subsequent embedding-touching ops return [`MemoryError::EmbeddingReopenRequired`]
+    /// (and [`reopen_required`](Self::reopen_required) reports the new dim) until the
+    /// consumer reopens the engine at that dimension. A same-dim reconstruction does
+    /// not fence. The provider must actually produce `new_fingerprint.dim`-wide
+    /// vectors (checked up front).
     ///
     /// After the promote, [`PromoteOutcome::rebuild_index`] is `true`: the active
     /// vectors changed, so a `SQLite`+HNSW backend's in-memory index is stale until
-    /// the next open (which rebuilds it via `build_from_db`). The live in-process
-    /// rebuild hook is **#624**; until then a same-process `ann` query between
-    /// promote and reopen may use the stale index. The brute-force vector path
-    /// (default features) reads `facts.embedding` directly and is correct
-    /// immediately.
+    /// the next open (which rebuilds it via `build_from_db`). For a same-dim
+    /// reconstruction the live in-process rebuild hook is **#624**; a different-dim
+    /// reconstruction rebuilds the index on the required reopen. The brute-force
+    /// vector path (default features) reads `facts.embedding` directly and is correct
+    /// immediately (same-dim) or on reopen (different-dim).
     ///
     /// # Errors
     ///
-    /// Returns [`MemoryError::EmbeddingDimension`] if `new_fingerprint.dim` differs
-    /// from the engine dimension (different-dim → #742), [`MemoryError::ReadOnly`]
-    /// from the write port on a read-only engine, or any embedding-provider /
-    /// storage failure surfaced by the backfill or promote.
+    /// Returns [`MemoryError::EmbeddingDimension`] if `new_fingerprint.dim` disagrees
+    /// with the provider's own `fingerprint().dim` (a misconfiguration, rejected
+    /// before any backfill), [`MemoryError::ReadOnly`] from the write port on a
+    /// read-only engine, or any embedding-provider / storage failure surfaced by the
+    /// backfill or promote.
     pub async fn reconstruct(
         &self,
         new_fingerprint: &EmbeddingFingerprint,
         embedder: &Arc<dyn EmbeddingProvider>,
     ) -> Result<PromoteOutcome> {
-        // Fail fast on a different-dim request (the promote also guards, but only
-        // after a full backfill — reject before that wasted work).
-        if new_fingerprint.dim != self.embed_dim {
+        // Fail fast on a genuine misconfiguration: the declared target identity's
+        // dimension must match what the provider actually produces. (A target dim
+        // that differs from the engine's *current* dim is the whole point of #742
+        // and is allowed — that is the different-dimension transition.)
+        if new_fingerprint.dim != embedder.fingerprint().dim {
             return Err(MemoryError::EmbeddingDimension {
-                expected: self.embed_dim,
-                actual: new_fingerprint.dim,
+                expected: new_fingerprint.dim,
+                actual: embedder.fingerprint().dim,
             });
         }
 
+        let target_dim = new_fingerprint.dim;
         let space = space_name_for(new_fingerprint);
 
         // 1. Open (or resume) the shadow space.
@@ -110,26 +125,36 @@ impl MemoryEngine {
             .begin_populating_space(&space, new_fingerprint)
             .await?;
 
-        // 2. Backfill every fact's content under the new identity.
-        self.backfill_space(&space, embedder, DEFAULT_BACKFILL_BATCH)
+        // 2. Backfill every fact's content under the new identity. Vectors are
+        //    validated against `target_dim` (which may differ from the engine's
+        //    current `embed_dim` — a different-dim reconstruction).
+        self.backfill_space(&space, embedder, target_dim, DEFAULT_BACKFILL_BATCH)
             .await?;
 
         // 3. Catch-up: re-embed facts ingested during the backfill (live
         //    reconstruction). The count is the stragglers caught before promote.
         let stragglers = self
-            .backfill_space(&space, embedder, DEFAULT_BACKFILL_BATCH)
+            .backfill_space(&space, embedder, target_dim, DEFAULT_BACKFILL_BATCH)
             .await?;
 
         // 4. Atomic promote (the completeness gate re-checks INSIDE the tx).
         let mut outcome = self.storage.promote_space(&space).await?;
         outcome.stragglers_caught = stragglers;
 
+        // 5. A DIFFERENT-dimension promote leaves this handle's cached `embed_dim`
+        //    stale (`facts.embedding` is now `target_dim`-wide while every read
+        //    deserializes at the old dim). Fence the handle: embedding-touching ops
+        //    refuse with `EmbeddingReopenRequired` until the consumer reopens the
+        //    engine at the new dim. A same-dim promote does NOT fence — the cached
+        //    dim stays valid (#623 behavior preserved exactly).
+        if outcome.new_fingerprint.dim != self.embed_dim {
+            self.reopen_required
+                .store(outcome.new_fingerprint.dim, Ordering::Release);
+        }
+
         Ok(outcome)
     }
 
-    /// Backfill the `populating` space `space_name`: re-embed every fact's content
-    /// with `embedder` and stage the vectors in `fact_vectors[space_name]`.
-    ///
     /// Backfill the `populating` space `space_name`: re-embed every fact's content
     /// with `embedder` and stage the vectors in `fact_vectors[space_name]`.
     ///
@@ -138,6 +163,12 @@ impl MemoryEngine {
     /// **actually written** this call (0 on a fully-backfilled space — the
     /// idempotent/crash-resume case). The space must already exist (open it with
     /// `begin_populating_space`); this method only fills it.
+    ///
+    /// `target_dim` is the dimension every produced vector must have — the
+    /// **populating space's** declared dim, NOT the engine's current `embed_dim`
+    /// (which differs for a different-dimension reconstruction, #742). This
+    /// per-vector check is the sole width invariant once `promote_space`'s storage
+    /// guard is gone, so it is load-bearing.
     ///
     /// `after_id` advances past each window to skip the already-written prefix —
     /// an intra-run optimization only; correctness rests on the port's cursorless
@@ -148,11 +179,13 @@ impl MemoryEngine {
     ///
     /// Propagates embedding-provider failures, a join error from the blocking
     /// embed task, an [`EmbeddingProvider::embed_batch`] contract violation
-    /// (length mismatch), or any storage-port failure.
+    /// (length mismatch), an [`MemoryError::EmbeddingDimension`] if a produced
+    /// vector is not `target_dim`-wide, or any storage-port failure.
     pub(crate) async fn backfill_space(
         &self,
         space_name: &str,
         embedder: &Arc<dyn EmbeddingProvider>,
+        target_dim: usize,
         batch_size: usize,
     ) -> Result<usize> {
         let mut after_id = 0_i64;
@@ -188,15 +221,17 @@ impl MemoryEngine {
                 )));
             }
 
-            // Defense in depth: a misconfigured provider whose declared fingerprint
-            // dim matches the active space (so the same-dim promote guard passes)
-            // but which actually returns wrong-width vectors would otherwise write
-            // corrupt blobs that the promote copy-swaps straight into
-            // `facts.embedding`. Reject any off-dimension vector before it lands.
+            // Defense in depth (the SOLE width invariant since `promote_space` no
+            // longer guards dim, #742 D4): a provider whose declared fingerprint dim
+            // matches the target space but which actually returns wrong-width vectors
+            // would otherwise write corrupt blobs that the promote copy-swaps straight
+            // into `facts.embedding`. Reject any vector not `target_dim`-wide before it
+            // lands. Note `target_dim`, NOT `self.embed_dim` — they differ for a
+            // different-dimension reconstruction.
             for emb in &embeddings {
-                if emb.len() != self.embed_dim {
+                if emb.len() != target_dim {
                     return Err(MemoryError::EmbeddingDimension {
-                        expected: self.embed_dim,
+                        expected: target_dim,
                         actual: emb.len(),
                     });
                 }
@@ -271,7 +306,10 @@ mod tests {
         begin(&engine).await;
 
         // A small batch forces several windows — exercises the loop's advance.
-        let written = engine.backfill_space(SPACE, &embedder(), 2).await.unwrap();
+        let written = engine
+            .backfill_space(SPACE, &embedder(), DIM, 2)
+            .await
+            .unwrap();
         assert_eq!(written, 5, "one vector per fact across multiple windows");
         assert_eq!(engine.storage().count_unbackfilled(SPACE).await.unwrap(), 0);
     }
@@ -283,12 +321,18 @@ mod tests {
         begin(&engine).await;
 
         assert_eq!(
-            engine.backfill_space(SPACE, &embedder(), 8).await.unwrap(),
+            engine
+                .backfill_space(SPACE, &embedder(), DIM, 8)
+                .await
+                .unwrap(),
             3
         );
         // Re-running over a fully-backfilled space writes nothing.
         assert_eq!(
-            engine.backfill_space(SPACE, &embedder(), 8).await.unwrap(),
+            engine
+                .backfill_space(SPACE, &embedder(), DIM, 8)
+                .await
+                .unwrap(),
             0
         );
         assert_eq!(engine.storage().count_unbackfilled(SPACE).await.unwrap(), 0);
@@ -322,7 +366,10 @@ mod tests {
         assert_eq!(engine.storage().count_unbackfilled(SPACE).await.unwrap(), 2);
 
         // Restart: the loop re-derives only the remaining 2 via the anti-join.
-        let written = engine.backfill_space(SPACE, &embedder(), 8).await.unwrap();
+        let written = engine
+            .backfill_space(SPACE, &embedder(), DIM, 8)
+            .await
+            .unwrap();
         assert_eq!(written, 2, "only the un-backfilled remainder is written");
         assert_eq!(engine.storage().count_unbackfilled(SPACE).await.unwrap(), 0);
     }
@@ -333,7 +380,10 @@ mod tests {
         seed(&engine, &["a", "b"]).await;
         begin(&engine).await;
         assert_eq!(
-            engine.backfill_space(SPACE, &embedder(), 8).await.unwrap(),
+            engine
+                .backfill_space(SPACE, &embedder(), DIM, 8)
+                .await
+                .unwrap(),
             2
         );
 
@@ -342,7 +392,10 @@ mod tests {
         seed(&engine, &["late-arrival"]).await;
         assert_eq!(engine.storage().count_unbackfilled(SPACE).await.unwrap(), 1);
         assert_eq!(
-            engine.backfill_space(SPACE, &embedder(), 8).await.unwrap(),
+            engine
+                .backfill_space(SPACE, &embedder(), DIM, 8)
+                .await
+                .unwrap(),
             1
         );
         assert_eq!(engine.storage().count_unbackfilled(SPACE).await.unwrap(), 0);
@@ -444,24 +497,67 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reconstruct_rejects_different_dim() {
+    async fn reconstruct_different_dim_fences_handle() {
+        // #742 (inverts the old `reconstruct_rejects_different_dim`): a different-dim
+        // reconstruction now SUCCEEDS (the same-dim guard is gone) and fences the
+        // handle — `facts.embedding` is now D′-wide, so the engine refuses reads
+        // until the consumer reopens at D′. (In-memory engine = terminal fence, no
+        // reopen possible; the full file-backed D→D′→reopen cycle is a separate test.)
         let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let old: Arc<dyn EmbeddingProvider> = Arc::new(TagEmbedder {
+            model: "old",
+            value: 0.1,
+            dim: DIM,
+        });
+        let mut ids = Vec::new();
+        for c in ["a", "b"] {
+            ids.push(engine.add_fact(&req(c), old.clone(), None).await.unwrap());
+        }
         let wide: Arc<dyn EmbeddingProvider> = Arc::new(TagEmbedder {
             model: "wide",
             value: 0.9,
             dim: DIM * 2,
         });
+        let new_fp = EmbeddingFingerprint::new("wide", "test", DIM * 2);
+
+        let outcome = engine.reconstruct(&new_fp, &wide).await.unwrap();
+        assert_eq!(outcome.promoted, 2);
+        assert_eq!(outcome.new_fingerprint.dim, DIM * 2);
+        assert!(outcome.rebuild_index);
+
+        // The handle is fenced at the new dim; reads refuse until reopen.
+        assert_eq!(engine.reopen_required(), Some(DIM * 2));
+        assert!(matches!(
+            engine.get_fact(ids[0]).await,
+            Err(MemoryError::EmbeddingReopenRequired { new_dim }) if new_dim == DIM * 2
+        ));
+    }
+
+    #[tokio::test]
+    async fn reconstruct_rejects_embedder_target_dim_mismatch() {
+        // The retained fail-fast: the declared target identity's dim must match what
+        // the provider actually produces (a genuine misconfiguration), rejected
+        // before any backfill work.
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let mismatched: Arc<dyn EmbeddingProvider> = Arc::new(TagEmbedder {
+            model: "wide",
+            value: 0.9,
+            dim: DIM, // provider produces DIM-wide, but the target declares DIM*2
+        });
         let err = engine
-            .reconstruct(&EmbeddingFingerprint::new("wide", "test", DIM * 2), &wide)
+            .reconstruct(
+                &EmbeddingFingerprint::new("wide", "test", DIM * 2),
+                &mismatched,
+            )
             .await
             .unwrap_err();
         assert!(
             matches!(
                 err,
                 MemoryError::EmbeddingDimension { expected, actual }
-                    if expected == DIM && actual == DIM * 2
+                    if expected == DIM * 2 && actual == DIM
             ),
-            "different-dim is #742, got {err:?}"
+            "embedder/target dim mismatch rejected, got {err:?}"
         );
     }
 
@@ -552,7 +648,10 @@ mod tests {
             actual: DIM + 1,
         });
 
-        let err = engine.backfill_space(SPACE, &liar, 8).await.unwrap_err();
+        let err = engine
+            .backfill_space(SPACE, &liar, DIM, 8)
+            .await
+            .unwrap_err();
         assert!(
             matches!(
                 err,

--- a/src/engine/resume.rs
+++ b/src/engine/resume.rs
@@ -25,6 +25,7 @@ impl MemoryEngine {
     /// or `MemoryError::Conflict` if [`ResumeConfig::validate`] rejects the config
     /// (out-of-range `high_importance_min` or a zero tier cap).
     pub async fn resume_context(&self, config: &ResumeConfig) -> Result<ResumeContext> {
+        self.ensure_open()?;
         // Fail fast at the public boundary: reject an invalid config before
         // acquiring the scope_tree lock or touching the DB (#359). The internal
         // tier walk below trusts its already-validated input.

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -5278,4 +5278,62 @@ mod snapshot_integration {
         assert_eq!(snap_graph_nodes, rebuild_graph_nodes);
         assert_eq!(snap_graph_edges, rebuild_graph_edges);
     }
+
+    // --- #742 Phase 1: the reconstruction dimension fence ---
+
+    #[tokio::test]
+    async fn fence_blocks_embedding_touching_ops_until_reopen() {
+        // A handle fenced by a different-dim reconstruction refuses embedding-touching
+        // reads/writes with the actionable EmbeddingReopenRequired, while
+        // dimension-independent accessors keep working.
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let embedder: std::sync::Arc<dyn EmbeddingProvider> =
+            std::sync::Arc::new(MockEmbedder { dim: DIM });
+        let req = |content: &str| AddFactRequest {
+            content: content.into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        };
+        let id = engine
+            .add_fact(&req("before fence"), embedder.clone(), None)
+            .await
+            .unwrap();
+
+        // Not fenced yet.
+        assert_eq!(engine.reopen_required(), None);
+
+        // Arm the fence at a new dimension (simulating a different-dim promote).
+        engine.force_reopen_fence(8);
+        assert_eq!(engine.reopen_required(), Some(8));
+
+        // Representative gated reads/writes now refuse with the actionable error.
+        assert!(matches!(
+            engine.get_fact(id).await,
+            Err(MemoryError::EmbeddingReopenRequired { new_dim: 8 })
+        ));
+        assert!(matches!(
+            engine.list_active_facts(None).await,
+            Err(MemoryError::EmbeddingReopenRequired { new_dim: 8 })
+        ));
+        assert!(matches!(
+            engine
+                .execute_query(&MemoryQuery::new().text("before"))
+                .await,
+            Err(MemoryError::EmbeddingReopenRequired { new_dim: 8 })
+        ));
+        assert!(matches!(
+            engine
+                .add_fact(&req("after fence"), embedder.clone(), None)
+                .await,
+            Err(MemoryError::EmbeddingReopenRequired { new_dim: 8 })
+        ));
+
+        // Dimension-independent accessors are NOT fenced.
+        assert_eq!(engine.embed_dim(), DIM);
+        assert_eq!(engine.reopen_required(), Some(8));
+        // A fenced flush is a clean no-op (not an error).
+        assert!(!engine.flush_snapshot().await.unwrap());
+    }
 }

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -5336,4 +5336,151 @@ mod snapshot_integration {
         // A fenced flush is a clean no-op (not an error).
         assert!(!engine.flush_snapshot().await.unwrap());
     }
+
+    /// The headline #742 test: a file-backed engine reconstructed to a NEW
+    /// dimension, then reopened at that dimension serves the new vectors.
+    #[tokio::test]
+    async fn reconstruct_different_dim_then_reopen_at_new_dim() {
+        const D2: usize = 8; // DIM (4) → 8
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("recon.db");
+        let req = |content: &str| AddFactRequest {
+            content: content.into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        };
+
+        // Session 1: ingest @ DIM, reconstruct to D2, get fenced, flush, drop.
+        let mut ids = Vec::new();
+        {
+            let engine =
+                MemoryEngine::open_from_config(&EngineConfig::new(db_path.clone(), DIM), None)
+                    .unwrap();
+            let old: std::sync::Arc<dyn EmbeddingProvider> =
+                std::sync::Arc::new(MockEmbedder { dim: DIM });
+            for c in ["alpha", "beta", "gamma"] {
+                ids.push(engine.add_fact(&req(c), old.clone(), None).await.unwrap());
+            }
+
+            let new_provider: std::sync::Arc<dyn EmbeddingProvider> =
+                std::sync::Arc::new(MockEmbedder { dim: D2 });
+            let new_fp = EmbeddingFingerprint::new("mock", "test", D2);
+            let outcome = engine.reconstruct(&new_fp, &new_provider).await.unwrap();
+            assert_eq!(outcome.promoted, 3);
+            assert_eq!(outcome.new_fingerprint.dim, D2);
+
+            // Fenced: reads refuse, flush is a clean no-op.
+            assert_eq!(engine.reopen_required(), Some(D2));
+            assert!(matches!(
+                engine.get_fact(ids[0]).await,
+                Err(MemoryError::EmbeddingReopenRequired { new_dim: D2 })
+            ));
+            assert!(!engine.flush_snapshot().await.unwrap());
+        }
+
+        // Session 2: reopen AT THE NEW DIM — validates clean (meta now D2), rebuilds
+        // the index @ D2, and serves the new D2-wide vectors.
+        {
+            let engine =
+                MemoryEngine::open_from_config(&EngineConfig::new(db_path.clone(), D2), None)
+                    .unwrap();
+            assert_eq!(engine.embed_dim(), D2);
+            assert_eq!(
+                engine.reopen_required(),
+                None,
+                "a fresh handle is not fenced"
+            );
+            for &id in &ids {
+                assert_eq!(
+                    engine.get_fact(id).await.unwrap().embedding,
+                    vec![0.5_f32; D2],
+                    "facts.embedding now serves the new D2-wide vectors"
+                );
+            }
+            assert_eq!(
+                engine
+                    .storage()
+                    .load_embedding_fingerprint()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .dim,
+                D2
+            );
+        }
+
+        // Reopening at the OLD dim is now rejected (the recorded identity is D2).
+        let err =
+            MemoryEngine::open_from_config(&EngineConfig::new(db_path, DIM), None).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                MemoryError::Migration(MigrationError::EmbedDimMismatch { stored, requested })
+                    if stored == D2 && requested == DIM
+            ),
+            "cold reopen at the old dim must report EmbedDimMismatch, got {err:?}"
+        );
+    }
+
+    /// Fence coverage: every cheap-to-call gated method refuses on a fenced handle.
+    /// (The full 26-method gated set is verified at the source; this exercises the
+    /// representative surface across reads/writes/inspection so a regression that
+    /// drops a guard is caught.)
+    #[tokio::test]
+    async fn fence_covers_representative_gated_surface() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+        let embedder: std::sync::Arc<dyn EmbeddingProvider> =
+            std::sync::Arc::new(MockEmbedder { dim: DIM });
+        let req = |content: &str| AddFactRequest {
+            content: content.into(),
+            fact_type: FactType::Semantic,
+            source_event_id: None,
+            scope: None,
+            opts: None,
+        };
+        engine
+            .add_fact(&req("seed"), embedder.clone(), None)
+            .await
+            .unwrap();
+        engine.force_reopen_fence(8);
+
+        let fenced = |r: Result<()>| {
+            assert!(matches!(
+                r,
+                Err(MemoryError::EmbeddingReopenRequired { new_dim: 8 })
+            ));
+        };
+        fenced(engine.get_fact(1).await.map(|_| ()));
+        fenced(engine.list_active_facts(None).await.map(|_| ()));
+        fenced(
+            engine
+                .list_summaries(&ConsolidationLevel::Cluster)
+                .await
+                .map(|_| ()),
+        );
+        fenced(
+            engine
+                .execute_query(&MemoryQuery::new().text("x"))
+                .await
+                .map(|_| ()),
+        );
+        fenced(
+            engine
+                .add_fact(&req("blocked"), embedder.clone(), None)
+                .await
+                .map(|_| ()),
+        );
+        fenced(engine.explain_fact(1).await.map(|_| ()));
+        fenced(engine.fact_history(1).await.map(|_| ()));
+        fenced(engine.statistics().await.map(|_| ()));
+        fenced(engine.forget(&ForgetPolicy::default()).await.map(|_| ()));
+        fenced(
+            engine
+                .resume_context(&ResumeConfig::default())
+                .await
+                .map(|_| ()),
+        );
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -419,6 +419,20 @@ pub enum MemoryError {
         actual: Box<crate::types::EmbeddingFingerprint>,
     },
 
+    /// A different-dimension background reconstruction (#742) promoted a new
+    /// embedding space at `new_dim`, so this engine handle's cached `embed_dim` is
+    /// now stale: its `facts.embedding` blobs are `new_dim`-wide but every read
+    /// deserializes at the old dimension. The handle is **fenced** — it refuses
+    /// embedding-touching reads/writes until the consumer drops it and reopens the
+    /// engine at `new_dim` (e.g. `EngineConfig::new(path, new_dim)`), which
+    /// re-validates cleanly and rebuilds the vector index at the new dimension.
+    /// Same-dimension reconstruction does not fence (the cached dim stays valid).
+    #[error(
+        "engine dimension changed to {new_dim} by reconstruction; \
+         reopen the engine at this dimension before further use"
+    )]
+    EmbeddingReopenRequired { new_dim: usize },
+
     /// A precondition or input-validation conflict; see [`ConflictError`] for the
     /// specific cause (incompatible query options, out-of-range parameters,
     /// malformed scope labels, restore/dump preconditions, or a consumer-trait

--- a/src/store/fact_vectors.rs
+++ b/src/store/fact_vectors.rs
@@ -249,19 +249,29 @@ pub fn promote_space(conn: &Connection, populating: &str) -> Result<PromoteOutco
 /// the streaming snapshot writer. Ordered by `(space_id, fact_id)` for a stable
 /// dump.
 ///
-/// Deserializes each blob at `embed_dim`: same-dim reconstruction (#623) keeps
-/// every non-active space at the engine dimension; the different-dim follow-up
-/// (#742) will thread per-space dims here.
+/// Deserializes each blob at **its own space's recorded dimension** (#742): after
+/// a different-dimension reconstruction the active space is D′ while a retained
+/// `deprecated` space is still D-wide, so a single engine `embed_dim` cannot decode
+/// every row. The per-space dims are read once from `embedding_spaces`; `embed_dim`
+/// is only a fallback for a row whose space is somehow absent (the FK makes that
+/// impossible). This preserves the deprecated space's rollback vectors across a
+/// dump/restore of a reconstructed store (no data loss).
 ///
 /// # Errors
 ///
 /// Returns [`MemoryError::Database`](crate::error::MemoryError::Database) on query
 /// failure, [`MemoryError::EmbeddingDimension`](crate::error::MemoryError::EmbeddingDimension)
-/// if a stored blob is not `embed_dim`-sized, or any error the callback returns.
+/// if a stored blob is not its space's dim, or any error the callback returns.
 pub fn for_each<F>(conn: &Connection, embed_dim: usize, mut cb: F) -> Result<()>
 where
     F: FnMut(i64, String, Vec<f32>) -> Result<()>,
 {
+    // Per-space dims: a non-active space may differ from the active `embed_dim`
+    // after a #742 different-dim reconstruction.
+    let space_dims: std::collections::HashMap<String, usize> = embedding_spaces::list_spaces(conn)?
+        .into_iter()
+        .map(|s| (s.name, s.fingerprint.dim))
+        .collect();
     let mut stmt = conn.prepare(
         "SELECT fact_id, space_id, embedding FROM fact_vectors ORDER BY space_id, fact_id",
     )?;
@@ -270,7 +280,8 @@ where
         let fact_id: i64 = row.get(0)?;
         let space_id: String = row.get(1)?;
         let blob: Vec<u8> = row.get(2)?;
-        let embedding = crate::store::deserialize_embedding(&blob, embed_dim)?;
+        let dim = space_dims.get(&space_id).copied().unwrap_or(embed_dim);
+        let embedding = crate::store::deserialize_embedding(&blob, dim)?;
         cb(fact_id, space_id, embedding)?;
     }
     Ok(())
@@ -708,5 +719,57 @@ mod tests {
         set_active(&conn, "model-a");
         let err = promote_space(&conn, "ghost").expect_err("absent");
         assert!(matches!(err, MemoryError::Internal(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn for_each_decodes_each_space_at_its_own_dim() {
+        // #742 (R6): a dump of a reconstructed store has a deprecated space at the
+        // OLD dim while the active space (engine embed_dim) is the NEW dim. `for_each`
+        // must decode each row at its space's own recorded dim — not the engine dim —
+        // so a dump at the new dim still preserves the deprecated rollback vectors.
+        let conn = fresh_conn();
+        // Active space at the NEW (wide) dim.
+        insert_active(
+            &conn,
+            &EmbeddingSpace::default_active(EmbeddingFingerprint::new("new", "tei", DIM * 2)),
+        )
+        .expect("active wide");
+        // A deprecated space at the OLD dim, holding old-dim retained vectors.
+        insert_active(
+            &conn,
+            &EmbeddingSpace {
+                name: "old".to_string(),
+                fingerprint: EmbeddingFingerprint::new("old", "tei", DIM),
+                status: SpaceStatus::Deprecated,
+            },
+        )
+        .expect("deprecated old");
+        let a = insert_fact(&conn, "alpha");
+        let b = insert_fact(&conn, "beta");
+        write_backfill_batch(
+            &conn,
+            "old",
+            &[(a, vec![0.3_f32; DIM]), (b, vec![0.3_f32; DIM])],
+        )
+        .expect("write old-dim vectors");
+
+        // for_each at the ACTIVE (wide) embed_dim must still decode the old DIM-wide rows.
+        let mut seen: Vec<(i64, String, Vec<f32>)> = Vec::new();
+        for_each(&conn, DIM * 2, |fid, space, emb| {
+            seen.push((fid, space, emb));
+            Ok(())
+        })
+        .expect("for_each across heterogeneous dims");
+
+        assert_eq!(seen.len(), 2);
+        for (_, space, emb) in &seen {
+            assert_eq!(space, "old");
+            assert_eq!(
+                emb.len(),
+                DIM,
+                "decoded at the space's own dim, not the engine dim"
+            );
+            assert_eq!(emb, &vec![0.3_f32; DIM]);
+        }
     }
 }

--- a/src/store/fact_vectors.rs
+++ b/src/store/fact_vectors.rs
@@ -140,9 +140,12 @@ pub fn count_unbackfilled(conn: &Connection, space_id: &str) -> Result<usize> {
 /// mid-promote failure can never leave partial state).
 ///
 /// Steps, in order:
-/// 0. **Same-dim guard** — `populating.dim == active.dim`, else
-///    [`MemoryError::EmbeddingDimension`]. Different-dim is the #742 follow-up
-///    (the engine `embed_dim` is frozen at open).
+/// 0. **Resolve** the active + populating spaces (no dim guard — a promote is
+///    dimension-agnostic at the storage layer since the copy-swap is a blob-level
+///    `UPDATE`; #742 allows `populating.dim != active.dim`. The width invariant is
+///    the engine-side `backfill_space` per-vector check against the populating
+///    space's declared dim, and a different-dim promote fences the engine handle
+///    until it reopens at the new dim).
 /// 1. **Completeness gate INSIDE the tx** (no TOCTOU) — every fact must already
 ///    have a populating vector. A non-zero count aborts (a straggler arrived
 ///    after the engine's pre-tx catch-up).
@@ -164,14 +167,20 @@ pub fn count_unbackfilled(conn: &Connection, space_id: &str) -> Result<usize> {
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::EmbeddingDimension`] on a dim mismatch (different-dim),
-/// [`MemoryError::Internal`] if there is no active space, the populating space is
-/// absent or not `populating`, or the completeness gate fails, or
+/// Returns [`MemoryError::Internal`] if there is no active space, the populating
+/// space is absent or not `populating`, or the completeness gate fails, or
 /// [`MemoryError::Database`] on a write failure (which rolls the transaction back).
 pub fn promote_space(conn: &Connection, populating: &str) -> Result<PromoteOutcome> {
     let tx = conn.unchecked_transaction()?;
 
-    // (0) Resolve both spaces and enforce the same-dim guard.
+    // (0) Resolve both spaces. NO dim guard: a promote is dimension-agnostic at the
+    // storage layer (the copy-swap below is a blob-level UPDATE), so #742 allows the
+    // populating space's dim to differ from the active one. The width invariant is
+    // enforced engine-side by `backfill_space`'s per-vector check against the
+    // populating space's declared dim (the sole backstop once this guard is gone),
+    // and a different-dim promote leaves the engine handle fenced until it reopens at
+    // the new dim. The completeness gate (step 1) still guarantees every fact has a
+    // populating vector, so the total copy-swap never nulls `facts.embedding`.
     let active = embedding_spaces::find_active(&tx)?.ok_or_else(|| {
         MemoryError::Internal("promote: no active embedding space to swap over".into())
     })?;
@@ -185,12 +194,6 @@ pub fn promote_space(conn: &Connection, populating: &str) -> Result<PromoteOutco
             "promote: space {populating:?} is {:?}, expected populating",
             new.status
         )));
-    }
-    if new.fingerprint.dim != active.fingerprint.dim {
-        return Err(MemoryError::EmbeddingDimension {
-            expected: active.fingerprint.dim,
-            actual: new.fingerprint.dim,
-        });
     }
 
     // (1) Completeness gate INSIDE the tx (no TOCTOU).
@@ -565,9 +568,14 @@ mod tests {
     }
 
     #[test]
-    fn promote_rejects_different_dim() {
+    fn promote_allows_different_dim() {
+        // #742 (inverts promote_rejects_different_dim): the storage promote is
+        // dimension-agnostic — it copy-swaps DIM*2-wide vectors into facts.embedding,
+        // flips identity, and retains the old DIM-wide vectors for rollback.
         let conn = fresh_conn();
-        set_active(&conn, "model-a"); // active dim = DIM
+        set_active(&conn, "model-a"); // active @ DIM; facts seeded @ DIM
+        let a = insert_fact(&conn, "alpha");
+        let b = insert_fact(&conn, "beta");
         insert_populating(
             &conn,
             &EmbeddingSpace {
@@ -577,20 +585,46 @@ mod tests {
             },
         )
         .expect("insert wide");
+        // Backfill the wide space with DIM*2-wide vectors.
+        let wide_rows: Vec<(i64, Vec<f32>)> = [a, b]
+            .iter()
+            .map(|&id| (id, vec![0.9_f32; DIM * 2]))
+            .collect();
+        write_backfill_batch(&conn, "wide", &wide_rows).expect("backfill wide");
 
-        let err = promote_space(&conn, "wide").expect_err("different dim");
-        assert!(
-            matches!(
-                err,
-                MemoryError::EmbeddingDimension { expected, actual }
-                    if expected == DIM && actual == DIM * 2
-            ),
-            "got {err:?}"
-        );
-        // Different-dim is #742; nothing changed here.
+        let outcome = promote_space(&conn, "wide").expect("promote allows different dim");
+        assert_eq!(outcome.promoted, 2);
+        assert_eq!(outcome.new_fingerprint.dim, DIM * 2);
+
+        // facts.embedding is now DIM*2-wide (the new space's vectors).
+        for id in [a, b] {
+            let blob: Vec<u8> = conn
+                .query_row(
+                    "SELECT embedding FROM facts WHERE id = ?1",
+                    params![id],
+                    |r| r.get(0),
+                )
+                .expect("blob");
+            assert_eq!(blob.len(), DIM * 2 * 4, "served vector is now D*2-wide");
+            assert_eq!(
+                deserialize_embedding(&blob, DIM * 2).expect("deserialize"),
+                vec![0.9_f32; DIM * 2]
+            );
+        }
+        // Identity flipped to the wide space; the old "default" is retained @ DIM
+        // for rollback, the populating rows cleaned up.
+        let active = find_active(&conn).expect("find").expect("active");
+        assert_eq!(active.name, "wide");
+        assert_eq!(active.fingerprint.dim, DIM * 2);
         assert_eq!(
-            find_active(&conn).expect("find").expect("active").name,
-            "default"
+            count_vectors(&conn, "default").expect("retained"),
+            2,
+            "old DIM-wide vectors retained for rollback"
+        );
+        assert_eq!(
+            count_vectors(&conn, "wide").expect("cleanup"),
+            0,
+            "populating rows deleted post-promote"
         );
     }
 


### PR DESCRIPTION
## What

**Different-dimension** background reconstruction: re-embed stored fact content under a new embedding identity at a **new `embed_dim`** (D→D′), with the same atomic-promote machinery #623 shipped for same-dim. Closes #742. Epic #610 Wave 2.

## The obstacle + the design (reopen-at-D′)

The storage layer is already dimension-agnostic (the promote copy-swap is a blob-level `UPDATE`). The one thing freezing the engine to one dimension is `embed_dim` — consumer-passed at open, cached immutably in the engine / pool / vector index / every `deserialize_embedding` read site. After a D′ promote, `facts.embedding` is D′-wide but the live handle still holds D.

So a different-dim promote **fences** the handle and the consumer **reopens at D′**:

- **Fence** (`AtomicUsize reopen_required`): after a different-dim promote, every embedding-touching method returns `MemoryError::EmbeddingReopenRequired { new_dim }`, and `reopen_required()` reports `Some(D′)`. A same-dim promote never fences (#623 behavior preserved). The hazard is structurally safe regardless: `deserialize_embedding` is a _checked_ length compare, so a missed gate fails loud (`EmbeddingDimension`), never silent corruption — the fence just upgrades that to an actionable error.
- **Reopen** at D′ re-runs the open path: `validate_embed_dim_against_meta` passes (the active identity is now D′) and the vector index rebuilds at D′ from `facts.embedding` for free — so **#624 is not a dependency** for the different-dim path. A truly in-place, no-reopen transition (interior-mutable `embed_dim` + a live index swap) is deferred.

A truly zero-downtime in-place transition was priced (the ideal) but deferred: it needs `embed_dim` interior-mutable across ~100 capture sites + an `ArcSwap` index (subsuming #624). Reopen-at-D′ is the shippable increment, strictly more capable than today.

## Phases (risk-first: read-safety net before triggers)

1. **P1** `a9a5b3f` — the fence: `EmbeddingReopenRequired` + `reopen_required` + `ensure_open()` guard on the 26 embedding-touching methods + `reopen_required()` accessor + fenced-flush no-op (the `embed_dim` header gate already rejects a stale sidecar on reopen; this just avoids a spurious `to_snapshot` error).
2. **P2** `5344cea` — triggers: drop `promote_space`'s same-dim guard (D4); `backfill_space` validates each vector against `target_dim` not `self.embed_dim` (D5, the sole width backstop); `reconstruct()` fail-fast on embedder-vs-target mismatch + arm the fence on a different-dim commit (D6/D1). Inverted the two "rejects-different-dim" tests.
3. **P3** `e5c63bf` — the headline file-backed **D→D′→reopen cycle** test (reopen serves D′-wide vectors; cold reopen at the old dim → `EmbedDimMismatch`) + a fence-coverage test + same-dim regression intact.
4. **P4** `1c312b9` — dump decodes each `fact_vectors` row at **its own space's dim** (M1, chosen over the plan's pragmatic M2-skip) so a reconstructed store round-trips with its deprecated rollback vectors intact — no data loss.
5. **P5** `8611cd6` — docs (reconstruction.md different-dim section, ADR 0015 §4, the migration doc).

## Scope

- Different-dim via **reopen-at-D′** (this PR). In-place no-reopen transition → deferred. Live in-process HNSW rebuild (same-dim) → #624. Live-write race → #625. Operator UX + query-across-spaces → #689.
- In-memory engines: a different-dim reconstruction leaves the handle terminally fenced (no shared-DB reopen) — documented.

## Verification

`cargo build/test --workspace` (1559) · `--all-features` (1603) · `clippy --workspace --all-targets --all-features -D warnings` clean · `fmt --check` · `cargo deny check` · sphinx docs build (zero new warnings). Branched off `origin/main` (`1f235aa`, contains #623).
