### PR TITLE
test(retrieval): cover include_expired_probe diagnostics wiring end-to-end

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -5529,7 +5529,7 @@ mod expired_probe_e2e {
         let expired_id = add_indexed_fact(&engine, "quasar discovered last year").await;
         engine
             .storage()
-            .expire_fact(expired_id, Utc::now())
+            .expire_fact(expired_id, Utc::now() - chrono::Duration::hours(1))
             .await
             .unwrap();
 
@@ -5557,7 +5557,7 @@ mod expired_probe_e2e {
         let expired_id = add_indexed_fact(&engine, "pulsar timing glitch").await;
         engine
             .storage()
-            .expire_fact(expired_id, Utc::now())
+            .expire_fact(expired_id, Utc::now() - chrono::Duration::hours(1))
             .await
             .unwrap();
 
@@ -5582,7 +5582,7 @@ mod expired_probe_e2e {
         let expired_id = add_indexed_fact(&engine, "nebula collapses inward").await;
         engine
             .storage()
-            .expire_fact(expired_id, Utc::now())
+            .expire_fact(expired_id, Utc::now() - chrono::Duration::hours(1))
             .await
             .unwrap();
 
@@ -5595,6 +5595,35 @@ mod expired_probe_e2e {
         assert_eq!(
             response.diagnostics.expired_matches, None,
             "vector-only query has no FTS5 terms — probe must be a no-op"
+        );
+    }
+
+    /// The probe must be FTS-restricted to the query term, not a blanket count of
+    /// all expired facts. Expire a fact that does NOT match the query term, then
+    /// probe for a different term: `Some(0)` proves the probe RAN (not `None`) yet
+    /// found zero matches (not `>= 1`) because the expired fact is off-term.
+    #[tokio::test]
+    async fn probe_is_fts_restricted_to_query_term() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+
+        // The expired fact shares no keyword with the query.
+        let expired_id = add_indexed_fact(&engine, "pulsar spins rapidly").await;
+        engine
+            .storage()
+            .expire_fact(expired_id, Utc::now() - chrono::Duration::hours(1))
+            .await
+            .unwrap();
+
+        // Probe for a DIFFERENT term — no expired 'quasar' fact exists.
+        let query = MemoryQuery::new().text("quasar").include_expired_probe();
+        let response = engine.execute_query(&query).await.unwrap();
+
+        // Some(0): the probe ran (not None) but is FTS-restricted to 'quasar',
+        // so the off-term expired 'pulsar' fact is not counted (not >= 1).
+        assert_eq!(
+            response.diagnostics.expired_matches,
+            Some(0),
+            "probe must run yet be restricted to the query term, not count all expired facts"
         );
     }
 }

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -5484,3 +5484,117 @@ mod snapshot_integration {
         );
     }
 }
