### PR TITLE
fix(mcp): harden dump_state path guard (symlink leaf + TOCTOU)

### DIFF
--- a/memory-engine/bin/mcp/src/tools/mod.rs
+++ b/memory-engine/bin/mcp/src/tools/mod.rs
@@ -1356,6 +1356,18 @@ fn default_dump_path(base_dir: &std::path::Path, ext: &str) -> PathBuf {
 ///   the destination with `O_NOFOLLOW` to fail atomically if a symlink leaf is
 ///   raced into place between this check and the write.
 fn validate_dump_path(p: &std::path::Path) -> Result<PathBuf, ErrorData> {
+    // Make the client path absolute FIRST, resolving it against the process cwd.
+    // `std::path::absolute` is purely lexical — it does NOT touch the filesystem
+    // (no canonicalization, no symlink resolution), it just guarantees a parent
+    // component exists. Without it, a bare leaf like `"dump.json"` has
+    // `parent() == Some("")`, and `canonicalize("")` fails with a confusing
+    // "No such file or directory" instead of the intended containment rejection.
+    // A cwd-relative path that resolves outside temp is still rejected by the
+    // `starts_with` check below — that is the correct outcome.
+    let p = std::path::absolute(p)
+        .map_err(|e| ValidationError::Other(format!("cannot resolve dump path: {e}")))?;
+    let p = p.as_path();
+
     // Canonicalize the temp root so the containment check compares resolved
     // paths on both sides. Fall back to the raw value if canonicalize fails
     // (e.g. a platform that does not pre-create the temp dir).
@@ -1895,6 +1907,7 @@ async fn handle_get_recent_insights(
 mod tests {
     use super::{
         default_dump_name, default_dump_path, get_usize, parse_consolidate_config, parse_fact_type,
+        validate_dump_path,
     };
     use memory_engine::types::FactType;
     use serde_json::json;
@@ -2109,5 +2122,58 @@ mod tests {
             let name = p.file_name().and_then(|n| n.to_str()).unwrap();
             assert!(name.starts_with("memory-dump-"), "unexpected name: {name}");
         }
+    }
+
+    /// Finding-1 regression (Gemini #836): a client path with no directory
+    /// component (a bare leaf such as `"dump.json"`) must NOT trip the confusing
+    /// `canonicalize("")` parent failure. `validate_dump_path` makes the path
+    /// absolute against cwd *first* (`std::path::absolute`, purely lexical), so a
+    /// bare leaf gains a real parent and is then judged by the *containment*
+    /// check — accepted when cwd is inside temp, rejected (with the temp-dir
+    /// error) when it is not. Both branches are asserted under one `set_current_dir`
+    /// guard because cwd is process-global; this is the only test that mutates it.
+    #[test]
+    fn validate_dump_path_handles_bare_relative_leaf() {
+        // Canonicalize temp so the asserted prefix matches `validate_dump_path`'s
+        // own canonical comparison (e.g. macOS `/tmp -> /private/tmp`).
+        let temp = std::fs::canonicalize(std::env::temp_dir()).unwrap();
+        let outside = std::env::current_dir().expect("cargo runs tests from the crate dir");
+        debug_assert!(
+            !outside.starts_with(&temp),
+            "test precondition: the crate dir must be outside temp"
+        );
+
+        let saved = std::env::current_dir().ok();
+
+        // (a) cwd OUTSIDE temp → the bare leaf resolves outside the jail and is
+        //     rejected by containment, with the temp-directory error (NOT a
+        //     parent-resolution error).
+        std::env::set_current_dir(&outside).unwrap();
+        let rejected = validate_dump_path(std::path::Path::new("dump.json"));
+
+        // (b) cwd INSIDE temp → the same bare leaf resolves into the jail and is
+        //     accepted, resolving to a path under temp.
+        std::env::set_current_dir(&temp).unwrap();
+        let accepted = validate_dump_path(std::path::Path::new("relative-dump.json"));
+
+        if let Some(prev) = saved {
+            let _ = std::env::set_current_dir(prev);
+        }
+
+        let err = rejected.expect_err("a bare leaf under a non-temp cwd must be rejected");
+        assert!(
+            err.message.contains("temp"),
+            "a relative leaf must be rejected by the temp-containment check, not a \
+             parent-resolution error; got: {}",
+            err.message
+        );
+
+        let resolved = accepted.expect("a relative leaf resolving into temp must be accepted");
+        assert!(
+            resolved.starts_with(&temp),
+            "resolved path {} must be inside temp {}",
+            resolved.display(),
+            temp.display()
+        );
     }
 }

--- a/memory-engine/bin/mcp/src/tools/mod.rs
+++ b/memory-engine/bin/mcp/src/tools/mod.rs
@@ -1353,8 +1353,15 @@ fn default_dump_path(base_dir: &std::path::Path, ext: &str) -> PathBuf {
 /// - **CWE-367 (TOCTOU):** the *resolved* path is returned and handed to the
 ///   engine, so the value that is validated is the value that is opened — the
 ///   original unresolved path is never used past this point. The lib then opens
-///   the destination with `O_NOFOLLOW` to fail atomically if a symlink leaf is
+///   the destination with `O_NOFOLLOW` to fail atomically if a symlink *leaf* is
 ///   raced into place between this check and the write.
+///
+///   **Residual (tracked in #851):** `O_NOFOLLOW` guards only the leaf, so a
+///   *parent directory* component swapped to a symlink after this check is still
+///   followed by the open. The default dump path's only parent is the temp root
+///   (sticky-bit-protected), so exposure is limited to a client-supplied
+///   *multi-level* path with an attacker-writable intermediate dir. The airtight
+///   fix is fd-relative opens (`openat`/`cap-std`), deferred to #851.
 fn validate_dump_path(p: &std::path::Path) -> Result<PathBuf, ErrorData> {
     // Make the client path absolute FIRST, resolving it against the process cwd.
     // `std::path::absolute` is purely lexical — it does NOT touch the filesystem

--- a/memory-engine/bin/mcp/src/tools/mod.rs
+++ b/memory-engine/bin/mcp/src/tools/mod.rs
@@ -1334,6 +1334,76 @@ fn default_dump_path(base_dir: &std::path::Path, ext: &str) -> PathBuf {
     base_dir.join(default_dump_name(&timestamp, pid, seq, ext))
 }
 
+/// Validate and resolve a client-supplied dump destination, confining it to the
+/// system temp directory.
+///
+/// Without this, an MCP client could direct a dump at an arbitrary path and
+/// overwrite host files. The hardening closes three lenses on one flaw
+/// (issues #296 / #354 / #414):
+///
+/// - **CWE-22 (path traversal):** both the temp root and the target are
+///   canonicalized, so the `starts_with` check compares fully-resolved paths.
+///   Canonicalizing the temp root also stops *false rejects* on platforms where
+///   the temp dir is itself a symlink (e.g. macOS `/tmp -> /private/tmp`).
+/// - **CWE-59 (symlink-leaf follow):** the *full* target is resolved — not just
+///   its parent — and a leaf that is itself a symlink is rejected outright via
+///   `symlink_metadata` (lstat, which does not follow the link). A parent-only
+///   guard would wave through a leaf symlink that escapes temp, and the
+///   downstream `File::create`/`VACUUM INTO` would follow it.
+/// - **CWE-367 (TOCTOU):** the *resolved* path is returned and handed to the
+///   engine, so the value that is validated is the value that is opened — the
+///   original unresolved path is never used past this point. The lib then opens
+///   the destination with `O_NOFOLLOW` to fail atomically if a symlink leaf is
+///   raced into place between this check and the write.
+fn validate_dump_path(p: &std::path::Path) -> Result<PathBuf, ErrorData> {
+    // Canonicalize the temp root so the containment check compares resolved
+    // paths on both sides. Fall back to the raw value if canonicalize fails
+    // (e.g. a platform that does not pre-create the temp dir).
+    let temp = std::env::temp_dir();
+    let canonical_temp = std::fs::canonicalize(&temp).unwrap_or(temp);
+
+    // Reject a leaf that is itself a symlink. `symlink_metadata` (lstat) does
+    // NOT follow the link, so this distinguishes a malicious leaf symlink
+    // (which a later `File::create`/`VACUUM INTO` would follow out of the jail)
+    // from a benign regular file. A non-existent leaf is fine — the common case.
+    match std::fs::symlink_metadata(p) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            return Err(
+                ValidationError::Other("dump path must not be a symlink".to_owned()).into(),
+            );
+        }
+        Ok(_) | Err(_) => {} // regular file / absent → resolve below
+    }
+
+    // Resolve the FULL target with parent symlinks collapsed. If the leaf
+    // exists, canonicalize the whole path; otherwise canonicalize the parent
+    // (resolving any symlinked components) and rejoin the leaf name.
+    let resolved = if p.exists() {
+        std::fs::canonicalize(p)
+            .map_err(|e| ValidationError::Other(format!("cannot resolve dump path: {e}")))?
+    } else {
+        let parent = p.parent().ok_or_else(|| {
+            ValidationError::Other("dump path has no parent directory".to_owned())
+        })?;
+        let file_name = p
+            .file_name()
+            .ok_or_else(|| ValidationError::Other("dump path has no file name".to_owned()))?;
+        let canonical_parent = std::fs::canonicalize(parent)
+            .map_err(|e| ValidationError::Other(format!("cannot resolve dump path parent: {e}")))?;
+        canonical_parent.join(file_name)
+    };
+
+    if !resolved.starts_with(&canonical_temp) {
+        return Err(ValidationError::Other(format!(
+            "dump path must be within the temp directory ({})",
+            canonical_temp.display()
+        ))
+        .into());
+    }
+
+    Ok(resolved)
+}
+
 async fn handle_dump_state(
     args: &Map<String, Value>,
     engine: &MemoryEngine,
@@ -1349,24 +1419,7 @@ async fn handle_dump_state(
     };
 
     let path = match get_str(args, "path") {
-        Some(p) => {
-            let p = PathBuf::from(p);
-            // Security: restrict client-supplied paths to the system temp directory.
-            // Without this, an MCP client could overwrite arbitrary files.
-            let temp = std::env::temp_dir();
-            let canonical = p
-                .parent()
-                .and_then(|parent| std::fs::canonicalize(parent).ok())
-                .unwrap_or_default();
-            if !canonical.starts_with(&temp) {
-                return Err(ValidationError::Other(format!(
-                    "dump path must be within the temp directory ({})",
-                    temp.display()
-                ))
-                .into());
-            }
-            p
-        }
+        Some(p) => validate_dump_path(&PathBuf::from(p))?,
         None => default_dump_path(&std::env::temp_dir(), ext),
     };
 

--- a/memory-engine/bin/mcp/tests/dump_path_security.rs
+++ b/memory-engine/bin/mcp/tests/dump_path_security.rs
@@ -1,0 +1,174 @@
+//! Security regression tests for the `memory_dump_state` path guard.
+//!
+//! Issues #296 / #354 / #414 (one vulnerability, three lenses) + test #320:
+//! the guard must keep a client-supplied dump destination inside the system
+//! temp directory and must not be defeatable by a symlink at the leaf
+//! (CWE-59 symlink-follow), a symlinked temp root (CWE-22), or a swap between
+//! check and use (CWE-367 TOCTOU).
+
+use std::sync::Arc;
+
+use memory_engine::MemoryEngine;
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine::types::{AddFactRequest, FactType};
+use memory_engine_mcp::tools;
+use serde_json::{Map, Value, json};
+
+struct FakeEmbed;
+impl EmbeddingProvider for FakeEmbed {
+    fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
+        Ok(vec![0.1, 0.2, 0.3])
+    }
+    fn fingerprint(&self) -> memory_engine::EmbeddingFingerprint {
+        memory_engine::EmbeddingFingerprint::new("mock", "test", 3)
+    }
+}
+
+fn test_engine() -> (MemoryEngine, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = MemoryEngine::builder(3)
+        .path(dir.path().join("test.db"))
+        .build()
+        .unwrap();
+    (engine, dir)
+}
+
+async fn add_test_fact(engine: &MemoryEngine, content: &str) -> i64 {
+    let emb: Arc<dyn EmbeddingProvider> = Arc::new(FakeEmbed);
+    engine
+        .add_fact(
+            &AddFactRequest {
+                content: content.into(),
+                fact_type: FactType::Semantic,
+                source_event_id: None,
+                scope: None,
+                opts: None,
+            },
+            emb,
+            None,
+        )
+        .await
+        .unwrap()
+}
+
+fn args(pairs: &[(&str, Value)]) -> Map<String, Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), v.clone()))
+        .collect()
+}
+
+/// A client-supplied path OUTSIDE the temp directory is rejected, and the error
+/// message names the temp-directory constraint (#296 / #354 CWE-22).
+#[tokio::test]
+async fn dump_state_rejects_path_outside_temp() {
+    let (engine, _dir) = test_engine();
+    add_test_fact(&engine, "fact").await;
+
+    let result = tools::dispatch(
+        "memory_dump_state",
+        args(&[
+            ("format", json!("json")),
+            ("path", json!("/etc/clobber.json")),
+        ]),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    )
+    .await;
+
+    let err = result.expect_err("dump outside temp must be rejected");
+    assert!(
+        err.message.contains("temp"),
+        "error must name the temp-directory constraint, got: {}",
+        err.message
+    );
+    assert!(
+        !std::path::Path::new("/etc/clobber.json").exists(),
+        "the out-of-temp target must NOT have been written"
+    );
+}
+
+/// A symlink LEAF whose target escapes temp must be rejected, and the escape
+/// target must not be written (#414 CWE-59 symlink-follow + #367 TOCTOU).
+///
+/// The leaf component is itself a symlink that lives inside temp but points
+/// outside it; the parent canonicalizes cleanly, so a parent-only guard would
+/// wave it through and the downstream `File::create`/`VACUUM INTO` would follow
+/// the link and clobber the external target.
+#[cfg(unix)]
+#[tokio::test]
+async fn dump_state_rejects_symlink_leaf_escaping_temp() {
+    let (engine, _dir) = test_engine();
+    add_test_fact(&engine, "fact").await;
+
+    // The escape target lives OUTSIDE temp.
+    let escape_dir = tempfile::Builder::new()
+        .prefix("dump-escape-")
+        .tempdir_in(env!("CARGO_TARGET_TMPDIR"))
+        .unwrap();
+    let escape_target = escape_dir.path().join("secret.json");
+
+    // A scratch dir INSIDE temp holding the malicious symlink leaf.
+    let in_temp = tempfile::tempdir().unwrap();
+    let link = in_temp.path().join("evil.json");
+    std::os::unix::fs::symlink(&escape_target, &link).unwrap();
+
+    let result = tools::dispatch(
+        "memory_dump_state",
+        args(&[
+            ("format", json!("json")),
+            ("path", json!(link.display().to_string())),
+        ]),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "a symlink leaf pointing outside temp must be rejected"
+    );
+    assert!(
+        !escape_target.exists(),
+        "the symlink target outside temp must NOT have been written"
+    );
+}
+
+/// The happy path — a fresh (non-symlink) destination inside temp — still works
+/// after hardening. Guards against over-restriction (#354 CWE-22 false reject).
+#[tokio::test]
+async fn dump_state_accepts_fresh_path_inside_temp() {
+    let (engine, dir) = test_engine();
+    add_test_fact(&engine, "fact").await;
+
+    let custom_path = dir.path().join("ok-dump.json");
+
+    let result = tools::dispatch(
+        "memory_dump_state",
+        args(&[
+            ("format", json!("json")),
+            ("path", json!(custom_path.display().to_string())),
+        ]),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    )
+    .await
+    .expect("a fresh path inside temp must be accepted");
+
+    let content = &result.content[0];
+    let v: Value = match &content.raw {
+        rmcp::model::RawContent::Text(t) => serde_json::from_str(&t.text).unwrap(),
+        _ => panic!("expected text content"),
+    };
+    let reported = v["path"].as_str().unwrap();
+    assert!(std::path::Path::new(reported).exists());
+}

