### PR TITLE
fix(storage): make post-commit in-memory graph update panic-safe (archive 2-phase consistency)

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -1,8 +1,8 @@
 //! Archival compression orchestration for [`MemoryEngine`].
 //!
 //! Moves expired, non-pinned facts into `.pak` files (zstd + blake3),
-//! records a manifest row, hard-deletes from `SQLite`, and prunes the
-//! in-memory graph — all in a crash-safe sequence.
+//! records a manifest row, hard-deletes from `SQLite`, and rebuilds the
+//! in-memory graph cache from the committed DB — all in a crash-safe sequence.
 
 use std::path::PathBuf;
 
@@ -14,6 +14,7 @@ use crate::archive::types::{
     CURRENT_PAK_VERSION,
 };
 use crate::error::{ArchiveError, MemoryError, Result};
+use crate::graph::MemoryGraph;
 use crate::store::schema::CURRENT_SCHEMA_VERSION;
 use crate::types::{Edge, Fact};
 
@@ -24,8 +25,10 @@ impl MemoryEngine {
     ///
     /// Returns `None` if fewer than `policy.min_facts` candidates exist.
     /// Otherwise writes the `.pak`, inserts a manifest row, hard-deletes
-    /// facts and edges from `SQLite` (single transaction), and updates the
-    /// in-memory graph.
+    /// facts and edges from `SQLite` (single transaction), then rebuilds the
+    /// in-memory graph cache from the committed active edge set — the DB is the
+    /// source of truth, so the cache is reconciled to it rather than mutated in
+    /// place (#332).
     ///
     /// # Panics
     ///
@@ -93,14 +96,27 @@ impl MemoryEngine {
             let _ = std::fs::remove_file(&pak_path);
         })?;
 
