### PR TITLE
test(retrieval): add fts_query fuzz target for the FTS5 query-text path

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -79,3 +79,10 @@ path = "fuzz_targets/embed_parse_response.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fts_query"
+path = "fuzz_targets/fts_query.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fts_query.rs
+++ b/fuzz/fuzz_targets/fts_query.rs
@@ -1,0 +1,25 @@
+//! Fuzz target for the FTS5 query-text path (#499 `search/testing-no-fuzz-targets`).
+//!
+//! `search::fts::fts_search` (reached from the engine's hybrid search) binds an
+//! untrusted query string into a SQLite FTS5 `MATCH ?` expression. FTS5 has its
+//! own mini query grammar (phrases, `NEAR`, column filters, `AND`/`OR`/`NOT`,
+//! prefix `*`, quoting), and malformed input surfaces as a syntax error at
+//! `query_map` time rather than at prepare time. The contract is total: every
+//! query string must either return rows or be caught and mapped to an empty
+//! result — never a panic, never a propagated error for a syntax-malformed query.
+//!
+//! This harness feeds arbitrary bytes (lossy-UTF-8-decoded) through the
+//! `#[cfg(fuzzing)]` `memory_engine::fuzz_seam::fuzz_fts_query` seam, which owns
+//! the in-memory DB setup (the store/schema helpers are `pub(crate)`) so this
+//! harness stays a thin `&[u8] -> ()` wrapper and does not widen the public API.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Lossy decode: FTS5 takes UTF-8 text, and the lossy replacement of invalid
+    // sequences is itself part of the surface we want to exercise (replacement
+    // chars, embedded NULs, lone surrogates collapsed to U+FFFD).
+    let query = String::from_utf8_lossy(data);
+    memory_engine::fuzz_seam::fuzz_fts_query(&query);
+});

