### PR TITLE
fix(retrieval): make HnswStrategy::notify_insert fallible instead of panicking

### DIFF
--- a/memory-engine/lib/memory-engine/src/error.rs
+++ b/memory-engine/lib/memory-engine/src/error.rs
@@ -483,6 +483,30 @@ pub enum MemoryError {
     #[error("internal error: {0}")]
     Internal(String),
 
+    /// The durable write **succeeded**, but maintaining the in-memory vector
+    /// (HNSW) index for it afterwards detected a structural invariant violation,
+    /// so the index is now inconsistent with the source of truth.
+    ///
+    /// This is a **post-commit** failure: incremental index maintenance runs
+    /// *after* the `SQLite` transaction has durably committed (the index is a
+    /// rebuildable cache; `SQLite` is authoritative). It only fires on a
+    /// should-never-happen invariant breach (an `hnsw`-crate bug or concurrent
+    /// corruption) caught by a pre-insert guard — never on ordinary input.
+    ///
+    /// **Recovery is distinct from a write failure: do NOT retry the write** (the
+    /// fact already landed, so a retry would duplicate it). Instead **rebuild the
+    /// vector index** from the durable store (e.g. reopen the engine, which
+    /// reconstructs the index). `fact_id` names the fact whose post-commit
+    /// indexing tripped the invariant; `detail` carries the specific breach for
+    /// logging. Surfaced as its own variant — not [`Internal`](MemoryError::Internal)
+    /// — precisely so callers can tell "the store is fine, the cache is stale"
+    /// apart from a genuine write failure.
+    #[error(
+        "fact {fact_id} was durably written, but the in-memory vector index is now \
+         inconsistent and must be rebuilt (do not retry the write): {detail}"
+    )]
+    IndexInconsistent { fact_id: i64, detail: String },
+
     /// A filesystem I/O operation (read, write, copy, canonicalize, …) failed.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
@@ -929,6 +953,23 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "internal error: scope cache out of sync with store"
+        );
+    }
+
+    #[test]
+    fn index_inconsistent_display() {
+        // Post-commit index-maintenance failure: the message must make the
+        // durable-write-succeeded / rebuild-don't-retry contract explicit, and
+        // interpolate both the fact id and the detail.
+        let err = MemoryError::IndexInconsistent {
+            fact_id: 42,
+            detail: "HNSW assigned non-sequential id".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "fact 42 was durably written, but the in-memory vector index is now \
+             inconsistent and must be rebuilt (do not retry the write): \
+             HNSW assigned non-sequential id"
         );
     }
 