--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -41,6 +41,11 @@ zstd = { version = "0.13", optional = true }
 tokio-postgres = { version = "0.7", default-features = false, optional = true }
 deadpool-postgres = { version = "0.14", optional = true }
 
+# `libc::O_NOFOLLOW` for the symlink-safe dump open (#296/#354/#414). Unix-only;
+# already in the dependency graph transitively, so this adds no new crate.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/memory-engine/lib/memory-engine/src/inspect/dump.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/dump.rs
@@ -24,6 +24,68 @@ fn tmp_path(path: &Path) -> std::path::PathBuf {
     path.with_file_name(name)
 }
 
+/// Create (or truncate) the dump's temporary write target, refusing to follow a
+/// symlink at the leaf.
+///
+/// The JSON dumps write to a sibling `<path>.tmp` and then atomically
+/// `rename` it onto `path`. `rename` does not follow a symlink at the
+/// destination (it replaces the link), but the create of the `.tmp` leaf would,
+/// so an attacker who pre-plants `<path>.tmp` as a symlink could redirect the
+/// write outside the intended directory. On Unix we open with `O_NOFOLLOW`, so
+/// such a leaf fails the open *atomically* — closing the check-then-use (TOCTOU)
+/// window that an out-of-band `symlink_metadata` probe would leave open
+/// (CWE-59 / CWE-367; part of the #296 / #354 / #414 hardening). The
+/// caller-facing path guard in `memory-engine-mcp` confines the destination to
+/// the temp directory; this is the in-engine backstop at the open site.
+///
+/// On non-Unix targets `O_NOFOLLOW` is unavailable, so this degrades to a plain
+/// create and the mcp-level `symlink_metadata` rejection remains the guard.
+fn create_dump_tmp(tmp: &Path) -> std::io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // `O_NOFOLLOW`: open fails with ELOOP if the final path component is a
+        // symlink. The value is platform-specific (Linux `0o400000`, macOS
+        // `0x100`, …); `libc` is not a dependency of this crate, so the constant
+        // is resolved per-target below.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        const O_NOFOLLOW: i32 = 0o400000;
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        ))]
+        const O_NOFOLLOW: i32 = 0x0100;
+        // Fallback for other Unix targets: 0 leaves behavior identical to a
+        // plain create rather than risk a wrong flag value.
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        )))]
+        const O_NOFOLLOW: i32 = 0;
+
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(O_NOFOLLOW)
+            .open(tmp)
+    }
+    #[cfg(not(unix))]
+    {
+        File::create(tmp)
+    }
+}
+
 /// Stream engine state as JSON to `writer`, one entity at a time.
 ///
 /// Produces the same JSON format as [`super::types::EngineSnapshot`] but never