--- a/memory-engine/lib/memory-engine/src/lib.rs
+++ b/memory-engine/lib/memory-engine/src/lib.rs
@@ -199,6 +199,9 @@ pub use engine::cycle::{
 /// - [`bootstrap::parse::parse_session_file`] /
 ///   [`bootstrap::parse::parse_content_blocks`] — the crate-internal JSONL session
 ///   parsers (`pub fn` inside a `pub(crate) mod`, so not reachable downstream).
+/// - [`search::fts::fuzz_fts_query`] — drives an untrusted query string through the
+///   FTS5 `MATCH` path on a seeded in-memory DB (the store/schema setup it needs is
+///   `pub(crate)`, so the seam owns it).
 ///
 /// `inspect::restore::read_snapshot` (the JSON import path) is already public, so
 /// it is fuzzed directly without going through this seam.
@@ -210,6 +213,7 @@ pub use engine::cycle::{
 pub mod fuzz_seam {
     pub use crate::bootstrap::parse::{parse_content_blocks, parse_session_file};
     pub use crate::engine::snapshot::{fuzz_wrap_payload, load_from_file};
+    pub use crate::search::fts::fuzz_fts_query;
 }
 
 #[cfg(test)]

--- a/memory-engine/lib/memory-engine/src/search/fts.rs
+++ b/memory-engine/lib/memory-engine/src/search/fts.rs
@@ -156,6 +156,76 @@ pub fn fts_count_expired(
     }
 }
 
+/// Fuzz-only seam (`--cfg fuzzing`, set only by `cargo fuzz`).
+///
+/// Drives an arbitrary, attacker-controlled query string through the full FTS5
+/// `MATCH` path on a freshly-seeded in-memory SQLite database. The seam owns the
+/// DB setup so the harness can stay a thin `&[u8] -> ()` wrapper while still
+/// reaching the crate-internal store/schema helpers (both `pub(crate)`).
+///
+/// The contract under test is total: any UTF-8 query string — balanced or not,
+/// containing FTS5 operators, column filters, quotes, NUL bytes, or arbitrary
+/// Unicode — must either return rows or be caught as an FTS5 syntax error and
+/// mapped to an empty result. It must NEVER panic and never propagate an error
+/// for a syntax-malformed query.
+///
+/// Compiled solely under `cargo fuzz` (`#[cfg(fuzzing)]`); adds nothing to the
+/// shipped crate.
+#[cfg(fuzzing)]
+#[doc(hidden)]
+pub fn fuzz_fts_query(query: &str) {
+    use crate::store::facts::FactStore;
+    use crate::store::schema::{init_schema, open_memory};
+    use crate::types::{FactType, NewFact};
+    use chrono::Utc;
+
+    const DIM: usize = 4;
+
+    // A panic here would be an environment failure (out of memory etc.), not a
+    // finding about the query path, so bail quietly instead of aborting.
+    let Ok(conn) = open_memory() else { return };
+    if init_schema(&conn).is_err() {
+        return;
+    }
+
+    let store = FactStore::new(&conn, DIM);
+    // Seed a couple of rows so the FTS5 index is non-empty: an empty index can
+    // short-circuit before the MATCH expression is fully evaluated, hiding
+    // parser-level panics in the query string.
+    for content in [
+        "Rust systems programming language",
+        "Python machine learning",
+    ] {
+        let fact = NewFact {
+            content: content.into(),
+            content_hash: String::new(),
+            embedding: vec![0.1; DIM],
+            fact_type: FactType::Episodic,
+            t_created: Utc::now(),
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            scope_id: 1,
+            base_importance: 0.5,
+            access_count: 0,
+            last_accessed: Utc::now(),
+            metadata: serde_json::json!({}),
+            is_pinned: false,
+        };
+        if store.insert(&fact).is_err() {
+            return;
+        }
+    }
+
+    // Drive the untrusted query through every public MATCH entry point: the
+    // active-only search, the filtered variant (with a fact-type + scope
+    // filter exercising the extra bind ordering), and the expired-count probe.
+    let _ = fts_search(&conn, query, 10, None, None);
+    let _ = fts_search(&conn, query, 10, Some(&FactType::Episodic), Some(&[1]));
+    let _ = fts_count_expired(&conn, query, None, None);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/memory-engine/lib/memory-engine/src/search/fts.rs
+++ b/memory-engine/lib/memory-engine/src/search/fts.rs
@@ -181,17 +181,18 @@ pub fn fuzz_fts_query(query: &str) {
 
     const DIM: usize = 4;
 
-    // A panic here would be an environment failure (out of memory etc.), not a
-    // finding about the query path, so bail quietly instead of aborting.
-    let Ok(conn) = open_memory() else { return };
-    if init_schema(&conn).is_err() {
-        return;
-    }
+    // These are fuzzer-setup invariants, not the fuzzed input: a failure here is a
+    // broken fuzzing environment (out of memory, missing FTS5 build, etc.), not a
+    // finding about the query path. Panic loudly so a broken env halts the fuzzer
+    // instead of silently running empty iterations and masking a dead test.
+    let conn = open_memory().expect("fuzzer DB setup failed: open_memory");
+    init_schema(&conn).expect("fuzzer DB setup failed: init_schema");
 
     let store = FactStore::new(&conn, DIM);
-    // Seed a couple of rows so the FTS5 index is non-empty: an empty index can
-    // short-circuit before the MATCH expression is fully evaluated, hiding
-    // parser-level panics in the query string.
+    // Seed a couple of rows so the FTS5 index is non-empty: seeding a non-empty
+    // index exercises the full row-materialisation + BM25 scoring path rather than
+    // an empty-result fast path, so any parser-level panic in the query string is
+    // reachable.
     for content in [
         "Rust systems programming language",
         "Python machine learning",
@@ -213,17 +214,26 @@ pub fn fuzz_fts_query(query: &str) {
             metadata: serde_json::json!({}),
             is_pinned: false,
         };
-        if store.insert(&fact).is_err() {
-            return;
-        }
+        store
+            .insert(&fact)
+            .expect("fuzzer DB setup failed: seed insert");
     }
 
     // Drive the untrusted query through every public MATCH entry point: the
     // active-only search, the filtered variant (with a fact-type + scope
     // filter exercising the extra bind ordering), and the expired-count probe.
-    let _ = fts_search(&conn, query, 10, None, None);
-    let _ = fts_search(&conn, query, 10, Some(&FactType::Episodic), Some(&[1]));
-    let _ = fts_count_expired(&conn, query, None, None);
+    //
+    // The fuzzed property is the *total* contract: every query string — balanced
+    // or malformed — must map to `Ok`, never propagate. FTS5 syntax errors are
+    // caught at `query_map`/`query_row` time and folded into an empty result
+    // (`Ok(vec![])` / `Ok(0)`), so `Err` here would be a real regression of that
+    // guarantee (or a genuine non-FTS5 DB fault) — assert it loudly.
+    fts_search(&conn, query, 10, None, None)
+        .expect("malformed query must map to Ok, not propagate");
+    fts_search(&conn, query, 10, Some(&FactType::Episodic), Some(&[1]))
+        .expect("malformed query must map to Ok, not propagate");
+    fts_count_expired(&conn, query, None, None)
+        .expect("malformed query must map to Ok, not propagate");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Adds a `fts_query` libFuzzer target covering the FTS5 query-text path — the previously-unfuzzed string input that reaches SQLite `FTS5 MATCH` from hybrid search.

- New `fuzz/fuzz_targets/fts_query.rs`, registered as a `[[bin]]` in `fuzz/Cargo.toml` (mirrors the existing snapshot/session targets: `libfuzzer_sys::fuzz_target!`, `test=false`/`doc=false`/`bench=false`).
- New `#[cfg(fuzzing)]` `fuzz_fts_query` seam in `search/fts.rs`, re-exported via `lib.rs`'s `fuzz_seam`. The seam stands up a seeded in-memory SQLite DB and drives the query through every public MATCH entry point: `fts_search` (active-only), the filtered variant (fact-type + scope binds, exercising the extra `?` ordering), and `fts_count_expired`.

## Why

`fts_search` binds attacker-controlled strings into a `MATCH ?` expression. FTS5 has its own query grammar (phrases, `NEAR`, column filters, boolean operators, prefix `*`, quoting), and malformed input surfaces as a syntax error at `query_map` time, caught and mapped to an empty result. That total contract — never panic, never propagate a syntax error — had zero fuzz coverage (gap from #499 `search/testing-no-fuzz-targets`).

The DB setup lives behind the `#[cfg(fuzzing)]` seam because the store/schema helpers it needs (`open_memory`, `init_schema`, `FactStore`) are `pub(crate)`; the seam keeps the harness a thin `&[u8] -> ()` wrapper and adds nothing to the shipped public API.

## Verification

- `cargo +nightly fuzz build fts_query` — compiles clean (release, 65 MB target binary produced).
- 30s smoke run (`-max_total_time=30`): 5529 execs, coverage reaches the `rusqlite::Row::get` / FTS5 MATCH path, no crash.
- `cargo fmt --check` clean on the new target and the touched lib; normal `cargo build -p memory-engine` still compiles (the seam is dead code off `--cfg fuzzing`).

Addresses one sub-finding of #499 (`search/testing-no-fuzz-targets`); #499 has other open sub-findings and is intentionally **not** closed here.

Part of #257.