### PR TITLE
fix(retrieval): re-index displaced node in MemoryGraph::remove_node after petgraph swap-remove

### DIFF
--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -122,6 +122,19 @@ impl MemoryGraph {
                 .edges_directed(idx, Direction::Incoming)
                 .map(|e| e.id()),
         );
+        // petgraph's `remove_edge` swap-removes: it relocates the current last
+        // edge into the freed slot, invalidating any still-pending cached
+        // `EdgeIndex` that pointed at that last slot. Removing highest-index
+        // first guarantees each edge we remove is always the current last edge,
+        // so swap-remove never relocates anything still in `to_remove`.
+        //
+        // The descending sort also groups duplicate indices adjacently so
+        // `dedup` can collapse them: a self-loop (source == target) is yielded
+        // by BOTH the Outgoing and Incoming iterators, pushing the same
+        // `EdgeIndex` twice. Without dedup the second `remove_edge` would delete
+        // an innocent relocated edge.
+        to_remove.sort_unstable_by(|a, b| b.cmp(a));
+        to_remove.dedup();
         for ei in to_remove {
             self.graph.remove_edge(ei);
         }
@@ -408,6 +421,79 @@ mod tests {
         let mut comp = g.connected_component(3);
         comp.sort_unstable();
         assert_eq!(comp, vec![2, 3]);
+    }
+
+    #[test]
+    fn remove_edges_by_fact_with_self_loop() {
+        let mut g = MemoryGraph::new();
+        // Self-loop on fact 1, plus a genuine edge 1→2 and an unrelated edge 3→4.
+        // The self-loop is yielded by BOTH the Outgoing and Incoming iterators,
+        // so its EdgeIndex is collected twice — without dedup the second remove
+        // would swap-delete an innocent edge.
+        g.add_edge(1, 1, make_edge_data(10, "self"));
+        g.add_edge(1, 2, make_edge_data(20, "a"));
+        g.add_edge(3, 4, make_edge_data(30, "unrelated"));
+        assert_eq!(g.edge_count(), 3);
+
+        // Must not panic (the double-collected self-loop would otherwise try to
+        // remove an already-relocated index).
+        g.remove_edges_by_fact(1);
+
+        // The self-loop (1→1) and the fact's edge (1→2) are gone.
+        assert_eq!(g.edge_count(), 1);
+        assert_eq!(g.degree(1), 0);
+        assert!(g.neighbors(1).is_empty());
+
+        // The unrelated edge 3→4 must survive intact, right endpoints and all.
+        assert_eq!(g.neighbors(3), vec![4]);
+        assert_eq!(g.degree(3), 1);
+        assert_eq!(g.degree(4), 1);
+    }
+
+    #[test]
+    fn remove_edges_by_fact_multi_edge_preserves_others() {
+        let mut g = MemoryGraph::new();
+        // This exact layout reproduces the swap-remove invalidation against real
+        // petgraph 0.7: removing fact 2's edges frees a non-last slot, so
+        // petgraph swap-relocates the current last edge into it, invalidating a
+        // still-pending cached EdgeIndex in `to_remove`. The buggy
+        // collection-order removal then either skips that stale (now
+        // out-of-bounds) index — LEAKING a fact-2 edge that should be gone — or
+        // deletes the wrong relocated edge. Verified empirically: under the bug,
+        // edge 13 (3→2) survives; the fix removes all of fact 2's edges and
+        // leaves only the genuine survivor 11 (1→3).
+        //
+        // Edges touching fact 2: 1→2 (in), 2→1 (out), 3→2 (in).
+        // The only edge NOT touching fact 2: 1→3 (must survive verbatim).
+        g.add_edge(1, 2, make_edge_data(10, "drop_in")); // EdgeIndex 0
+        g.add_edge(1, 3, make_edge_data(11, "survivor")); // EdgeIndex 1
+        g.add_edge(2, 1, make_edge_data(12, "drop_out")); // EdgeIndex 2
+        g.add_edge(3, 2, make_edge_data(13, "drop_in2")); // EdgeIndex 3
+        assert_eq!(g.edge_count(), 4);
+
+        g.remove_edges_by_fact(2);
+
+        // Exactly one edge survives — the only one not touching fact 2.
+        assert_eq!(g.edge_count(), 1);
+
+        // Fact 2 is fully disconnected: none of its three edges leaked.
+        assert_eq!(g.degree(2), 0);
+        assert!(g.neighbors(2).is_empty());
+
+        // The survivor 1→3 resolves to the correct endpoints/degree.
+        assert_eq!(g.neighbors(1), vec![3]);
+        assert_eq!(g.degree(1), 1);
+        assert_eq!(g.degree(3), 1);
+
+        // Cross-check via the snapshot: exactly the survivor, all data intact.
+        let snap = g.to_snapshot();
+        assert_eq!(snap.edges.len(), 1);
+        let e = &snap.edges[0];
+        assert_eq!(e.edge_id, 11);
+        assert_eq!(e.source, 1);
+        assert_eq!(e.target, 3);
+        assert_eq!(e.relation_type, "survivor");
+        assert!((e.weight - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -424,6 +424,81 @@ mod tests {
     }
 
     #[test]
+    fn remove_node_in_loop_keeps_map_consistent() {
+        // The single-removal test above exercises `remove_node`'s re-index guard
+        // exactly once, so it cannot catch a regression that only COMPOUNDS over
+        // a sequence of removals — the documented loop-safe contract. This test
+        // removes two non-last nodes in sequence, and crucially the SECOND node
+        // removed is one that was itself DISPLACED (swap-relocated) by the first
+        // removal. A stale-map regression therefore compounds: the first removal
+        // leaves a wrong index that the second removal then builds another
+        // wrong index on top of.
+        //
+        // Layout (verified against petgraph 0.7 swap-remove order):
+        //   insertion order fixes NodeIndex: 1→idx0, 2→idx1, 3→idx2, 4→idx3,
+        //   5→idx4. Edges form a chain 1→2→3→4→5 plus a shortcut 1→5.
+        //
+        //   remove_node(1) frees idx0; petgraph swaps the last node (fact 5 at
+        //   idx4) into idx0. The guard rewrites node_map[5]=idx0.
+        //   remove_node(5) — fact 5 now lives at idx0 (it was displaced) — frees
+        //   idx0 again; petgraph swaps the new last node (fact 4 at idx3) into
+        //   idx0. The guard must rewrite node_map[4]=idx0.
+        //
+        // Without the guard, node_map[4] keeps its stale original idx3. After two
+        // swap-removes idx3 no longer holds fact 4, so neighbors(4)/degree(4)
+        // resolve against the wrong slot — empirically reporting a phantom 4→5
+        // edge that should be gone. The assertions below pin the correct (guarded)
+        // state and fail under that regression.
+        let mut g = MemoryGraph::new();
+        g.add_edge(1, 2, make_edge_data(10, "a")); // 1→idx0, 2→idx1
+        g.add_edge(2, 3, make_edge_data(20, "b")); // 3→idx2
+        g.add_edge(3, 4, make_edge_data(30, "c")); // 4→idx3
+        g.add_edge(4, 5, make_edge_data(40, "d")); // 5→idx4
+        g.add_edge(1, 5, make_edge_data(50, "e")); // shortcut
+        assert_eq!(g.node_count(), 5);
+
+        // --- First removal: a non-last node, displacing fact 5 into its slot. ---
+        g.remove_node(1);
+        assert!(!g.has_node(1));
+        assert_eq!(g.node_count(), 4);
+        // Every survivor still resolves to its correct neighbors after removal #1.
+        assert_eq!(g.neighbors(2), vec![3]);
+        assert_eq!(g.neighbors(3), vec![4]);
+        assert_eq!(g.neighbors(4), vec![5]);
+        assert!(g.neighbors(5).is_empty());
+        // Fact 5 was the displaced node; the 4→5 edge must still be visible.
+        assert_eq!(g.degree(5), 1);
+
+        // --- Second removal: the DISPLACED node itself, compounding the swap. ---
+        g.remove_node(5);
+        assert!(!g.has_node(5));
+        assert_eq!(g.node_count(), 3);
+
+        // After the loop, the whole map must be consistent. Fact 4 (the node now
+        // swapped into the freed slot) is the canary: its only out-edge (4→5) is
+        // gone with fact 5, so its outgoing neighbors are empty. Under the stale-
+        // map regression this wrongly reports a phantom [5].
+        assert_eq!(g.neighbors(4), Vec::<i64>::new());
+        // 4 still has its incoming edge 3→4, so total degree is the inbound 1.
+        assert_eq!(g.degree(4), 1);
+
+        // The untouched interior nodes resolve correctly end to end.
+        assert!(g.has_node(2));
+        assert!(g.has_node(3));
+        assert!(g.has_node(4));
+        assert_eq!(g.neighbors(2), vec![3]);
+        assert_eq!(g.neighbors(3), vec![4]);
+        assert_eq!(g.degree(2), 1);
+        assert_eq!(g.degree(3), 2); // 2→3 (in) + 3→4 (out)
+
+        // The surviving chain 2→3→4 is one connected component, nothing leaked.
+        let mut comp = g.connected_component(2);
+        comp.sort_unstable();
+        assert_eq!(comp, vec![2, 3, 4]);
+        assert_eq!(g.edge_count(), 2); // only 2→3 and 3→4 remain
+    }
+
+    #[test]
     fn remove_edges_by_fact_with_self_loop() {
         let mut g = MemoryGraph::new();
         // Self-loop on fact 1, plus a genuine edge 1→2 and an unrelated edge 3→4.

--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -82,11 +82,25 @@ impl MemoryGraph {
     ///
     /// No-op if the fact id is not in the graph.
     /// Used by archival after hard-deleting facts from `SQLite`.
+    ///
+    /// petgraph's [`DiGraph::remove_node`] uses swap-remove: the former last
+    /// node is relocated into the freed slot, which invalidates that node's
+    /// cached [`NodeIndex`]. This method handles that re-indexing — after the
+    /// removal it rewrites `node_map` for the displaced node so every surviving
+    /// node still resolves to its correct index. Callers may therefore remove
+    /// nodes in a loop (e.g. archival) without corrupting the map.
     pub fn remove_node(&mut self, fact_id: i64) {
         let Some(idx) = self.node_map.remove(&fact_id) else {
             return;
         };
         self.graph.remove_node(idx);
+        // Swap-remove relocated the former last node into `idx`. Its weight is
+        // the displaced fact id; rewrite its `node_map` entry to point at `idx`.
+        // `node_weight` returns `None` when the removed node *was* the last slot
+        // (no displacement), making the guard a no-op in that case.
+        if let Some(&displaced_fact_id) = self.graph.node_weight(idx) {
+            self.node_map.insert(displaced_fact_id, idx);
+        }
     }
 
     /// Remove all edges involving a given fact id (as source or target).
@@ -362,6 +376,38 @@ mod tests {
         g.remove_edge_by_id(10);
         assert_eq!(g.edge_count(), 1);
         assert!(g.neighbors(1) == vec![3]);
+    }
+
+    #[test]
+    fn remove_node_keeps_surviving_nodes_accessible() {
+        let mut g = MemoryGraph::new();
+        // Build a chain so petgraph assigns: 1→NodeIndex(0), 2→NodeIndex(1),
+        // 3→NodeIndex(2). Removing node 1 (NodeIndex(0)) makes petgraph
+        // swap-remove the last node (3, at NodeIndex(2)) into slot 0, so
+        // node_map[3] would point at the now-removed last slot without the fix.
+        g.add_edge(1, 2, make_edge_data(10, "a"));
+        g.add_edge(2, 3, make_edge_data(20, "b"));
+        assert_eq!(g.node_count(), 3);
+
+        // Remove a NON-last node to force a displacement.
+        g.remove_node(1);
+
+        // Node 1 is gone.
+        assert!(!g.has_node(1));
+        assert_eq!(g.node_count(), 2);
+
+        // The displaced node (3) and the untouched node (2) must still resolve
+        // to their correct edges/neighbors — the edge 2→3 survives.
+        assert!(g.has_node(2));
+        assert!(g.has_node(3));
+        assert_eq!(g.neighbors(2), vec![3]);
+        assert_eq!(g.degree(2), 1);
+        assert_eq!(g.degree(3), 1);
+
+        // Connectivity of the surviving component must be intact.
+        let mut comp = g.connected_component(3);
+        comp.sort_unstable();
+        assert_eq!(comp, vec![2, 3]);
     }
 
     #[test]


### PR DESCRIPTION
## What

`MemoryGraph::remove_node` now keeps `node_map` consistent after petgraph's swap-remove, and the previously-untested path gains a regression test + a documented invalidation contract.

## Why

petgraph 0.7 `DiGraph::remove_node` uses **swap-remove**: deleting the node at `NodeIndex(k)` relocates the former last node (at `NodeIndex(N-1)`) into slot `k`, invalidating that displaced node's cached `NodeIndex`. The old `remove_node` dropped the deleted fact from `node_map` but never updated the entry for the **displaced** fact — leaving a stale (out-of-range or aliased) `NodeIndex`.

Every later lookup on the displaced fact (`has_node` / `neighbors` / `degree` / `connected_component` / `remove_edges_by_fact` / `ensure_node`) then resolved against the wrong slot, silently returning empty/wrong data or wiring new edges to the wrong node. The only production caller is the archival loop (`engine/archive.rs`, `#[cfg(feature = "archive")]`), which removes many nodes in sequence — so the corruption is **cumulative**.

## Fix

After `graph.remove_node(idx)`, read back `node_weight(idx)` (the displaced fact id, or `None` when the removed node *was* the last slot — a no-op) and rewrite its `node_map` entry to `idx`. This is the minimal, local Option B from the findings; deliberately **not** switching to `StableDiGraph` (larger blast radius, conflicts with other in-flight PRs on this file).

## Tests

`remove_node_keeps_surviving_nodes_accessible` builds a 3-node chain, removes a **non-last** node to force a displacement, and asserts every surviving node still resolves to its correct neighbors/degree/component. Confirmed RED before the fix (the displaced node's `degree` resolved to 0), GREEN after. Full `cargo test -p memory-engine` (1217) green; `cargo fmt --check` clean; `cargo clippy -p memory-engine --all-targets` clean on the changed file (incl. `--features archive`).

Part of #257, #499.

Closes #261
Closes #284
Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: edge sibling of the swap-remove bug (adversarial-review BLOCKER)

Adversarial review found the **same petgraph swap-remove invalidation** in `remove_edges_by_fact` — now for **edges** (`Graph::remove_edge` swap-removes, relocating the current last edge into the freed slot). The old code collected a node's outgoing+incoming `EdgeIndex`es into `to_remove` and removed them in collection order, which:

1. **Invalidates a still-pending cached `EdgeIndex`** when a prior `remove_edge` swap-relocates the last edge into the freed slot — silently **leaking** the relocated edge (or deleting the wrong one).
2. **Double-deletes** on a **self-loop** (`source == target`): it is yielded by BOTH the Outgoing and Incoming iterators, so its `EdgeIndex` is pushed twice and the second `remove_edge` deletes an innocent relocated edge.

**Fix:** sort `to_remove` **descending** then `dedup()` before removing — highest-index-first guarantees each removed edge is always the current last edge (swap-remove relocates nothing still pending); `dedup` (valid only after the sort) collapses the self-loop duplicate.

Two TDD tests added, both verified RED against real petgraph 0.7 under the bug, GREEN after:
- `remove_edges_by_fact_with_self_loop`
- `remove_edges_by_fact_multi_edge_preserves_others`

This folds the adversarial-review BLOCKER into this PR as the **edge sibling** of the `remove_node` swap-remove fix above.