@@ -148,7 +210,7 @@ where
 /// [`MemoryError::Serialization`] on JSON serialization failure.
 pub fn dump_json(conn: &Connection, embed_dim: usize, path: &Path) -> Result<()> {
     let tmp = tmp_path(path);
-    let file = File::create(&tmp)?;
+    let file = create_dump_tmp(&tmp)?;
     let mut buf = BufWriter::new(file);
     match stream_snapshot(conn, embed_dim, &mut buf) {
         Ok(()) => {
@@ -172,7 +234,7 @@ pub fn dump_json(conn: &Connection, embed_dim: usize, path: &Path) -> Result<()>
 #[cfg(feature = "compress-gzip")]
 pub fn dump_json_gzip(conn: &Connection, embed_dim: usize, path: &Path) -> Result<()> {
     let tmp = tmp_path(path);
-    let file = File::create(&tmp)?;
+    let file = create_dump_tmp(&tmp)?;
     let mut encoder =
         flate2::write::GzEncoder::new(BufWriter::new(file), flate2::Compression::default());
     match stream_snapshot(conn, embed_dim, &mut encoder) {
@@ -198,7 +260,7 @@ pub fn dump_json_gzip(conn: &Connection, embed_dim: usize, path: &Path) -> Resul
 #[cfg(feature = "compress-zstd")]
 pub fn dump_json_zstd(conn: &Connection, embed_dim: usize, path: &Path) -> Result<()> {
     let tmp = tmp_path(path);
-    let file = File::create(&tmp)?;
+    let file = create_dump_tmp(&tmp)?;
     let mut encoder = zstd::Encoder::new(BufWriter::new(file), zstd::DEFAULT_COMPRESSION_LEVEL)?;
     match stream_snapshot(conn, embed_dim, &mut encoder) {
         Ok(()) => {
@@ -654,6 +716,41 @@ mod tests {
                 Err(MemoryError::Conflict(ConflictError::DumpTargetIsDirectory))
             ),
             "a symlink to a directory must be refused, got {result:?}"
+        );
+    }
+
+    /// `O_NOFOLLOW` backstop (#296 / #354 / #414): if the sibling `<path>.tmp`
+    /// write target is a pre-planted symlink, `dump_json` must fail at the open
+    /// rather than follow the link and clobber its target. This closes the
+    /// in-engine TOCTOU window beneath the mcp-level path guard.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dump_json_refuses_symlinked_tmp_leaf() {
+        use crate::store::schema::{init_schema, migrate, open_memory};
+
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+        migrate(&conn, None).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("dump.json");
+
+        // Pre-plant the `.tmp` write target as a symlink pointing at a file we
+        // must not be tricked into overwriting.
+        let victim = dir.path().join("victim.txt");
+        std::fs::write(&victim, b"do not clobber").unwrap();
+        let tmp = tmp_path(&target);
+        std::os::unix::fs::symlink(&victim, &tmp).unwrap();
+
+        let result = dump_json(&conn, DIM, &target);
+        assert!(
+            result.is_err(),
+            "dump_json must refuse to follow a symlinked .tmp leaf, got {result:?}"
+        );
+        assert_eq!(
+            std::fs::read(&victim).unwrap(),
+            b"do not clobber",
+            "the symlink target must NOT have been overwritten"
         );
     }
 }

--- a/memory-engine/lib/memory-engine/src/inspect/dump.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/dump.rs
@@ -44,40 +44,17 @@ fn create_dump_tmp(tmp: &Path) -> std::io::Result<File> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        // `O_NOFOLLOW`: open fails with ELOOP if the final path component is a
-        // symlink. The value is platform-specific (Linux `0o400000`, macOS
-        // `0x100`, …); `libc` is not a dependency of this crate, so the constant
-        // is resolved per-target below.
-        #[cfg(any(target_os = "linux", target_os = "android"))]
-        const O_NOFOLLOW: i32 = 0o400000;
-        #[cfg(any(
-            target_os = "macos",
-            target_os = "ios",
-            target_os = "freebsd",
-            target_os = "dragonfly",
-            target_os = "openbsd",
-            target_os = "netbsd"
-        ))]
-        const O_NOFOLLOW: i32 = 0x0100;
-        // Fallback for other Unix targets: 0 leaves behavior identical to a
-        // plain create rather than risk a wrong flag value.
-        #[cfg(not(any(
-            target_os = "linux",
-            target_os = "android",
-            target_os = "macos",
-            target_os = "ios",
-            target_os = "freebsd",
-            target_os = "dragonfly",
-            target_os = "openbsd",
-            target_os = "netbsd"
-        )))]
-        const O_NOFOLLOW: i32 = 0;
-
+        // `O_NOFOLLOW`: the open fails with `ELOOP` if the final path component
+        // is a symlink. The flag value is arch-specific (e.g. `0x20000` on
+        // x86_64 but `0x8000` on aarch64), so we take it from `libc`, which the
+        // toolchain resolves correctly per target. A hand-maintained constant
+        // hardcoded the x86_64 value and silently disabled the guard on ARM64
+        // Linux (CWE-59 / CWE-367; part of the #296 / #354 / #414 hardening).
         std::fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