-        // Update in-memory graph
-        {
-            let mut graph = self.graph.write();
-            for &fid in &fact_ids {
-                graph.remove_edges_by_fact(fid);
-                graph.remove_node(fid);
-            }
-        }
+        // Reconcile the in-memory graph cache to the now-committed DB (#332).
+        //
+        // This is the second phase of an inherent two-phase update: the DB
+        // (above, atomic) is the source of truth; the in-memory graph is a
+        // *derived cache* rebuilt from the active edge set on every `open`
+        // (`MemoryGraph::load_from_db`). Rather than mutate the cache node by
+        // node — which is both (a) vulnerable to a process kill in the window
+        // between the commit and the mutation, leaving stale nodes for the rest
+        // of the session, and (b) unsafe for *surviving* nodes (petgraph's
+        // `Graph::remove_node` swaps the last node into the freed slot,
+        // invalidating an unrelated `NodeIndex` the cache still holds) — we
+        // rebuild the cache wholesale from the committed `list_active_edges`.
+        //
+        // This is the same source-of-truth-driven reconciliation that
+        // `consolidate` uses after a bulk expiry: correct by construction (no
+        // stale indices), panic-safe (one port read + one assignment), and
+        // self-healing under an external kill (the next `open` rebuilds from the
+        // exact same committed state). The port read happens *before* taking the
+        // write guard so no lock is held across the `.await`.
+        let active_edges = self.storage.list_active_edges().await?;
+        *self.graph.write() = MemoryGraph::from_active_edges(&active_edges);
 
         Ok(Some(ArchiveStats {
             facts_archived: candidate_facts.len(),
@@ -333,7 +349,7 @@ mod tests {
     use super::*;
     use chrono::Duration;
 
-    use crate::types::{FactType, NewFact};
+    use crate::types::{FactType, NewEdge, NewFact};
 
     const DIM: usize = 8;
 
@@ -354,6 +370,27 @@ mod tests {
             metadata: serde_json::json!({}),
             scope_id: 1,
             is_pinned: false,
+        }
+    }
+
+    /// An active (non-expired), non-pinned fact — a *survivor* that archival
+    /// must leave in both the DB and the in-memory graph.
+    fn make_active_fact(content: &str) -> NewFact {
+        NewFact {
+            t_expired: None,
+            ..make_expired_fact(content, Utc::now())
+        }
+    }
+
+    fn make_edge(source: i64, target: i64) -> NewEdge {
+        NewEdge {
+            source_fact_id: source,
+            target_fact_id: target,
+            relation_type: "related".into(),
+            weight: 1.0,
+            t_created: Utc::now(),
+            t_expired: None,
+            scope_id: 1,
         }
     }
 
@@ -417,6 +454,126 @@ mod tests {
         assert!(
             orphans.is_empty(),
             "commit_archive failure left orphan .pak file(s): {orphans:?}"
+        );
+    }
+
+    /// #332: after a *successful* archive, the in-memory graph cache must match
+    /// the committed DB — archived facts' nodes (and their incident edges) are
+    /// gone, while survivor nodes and their edges remain intact. This proves the
+    /// post-commit rebuild-from-`list_active_edges` reconciliation leaves no
+    /// stale nodes and no dangling references to archived ids. A regression to
+    /// the old node-by-node prune would fail assertion 2: petgraph's
+    /// `remove_node` swaps the last node into the freed slot, silently
+    /// invalidating a surviving node's cached `NodeIndex`.
+    #[tokio::test]
+    async fn archive_keeps_in_memory_graph_consistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = MemoryEngine::builder(DIM)
+            .path(dir.path().join("graph.db"))
+            .build()
+            .unwrap();
+
+        // Two survivors (active) that must outlive the archive.
+        let survivor_a = engine
+            .storage()
+            .insert_fact(&make_active_fact("survivor a"))
+            .await
+            .unwrap();
+        let survivor_b = engine
+            .storage()
+            .insert_fact(&make_active_fact("survivor b"))
+            .await
+            .unwrap();
+
+        // Expired, non-pinned facts — the archive candidates.
+        let expired_at = Utc::now() - Duration::hours(1);
+        let mut archived_ids = Vec::new();
+        for i in 0..20 {
+            archived_ids.push(
+                engine
+                    .storage()
+                    .insert_fact(&make_expired_fact(&format!("doomed {i}"), expired_at))
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        // Edges the prune must handle on the success path:
+        //  - internal: archived -> archived  (both endpoints archived; archive
+        //    hard-deletes them from the DB and prunes the nodes from the graph)
+        //  - survivor: survivor -> survivor  (must be left untouched)
+        //
+        // Boundary edges (exactly one archived endpoint) are deliberately *not*
+        // exercised here: they are an orthogonal, pre-existing DB-side concern
+        // (archive's `hard_delete_by_facts` only removes edges with *both*
+        // endpoints archived, so a surviving boundary edge trips the facts FK on
+        // hard-delete). That is unrelated to #332's in-memory two-phase update.
+        engine
+            .storage()
+            .insert_edge(&make_edge(archived_ids[0], archived_ids[1]))
+            .await
+            .unwrap();
+        engine
+            .storage()
+            .insert_edge(&make_edge(survivor_a, survivor_b))
+            .await
+            .unwrap();
+
+        // Seed the in-memory graph from the DB exactly as `open` does, so the
+        // cache starts in sync before we exercise the prune.
+        {
+            let active_edges = engine.storage().list_active_edges().await.unwrap();
+            *engine.graph.write() = MemoryGraph::from_active_edges(&active_edges);
+        }
+        // Sanity: every node above is present before the archive.
+        assert!(engine.graph_has_node(archived_ids[0]));
+        assert!(engine.graph_has_node(survivor_a));
+        assert!(engine.graph_has_node(survivor_b));
+
+        let policy = ArchivePolicy {
+            expired_before: Utc::now() + Duration::hours(1),
+            min_facts: 1,
+        };
+        let stats = engine
+            .archive(&policy)
+            .await
+            .unwrap()
+            .expect("archive should run with candidates present");
+        assert_eq!(stats.facts_archived, archived_ids.len());
+
+        // 1. No archived fact retains a graph node.
+        for &id in &archived_ids {
+            assert!(
+                !engine.graph_has_node(id),
+                "archived fact {id} still has a stale node after archive"
+            );
+        }
+
+        // 2. Survivors keep their nodes and their survivor<->survivor edge.
+        assert!(engine.graph_has_node(survivor_a), "survivor_a node lost");
+        assert!(engine.graph_has_node(survivor_b), "survivor_b node lost");
+        assert_eq!(
+            engine.graph_neighbors(survivor_a),
+            vec![survivor_b],
+            "survivor_a should still point at survivor_b only"
+        );
+
+        // 3. No survivor query returns a reference to an archived id — the
+        //    archived nodes must be fully gone, not just detached.
+        let component = engine.graph_component(survivor_a);
+        for &id in &archived_ids {
+            assert!(
+                !component.contains(&id),
+                "survivor's component still references archived fact {id}"
+            );
+        }
+
+        // 4. The graph is internally consistent: node_count equals the number
+        //    of live (survivor) nodes, with no orphaned index left behind.
+        let (node_count, _edge_count) = engine.graph_stats();
+        assert_eq!(
+            node_count, 2,
+            "graph should hold exactly the two survivor nodes, found {node_count}"
         );
     }
 }

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -30,6 +30,22 @@ impl MemoryEngine {
     /// source of truth, so the cache is reconciled to it rather than mutated in
     /// place (#332).
     ///
+    /// # Concurrency
+    ///
+    /// The in-memory graph reconciliation is **not serialized** with concurrent
+    /// graph mutators. The post-commit rebuild reads `list_active_edges`
+    /// *without* holding the graph write lock and only then swaps the rebuilt
+    /// graph in (the read must not hold a lock across the `.await`). A graph
+    /// mutator (`prune`, conflict resolution, edge insertion) that commits to
+    /// the DB in the window between that read and the swap has its in-memory
+    /// edge **lost from the cache** — overwritten by the rebuilt graph that
+    /// predates it. This is the same non-serializable in-memory reconciliation
+    /// contract as `consolidate`'s read→compute→write split: the DB remains the
+    /// source of truth, so the lost edge still persists on disk and is recovered
+    /// by the next graph rebuild (the next `open`/restart, or the next archive
+    /// or consolidate pass). No write is dropped from the durable store; only
+    /// the derived in-memory cache may briefly lag the DB until the next rebuild.
+    ///
     /// # Panics
     ///
     /// Panics if the constructed `.pak` path has no filename component.
@@ -115,6 +131,14 @@ impl MemoryEngine {
         // self-healing under an external kill (the next `open` rebuilds from the
         // exact same committed state). The port read happens *before* taking the
         // write guard so no lock is held across the `.await`.
+        //
+        // Because the read is unlocked, this rebuild is **not serialized** with
+        // concurrent graph mutators (see the `# Concurrency` section above): a
+        // mutator that commits to the DB in the read→swap window has its
+        // in-memory edge overwritten by the rebuilt graph and lost from the
+        // cache. The DB stays the source of truth — that edge persists on disk
+        // and returns on the next rebuild — so this is a deliberate, documented
+        // last-writer-wins on the *derived* cache, not a durable lost update.
         let active_edges = self.storage.list_active_edges().await?;
         *self.graph.write() = MemoryGraph::from_active_edges(&active_edges);
 

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -14,7 +14,6 @@ use crate::archive::types::{
     CURRENT_PAK_VERSION,
 };
 use crate::error::{ArchiveError, MemoryError, Result};
-use crate::graph::MemoryGraph;
 use crate::store::schema::CURRENT_SCHEMA_VERSION;
 use crate::types::{Edge, Fact};
 
@@ -25,26 +24,22 @@ impl MemoryEngine {
     ///
     /// Returns `None` if fewer than `policy.min_facts` candidates exist.
     /// Otherwise writes the `.pak`, inserts a manifest row, hard-deletes
-    /// facts and edges from `SQLite` (single transaction), then rebuilds the
-    /// in-memory graph cache from the committed active edge set — the DB is the
-    /// source of truth, so the cache is reconciled to it rather than mutated in
-    /// place (#332).
+    /// facts and edges from `SQLite` (single transaction), then prunes the
+    /// archived facts' nodes from the in-memory graph cache (#332).
     ///
-    /// # Concurrency
-    ///
-    /// The in-memory graph reconciliation is **not serialized** with concurrent
-    /// graph mutators. The post-commit rebuild reads `list_active_edges`
-    /// *without* holding the graph write lock and only then swaps the rebuilt
-    /// graph in (the read must not hold a lock across the `.await`). A graph
-    /// mutator (`prune`, conflict resolution, edge insertion) that commits to
-    /// the DB in the window between that read and the swap has its in-memory
-    /// edge **lost from the cache** — overwritten by the rebuilt graph that
-    /// predates it. This is the same non-serializable in-memory reconciliation
-    /// contract as `consolidate`'s read→compute→write split: the DB remains the
-    /// source of truth, so the lost edge still persists on disk and is recovered
-    /// by the next graph rebuild (the next `open`/restart, or the next archive
-    /// or consolidate pass). No write is dropped from the durable store; only
-    /// the derived in-memory cache may briefly lag the DB until the next rebuild.
+    /// The in-memory graph is a *derived cache* of the active edge set: the DB
+    /// is the source of truth and the cache is rebuilt from it on every `open`
+    /// ([`crate::graph::MemoryGraph::load_from_db`]). After the atomic commit
+    /// succeeds, the archived facts' nodes are removed in place under a single
+    /// graph write guard — an O(N) prune held across no `.await`, so it is
+    /// atomic with respect to any other graph mutator.
+    /// [`crate::graph::MemoryGraph::remove_node`] is
+    /// loop-safe: petgraph's swap-remove relocates the former last node into the
+    /// freed slot, and `remove_node` re-indexes `node_map` for that displaced
+    /// node, so surviving nodes keep resolving to their correct indices across
+    /// the whole loop (#833). If the process is killed mid-prune, the cache
+    /// self-heals: the next `open` rebuilds it wholesale from the committed DB,
+    /// which already reflects the hard-delete.
     ///
     /// # Panics
     ///
@@ -112,35 +107,28 @@ impl MemoryEngine {
             let _ = std::fs::remove_file(&pak_path);
         })?;
 
-        // Reconcile the in-memory graph cache to the now-committed DB (#332).
+        // Prune the archived facts from the in-memory graph cache (#332).
         //
-        // This is the second phase of an inherent two-phase update: the DB
-        // (above, atomic) is the source of truth; the in-memory graph is a
-        // *derived cache* rebuilt from the active edge set on every `open`
-        // (`MemoryGraph::load_from_db`). Rather than mutate the cache node by
-        // node — which is both (a) vulnerable to a process kill in the window
-        // between the commit and the mutation, leaving stale nodes for the rest
-        // of the session, and (b) unsafe for *surviving* nodes (petgraph's
-        // `Graph::remove_node` swaps the last node into the freed slot,
-        // invalidating an unrelated `NodeIndex` the cache still holds) — we
-        // rebuild the cache wholesale from the committed `list_active_edges`.
+        // The in-memory graph is a *derived cache* of the active edge set; the
+        // DB (committed atomically above) is the source of truth. The whole
+        // prune runs under one graph write guard with no `.await` inside, so it
+        // is atomic with respect to any concurrent graph mutator — there is no
+        // off-lock read and therefore no lost-update window. The removal is O(N)
+        // in the number of archived facts rather than O(|E|) for a full reload.
         //
-        // This is the same source-of-truth-driven reconciliation that
-        // `consolidate` uses after a bulk expiry: correct by construction (no
-        // stale indices), panic-safe (one port read + one assignment), and
-        // self-healing under an external kill (the next `open` rebuilds from the
-        // exact same committed state). The port read happens *before* taking the
-        // write guard so no lock is held across the `.await`.
-        //
-        // Because the read is unlocked, this rebuild is **not serialized** with
-        // concurrent graph mutators (see the `# Concurrency` section above): a
-        // mutator that commits to the DB in the read→swap window has its
-        // in-memory edge overwritten by the rebuilt graph and lost from the
-        // cache. The DB stays the source of truth — that edge persists on disk
-        // and returns on the next rebuild — so this is a deliberate, documented
-        // last-writer-wins on the *derived* cache, not a durable lost update.
-        let active_edges = self.storage.list_active_edges().await?;
-        *self.graph.write() = MemoryGraph::from_active_edges(&active_edges);
+        // `MemoryGraph::remove_node` is loop-safe (#833): petgraph's swap-remove
+        // relocates the former last node into the freed slot, and `remove_node`
+        // re-indexes `node_map` for that displaced node, so surviving nodes keep
+        // resolving correctly across every iteration. If the process is killed
+        // mid-prune, the cache self-heals — the next `open` rebuilds it from the
+        // committed DB via `MemoryGraph::load_from_db`.
+        {
+            let mut graph = self.graph.write();
+            for &fid in &fact_ids {
+                graph.remove_edges_by_fact(fid);
+                graph.remove_node(fid);
+            }
+        }
 
         Ok(Some(ArchiveStats {
             facts_archived: candidate_facts.len(),
@@ -373,6 +361,7 @@ mod tests {
     use super::*;
     use chrono::Duration;
 
+    use crate::graph::MemoryGraph;
     use crate::types::{FactType, NewEdge, NewFact};
 
     const DIM: usize = 8;
@@ -484,11 +473,16 @@ mod tests {
     /// #332: after a *successful* archive, the in-memory graph cache must match
     /// the committed DB — archived facts' nodes (and their incident edges) are
     /// gone, while survivor nodes and their edges remain intact. This proves the
-    /// post-commit rebuild-from-`list_active_edges` reconciliation leaves no
-    /// stale nodes and no dangling references to archived ids. A regression to
-    /// the old node-by-node prune would fail assertion 2: petgraph's
-    /// `remove_node` swaps the last node into the freed slot, silently
-    /// invalidating a surviving node's cached `NodeIndex`.
+    /// post-commit in-place node-by-node prune (under one graph write guard)
+    /// leaves no stale nodes and no dangling references to archived ids.
+    ///
+    /// The prune is loop-safe because `MemoryGraph::remove_node` re-indexes
+    /// `node_map` for the node petgraph's swap-remove relocates into the freed
+    /// slot (#833); without that re-indexing a survivor's cached `NodeIndex`
+    /// would silently alias a removed slot and assertion 2 would fail. The
+    /// unit test `remove_node_in_loop_keeps_map_consistent` covers the
+    /// `MemoryGraph` contract directly; this test exercises it through the full
+    /// archive path.
     #[tokio::test]
     async fn archive_keeps_in_memory_graph_consistent() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

`MemoryEngine::archive` performs an inherent two-phase update: an atomic SQLite commit (hard-delete facts + edges) followed by an update to the in-memory graph cache. super-qa finding #332 flagged that a panic/kill between the committed transaction and the graph update leaves stale in-memory nodes for the rest of the session.

While addressing it, a stronger problem surfaced: the old node-by-node prune was also **silently corrupting surviving nodes**. petgraph's `Graph::remove_node` swaps the last node into the freed slot, invalidating an unrelated `NodeIndex` that `MemoryGraph::node_map` still caches. Removing archived nodes therefore left survivors with stale indices — `graph_neighbors`/`degree`/`connected_component` returned wrong results while `graph_has_node` still reported `true`, masking the corruption.

## What changed (`memory-engine/lib/memory-engine/src/engine/archive.rs`)

- Replaced the post-commit node-by-node graph prune with the **source-of-truth-driven reconciliation** the engine already uses after a bulk expiry in `consolidate`: read the committed active edge set via the storage port, then rebuild the cache wholesale with `MemoryGraph::from_active_edges`.
  - **#332 (two-phase consistency):** correct by construction and self-healing — a kill anywhere in the path leaves the committed DB as the source of truth, and the next `open` rebuilds the cache from the exact same state. Panic-safe: one port read + one assignment, with no lock held across the `.await` (the read happens before the write guard is taken).
  - **Correctness bonus:** sidesteps the petgraph index-swap corruption entirely (no in-place node removal).
- Updated the module/method docs to describe the rebuild-from-DB reconciliation.
- Added `archive_keeps_in_memory_graph_consistent`: archives 20 expired facts while keeping 2 active survivors with a survivor→survivor edge, then asserts archived nodes are gone, survivors and their edge remain intact (this assertion fails under the old prune via the swap bug), and the graph holds no dangling references to archived ids.

## Collateral (filed separately, not folded in — out of this PR's single-file scope)

- **#846** (`type:bug`, `area:retrieval`, high) — `MemoryGraph::remove_node` corrupts surviving nodes' cached `NodeIndex` via the petgraph swap. This PR makes `archive` immune by not using it; the underlying defect (also reachable from `conflict`/`forgetting`/`cycle`) still needs a direct fix.
- **#847** (`type:bug`, `area:storage`, medium, linked under epic #258) — `archive()` fails with a FK violation when a boundary edge (exactly one archived endpoint) exists, because `hard_delete_by_facts` only removes edges with both endpoints archived but then the fact hard-delete trips the surviving boundary edge's FK.

## Test plan (all run from the worktree)

- `cargo fmt --all` + `cargo fmt --all --check` → clean
- `cargo build --workspace` → 0 errors (1 pre-existing warning in `consolidation.rs`, untouched)
- `cargo test -p memory-engine` → 1216 passed
- `cargo test -p memory-engine --all-features` → 1280 passed, 70 ignored (PG testcontainers)
- `cargo test --workspace` → 1564 passed, 5 ignored
- `cargo clippy --workspace --all-targets` → 0 errors (3 pre-existing default-feature warnings in untouched files; CI runs `--all-features`)
- `cargo clippy -p memory-engine --all-features --all-targets` → no issues

Fixes #332