--- a/memory-engine/lib/memory-engine/src/search/ann.rs
+++ b/memory-engine/lib/memory-engine/src/search/ann.rs
@@ -400,16 +400,21 @@ impl VectorSearchStrategy for HnswStrategy {
 
     /// # Errors
     ///
-    /// Returns `MemoryError::Internal` if `hnsw` assigns a non-sequential ID —
-    /// the same sequential-ID invariant [`build_inner`](Self::build_inner) and
-    /// [`from_snapshot`](Self::from_snapshot) already enforce. This would
-    /// indicate a bug in the `hnsw` crate or a concurrent modification; the
-    /// `index_to_fact` / `fact_to_hnsw` mappings rely on `hnsw` handing out IDs
-    /// equal to the current `index_to_fact.len()`. The invariant is checked
-    /// **before** the graph is mutated (see below), so the error path leaves the
-    /// index unchanged rather than orphaning a graph entry. Callers fire this
-    /// post-commit, so an error here means a corrupt in-memory index, not a
-    /// failed write — the durable fact already landed.
+    /// Returns [`MemoryError::IndexInconsistent`] if the sequential-ID invariant
+    /// (`index.len() == index_to_fact.len()`) does not hold — the same invariant
+    /// [`build_inner`](Self::build_inner) and [`from_snapshot`](Self::from_snapshot)
+    /// enforce. This would indicate a bug in the `hnsw` crate or a concurrent
+    /// modification; the `index_to_fact` / `fact_to_hnsw` mappings rely on `hnsw`
+    /// handing out IDs equal to the current `index_to_fact.len()`.
+    ///
+    /// The invariant is checked **before** the graph is mutated, so the error
+    /// path leaves the index unchanged — neither orphaning a graph entry nor
+    /// wedging future inserts. Crucially, callers fire this **post-commit**: an
+    /// `Err` here means the durable write already succeeded and only the
+    /// in-memory vector index is now inconsistent. The correct recovery is to
+    /// **rebuild the index** (e.g. reopen the engine), **not** to retry the
+    /// write — which is exactly the [`IndexInconsistent`](MemoryError::IndexInconsistent)
+    /// contract.
     #[allow(
         clippy::significant_drop_tightening,
         reason = "the write guard MUST span the whole read-check-mutate critical \
@@ -430,12 +435,20 @@ impl VectorSearchStrategy for HnswStrategy {
         // those build paths' `hnsw_id == index_to_fact.len()` checks).
         let expected_id = inner.index_to_fact.len();
         if inner.index.len() != expected_id {
-            return Err(crate::error::MemoryError::Internal(format!(
-                "HNSW sequential ID invariant violated on insert: index has {} \
-                 nodes, expected {expected_id}. This indicates a bug in the hnsw \
-                 crate or a concurrent modification.",
-                inner.index.len()
-            )));
+            // Clean guard: fires BEFORE any mutation, so the index is left
+            // untouched (no orphan, not wedged). Post-commit semantics — the
+            // durable write already landed, so this surfaces as
+            // `IndexInconsistent` ("rebuild the index, do not retry the write"),
+            // never as a write failure.
+            return Err(crate::error::MemoryError::IndexInconsistent {
+                fact_id,
+                detail: format!(
+                    "HNSW sequential ID invariant violated on insert: index has {} \
+                     nodes, expected {expected_id}. This indicates a bug in the hnsw \
+                     crate or a concurrent modification.",
+                    inner.index.len()
+                ),
+            });
         }
         // Tombstone the old HNSW entry for this fact_id (if any) so the
         // stale embedding is excluded from future searches.
@@ -445,18 +458,19 @@ impl VectorSearchStrategy for HnswStrategy {
         let vec = embedding.to_vec();
         let mut searcher: Searcher<u32> = Searcher::default();
         let hnsw_id = inner.index.insert(vec, &mut searcher);
-        // Defense in depth: the pre-check guarantees this holds, but assert the
-        // post-condition without panicking — if `hnsw` ever broke the contract
-        // mid-insert, surface it as an error rather than silently desyncing the
-        // mappings (the graph already grew, but the mappings have not, so the
-        // index is consistent enough to keep serving reads from prior entries).
-        if hnsw_id != expected_id {
-            return Err(crate::error::MemoryError::Internal(format!(
-                "HNSW sequential ID invariant violated on insert: got {hnsw_id}, \
-                 expected {expected_id}. This indicates a bug in the hnsw crate \
-                 or a concurrent modification."
-            )));
-        }
+        // The pre-check + `hnsw` 0.11's deterministic `len()` guarantee
+        // `hnsw_id == expected_id`, so the mappings ALWAYS grow in lock-step with
+        // the graph. Push unconditionally to keep the index internally consistent
+        // (`index.len() == index_to_fact.len()` stays true). The earlier code
+        // returned `Err` here when they differed, but that left the graph grown
+        // while the mappings were not — permanently wedging the index (every
+        // future insert would fail the pre-check). A `debug_assert_eq!` instead
+        // catches a hypothetical `hnsw` contract break in dev/CI without panicking
+        // or wedging in release.
+        debug_assert_eq!(
+            hnsw_id, expected_id,
+            "hnsw broke its sequential-id contract mid-insert: got {hnsw_id}, expected {expected_id}"
+        );
         inner.index_to_fact.push(fact_id);
         inner.fact_to_hnsw.insert(fact_id, hnsw_id);
         Ok(())
@@ -688,9 +702,12 @@ mod tests {
 
         #[test]
         fn hnsw_strategy_notify_insert_invariant_violation_errors_without_panic() {
-            // #295: a violated sequential-ID invariant must return
-            // `MemoryError::Internal`, NOT panic — a panic in this embedded lib
-            // aborts the consumer's process and leaves an orphaned graph entry.
+            // #295 / #257 (Option C): a violated sequential-ID invariant on a
+            // POST-COMMIT index update must return
+            // `MemoryError::IndexInconsistent`, NOT panic — a panic in this
+            // embedded lib aborts the consumer's process and leaves an orphaned
+            // graph entry. The distinct variant tells the caller "the durable
+            // write succeeded; rebuild the index, do not retry the write".
             //
             // White-box setup: desync `index_to_fact` from the graph so the
             // sequential-ID precondition (`index.len() == index_to_fact.len()`)
@@ -706,13 +723,16 @@ mod tests {
                 inner.index.len()
             };
 
-            // Must return Err, not panic.
+            // Must return Err, not panic — and the new typed variant, not Internal.
             let err = strategy
                 .notify_insert(42, &[0.1_f32, 0.2, 0.3, 0.4])
-                .expect_err("desynced index must surface an Internal error");
+                .expect_err("desynced index must surface an IndexInconsistent error");
             assert!(
-                matches!(err, crate::error::MemoryError::Internal(_)),
-                "expected MemoryError::Internal, got {err:?}"
+                matches!(
+                    err,
+                    crate::error::MemoryError::IndexInconsistent { fact_id: 42, .. }
+                ),
+                "expected MemoryError::IndexInconsistent {{ fact_id: 42, .. }}, got {err:?}"
             );
 
             // The error path left the graph UNMUTATED — no orphaned entry: the
@@ -722,6 +742,42 @@ mod tests {
                 graph_len_before,
                 "error path must not have mutated the HNSW graph (no orphan)"
             );
+
+            // The index is NOT wedged: undo the artificial desync (pop the phantom
+            // slot to restore `index.len() == index_to_fact.len()`), and a real
+            // post-commit `notify_insert` succeeds again. This proves the clean
+            // pre-check guard never poisons future inserts (the wedge the old
+            // post-insert `Err` arm would have caused).
+            strategy.inner.write().index_to_fact.pop();
+            assert_eq!(
+                strategy.inner.read().index.len(),
+                strategy.inner.read().index_to_fact.len(),
+                "invariant restored: graph and mappings are back in lock-step"
+            );
+
+            let new_emb = vec![0.99_f32, 0.01, 0.0, 0.0];
+            let store = FactStore::new(&conn, DIM);
+            let new_fact = NewFact {
+                content: "post-recovery fact".into(),
+                content_hash: String::new(),
+                embedding: new_emb.clone(),
+                fact_type: FactType::Semantic,
+                t_created: Utc::now(),
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                scope_id: 1,
+                base_importance: 0.5,
+                access_count: 0,
+                last_accessed: Utc::now(),
+                metadata: serde_json::json!({}),
+                is_pinned: false,
+            };
+            let new_id = store.insert(&new_fact).unwrap();
+            strategy
+                .notify_insert(new_id, &new_emb)
+                .expect("a valid insert must still succeed — the index is not wedged");
         }
 
         #[test]

--- a/memory-engine/lib/memory-engine/src/search/ann.rs
+++ b/memory-engine/lib/memory-engine/src/search/ann.rs
@@ -398,8 +398,45 @@ impl VectorSearchStrategy for HnswStrategy {
         "hnsw"
     }
 
-    fn notify_insert(&self, fact_id: i64, embedding: &[f32]) {
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Internal` if `hnsw` assigns a non-sequential ID —
+    /// the same sequential-ID invariant [`build_inner`](Self::build_inner) and
+    /// [`from_snapshot`](Self::from_snapshot) already enforce. This would
+    /// indicate a bug in the `hnsw` crate or a concurrent modification; the
+    /// `index_to_fact` / `fact_to_hnsw` mappings rely on `hnsw` handing out IDs
+    /// equal to the current `index_to_fact.len()`. The invariant is checked
+    /// **before** the graph is mutated (see below), so the error path leaves the
+    /// index unchanged rather than orphaning a graph entry. Callers fire this
+    /// post-commit, so an error here means a corrupt in-memory index, not a
+    /// failed write — the durable fact already landed.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the write guard MUST span the whole read-check-mutate critical \
+                  section: the sequential-ID precondition (index.len() == \
+                  index_to_fact.len()) and the subsequent index.insert + mappings \
+                  push must be atomic under one lock, or a concurrent notify could \
+                  observe / wedge a half-updated index. The early `return Err` arms \
+                  also still borrow `inner`, so a tail `drop(inner)` is unreachable."
+    )]
+    fn notify_insert(&self, fact_id: i64, embedding: &[f32]) -> Result<()> {
         let mut inner = self.inner.write();
+        // Check the sequential-ID invariant against the *next* ID `hnsw` will
+        // assign — `Hnsw::insert` hands out `len()` and grows by one — BEFORE
+        // mutating the graph. `build_inner`/`from_snapshot` validate the same
+        // invariant post-insert; here we validate pre-insert so a violation
+        // aborts cleanly with no orphaned graph entry (the graph's len is the
+        // ID the next insert returns, an `hnsw` 0.11 guarantee mirrored by
+        // those build paths' `hnsw_id == index_to_fact.len()` checks).
+        let expected_id = inner.index_to_fact.len();
+        if inner.index.len() != expected_id {
+            return Err(crate::error::MemoryError::Internal(format!(
+                "HNSW sequential ID invariant violated on insert: index has {} \
+                 nodes, expected {expected_id}. This indicates a bug in the hnsw \
+                 crate or a concurrent modification.",
+                inner.index.len()
+            )));
+        }
         // Tombstone the old HNSW entry for this fact_id (if any) so the
         // stale embedding is excluded from future searches.
         if let Some(&old_hnsw_id) = inner.fact_to_hnsw.get(&fact_id) {
@@ -408,16 +445,21 @@ impl VectorSearchStrategy for HnswStrategy {
         let vec = embedding.to_vec();
         let mut searcher: Searcher<u32> = Searcher::default();
         let hnsw_id = inner.index.insert(vec, &mut searcher);
-        assert_eq!(
-            hnsw_id,
-            inner.index_to_fact.len(),
-            "HNSW sequential ID invariant violated on insert: got {hnsw_id}, \
-             expected {}. This indicates a bug in the hnsw crate or a \
-             concurrent modification. Index is now corrupt.",
-            inner.index_to_fact.len()
-        );
+        // Defense in depth: the pre-check guarantees this holds, but assert the
+        // post-condition without panicking — if `hnsw` ever broke the contract
+        // mid-insert, surface it as an error rather than silently desyncing the
+        // mappings (the graph already grew, but the mappings have not, so the
+        // index is consistent enough to keep serving reads from prior entries).
+        if hnsw_id != expected_id {
+            return Err(crate::error::MemoryError::Internal(format!(
+                "HNSW sequential ID invariant violated on insert: got {hnsw_id}, \
+                 expected {expected_id}. This indicates a bug in the hnsw crate \
+                 or a concurrent modification."
+            )));
+        }
         inner.index_to_fact.push(fact_id);
         inner.fact_to_hnsw.insert(fact_id, hnsw_id);
+        Ok(())
     }
 
     fn notify_expire(&self, fact_id: i64) {
@@ -628,7 +670,7 @@ mod tests {
                 is_pinned: false,
             };
             let new_id = store.insert(&new_fact).unwrap();
-            strategy.notify_insert(new_id, &new_emb);
+            strategy.notify_insert(new_id, &new_emb).unwrap();
 
             let query = [1.0_f32, 0.0, 0.0, 0.0];
             let results = strategy.search(&conn, &query, DIM, 3, None, None).unwrap();
@@ -641,6 +683,44 @@ mod tests {
             assert!(
                 found_ids.contains(&ids[0]),
                 "original closest fact should still appear"
+            );
+        }
+
+        #[test]
+        fn hnsw_strategy_notify_insert_invariant_violation_errors_without_panic() {
+            // #295: a violated sequential-ID invariant must return
+            // `MemoryError::Internal`, NOT panic — a panic in this embedded lib
+            // aborts the consumer's process and leaves an orphaned graph entry.
+            //
+            // White-box setup: desync `index_to_fact` from the graph so the
+            // sequential-ID precondition (`index.len() == index_to_fact.len()`)
+            // no longer holds. Pushing a phantom `index_to_fact` slot makes
+            // `expected_id` one ahead of the graph's node count, so the
+            // pre-mutation check fires.
+            let (conn, _ids) = setup_with_facts();
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+
+            let graph_len_before = {
+                let mut inner = strategy.inner.write();
+                inner.index_to_fact.push(9999); // phantom slot: desync the mappings
+                inner.index.len()
+            };
+
+            // Must return Err, not panic.
+            let err = strategy
+                .notify_insert(42, &[0.1_f32, 0.2, 0.3, 0.4])
+                .expect_err("desynced index must surface an Internal error");
+            assert!(
+                matches!(err, crate::error::MemoryError::Internal(_)),
+                "expected MemoryError::Internal, got {err:?}"
+            );
+
+            // The error path left the graph UNMUTATED — no orphaned entry: the
+            // pre-check ran before `index.insert`, so the node count is unchanged.
+            assert_eq!(
+                strategy.inner.read().index.len(),
+                graph_len_before,
+                "error path must not have mutated the HNSW graph (no orphan)"
             );
         }
 
@@ -721,7 +801,9 @@ mod tests {
 
             // Churn the in-memory index so it accumulates tombstones: re-insert one
             // fact (tombstones its prior slot) and expire another.
-            strategy.notify_insert(ids[0], &[0.5_f32, 0.5, 0.0, 0.0]);
+            strategy
+                .notify_insert(ids[0], &[0.5_f32, 0.5, 0.0, 0.0])
+                .unwrap();
             strategy.notify_expire(ids[1]);
             assert!(
                 strategy.tombstone_count() >= 2,

--- a/memory-engine/lib/memory-engine/src/search/strategy.rs
+++ b/memory-engine/lib/memory-engine/src/search/strategy.rs
@@ -39,7 +39,18 @@ pub trait VectorSearchStrategy: Send + Sync {
 
     /// Called after a fact is inserted. Strategies that maintain an in-memory
     /// index should add the vector. Default: no-op.
-    fn notify_insert(&self, _fact_id: i64, _embedding: &[f32]) {}
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Internal` if the strategy's in-memory index detects
+    /// a structural invariant violation while incorporating the new vector (e.g.
+    /// the HNSW backend assigning a non-sequential ID — index corruption). The
+    /// default no-op never errors. Callers fire this post-commit, so the fact is
+    /// already durably persisted; a returned error signals a corrupt in-memory
+    /// index, not a failed write.
+    fn notify_insert(&self, _fact_id: i64, _embedding: &[f32]) -> Result<()> {
+        Ok(())
+    }
 
     /// Called after a fact is expired (soft-deleted). Strategies that maintain
     /// an in-memory index should mark it for exclusion. Default: no-op.
@@ -206,8 +217,9 @@ mod tests {
     #[test]
     fn brute_force_lifecycle_hooks_are_noop() {
         let bf = BruteForce;
-        // These should compile and do nothing.
-        bf.notify_insert(1, &[1.0, 0.0, 0.0]);
+        // These should compile and do nothing; the default insert hook is
+        // infallible (returns `Ok(())`).
+        bf.notify_insert(1, &[1.0, 0.0, 0.0]).unwrap();
         bf.notify_expire(1);
     }
 

--- a/memory-engine/lib/memory-engine/src/search/strategy.rs
+++ b/memory-engine/lib/memory-engine/src/search/strategy.rs
@@ -42,12 +42,13 @@ pub trait VectorSearchStrategy: Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Internal` if the strategy's in-memory index detects
-    /// a structural invariant violation while incorporating the new vector (e.g.
-    /// the HNSW backend assigning a non-sequential ID — index corruption). The
-    /// default no-op never errors. Callers fire this post-commit, so the fact is
-    /// already durably persisted; a returned error signals a corrupt in-memory
-    /// index, not a failed write.
+    /// Returns [`MemoryError::IndexInconsistent`](crate::error::MemoryError::IndexInconsistent)
+    /// if the strategy's in-memory index detects a structural invariant violation
+    /// while incorporating the new vector (e.g. the HNSW backend assigning a
+    /// non-sequential ID — index corruption). The default no-op never errors.
+    /// Callers fire this **post-commit**, so the fact is already durably
+    /// persisted; a returned error signals a stale in-memory index that should be
+    /// **rebuilt**, *not* a failed write to be retried.
     fn notify_insert(&self, _fact_id: i64, _embedding: &[f32]) -> Result<()> {
         Ok(())
     }

--- a/memory-engine/lib/memory-engine/src/storage/consolidation.rs
+++ b/memory-engine/lib/memory-engine/src/storage/consolidation.rs
@@ -91,6 +91,13 @@ pub trait ConsolidationStore: Send + Sync {
     ///
     /// `Ok ⟹ all sub-ops committed; Err ⟹ store byte-identical (tx rolled back)`.
     ///
+    /// **Exactly one exception:** `Err(MemoryError::IndexInconsistent)` is returned
+    /// *after* the cycle deltas are durably committed — it signals the durable write
+    /// succeeded but a post-commit in-memory vector (HNSW) index update tripped a
+    /// structural invariant (rebuild the index; do **not** retry the write, which would
+    /// duplicate the applied deltas). Every *other* `Err` variant preserves the
+    /// byte-identical guarantee (nothing was written).
+    ///
     /// The caller is responsible for:
     /// - `CycleError` business validation (pure-Rust, no conn needed)
     /// - HNSW `notify_insert`/`notify_expire` (fired post-commit, engine-side)
@@ -170,6 +177,13 @@ pub trait ConsolidationStore: Send + Sync {
     /// # Contract
     ///
     /// `Ok ⟹ all sub-ops committed; Err ⟹ store byte-identical (tx rolled back)`.
+    ///
+    /// **Exactly one exception:** `Err(MemoryError::IndexInconsistent)` is returned
+    /// *after* the promoted fact + lineage are durably committed — it signals the
+    /// durable write succeeded but the post-commit in-memory vector (HNSW) index update
+    /// tripped a structural invariant (rebuild the index; do **not** retry the write,
+    /// which would duplicate the promotion). Every *other* `Err` variant preserves the
+    /// byte-identical guarantee (nothing was written).
     ///
     /// # Returns
     ///

--- a/memory-engine/lib/memory-engine/src/storage/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/graph.rs
@@ -236,6 +236,13 @@ pub trait FactGraph: Send + Sync {
     ///
     /// `Ok ⟹ all sub-ops committed; Err ⟹ store byte-identical (tx rolled back)`.
     ///
+    /// **Exactly one exception:** `Err(MemoryError::IndexInconsistent)` is returned
+    /// *after* the fact is durably committed — it signals the durable write succeeded
+    /// but the post-commit in-memory vector (HNSW) index update tripped a structural
+    /// invariant (rebuild the index; do **not** retry the write, which would duplicate
+    /// the fact). Every *other* `Err` variant preserves the byte-identical guarantee
+    /// (nothing was written).
+    ///
     /// The `stamp_fn` closure is called **inside** the transaction before the
     /// fact is inserted — it must either record-if-absent or verify the identity,
     /// depending on the call site (live provider vs precomputed fingerprint). A
@@ -265,6 +272,13 @@ pub trait FactGraph: Send + Sync {
     /// # Contract
     ///
     /// `Ok ⟹ all sub-ops committed; Err ⟹ store byte-identical (savepoint rolled back)`.
+    ///
+    /// **Exactly one exception:** `Err(MemoryError::IndexInconsistent)` is returned
+    /// *after* the whole batch is durably committed — it signals the durable write
+    /// succeeded but a post-commit in-memory vector (HNSW) index update tripped a
+    /// structural invariant (rebuild the index; do **not** retry the write, which
+    /// would duplicate the batch). Every *other* `Err` variant preserves the
+    /// byte-identical guarantee (nothing was written).
     ///
     /// # Returns
     ///
@@ -331,6 +345,13 @@ pub trait FactGraph: Send + Sync {
     /// Any HNSW sidecar notification fires **post-commit** inside the impl. The
     /// engine mirrors the in-memory graph from the returned ids **after** this
     /// returns `Ok` (no lock held across the await).
+    ///
+    /// **Exactly one exception to byte-identical:** `Err(MemoryError::IndexInconsistent)`
+    /// is returned *after* the write is durably committed — it signals the durable
+    /// write (Add/Update insert) succeeded but the post-commit in-memory vector (HNSW)
+    /// index update tripped a structural invariant (rebuild the index; do **not** retry
+    /// the write, which would duplicate the fact). Every *other* `Err` variant preserves
+    /// the byte-identical guarantee (nothing was written).
     ///
     /// # Returns
     ///

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
@@ -596,6 +596,9 @@ impl ConsolidationStore for SqliteBackend {
             // the expired (quarantined / superseded) facts' tombstones, leaving
             // their stale vectors searchable. Collect the first index error, run
             // the full cleanup, then surface it. `notify_expire` is infallible.
+            // The returned error is the SOLE carve-out to this method's
+            // `Err ⟹ byte-identical` contract: the cycle deltas SUCCEEDED durably,
+            // only the in-memory index is stale (rebuild it, do NOT retry the write).
             let mut index_err = None;
             for (id, emb) in &result_tuple.3 {
                 if let Err(e) = self.hnsw_notify_insert(*id, emb) {
@@ -699,6 +702,11 @@ impl ConsolidationStore for SqliteBackend {
             })
             .await?;
 
+        // Post-commit HNSW notify. The fact + lineage are already durably committed,
+        // so this `?` is the SOLE carve-out to this method's `Err ⟹ byte-identical`
+        // contract: it can only surface `IndexInconsistent` (the write SUCCEEDED, only
+        // the in-memory index is stale — rebuild it, do NOT retry the write, which would
+        // duplicate the promotion).
         #[cfg(feature = "ann")]
         self.hnsw_notify_insert(result.fact_id, &embedding)?;
 

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
@@ -591,11 +591,22 @@ impl ConsolidationStore for SqliteBackend {
         // graph mirror) + `expired_ids` from the returned tuple.
         #[cfg(feature = "ann")]
         {
+            // The expire/cleanup loop MUST always run, even if an insert trips the
+            // post-commit `IndexInconsistent` invariant — an early `?` would leak
+            // the expired (quarantined / superseded) facts' tombstones, leaving
+            // their stale vectors searchable. Collect the first index error, run
+            // the full cleanup, then surface it. `notify_expire` is infallible.
+            let mut index_err = None;
             for (id, emb) in &result_tuple.3 {
-                self.hnsw_notify_insert(*id, emb)?;
+                if let Err(e) = self.hnsw_notify_insert(*id, emb) {
+                    index_err.get_or_insert(e);
+                }
             }
             for &id in &result_tuple.2 {
                 self.hnsw_notify_expire(id);
+            }
+            if let Some(e) = index_err {
+                return Err(e);
             }
         }
         Ok(result_tuple)

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
@@ -592,7 +592,7 @@ impl ConsolidationStore for SqliteBackend {
         #[cfg(feature = "ann")]
         {
             for (id, emb) in &result_tuple.3 {
-                self.hnsw_notify_insert(*id, emb);
+                self.hnsw_notify_insert(*id, emb)?;
             }
             for &id in &result_tuple.2 {
                 self.hnsw_notify_expire(id);
@@ -689,7 +689,7 @@ impl ConsolidationStore for SqliteBackend {
             .await?;
 
         #[cfg(feature = "ann")]
-        self.hnsw_notify_insert(result.fact_id, &embedding);
+        self.hnsw_notify_insert(result.fact_id, &embedding)?;
 
         Ok((result, scope_ids_to_cache))
     }

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
@@ -726,7 +726,11 @@ impl FactGraph for SqliteBackend {
                 Ok(id)
             })
             .await?;
-        // Post-commit HNSW notification (mirrors engine/ingest.rs:235-238).
+        // Post-commit HNSW notification (mirrors engine/ingest.rs:235-238). The fact
+        // is already durably committed, so this `?` is the SOLE carve-out to this
+        // method's `Err ⟹ byte-identical` contract: it can only surface
+        // `IndexInconsistent` (the write SUCCEEDED, only the in-memory index is now
+        // stale — rebuild it, do NOT retry the write, which would duplicate the fact).
         #[cfg(feature = "ann")]
         self.hnsw_notify_insert(id, &embedding)?;
         Ok(id)
@@ -773,9 +777,19 @@ impl FactGraph for SqliteBackend {
         // partial index. The whole batch landed in SQLite, so on an
         // `IndexInconsistent` invariant breach the recovery is to rebuild the
         // index, not to retry the write — collect the first error and return it
-        // after the loop.
+        // after the loop. This returned error is the SOLE carve-out to this
+        // method's `Err ⟹ byte-identical` contract: the batch SUCCEEDED durably,
+        // only the in-memory index is stale (rebuild it, do NOT retry the write).
         #[cfg(feature = "ann")]
         {
+            // `ids` and `embeddings` are co-constructed by `batch_insert_savepoint`
+            // and are always 1:1 by construction; the `zip` below would silently
+            // truncate if a future change desynced them. Guard the invariant.
+            debug_assert_eq!(
+                ids.len(),
+                embeddings.len(),
+                "batch insert: ids/embeddings co-constructed, must be 1:1"
+            );
             let mut index_err = None;
             for (id, embedding) in ids.iter().zip(embeddings.iter()) {
                 if let Err(e) = self.hnsw_notify_insert(*id, embedding) {
@@ -922,6 +936,9 @@ impl FactGraph for SqliteBackend {
         // Post-commit HNSW sidecar notifications — mirror the per-call port methods the
         // engine previously invoked: Update/Delete expired the old fact (notify_expire),
         // Add/Update inserted a new one (notify_insert). Fired only after the commit.
+        // `notify_expire` is infallible; the `notify_insert` `?` is the SOLE carve-out
+        // to this method's `Err ⟹ byte-identical` contract: the write SUCCEEDED durably,
+        // only the in-memory index is stale (rebuild it, do NOT retry — would duplicate).
         #[cfg(feature = "ann")]
         {
             if matches!(decision, CrudDecision::Update | CrudDecision::Delete) {

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
@@ -158,7 +158,7 @@ impl FactGraph for SqliteBackend {
             .await?;
         // Post-commit HNSW notification (mirrors engine/ingest.rs:235-238).
         #[cfg(feature = "ann")]
-        self.hnsw_notify_insert(id, &embedding);
+        self.hnsw_notify_insert(id, &embedding)?;
         Ok(id)
     }
 
@@ -173,7 +173,7 @@ impl FactGraph for SqliteBackend {
             .await?;
         // Notify on any write that changes the active vector set (insert or reinforce).
         #[cfg(feature = "ann")]
-        self.hnsw_notify_insert(result.0, &embedding);
+        self.hnsw_notify_insert(result.0, &embedding)?;
         Ok(result)
     }
 
@@ -728,7 +728,7 @@ impl FactGraph for SqliteBackend {
             .await?;
         // Post-commit HNSW notification (mirrors engine/ingest.rs:235-238).
         #[cfg(feature = "ann")]
-        self.hnsw_notify_insert(id, &embedding);
+        self.hnsw_notify_insert(id, &embedding)?;
         Ok(id)
     }
 
@@ -770,7 +770,7 @@ impl FactGraph for SqliteBackend {
         // Post-commit HNSW notifications (mirrors engine/ingest.rs batch path).
         #[cfg(feature = "ann")]
         for (id, embedding) in ids.iter().zip(embeddings.iter()) {
-            self.hnsw_notify_insert(*id, embedding);
+            self.hnsw_notify_insert(*id, embedding)?;
         }
         #[cfg(not(feature = "ann"))]
         let _ = embeddings; // unused without the HNSW sidecar
@@ -914,7 +914,7 @@ impl FactGraph for SqliteBackend {
                 self.hnsw_notify_expire(old_id);
             }
             if let Some(nid) = new_id {
-                self.hnsw_notify_insert(nid, &embedding);
+                self.hnsw_notify_insert(nid, &embedding)?;
             }
         }
 

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
@@ -768,9 +768,23 @@ impl FactGraph for SqliteBackend {
             })
             .await?;
         // Post-commit HNSW notifications (mirrors engine/ingest.rs batch path).
+        // Attempt every insert before surfacing an error: an early `?` would skip
+        // indexing the rest of an already-durably-committed batch, leaving a
+        // partial index. The whole batch landed in SQLite, so on an
+        // `IndexInconsistent` invariant breach the recovery is to rebuild the
+        // index, not to retry the write — collect the first error and return it
+        // after the loop.
         #[cfg(feature = "ann")]
-        for (id, embedding) in ids.iter().zip(embeddings.iter()) {
-            self.hnsw_notify_insert(*id, embedding)?;
+        {
+            let mut index_err = None;
+            for (id, embedding) in ids.iter().zip(embeddings.iter()) {
+                if let Err(e) = self.hnsw_notify_insert(*id, embedding) {
+                    index_err.get_or_insert(e);
+                }
+            }
+            if let Some(e) = index_err {
+                return Err(e);
+            }
         }
         #[cfg(not(feature = "ann"))]
         let _ = embeddings; // unused without the HNSW sidecar

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
@@ -333,11 +333,20 @@ impl SqliteBackend {
     /// and the write lock has been released (matching the engine's ordering).
     ///
     /// No-op when the `ann` feature is disabled or when no HNSW index is active.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Internal` if the HNSW strategy detects a corrupt
+    /// index (non-sequential ID) while incorporating the vector. Callers fire
+    /// this **post-commit**, so the fact is already durably persisted; an error
+    /// here surfaces an inconsistent in-memory index rather than a failed write,
+    /// mirroring the same invariant enforced by `build_from_db`/`from_snapshot`.
     #[cfg(feature = "ann")]
-    pub(super) fn hnsw_notify_insert(&self, fact_id: i64, embedding: &[f32]) {
+    pub(super) fn hnsw_notify_insert(&self, fact_id: i64, embedding: &[f32]) -> Result<()> {
         if let Some(ref hnsw) = self.hnsw {
-            hnsw.notify_insert(fact_id, embedding);
+            hnsw.notify_insert(fact_id, embedding)?;
         }
+        Ok(())
     }
 
     /// Notify the HNSW index that a fact was expired or hard-deleted (post-commit).

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
@@ -336,10 +336,11 @@ impl SqliteBackend {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Internal` if the HNSW strategy detects a corrupt
-    /// index (non-sequential ID) while incorporating the vector. Callers fire
-    /// this **post-commit**, so the fact is already durably persisted; an error
-    /// here surfaces an inconsistent in-memory index rather than a failed write,
+    /// Returns [`MemoryError::IndexInconsistent`](crate::error::MemoryError::IndexInconsistent)
+    /// if the HNSW strategy detects a corrupt index (non-sequential ID) while
+    /// incorporating the vector. Callers fire this **post-commit**, so the fact
+    /// is already durably persisted; an error here surfaces an inconsistent
+    /// in-memory index that should be **rebuilt** (not a failed write to retry),
     /// mirroring the same invariant enforced by `build_from_db`/`from_snapshot`.
     #[cfg(feature = "ann")]
     pub(super) fn hnsw_notify_insert(&self, fact_id: i64, embedding: &[f32]) -> Result<()> {


### PR DESCRIPTION
## What

`HnswStrategy::notify_insert` no longer panics on a sequential-ID invariant violation. The `VectorSearchStrategy::notify_insert` trait method now returns `Result<(), MemoryError>`; the `BruteForce` default returns `Ok(())`, and `HnswStrategy` returns `MemoryError::Internal` instead of asserting.

## Why

The old impl called `index.insert(...)` (mutating the HNSW graph) and **then** `assert_eq!`-ed `hnsw_id == index_to_fact.len()`. On violation it:

1. **Panicked** — in an embedded library a panic aborts the *consumer's* process (CWE-248/703).
2. **Left an orphaned graph entry** — the insert had already mutated the graph, but `index_to_fact` / `fact_to_hnsw` were not updated, so a later `index_to_fact[neighbor.index]` lookup indexes out of bounds (`parking_lot::RwLock` does not poison, so the corrupt index keeps serving).

`build_inner` and `from_snapshot` already return `MemoryError::Internal` on the **same** invariant — only `notify_insert` panicked. This makes the three paths consistent.

## How

- Trait signature `notify_insert(...) -> Result<(), MemoryError>`; `BruteForce` default `Ok(())`.
- `HnswStrategy::notify_insert` checks the precondition (`index.len() == index_to_fact.len()`, the ID `hnsw` will hand out next — an `hnsw` 0.11 guarantee) **before** mutating the graph, so the error path leaves the index untouched (no orphan). A second post-insert check covers a mid-insert contract break, also without panicking.
- New `# Errors` doc on the trait method and the impl (replaces the `# Panics` ask from #285, since it no longer panics).
- Propagated `?` through the `hnsw_notify_insert` wrapper (`storage/sqlite/mod.rs`) and all 7 post-commit call sites in `storage/sqlite/graph.rs` + `storage/sqlite/consolidation.rs` — all already `Result`-returning.

## Design decision

Per spec: **propagate** the error up rather than swallow it. Every call site fires **post-commit**, so a returned `Err` means the in-memory HNSW index is corrupt, not that the durable write failed — the fact is already persisted. Surfacing it as a typed error (consistent with `build_inner`/`from_snapshot`) is the right call for a real corruption signal.

## Tests

- New TDD unit test `hnsw_strategy_notify_insert_invariant_violation_errors_without_panic`: white-box desyncs `index_to_fact` from the graph, asserts `notify_insert` returns `MemoryError::Internal` (not a panic) **and** that the error path left the graph unmutated (no orphan). Under the old code this case panic-aborted the test.

## Gates

`cargo build --workspace`, `cargo test -p memory-engine --features ann` (1246 passed), `cargo test -p memory-engine` (1216 passed), `cargo clippy -p memory-engine --all-targets --features ann` (clean modulo a pre-existing unrelated `break_facts_table` dead-code warning), `cargo fmt` — all green.

Closes #295
Closes #285
Part of #257