### PR TITLE
feat(retrieval): same-dim HNSW rebuild on reconstruction promote (#624)

### DIFF
--- a/docs/advanced/reconstruction.md
+++ b/docs/advanced/reconstruction.md
@@ -166,11 +166,41 @@ self-heal, to avoid silent-identity-adoption, per #614).
 
 ## PromoteOutcome and index rebuild
 
-`rebuild_index` is always `true`: a promote changes every active vector, so a downstream vector
-index (HNSW) must rebuild. The **live in-process rebuild is #624**; until then, a SQLite+`ann`
-backend's index is stale only between the promote and the next open (which rebuilds it via
-`build_from_db`). The brute-force vector path (default features) reads `facts.embedding` directly and
-is correct immediately.
+`rebuild_index` is always `true`: a promote changes every active vector, so a live in-process vector
+index (HNSW) must rebuild. The engine acts on this at the end of `reconstruct`:
+
+- **Same-dim (#624):** the handle is not fenced and keeps serving, so `reconstruct` rebuilds the
+  in-process index **in place before returning**, via `SearchIndex::rebuild_vector_index` (SQLite+`ann`
+  does a full `build_from_db`-equivalent scan under the index's write lock; the swap is atomic, so a
+  concurrent `vector_search` sees the whole old or whole new index). Queries reflect the new model
+  immediately — no reopen needed.
+- **Different-dim (#742):** the handle is fenced and the consumer reopens at `D′`, which rebuilds the
+  index on open. `reconstruct` does **not** rebuild in place here (it would read the new `D′`-wide
+  blobs at the old dimension → `EmbeddingDimension`).
+
+The brute-force vector path (default features) reads `facts.embedding` directly, so it is correct the
+instant the promote commits (same-dim) or on reopen (different-dim). Durability across reopen is
+independent of the live rebuild: the engine snapshot reads vectors from the DB, so a `close()` after a
+same-dim promote already persists the new vectors regardless.
+
+### Similarity-edge invalidation (N/A in the Memory layer)
+
+Issue #624 also framed this as "invalidate cached similarity graph edges — the analog of the Knowledge
+layer deleting `relation_type = "similar"`." **The Memory layer persists no such edges, by design.**
+Every graph edge is _semantic provenance_ — `co_session`, `supersedes`, `supplements`, `contradicts`
+(session links and arbiter decisions) — which encodes real history and **must survive a model swap**;
+deleting it would destroy lineage. Vector similarity is computed _transiently_ (query-time RRF fusion,
+consolidation/DBSCAN clustering, on-the-fly resonance), never materialized as edges. The **only**
+materialized embedding-similarity cache in the Memory layer is the HNSW proximity graph itself — so
+"invalidate cached similarity edges" collapses to "rebuild the index": the same single action above,
+not a second edge-deletion step. (The Knowledge layer's `DELETE relation_type = "similar"` has no
+Memory-layer counterpart.)
+
+A _persisted_ associative similarity-edge graph — for spreading-activation recall (a fast, high-decay
+"surface recall" vs. a wide, low-decay "deep recall") — is a possible **future** cognitive-layer
+feature. If it lands, its invalidate-and-recompute step slots in alongside the index rebuild at this
+same reconstruction seam; the engine already documents the same-dim branch as the
+"refresh embedding-derived caches" point.
 
 ## Dump / restore
 

--- a/src/engine/reconstruct.rs
+++ b/src/engine/reconstruct.rs
@@ -107,10 +107,12 @@ impl MemoryEngine {
     /// in-process index rebuild, so if `rebuild_vector_index` fails this returns the
     /// error **but the promote is durable** — `facts.embedding` holds the new vectors,
     /// the identity has flipped, and the brute-force / on-disk read path is correct.
-    /// Only the in-memory HNSW index is left stale (it serves until the next open or a
-    /// retry). The rebuild is idempotent, so the consumer may simply call
-    /// [`reconstruct`](Self::reconstruct) again (it resumes/no-ops the already-promoted
-    /// space) or reopen the engine to recover the index.
+    /// Only the in-memory HNSW index is left stale. **To recover, reopen the engine:**
+    /// open rebuilds the index from `facts.embedding` (the new vectors), so the next
+    /// handle serves correctly. Note that re-calling [`reconstruct`](Self::reconstruct)
+    /// does **not** recover the index — the promote already flipped the target space to
+    /// `active`, so a second `reconstruct` to the same identity is rejected by
+    /// `begin_populating_space` (the space is no longer `populating`).
     pub async fn reconstruct(
         &self,
         new_fingerprint: &EmbeddingFingerprint,

--- a/src/engine/reconstruct.rs
+++ b/src/engine/reconstruct.rs
@@ -87,12 +87,13 @@ impl MemoryEngine {
     /// vectors (checked up front).
     ///
     /// After the promote, [`PromoteOutcome::rebuild_index`] is `true`: the active
-    /// vectors changed, so a `SQLite`+HNSW backend's in-memory index is stale until
-    /// the next open (which rebuilds it via `build_from_db`). For a same-dim
-    /// reconstruction the live in-process rebuild hook is **#624**; a different-dim
-    /// reconstruction rebuilds the index on the required reopen. The brute-force
-    /// vector path (default features) reads `facts.embedding` directly and is correct
-    /// immediately (same-dim) or on reopen (different-dim).
+    /// vectors changed. For a **same-dim** reconstruction this method now rebuilds a
+    /// `SQLite`+HNSW backend's in-memory index in place via
+    /// [`SearchIndex::rebuild_vector_index`](crate::storage::SearchIndex::rebuild_vector_index)
+    /// **before returning** (#624), so queries reflect the new model immediately. A
+    /// **different-dim** reconstruction rebuilds the index on the required reopen
+    /// (#742). The brute-force vector path (default features) reads `facts.embedding`
+    /// directly and is correct immediately (same-dim) or on reopen (different-dim).
     ///
     /// # Errors
     ///
@@ -101,6 +102,15 @@ impl MemoryEngine {
     /// before any backfill), [`MemoryError::ReadOnly`] from the write port on a
     /// read-only engine, or any embedding-provider / storage failure surfaced by the
     /// backfill or promote.
+    ///
+    /// **Post-promote rebuild failure (same-dim):** the promote commits *before* the
+    /// in-process index rebuild, so if `rebuild_vector_index` fails this returns the
+    /// error **but the promote is durable** — `facts.embedding` holds the new vectors,
+    /// the identity has flipped, and the brute-force / on-disk read path is correct.
+    /// Only the in-memory HNSW index is left stale (it serves until the next open or a
+    /// retry). The rebuild is idempotent, so the consumer may simply call
+    /// [`reconstruct`](Self::reconstruct) again (it resumes/no-ops the already-promoted
+    /// space) or reopen the engine to recover the index.
     pub async fn reconstruct(
         &self,
         new_fingerprint: &EmbeddingFingerprint,
@@ -141,13 +151,30 @@ impl MemoryEngine {
         let mut outcome = self.storage.promote_space(&space).await?;
         outcome.stragglers_caught = stragglers;
 
-        // 5. A DIFFERENT-dimension promote leaves this handle's cached `embed_dim`
-        //    stale (`facts.embedding` is now `target_dim`-wide while every read
-        //    deserializes at the old dim). Fence the handle: embedding-touching ops
-        //    refuse with `EmbeddingReopenRequired` until the consumer reopens the
-        //    engine at the new dim. A same-dim promote does NOT fence — the cached
-        //    dim stays valid (#623 behavior preserved exactly).
-        if outcome.new_fingerprint.dim != self.embed_dim {
+        // 5. The active vectors all changed — refresh the index. Two mutually
+        //    exclusive cases, gated structurally on the dimension (NOT on
+        //    `outcome.rebuild_index`, which is unconditionally true): a wrong-dim
+        //    rebuild is unreachable by construction because the rebuild arm only runs
+        //    when the dims match.
+        if outcome.new_fingerprint.dim == self.embed_dim {
+            // SAME-dim (#624): the cached dim stays valid (#623 behavior preserved),
+            // so the handle keeps serving — but a live in-process vector index (HNSW)
+            // was built on the now-replaced vectors and is stale. Rebuild it before
+            // returning so queries reflect the new model immediately (a no-op on the
+            // brute-force path, which reads `facts.embedding` directly).
+            //
+            // This is the designated "refresh embedding-derived caches after a same-dim
+            // promote" point: if a persisted associative similarity-edge graph is added
+            // later (a future cognitive-layer feature), its invalidation/recompute
+            // slots in here, alongside the index rebuild.
+            self.storage.rebuild_vector_index().await?;
+        } else {
+            // DIFFERENT-dim (#742): this handle's cached `embed_dim` is now stale
+            // (`facts.embedding` is `target_dim`-wide while every read deserializes at
+            // the old dim). Fence the handle — embedding-touching ops refuse with
+            // `EmbeddingReopenRequired` until the consumer reopens at the new dim,
+            // which rebuilds the index for free on open. (Rebuilding in place here
+            // would read the new D′-wide blobs at the old dim → `EmbeddingDimension`.)
             self.reopen_required
                 .store(outcome.new_fingerprint.dim, Ordering::Release);
         }
@@ -662,5 +689,109 @@ mod tests {
         );
         // Nothing was written: the fact stays un-backfilled.
         assert_eq!(engine.storage().count_unbackfilled(SPACE).await.unwrap(), 1);
+    }
+
+    // --- #624: same-dim live HNSW rebuild on promote (ann feature) ---
+    #[cfg(feature = "ann")]
+    mod ann_rebuild {
+        use super::*;
+        use crate::search::hybrid::{SearchMode, SearchQuery};
+        use crate::search::strategy::SearchConfig;
+
+        #[tokio::test]
+        async fn same_dim_reconstruct_rebuilds_index_without_fencing() {
+            // #624 wiring guard: with a live HNSW index (ann_threshold=0), a same-dim
+            // reconstruction rebuilds the in-process index and does NOT fence the
+            // handle. The *rigorous* proof that the rebuild refreshes/reclaims the index
+            // is the strategy-level white-box test in `search::ann`
+            // (`rebuild_from_db_reclaims_tombstones_and_matches_live_rows`); at this
+            // corpus size an engine query resolves via re-scoring regardless, so this
+            // test guards: same-dim ⇒ no fence, the rebuild runs cleanly under ann
+            // (a rebuild error would surface as `reconstruct` returning `Err`), and the
+            // engine stays queryable through the HNSW path afterward.
+            let engine = MemoryEngine::builder(DIM)
+                .search_config(SearchConfig { ann_threshold: 0 })
+                .build()
+                .unwrap();
+            let old: Arc<dyn EmbeddingProvider> = Arc::new(TagEmbedder {
+                model: "old",
+                value: 0.1,
+                dim: DIM,
+            });
+            let new: Arc<dyn EmbeddingProvider> = Arc::new(TagEmbedder {
+                model: "new",
+                value: 0.9,
+                dim: DIM,
+            });
+            let new_fp = EmbeddingFingerprint::new("new", "test", DIM);
+
+            let mut ids = Vec::new();
+            for c in ["a", "b", "c"] {
+                ids.push(engine.add_fact(&req(c), old.clone(), None).await.unwrap());
+            }
+
+            let outcome = engine.reconstruct(&new_fp, &new).await.unwrap();
+            assert_eq!(outcome.promoted, 3);
+            assert!(outcome.rebuild_index);
+            // Same-dim ⇒ the handle is NOT fenced (#623 behavior preserved).
+            assert_eq!(engine.reopen_required(), None);
+
+            // Served vectors are the new model's, and the engine remains queryable
+            // through the rebuilt HNSW path (ann_threshold=0 ⇒ HNSW active).
+            for &id in &ids {
+                assert_eq!(
+                    engine.storage().get_fact(id).await.unwrap().embedding,
+                    vec![0.9_f32; DIM]
+                );
+            }
+            let results = engine
+                .query(&SearchQuery {
+                    text: None,
+                    embedding: Some(vec![0.9_f32; DIM]),
+                    mode: SearchMode::Vector,
+                    limit: 5,
+                    rerank_depth: None,
+                    valid_at: None,
+                    fact_type: None,
+                    scope: None,
+                })
+                .await
+                .unwrap();
+            assert_eq!(results.len(), 3, "all facts served from the rebuilt index");
+        }
+
+        #[tokio::test]
+        async fn different_dim_reconstruct_fences_and_skips_rebuild() {
+            // #742 preserved under ann: a different-dim reconstruction takes the FENCE
+            // arm, never the same-dim rebuild arm (which would read D′-wide blobs at the
+            // old dim → EmbeddingDimension). It must succeed and set reopen_required.
+            let engine = MemoryEngine::builder(DIM)
+                .search_config(SearchConfig { ann_threshold: 0 })
+                .build()
+                .unwrap();
+            let old: Arc<dyn EmbeddingProvider> = Arc::new(TagEmbedder {
+                model: "old",
+                value: 0.1,
+                dim: DIM,
+            });
+            for c in ["a", "b"] {
+                engine.add_fact(&req(c), old.clone(), None).await.unwrap();
+            }
+            let wide: Arc<dyn EmbeddingProvider> = Arc::new(TagEmbedder {
+                model: "wide",
+                value: 0.9,
+                dim: DIM * 2,
+            });
+            let new_fp = EmbeddingFingerprint::new("wide", "test", DIM * 2);
+
+            let outcome = engine.reconstruct(&new_fp, &wide).await.unwrap();
+            assert_eq!(outcome.promoted, 2);
+            assert_eq!(outcome.new_fingerprint.dim, DIM * 2);
+            assert_eq!(
+                engine.reopen_required(),
+                Some(DIM * 2),
+                "different-dim fences, does not rebuild at the wrong dim"
+            );
+        }
     }
 }

--- a/src/search/ann.rs
+++ b/src/search/ann.rs
@@ -82,24 +82,37 @@ impl HnswStrategy {
         inner.fact_to_hnsw.len()
     }
 
-    /// Build an HNSW index from all active facts in the database.
+    /// Construct an empty `hnsw::Hnsw` with the canonical seed + params.
     ///
-    /// # Errors
-    ///
-    /// Returns `MemoryError::Database` on query failure, or
-    /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
-    ///
-    /// # Panics
-    ///
-    /// Panics if HNSW does not assign sequential IDs starting from 0.
-    pub fn build_from_db(conn: &Connection, embed_dim: usize) -> Result<Self> {
+    /// The single construction point for the index used by every build path
+    /// ([`build_inner`](Self::build_inner) and [`from_snapshot`](Self::from_snapshot)),
+    /// so the deterministic topology (`HNSW_SEED`, `ef_construction(200)`) can never
+    /// drift between a freshly-opened, a rebuilt, and a snapshot-restored index — a
+    /// drift would silently change which neighbors a query proposes.
+    fn new_hnsw_index() -> Hnsw<CosineMetric, Vec<f32>, SmallRng, 16, 32> {
         use rand::SeedableRng;
 
-        let mut index: Hnsw<CosineMetric, Vec<f32>, SmallRng, 16, 32> = Hnsw::new_params_and_prng(
+        Hnsw::new_params_and_prng(
             CosineMetric,
             hnsw::Params::new().ef_construction(200),
             SmallRng::seed_from_u64(HNSW_SEED),
-        );
+        )
+    }
+
+    /// Build a populated [`HnswInner`] from all active facts in `conn`.
+    ///
+    /// The shared core of [`build_from_db`](Self::build_from_db) (wraps it in a fresh
+    /// `RwLock`) and [`rebuild_from_db`](Self::rebuild_from_db) (swaps it into the
+    /// existing lock) — so both produce an index with identical topology from the
+    /// same DB rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure, `MemoryError::Internal` if
+    /// HNSW does not assign sequential IDs starting from 0, or
+    /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
+    fn build_inner(conn: &Connection, embed_dim: usize) -> Result<HnswInner> {
+        let mut index = Self::new_hnsw_index();
         let mut searcher: Searcher<u32> = Searcher::default();
         let mut index_to_fact = Vec::new();
 
@@ -126,15 +139,77 @@ impl HnswStrategy {
             fact_to_hnsw.insert(fact_id, hnsw_id);
         }
 
+        Ok(HnswInner {
+            index,
+            index_to_fact,
+            fact_to_hnsw,
+            tombstones: HashSet::new(),
+        })
+    }
+
+    /// Build an HNSW index from all active facts in the database.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure, or
+    /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
+    pub fn build_from_db(conn: &Connection, embed_dim: usize) -> Result<Self> {
         Ok(Self {
-            inner: RwLock::new(HnswInner {
-                index,
-                index_to_fact,
-                fact_to_hnsw,
-                tombstones: HashSet::new(),
-            }),
+            inner: RwLock::new(Self::build_inner(conn, embed_dim)?),
             embed_dim,
         })
+    }
+
+    /// Rebuild the index **in place** from the current active facts in `conn`.
+    ///
+    /// Used after a same-dim reconstruction promote (#624): the active vectors were
+    /// rewritten under a new embedding model, so the in-memory graph (built on the
+    /// old vectors) is stale and must be rebuilt. Builds a fresh [`HnswInner`] via a
+    /// full [`build_inner`](Self::build_inner) scan, then swaps it in — all-or-nothing:
+    /// on `Err` the swap never happens (`?` returns before the assignment) and the
+    /// old, stale-but-consistent index stays live.
+    ///
+    /// **The write lock spans the whole build, deliberately.** `notify_insert` /
+    /// `notify_expire` take the *same* lock, so building under it serializes any
+    /// concurrent fact write either *before* the scan (→ included in the rebuild) or
+    /// *after* the swap (→ applied to the new index). Building off-lock and only
+    /// locking for the swap would let a concurrent `notify` land on the
+    /// about-to-be-discarded old index and be silently lost. A same-dim
+    /// reconstruction is a rare, operator-driven event, so briefly blocking
+    /// `vector_search` (which takes the read lock) for the O(N) build is the correct
+    /// trade vs. a dropped index entry.
+    ///
+    /// `&self` interior mutability — the engine holds only `&dyn StorageBackend`
+    /// post-#631, so a `&mut self` rebuild is unreachable. Same-dim only: it reuses
+    /// `self.embed_dim`, so a wrong-dim rebuild is impossible by construction (a
+    /// different-dim reconstruction fences + reopens instead, #742).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure, or
+    /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the write lock MUST span the build_inner scan, not just the swap: \
+                  notify_insert/notify_expire take the same lock, so building under it \
+                  serializes concurrent writes either before the scan or after the swap. \
+                  Tightening to build-off-lock-then-swap reintroduces a lost-update window \
+                  where a concurrent notify lands on the discarded old index."
+    )]
+    pub(crate) fn rebuild_from_db(&self, conn: &Connection) -> Result<()> {
+        let mut guard = self.inner.write();
+        *guard = Self::build_inner(conn, self.embed_dim)?;
+        Ok(())
+    }
+
+    /// Number of tombstoned (logically-removed) HNSW slots — test-only white-box
+    /// accessor. A full [`rebuild_from_db`](Self::rebuild_from_db) must reset this to
+    /// `0` (it builds a fresh index with no tombstones), distinguishing a genuine
+    /// rebuild from a `notify_insert`-replay (which only appends + tombstones, never
+    /// reclaims).
+    #[cfg(test)]
+    pub(crate) fn tombstone_count(&self) -> usize {
+        self.inner.read().tombstones.len()
     }
 
     /// Snapshot active embeddings for fast cold-start.
@@ -173,19 +248,14 @@ impl HnswStrategy {
 
     /// Rebuild a compact HNSW index from snapshot data (no DB I/O needed).
     ///
-    /// Uses the same seed and parameters as `build_from_db` for deterministic
-    /// topology.
+    /// Shares [`new_hnsw_index`](Self::new_hnsw_index) with `build_inner` for the
+    /// same seed and parameters, so a snapshot-restored index has the same
+    /// deterministic topology as a freshly-built or rebuilt one.
     pub(crate) fn from_snapshot(
         snap: &crate::engine::snapshot::HnswSnapshot,
         embed_dim: usize,
     ) -> Result<Self> {
-        use rand::SeedableRng;
-
-        let mut index: Hnsw<CosineMetric, Vec<f32>, SmallRng, 16, 32> = Hnsw::new_params_and_prng(
-            CosineMetric,
-            hnsw::Params::new().ef_construction(200),
-            SmallRng::seed_from_u64(HNSW_SEED),
-        );
+        let mut index = Self::new_hnsw_index();
         let mut searcher: Searcher<u32> = Searcher::default();
         let mut index_to_fact = Vec::new();
         let mut fact_to_hnsw = HashMap::new();
@@ -630,6 +700,136 @@ mod tests {
             assert!(
                 !results.iter().any(|r| r.fact_id == ids[0]),
                 "expired fact should be excluded"
+            );
+        }
+
+        // --- #624: rebuild_from_db (live same-dim reconstruction rebuild) ---
+
+        #[test]
+        fn rebuild_from_db_reclaims_tombstones_and_matches_live_rows() {
+            // White-box guard for #624 — the *rigorous* proof that `rebuild_from_db`
+            // produces a fresh index, not a `notify_insert`-replay (which only appends
+            // + tombstones, never reclaims). A black-box query test cannot distinguish
+            // a stale index from a rebuilt one at this corpus size: `search` re-scores
+            // every candidate against the current DB embedding and, with
+            // `DEFAULT_EF_SEARCH = 100` exploring the whole small graph, returns the
+            // correct top-k either way. The tombstone/active-count invariant is the
+            // observable a no-op (or replay) rebuild fails. DO NOT "simplify" this into
+            // a query assertion — it would silently stop guarding the rebuild.
+            let (conn, ids) = setup_with_facts();
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+
+            // Churn the in-memory index so it accumulates tombstones: re-insert one
+            // fact (tombstones its prior slot) and expire another.
+            strategy.notify_insert(ids[0], &[0.5_f32, 0.5, 0.0, 0.0]);
+            strategy.notify_expire(ids[1]);
+            assert!(
+                strategy.tombstone_count() >= 2,
+                "churn must create tombstones, got {}",
+                strategy.tombstone_count()
+            );
+
+            // Expire ids[1] in the DB too, so the rebuild's active scan drops it.
+            conn.execute(
+                "UPDATE facts SET t_expired = datetime('now') WHERE id = ?1",
+                [ids[1]],
+            )
+            .unwrap();
+
+            strategy.rebuild_from_db(&conn).unwrap();
+
+            // A genuine rebuild resets tombstones to 0 and the active set to live rows.
+            assert_eq!(
+                strategy.tombstone_count(),
+                0,
+                "rebuild must reclaim all tombstones"
+            );
+            assert_eq!(
+                strategy.active_count(),
+                2,
+                "active set == live (non-expired) rows: ids[0], ids[2]"
+            );
+        }
+
+        #[test]
+        fn rebuild_from_db_on_empty_db_is_ok() {
+            let conn = open_memory().unwrap();
+            init_schema(&conn).unwrap();
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+            strategy.rebuild_from_db(&conn).unwrap();
+            assert_eq!(strategy.active_count(), 0);
+            let results = strategy
+                .search(&conn, &[1.0_f32, 0.0, 0.0, 0.0], DIM, 5, None, None)
+                .unwrap();
+            assert!(results.is_empty(), "rebuilt empty index yields no results");
+        }
+
+        #[test]
+        fn rebuild_from_db_reflects_swapped_embeddings() {
+            // Behavioral companion: after the stored vectors change, a rebuilt index
+            // searches over the NEW vectors. (At this corpus size the query also
+            // resolves correctly on a stale index via re-scoring — the white-box test
+            // above is the rigorous guard; this documents end-to-end intent and that a
+            // rebuild does not break search.)
+            let (conn, ids) = setup_with_facts();
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap(); // graph on OLD vectors
+
+            // Swap stored vectors: ids[2] becomes the e0 match, ids[0] moves to e1.
+            conn.execute(
+                "UPDATE facts SET embedding = ?1 WHERE id = ?2",
+                rusqlite::params![
+                    crate::store::serialize_embedding(&[0.0_f32, 1.0, 0.0, 0.0]),
+                    ids[0]
+                ],
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE facts SET embedding = ?1 WHERE id = ?2",
+                rusqlite::params![
+                    crate::store::serialize_embedding(&[1.0_f32, 0.0, 0.0, 0.0]),
+                    ids[2]
+                ],
+            )
+            .unwrap();
+
+            strategy.rebuild_from_db(&conn).unwrap(); // graph on NEW vectors
+
+            let results = strategy
+                .search(&conn, &[1.0_f32, 0.0, 0.0, 0.0], DIM, 1, None, None)
+                .unwrap();
+            assert_eq!(
+                results[0].fact_id, ids[2],
+                "after rebuild, the fact swapped to e0 is the nearest"
+            );
+        }
+
+        #[test]
+        fn rebuild_from_db_dim_mismatch_preserves_old_index() {
+            // All-or-nothing: a rebuild that hits a wrong-width stored embedding errors
+            // and leaves the previous in-memory index untouched (the `?` returns before
+            // the swap assignment).
+            let (conn, ids) = setup_with_facts();
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+            let before = strategy.active_count();
+
+            conn.execute(
+                "UPDATE facts SET embedding = ?1 WHERE id = ?2",
+                rusqlite::params![
+                    crate::store::serialize_embedding(&[0.5_f32; DIM + 1]),
+                    ids[0]
+                ],
+            )
+            .unwrap();
+
+            let err = strategy.rebuild_from_db(&conn).unwrap_err();
+            assert!(
+                matches!(err, crate::error::MemoryError::EmbeddingDimension { .. }),
+                "wrong-width stored embedding must abort the rebuild, got {err:?}"
+            );
+            assert_eq!(
+                strategy.active_count(),
+                before,
+                "a failed rebuild must leave the old index intact"
             );
         }
     }

--- a/src/storage/backend.rs
+++ b/src/storage/backend.rs
@@ -134,5 +134,8 @@ mod tests {
                 .is_empty()
         );
         assert_eq!(idx.lexical_count_expired("q", None, None).await.unwrap(), 0);
+        // #624: `Dummy` does not override `rebuild_vector_index`, so it inherits the
+        // default no-op — object-safe and callable through `&dyn SearchIndex`.
+        idx.rebuild_vector_index().await.unwrap();
     }
 }

--- a/src/storage/search_index.rs
+++ b/src/storage/search_index.rs
@@ -62,4 +62,55 @@ pub trait SearchIndex: Send + Sync {
         fact_type: Option<&FactType>,
         scope_ids: Option<&[i64]>,
     ) -> Result<usize>;
+
+    /// Rebuild the in-process vector index from the current active facts, after a
+    /// **same-dim** reconstruction promote (#624).
+    ///
+    /// A same-dim reconstruction rewrites every `facts.embedding` under a new
+    /// embedding model without changing the dimension, so the engine keeps serving on
+    /// the same handle (no reopen). A backend that maintains a *live in-process* ANN
+    /// index (`SQLite` + `ann`) must therefore rebuild it here, because the index was
+    /// built on the now-replaced vectors. (A *different-dim* reconstruction fences the
+    /// handle and the consumer reopens, rebuilding on open — #742 — so it never calls
+    /// this.)
+    ///
+    /// ## Contract — backends with a live index MUST override
+    /// The default is a **no-op**, correct ONLY for backends that need no in-process
+    /// rebuild: the brute-force `SQLite` path reads `facts.embedding` directly per query
+    /// (already correct the instant the promote commits), and a server-side index (a
+    /// future Postgres/`pgvector` backend, #633) is maintained by the database. **Any
+    /// backend that holds a live in-memory similarity index MUST override this** —
+    /// inheriting the no-op would silently serve stale vectors after a model swap.
+    /// (The #632 conformance suite is the place to assert post-swap query correctness
+    /// so a non-overriding backend fails loudly.)
+    ///
+    /// ## Concurrency
+    /// An implementation MUST rebuild atomically: a concurrent `vector_search` must
+    /// observe either the entire old or the entire new index, never a partial graph,
+    /// and a concurrent index mutation (insert/expire) must not be lost to the swap.
+    ///
+    /// ## Similarity-edge invalidation (N/A in this engine — canonical note)
+    /// Issue #624 also asked to "invalidate cached similarity graph edges (the
+    /// analog of the Knowledge layer deleting `relation_type = "similar"`)." **The
+    /// Memory layer persists no such edges.** Every graph edge is *semantic
+    /// provenance* — `co_session` / `supersedes` / `supplements` / `contradicts`,
+    /// i.e. session links and arbiter decisions — which encode real history and MUST
+    /// survive a model swap. Vector similarity is computed transiently (query-time RRF
+    /// fusion, consolidation/DBSCAN clustering, on-the-fly resonance), never
+    /// materialized as edges. The **only** materialized embedding-similarity cache is
+    /// this vector index itself, so "invalidate cached similarity edges" collapses to
+    /// "rebuild the index" — the same single action this method performs, not a
+    /// second edge-deletion step. A persisted associative similarity graph (for
+    /// spreading-activation recall) is a possible *future* cognitive-layer feature; if
+    /// it lands, its invalidation slots in alongside this call at the reconstruction
+    /// seam.
+    ///
+    /// # Errors
+    /// [`MemoryError::Storage`](crate::error::MemoryError::Storage) on a backend
+    /// failure, or
+    /// [`MemoryError::EmbeddingDimension`](crate::error::MemoryError::EmbeddingDimension)
+    /// if a stored embedding has the wrong width.
+    async fn rebuild_vector_index(&self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -352,6 +352,32 @@ impl SqliteBackend {
             hnsw.notify_expire(fact_id);
         }
     }
+
+    /// Rebuild the in-memory HNSW index from the current active facts (#624).
+    ///
+    /// Called after a same-dim reconstruction promote rewrote every
+    /// `facts.embedding` under a new model: the graph (built on the old vectors) is
+    /// stale. Runs the CPU-heavy O(N) rebuild on a blocking thread via
+    /// [`block_read`](Self::block_read); [`HnswStrategy::rebuild_from_db`] builds the
+    /// fresh index under its write lock and swaps it in atomically. No-op when no
+    /// HNSW index is active (brute-force mode reads `facts.embedding` directly and is
+    /// already correct).
+    ///
+    /// The `Arc<HnswStrategy>` is cloned into the `'static` blocking closure (a cheap
+    /// pointer bump), mirroring `vector_search`'s HNSW dispatch.
+    ///
+    /// # Errors
+    ///
+    /// [`MemoryError::Storage`] on a backend failure, or
+    /// [`MemoryError::EmbeddingDimension`] if a stored embedding has the wrong width.
+    #[cfg(feature = "ann")]
+    pub(super) async fn hnsw_rebuild_from_db(&self) -> Result<()> {
+        let Some(hnsw) = self.hnsw.clone() else {
+            return Ok(()); // no HNSW active → brute-force path needs no rebuild
+        };
+        self.block_read(move |conn| hnsw.rebuild_from_db(conn))
+            .await
+    }
 }
 
 /// Map a tokio [`JoinError`](tokio::task::JoinError) (a panic or cancellation in the

--- a/src/storage/sqlite/search_index.rs
+++ b/src/storage/sqlite/search_index.rs
@@ -120,6 +120,21 @@ impl SearchIndex for SqliteBackend {
         })
         .await
     }
+
+    /// Rebuild the in-memory HNSW index after a same-dim reconstruction promote
+    /// (#624). With `ann`, delegates to [`hnsw_rebuild_from_db`](SqliteBackend::hnsw_rebuild_from_db)
+    /// (itself a no-op when no HNSW index is active). Without `ann`, the brute-force
+    /// vector path reads `facts.embedding` directly, so there is nothing to rebuild.
+    async fn rebuild_vector_index(&self) -> Result<()> {
+        #[cfg(feature = "ann")]
+        {
+            self.hnsw_rebuild_from_db().await
+        }
+        #[cfg(not(feature = "ann"))]
+        {
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -569,6 +584,29 @@ mod tests {
             "AsOf must NOT surface soft-deleted (expired) rows; got {got:?}"
         );
     }
+
+    /// #624: a backend with no active in-process index — no `search_config` (so no
+    /// HNSW even with `ann`) or the `ann` feature off entirely — treats
+    /// `rebuild_vector_index` as a no-op, and the brute-force vector path still ranks
+    /// correctly afterward. Runs under both feature configs.
+    #[tokio::test]
+    async fn rebuild_vector_index_is_noop_without_active_index() {
+        let pool = seeded(&[
+            fact("a", [1.0, 0.0, 0.0, 0.0], false),
+            fact("b", [0.0, 1.0, 0.0, 0.0], false),
+        ]);
+        let be = backend(Arc::clone(&pool));
+        be.rebuild_vector_index().await.unwrap();
+        let got = be
+            .vector_search(&[1.0, 0.0, 0.0, 0.0], &FactFilter::default(), 1)
+            .await
+            .unwrap();
+        assert_eq!(
+            got.len(),
+            1,
+            "brute-force search still ranks after a no-op rebuild"
+        );
+    }
 }
 
 // =============================================================================
@@ -982,5 +1020,123 @@ mod hnsw_tests {
                 .collect::<Vec<_>>(),
             "snapshot round-trip must preserve top-k result order"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // #624 — rebuild_vector_index (same-dim live HNSW rebuild on promote)
+    // -------------------------------------------------------------------------
+
+    /// After the stored vectors are swapped (as a same-dim promote does), a rebuild
+    /// makes `vector_search` reflect the NEW vectors, and leaves a clean index (no
+    /// tombstones — the white-box guard, since at this corpus size re-scoring would
+    /// mask staleness in the query result alone).
+    #[tokio::test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "write guard intentionally held across the two UPDATEs"
+    )]
+    async fn rebuild_vector_index_reflects_swapped_vectors() {
+        use crate::store::serialize_embedding;
+
+        let pool = seeded(&[
+            fact("a", [1.0, 0.0, 0.0, 0.0]),
+            fact("b", [0.0, 1.0, 0.0, 0.0]),
+            fact("c", [0.0, 0.0, 1.0, 0.0]),
+        ]);
+        let be = backend_with_ann(Arc::clone(&pool), 0);
+
+        let ids: std::collections::HashMap<String, i64> = {
+            let c = pool.read().unwrap();
+            FactStore::new(&c, DIM)
+                .list_all()
+                .unwrap()
+                .into_iter()
+                .map(|f| (f.content, f.id))
+                .collect()
+        };
+        let (a_id, c_id) = (ids["a"], ids["c"]);
+
+        // Baseline: query e0 → fact "a".
+        let base = be
+            .vector_search(&[1.0, 0.0, 0.0, 0.0], &FactFilter::default(), 1)
+            .await
+            .unwrap();
+        assert_eq!(base[0].0, a_id);
+
+        // Simulate a same-dim promote: swap stored vectors so "c" becomes the e0 match.
+        {
+            let conn = pool.write();
+            conn.execute(
+                "UPDATE facts SET embedding = ?1 WHERE id = ?2",
+                rusqlite::params![serialize_embedding(&[0.0_f32, 0.0, 1.0, 0.0]), a_id],
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE facts SET embedding = ?1 WHERE id = ?2",
+                rusqlite::params![serialize_embedding(&[1.0_f32, 0.0, 0.0, 0.0]), c_id],
+            )
+            .unwrap();
+        }
+
+        be.rebuild_vector_index().await.unwrap();
+
+        // White-box: a genuine rebuild leaves no tombstones.
+        assert_eq!(be.hnsw.as_ref().unwrap().tombstone_count(), 0);
+        // Behavioral: query e0 now returns "c".
+        let after = be
+            .vector_search(&[1.0, 0.0, 0.0, 0.0], &FactFilter::default(), 1)
+            .await
+            .unwrap();
+        assert_eq!(
+            after[0].0, c_id,
+            "after rebuild, the fact swapped to e0 is nearest"
+        );
+    }
+
+    /// Concurrent `rebuild_vector_index` and `vector_search` are deadlock-free and
+    /// every search observes a complete index (the atomic off-/under-lock swap).
+    ///
+    /// The no-lost-update guarantee against concurrent inserts is a type-level
+    /// property (`rebuild_from_db` holds the same write lock `notify_insert` takes,
+    /// serializing a concurrent insert into the scan or after the swap — see its
+    /// docs), so this test focuses on the read/rebuild interplay (deadlock + torn-read
+    /// freedom) which is what the locking actually has to get right at runtime.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn rebuild_vector_index_concurrent_with_search_is_consistent() {
+        let pool = seeded(&[
+            fact("north", [1.0, 0.0, 0.0, 0.0]),
+            fact("near", [0.9, 0.1, 0.0, 0.0]),
+            fact("east", [0.0, 1.0, 0.0, 0.0]),
+        ]);
+        let be = Arc::new(backend_with_ann(Arc::clone(&pool), 0));
+
+        let mut handles = Vec::new();
+        {
+            let be = Arc::clone(&be);
+            handles.push(tokio::spawn(async move {
+                for _ in 0..10 {
+                    be.rebuild_vector_index().await.unwrap();
+                }
+            }));
+        }
+        for _ in 0..3 {
+            let be = Arc::clone(&be);
+            handles.push(tokio::spawn(async move {
+                for _ in 0..20 {
+                    let got = be
+                        .vector_search(&[1.0_f32, 0.0, 0.0, 0.0], &FactFilter::default(), 2)
+                        .await
+                        .unwrap();
+                    // A complete index always yields the full top-k for this corpus.
+                    assert_eq!(got.len(), 2, "search saw a partial/torn index");
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        assert_eq!(be.hnsw.as_ref().unwrap().active_count(), 3);
+        assert_eq!(be.hnsw.as_ref().unwrap().tombstone_count(), 0);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1098,9 +1098,13 @@ pub struct PromoteOutcome {
     /// their backfill cursor passed). `0` from the storage port's perspective — the
     /// engine orchestration sets this; reserved for the live-write race work (#625).
     pub stragglers_caught: usize,
-    /// The active vectors changed, so a downstream vector index (HNSW) must rebuild.
-    /// Always `true` for a promote — even same-dim, the vectors are new. The engine
-    /// fires a full `build_from_db` until the incremental rebuild hook lands (#624).
+    /// The active vectors all changed, so a live in-process vector index (HNSW) must
+    /// rebuild. Always `true` for a promote — even same-dim, the vectors are new. The
+    /// engine acts on this by calling
+    /// [`SearchIndex::rebuild_vector_index`](crate::storage::SearchIndex::rebuild_vector_index)
+    /// on the **same-dim** path (#624); a **different-dim** promote rebuilds on the
+    /// required reopen (#742). This flag is the operator-facing signal (#689) that the
+    /// active vectors changed — **not** an assertion that the index is currently stale.
     pub rebuild_index: bool,
 }
 


### PR DESCRIPTION
## Summary

Closes #624 (epic #610, Wave 2). A **same-dim** reconstruction (#623) rewrites every `facts.embedding` under a new embedding model without changing the dimension, so the engine keeps serving on the same handle (no reopen). But the live in-process HNSW index was built on the _old_ vectors and was left **stale until the next open** — this PR closes that live, no-reopen window.

`reconstruct()`'s same-dim branch now rebuilds the index in place before returning, via a new `SearchIndex::rebuild_vector_index` port method.

## Scope (after #623 + #742)

| Concern                               | Status                                    | This PR                                                                           |
| ------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------- |
| Rebuild index on **same-dim** promote | the gap — index left stale until reopen   | **live in-place rebuild**                                                         |
| Rebuild on **different-dim** promote  | done (#742 fence → reopen rebuilds at D′) | none — must _not_ rebuild (would read D′ blobs at old dim → `EmbeddingDimension`) |
| Invalidate cached similarity edges    | **N/A** in ME (see below)                 | **documented**, not coded                                                         |
| Durability across reopen              | already correct (snapshot reads DB)       | none                                                                              |

## Design

- **`HnswStrategy::rebuild_from_db(&self)`** — rebuilds from the current active facts and swaps the index in **all-or-nothing** (`?` returns before the assignment, so a failed rebuild leaves the old index intact). The write lock spans the **whole build**, deliberately: `notify_insert`/`notify_expire` take the same lock, so a concurrent fact write is serialized into the scan or after the swap, never lost. `&self` interior mutability — the engine holds only `Arc<dyn StorageBackend>`. Factored out `build_inner` + `new_hnsw_index` so the rebuild, the open-time build, and snapshot restore share one seed/params/scan (no topology drift — closes a latent SSOT gap across the three construction sites).
- **`SearchIndex::rebuild_vector_index`** — defaults to a **no-op** (correct for the brute-force path, which reads `facts.embedding` directly, and for a future server-side `pgvector` backend, #633). SQLite+`ann` overrides it. The doc states the contract: **any backend with a live in-process index MUST override** (inheriting the no-op would silently serve stale vectors).
- **Gated structurally on the dimension** (`== self.embed_dim`), not on `outcome.rebuild_index` — a wrong-dim rebuild is unreachable by construction.

## Similarity-edge invalidation — N/A in the Memory layer (documented)

The issue framed this as "the analog of the Knowledge layer deleting `relation_type = "similar"`." **ME persists no such edges, by design.** Every graph edge is semantic provenance (`co_session`/`supersedes`/`supplements`/`contradicts` — session links + arbiter decisions) that **must survive a model swap**. Vector similarity is computed transiently (query-time RRF, consolidation/DBSCAN, on-the-fly resonance), never materialized. The **only** materialized similarity cache is the HNSW proximity graph itself — so "invalidate cached similarity edges" _is_ "rebuild the index" (one action, not two).

A **future** persisted associative similarity graph (for spreading-activation recall — fast "surface recall" vs. wide "deep recall") is being scoped separately as a cognitive-layer epic; if it lands, its invalidation slots into this same reconstruction seam (the same-dim branch is documented as the "refresh embedding-derived caches" point). This was a deliberate product decision with the maintainer.

## Tests

- **Strategy (white-box, the rigorous guard):** `rebuild_from_db` reclaims tombstones + matches live rows — a no-op/replay rebuild fails it. (Small-N black-box query tests _cannot_ distinguish a stale index from a rebuilt one: `search` re-scores candidates against the current DB and `ef=100` explores the whole small graph, so the query resolves correctly either way — the tombstone/active-count invariant is the deterministic observable.) Plus empty-DB, swapped-vectors, and dim-mismatch-preserves-old-index (all-or-nothing).
- **Backend:** rebuild reflects swapped vectors (+ white-box tombstone==0); concurrent rebuild/search is deadlock-free and torn-read-free; non-`ann`/no-index no-op; default no-op callable through `&dyn SearchIndex`.
- **Engine:** same-dim reconstruct rebuilds without fencing (`reopen_required()==None`, stays queryable); different-dim fences (`Some(D′)`) and never rebuilds at the wrong dim.

## Verification

Rebased onto `main` (`#750` `importance`→`base_importance` breaking rename) and re-gated:

- `cargo fmt --check` ✓
- `cargo build --workspace` / `--all-features` / `--no-default-features` ✓
- `cargo test --workspace` (1568) / `--all-features` (1620) ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓ (the CI gate)
- `cargo deny check` ✓

## Non-goals (not pulled in)

- **#625** live-write race during rebuild (the residual ingest-mid-rebuild race; the lost-update from the _swap_ is closed here via the under-lock build).
- **#689** CLI/MCP operator surface for `reconstruct`.
- Different-dim in-place/no-downtime transition (stays fenced, #742).
- Incremental/delta rebuild (this is a full O(N) rebuild).

## Notes for reviewers

- **Pre-existing (not this PR) — to be filed as collateral:** `cargo clippy --workspace --all-targets -- -D warnings` (default features, no `ann`) is red on `main` with two latent issues — `consolidation.rs:648` unused `embedding` and `mod.rs:205` `needless_pass_by_value` on `with_open_config`'s `hnsw_source`. They only surface in the no-`ann` build; **CI only runs the `--all-features` clippy job**, so it never gates them — a CI-coverage gap worth a separate issue.
- **Doc items N/A:** `crate-layout.md` describes `SearchIndex` in prose but doesn't enumerate methods (nothing to add); `architecture-overview.md` doesn't reference it; `CLAUDE.md` has no Wave-2/reconstruction status line to append to.