-            .custom_flags(O_NOFOLLOW)
+            .custom_flags(libc::O_NOFOLLOW)
             .open(tmp)
     }
     #[cfg(not(unix))]

--- a/memory-engine/lib/memory-engine/src/inspect/dump.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/dump.rs
@@ -63,6 +63,51 @@ fn create_dump_tmp(tmp: &Path) -> std::io::Result<File> {
     }
 }
 
+/// Mint a fresh, empty, server-named sibling temp file as the `VACUUM INTO`
+/// target, never following a symlink at the leaf.
+///
+/// `VACUUM INTO` follows a symlink at its destination leaf, so writing it
+/// directly at the caller-supplied `path` leaves a TOCTOU window (CWE-59 /
+/// CWE-367): the mcp-level guard lstat-rejects a symlink leaf, but an attacker
+/// with write access to the directory can race a symlink into place *after* the
+/// check and *before* the `VACUUM INTO`. We close that by VACUUM-ing into an
+/// **unpredictably-named** sibling created with `O_NOFOLLOW | O_EXCL`
+/// (`create_new`) — the open fails atomically if the name is a symlink or
+/// already exists — and then atomically `rename` it onto `path`. `rename`
+/// replaces a destination symlink rather than following it, so the final move is
+/// safe; this mirrors the symlink-safe JSON write-then-rename path.
+///
+/// `VACUUM INTO` accepts an *empty* target file (`SQLite` requirement: the
+/// `INTO` file must not previously exist or must be empty), so the empty file
+/// minted here is a valid `VACUUM` destination.
+///
+/// On non-Unix targets `O_NOFOLLOW` is unavailable, so this degrades to a plain
+/// `create_new` (still `O_EXCL` + an unpredictable name); the mcp-level
+/// `symlink_metadata` rejection remains the guard there.
+fn mint_sqlite_vacuum_tmp(dir: &Path) -> std::io::Result<tempfile::NamedTempFile> {
+    tempfile::Builder::new()
+        .prefix(".dump-")
+        .suffix(".db.tmp")
+        .make_in(dir, |p| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .custom_flags(libc::O_NOFOLLOW)
+                    .open(p)
+            }
+            #[cfg(not(unix))]
+            {
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(p)
+            }
+        })
+}
+
 /// Stream engine state as JSON to `writer`, one entity at a time.
 ///
 /// Produces the same JSON format as [`super::types::EngineSnapshot`] but never