+
+/// End-to-end coverage for the `include_expired_probe` diagnostics contract
+/// (issue #324). These tests drive the full `execute_query` path — the only
+/// place that calls `lexical_count_expired` and writes
+/// `QueryDiagnostics::expired_matches` — rather than just the builder setter.
+///
+/// The contract (engine/query.rs, search/hybrid.rs): `expired_matches` is
+/// `Some(count)` ONLY when the probe is opted in AND the query carries text;
+/// it stays `None` when the probe is off, and `None` for a vector-only query
+/// (no FTS5 terms to probe — the documented limitation in `search/hybrid.rs`).
+mod expired_probe_e2e {
+    use super::*;
+
+    /// Add a fact through the engine's normal write path (which indexes it into
+    /// FTS5, so the expired probe's `MATCH` query can find it) and return its id.
+    async fn add_indexed_fact(engine: &MemoryEngine, content: &str) -> i64 {
+        let embedder: std::sync::Arc<dyn EmbeddingProvider> =
+            std::sync::Arc::new(MockEmbedder { dim: DIM });
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: content.into(),
+                    fact_type: FactType::Semantic,
+                    source_event_id: None,
+                    scope: None,
+                    opts: None,
+                },
+                embedder,
+                None,
+            )
+            .await
+            .unwrap()
+    }
+
+    /// A text query with the probe enabled must populate `expired_matches` with
+    /// a non-zero count once a matching fact has been expired.
+    #[tokio::test]
+    async fn text_query_with_probe_counts_expired_matches() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+
+        // Two facts share the keyword; one stays active, one gets expired.
+        add_indexed_fact(&engine, "quasar emits intense radiation").await;
+        let expired_id = add_indexed_fact(&engine, "quasar discovered last year").await;
+        engine
+            .storage()
+            .expire_fact(expired_id, Utc::now())
+            .await
+            .unwrap();
+
+        let query = MemoryQuery::new().text("quasar").include_expired_probe();
+        let response = engine.execute_query(&query).await.unwrap();
+
+        // The probe ran (Some) and saw exactly the one expired match.
+        assert_eq!(
+            response.diagnostics.expired_matches,
+            Some(1),
+            "probe must report the single expired 'quasar' fact"
+        );
+        // Only the still-active fact is returned in results.
+        assert_eq!(response.results.len(), 1);
+        assert!(response.results[0].fact.content.contains("intense"));
+    }
+
+    /// Without `include_expired_probe`, the probe must not run: `expired_matches`
+    /// stays `None` even when matching expired facts exist.
+    #[tokio::test]
+    async fn text_query_without_probe_leaves_expired_matches_none() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+
+        add_indexed_fact(&engine, "pulsar spins rapidly").await;
+        let expired_id = add_indexed_fact(&engine, "pulsar timing glitch").await;
+        engine
+            .storage()
+            .expire_fact(expired_id, Utc::now())
+            .await
+            .unwrap();
+
+        // Same query, probe NOT enabled.
+        let query = MemoryQuery::new().text("pulsar");
+        let response = engine.execute_query(&query).await.unwrap();
+
+        assert_eq!(
+            response.diagnostics.expired_matches, None,
+            "probe must stay off when not opted in"
+        );
+    }
+
+    /// A vector-only query (no text) with the probe set must still leave
+    /// `expired_matches` as `None` — there are no FTS5 terms to probe. This is
+    /// the documented limitation in `search/hybrid.rs`.
+    #[tokio::test]
+    async fn vector_only_query_with_probe_leaves_expired_matches_none() {
+        let engine = MemoryEngine::builder(DIM).build().unwrap();
+
+        add_indexed_fact(&engine, "nebula glows faintly").await;
+        let expired_id = add_indexed_fact(&engine, "nebula collapses inward").await;
+        engine
+            .storage()
+            .expire_fact(expired_id, Utc::now())
+            .await
+            .unwrap();
+
+        // No text — embedding only — yet the probe flag is set.
+        let query = MemoryQuery::new()
+            .embedding(vec![0.5; DIM])
+            .include_expired_probe();
+        let response = engine.execute_query(&query).await.unwrap();
+
+        assert_eq!(
+            response.diagnostics.expired_matches, None,
+            "vector-only query has no FTS5 terms — probe must be a no-op"
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds three engine-level (full-stack) tests to `engine/tests.rs` that exercise the `include_expired_probe` diagnostics contract through `execute_query`:

1. **Text query + probe** — after expiring one of two facts sharing a keyword, `diagnostics.expired_matches == Some(1)` and only the active fact is returned.
2. **Text query, no probe** — `expired_matches == None` even though a matching expired fact exists (probe stays off unless opted in).
3. **Vector-only query + probe** — `expired_matches == None`; a query with no text has no FTS5 terms to probe (the documented limitation in `search/hybrid.rs`).

## Why

The flag was previously covered only as a builder setter (`search/query.rs`). The execution path in `engine/query.rs` that calls `lexical_count_expired` and writes `QueryDiagnostics::expired_matches` was never asserted end-to-end, so the contract — `Some` only when the probe is opted in **and** the query carries text, `None` otherwise — could silently regress.

Facts are inserted via the engine's normal `add_fact` write path so they land in the FTS5 index the probe's `MATCH` query scans.

## Verification

- `cargo test -p memory-engine` — 1219 passed.
- `cargo clippy -p memory-engine --all-targets` — no new warnings (the 3 remaining warnings pre-exist on `main` in unrelated `storage/` files).
- `cargo fmt` — clean.
- Confirmed the positive test fails (`None` vs `Some(1)`) when the wiring is temporarily broken, proving it genuinely exercises the path.

Closes #324.
Part of #257.