@@ -256,15 +301,23 @@ pub fn dump_json_zstd(conn: &Connection, embed_dim: usize, path: &Path) -> Resul
 ///
 /// Works for both file-backed and in-memory databases (`SQLite` 3.27+).
 ///
-/// # Trusted-path contract
+/// # Symlink safety
 ///
-/// `path` is treated as a caller-controlled destination. The function probes
-/// the path and then writes to it, leaving an inherent check-then-act (TOCTOU)
-/// window; it does **not** defend against an adversary racing the filesystem to
-/// swap `path` between the probe and the write. Callers must not direct dumps at
-/// a location writable by an untrusted party. The guards below turn the common
-/// *mistakes* (live DB, a directory) into clear errors — they are not a defense
-/// against a concurrent attacker.
+/// `path` is a caller-controlled destination, but the symlink-leaf race that
+/// `VACUUM INTO` would otherwise open is closed: rather than VACUUM-ing straight
+/// at `path` (which follows a symlink at the leaf), we VACUUM into an
+/// unpredictably-named sibling temp file created with `O_NOFOLLOW | O_EXCL`
+/// (see [`mint_sqlite_vacuum_tmp`]) and then atomically `rename` it onto `path`.
+/// `rename` *replaces* a destination symlink rather than following it, so an
+/// attacker who swaps `path` to a symlink between the guards and the move cannot
+/// redirect the write outside the directory (CWE-59 / CWE-367; #296 / #354 /
+/// #414 hardening — symmetric with the JSON write-then-rename path).
+///
+/// Residual: this does not confine *where* `path` itself points (a caller can
+/// still name a destination outside any sandbox); the mcp-level
+/// `validate_dump_path` guard handles that containment. The live-DB and
+/// directory checks below remain best-effort probes that turn the common
+/// *mistakes* into clear typed errors.
 ///
 /// # Errors
 ///
@@ -295,43 +348,45 @@ pub fn dump_sqlite(conn: &Connection, path: &Path) -> Result<()> {
         }
     }
 
-    // Re-run support: `VACUUM INTO` refuses to write to a path that already
-    // exists, so a prior dump file must be unlinked first.
-    //
-    // Trusted-path contract: `path` is a caller-controlled dump destination. A
-    // residual check-then-act window remains between this probe and the
-    // `VACUUM INTO` below (a classic TOCTOU); the engine does *not* defend
-    // against an adversary racing the filesystem in that window, so callers
-    // MUST NOT direct dumps at a location writable by an untrusted party.
-    //
-    // What this guard *does* enforce: probe with `symlink_metadata` (which does
-    // not follow symlinks, unlike the previous `path.exists()`) and only ever
-    // unlink a non-directory. A directory target is rejected with a clear typed
-    // error instead of the opaque "Is a directory" I/O failure.
+    // Best-effort *mistake* guard (not a security boundary): reject an existing
+    // directory at `path` with a clear typed error instead of letting the final
+    // `rename` fail opaquely. `is_dir()` follows symlinks, so this also refuses a
+    // symlink that resolves to a directory. A regular file or absent leaf is the
+    // normal case and is replaced atomically by the rename below.
     match std::fs::symlink_metadata(path) {
-        Ok(_) => {
-            // `is_dir()` follows symlinks, so this refuses both a real directory
-            // and a symlink that resolves to one — neither is a valid VACUUM INTO
-            // target and we must never unlink a directory. A symlink to a regular
-            // file (or a broken symlink) is removed as the link itself.
-            if path.is_dir() {
-                return Err(MemoryError::Conflict(ConflictError::DumpTargetIsDirectory));
-            }
-            std::fs::remove_file(path)?;
+        Ok(_) if path.is_dir() => {
+            return Err(MemoryError::Conflict(ConflictError::DumpTargetIsDirectory));
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // absent: nothing to remove
+        Ok(_) => {} // regular file / file-symlink: replaced by rename
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // absent: nothing to do
         Err(e) => return Err(MemoryError::Io(e)),
     }
 
-    let escaped = path.to_string_lossy().replace('\'', "''");
+    // The rename target dir is `path`'s parent; the temp must be a sibling there
+    // so the final `rename` is intra-directory (atomic, no cross-device copy).
+    let dir = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let dir = dir.unwrap_or_else(|| Path::new("."));
+
+    // VACUUM INTO a fresh, symlink-safe, server-named sibling temp, then
+    // atomically rename it onto `path`. This closes the symlink-leaf TOCTOU
+    // (`VACUUM INTO` follows a destination symlink; `rename` replaces it).
+    let tmp = mint_sqlite_vacuum_tmp(dir).map_err(MemoryError::Io)?;
+    let tmp_path = tmp.path().to_path_buf();
+
+    let escaped = tmp_path.to_string_lossy().replace('\'', "''");
     if escaped.contains('\0') {
         return Err(MemoryError::Internal(
-            "dump path contains null byte".to_string(),
+            "dump temp path contains null byte".to_string(),
         ));
     }
     let sql = format!("VACUUM INTO '{escaped}'");
     conn.execute_batch(&sql)
         .map_err(|e| MemoryError::Internal(format!("VACUUM INTO failed: {e}")))?;
+
+    // Atomic publish: `persist` renames the temp onto `path`, replacing any
+    // existing file (or symlink leaf) without following it. On failure the
+    // `NamedTempFile` drop removes the temp, leaving `path` untouched.
+    tmp.persist(path).map_err(|e| MemoryError::Io(e.error))?;
 
     Ok(())
 }
@@ -729,5 +784,54 @@ mod tests {
             b"do not clobber",
             "the symlink target must NOT have been overwritten"
         );
+    }
+
+    /// `SQLite`-path symlink safety (#296 / #354 / #414): if the final dump
+    /// target is a pre-planted symlink to a file we must not clobber,
+    /// `dump_sqlite` must not follow it. It VACUUM-s into a fresh
+    /// `O_NOFOLLOW | O_EXCL` sibling temp and `rename`s onto the target —
+    /// `rename` replaces the symlink (operating on the link, not its referent),
+    /// so the victim stays intact and the target path becomes a real `SQLite`
+    /// file. This closes the `VACUUM INTO` symlink-leaf TOCTOU that the mcp
+    /// lstat-reject alone left racy.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dump_sqlite_replaces_symlinked_target_without_following() {
+        use crate::store::schema::{init_schema, open_memory};
+
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let victim = dir.path().join("victim.txt");
+        std::fs::write(&victim, b"do not clobber").unwrap();
+
+        // The dump target is a symlink pointing at the victim.
+        let target = dir.path().join("dump.db");
+        std::os::unix::fs::symlink(&victim, &target).unwrap();
+
+        dump_sqlite(&conn, &target).expect("dump must succeed by replacing the symlink");
+
+        // The victim referent is untouched: the write did not follow the link.
+        assert_eq!(
+            std::fs::read(&victim).unwrap(),
+            b"do not clobber",
+            "the symlink target must NOT have been overwritten"
+        );
+        // The target is now a real (non-symlink) SQLite file containing the dump.
+        let meta = std::fs::symlink_metadata(&target).unwrap();
+        assert!(
+            !meta.file_type().is_symlink(),
+            "dump target must be a regular file after the rename, not a symlink"
+        );
+        let dump_conn = rusqlite::Connection::open_with_flags(
+            &target,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .expect("dumped target must be a valid SQLite database");
+        let n: i64 = dump_conn
+            .query_row("SELECT count(*) FROM facts", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "fresh in-memory db dumps an empty facts table");
     }
 }


### PR DESCRIPTION
## Summary

`memory_dump_state` lets an MCP client choose the dump destination but the guard
only canonicalized the path's **parent** and then handed the **original
unresolved** path to the engine. This is one vulnerability through three lenses:

- **CWE-59 (symlink-leaf follow):** the final filename component was never
  resolved, so a symlink leaf (e.g. `/tmp/x -> ~/.ssh/authorized_keys`) was
  followed by the downstream `File::create` / `VACUUM INTO`, writing outside the
  temp jail.
- **CWE-22 (path traversal):** `std::env::temp_dir()` was not canonicalized, so a
  symlinked temp root (e.g. macOS `/tmp -> /private/tmp`) could falsely reject
  legitimate in-temp paths — both sides of the containment check must resolve.
- **CWE-367 (TOCTOU):** the value validated (parent) differed from the value
  opened (the original path), leaving a check-then-use window.

The maintainer-approved fix **hardens in place** — the client keeps the ability
to choose a path *within* temp.

## Changes

**`memory-engine/bin/mcp/src/tools/mod.rs`** — new `validate_dump_path()`:
- canonicalizes the temp root (fallback to the raw value if canonicalize fails);
- rejects a leaf that is itself a symlink via `symlink_metadata` (lstat, no follow);
- resolves the **full** target — canonicalize the whole path when the leaf
  exists, else canonicalize the parent and rejoin the `file_name`;
- re-checks `resolved.starts_with(canonical_temp)`;
- returns the **resolved** path so the value validated is the value opened
  (closes the validate≠open TOCTOU gap at the mcp layer).

**`memory-engine/lib/memory-engine/src/inspect/dump.rs`** — in-engine backstop:
- the JSON dumps write a sibling `<path>.tmp` then atomically `rename` it onto
  `path`. `rename` does not follow a destination symlink, but the create of the
  `.tmp` leaf does. New `create_dump_tmp()` opens that leaf with **`O_NOFOLLOW`**
  on Unix, so a raced-in symlink leaf fails the open **atomically** — closing the
  residual TOCTOU at the open site itself. Degrades to a plain create on non-Unix,
  where the mcp lstat rejection remains the guard. `libc` is not a dependency of
  the lib, so the flag value is resolved per-target (no new dependency added).
  Behavior-preserving for the normal (non-symlink) path.

## Tests (TDD — written first, watched fail)

- `memory-engine/bin/mcp/tests/dump_path_security.rs` (new):
  - out-of-temp path (`/etc/clobber.json`) → `Err`, message names the temp
    constraint, target not written;
  - `#[cfg(unix)]` symlink-leaf-escaping-temp → `Err`, escape target not written
    (this was the failing case that confirmed the CWE-59 hole);
  - fresh in-temp path → still accepted (no over-restriction regression).
- `inspect::dump::dump_json_refuses_symlinked_tmp_leaf` (new lib unit test):
  proves the `O_NOFOLLOW` backstop refuses a pre-planted symlinked `.tmp` leaf
  and does not clobber its target.
- Existing `tools.rs` dump tests (incl. `test_dump_state_custom_path`) still pass.

## Gates

- `cargo test -p memory-engine-mcp` → ok (incl. `dump_path_security` 3/3)
- `cargo test -p memory-engine` → ok (1157 + integration)
- `cargo clippy -p memory-engine-mcp -p memory-engine --all-targets` → no new
  warnings (4 remaining are pre-existing on main, unrelated to this change)
- `cargo fmt --check` → clean
- `cargo build --workspace` → Finished
- No `Cargo.toml` / `Cargo.lock` change → supply-chain gate unaffected.

Closes #296
Closes #354
Closes #414
Part of #320
Part of #256