### PR TITLE
refactor(storage): introduce NewArchiveManifest param object (remove too_many_arguments)

### DIFF
--- a/memory-engine/lib/memory-engine/src/storage/sqlite/cold_storage.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/cold_storage.rs
@@ -12,7 +12,7 @@ use super::SqliteBackend;
 use crate::archive::ArchiveManifestEntry;
 use crate::error::Result;
 use crate::storage::cold_storage::ColdStorage;
-use crate::store::archive_manifest::ArchiveManifestStore;
+use crate::store::archive_manifest::{ArchiveManifestStore, NewArchiveManifest};
 
 #[async_trait]
 impl ColdStorage for SqliteBackend {
@@ -34,8 +34,8 @@ impl ColdStorage for SqliteBackend {
         let pak_path = pak_path.to_owned();
         let blake3_hash = blake3_hash.to_owned();
         self.block_write(move |c| {
-            ArchiveManifestStore::new(c).insert(
-                &pak_path,
+            ArchiveManifestStore::new(c).insert(&NewArchiveManifest {
+                pak_path: &pak_path,
                 created_at,
                 fact_count,
                 edge_count,
@@ -44,8 +44,8 @@ impl ColdStorage for SqliteBackend {
                 t_created_min,
                 t_created_max,
                 size_bytes,
-                &blake3_hash,
-            )
+                blake3_hash: &blake3_hash,
+            })
         })
         .await
     }
@@ -103,18 +103,18 @@ impl ColdStorage for SqliteBackend {
                 ArchiveError::Transaction(format!("failed to begin transaction: {e}"))
             })?;
 
-            ArchiveManifestStore::new(&tx).insert(
-                &pak_filename,
-                now,
+            ArchiveManifestStore::new(&tx).insert(&NewArchiveManifest {
+                pak_path: &pak_filename,
+                created_at: now,
                 fact_count,
                 edge_count,
                 fact_id_min,
                 fact_id_max,
                 t_created_min,
                 t_created_max,
-                pak_size_bytes,
-                &blake3_hash,
-            )?;
+                size_bytes: pak_size_bytes,
+                blake3_hash: &blake3_hash,
+            })?;
 
             // Delete edges first (FK safety), then facts.
             EdgeStore::new(&tx).hard_delete_by_facts(&fact_ids)?;

--- a/memory-engine/lib/memory-engine/src/store/archive_manifest.rs
+++ b/memory-engine/lib/memory-engine/src/store/archive_manifest.rs
@@ -9,6 +9,39 @@ pub struct ArchiveManifestStore<'a> {
     conn: &'a Connection,
 }
 
+/// Parameter object for [`ArchiveManifestStore::insert`].
+///
+/// Bundles the ten columns of a new `archive_manifest` row so call sites pass a
+/// single named-field value instead of a long positional argument list. This
+/// removes the argument-order footgun and the `clippy::too_many_arguments`
+/// suppression on `insert`.
+///
+/// The two string fields borrow (`&'a str`) — the manifest insert does not retain
+/// them past the call, so no allocation is forced on the caller.
+#[derive(Debug, Clone, Copy)]
+pub struct NewArchiveManifest<'a> {
+    /// Relative path of the `.pak` file (unique key).
+    pub pak_path: &'a str,
+    /// System time the archive was created.
+    pub created_at: DateTime<Utc>,
+    /// Number of facts archived into the `.pak`.
+    pub fact_count: i64,
+    /// Number of edges archived into the `.pak`.
+    pub edge_count: i64,
+    /// Smallest archived fact id.
+    pub fact_id_min: i64,
+    /// Largest archived fact id.
+    pub fact_id_max: i64,
+    /// Earliest `t_created` across the archived facts.
+    pub t_created_min: DateTime<Utc>,
+    /// Latest `t_created` across the archived facts.
+    pub t_created_max: DateTime<Utc>,
+    /// Size of the `.pak` file in bytes.
+    pub size_bytes: i64,
+    /// BLAKE3 hash of the `.pak` file contents.
+    pub blake3_hash: &'a str,
+}
+
 impl<'a> ArchiveManifestStore<'a> {
     /// Create a new `ArchiveManifestStore` borrowing the given connection.
     #[must_use]
@@ -23,35 +56,22 @@ impl<'a> ArchiveManifestStore<'a> {
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on SQL failure (e.g. duplicate `pak_path`).
-    #[allow(clippy::too_many_arguments)]
-    pub fn insert(
-        &self,
-        pak_path: &str,
-        created_at: DateTime<Utc>,
-        fact_count: i64,
-        edge_count: i64,
-        fact_id_min: i64,
-        fact_id_max: i64,
-        t_created_min: DateTime<Utc>,
-        t_created_max: DateTime<Utc>,
-        size_bytes: i64,
-        blake3_hash: &str,
-    ) -> Result<i64> {
+    pub fn insert(&self, m: &NewArchiveManifest<'_>) -> Result<i64> {
         self.conn.execute(
             "INSERT INTO archive_manifest (pak_path, created_at, fact_count, edge_count,
               fact_id_min, fact_id_max, t_created_min, t_created_max, size_bytes, blake3_hash)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             rusqlite::params![
-                pak_path,
-                created_at.to_rfc3339(),
-                fact_count,
-                edge_count,
-                fact_id_min,
-                fact_id_max,
-                t_created_min.to_rfc3339(),
-                t_created_max.to_rfc3339(),
-                size_bytes,
-                blake3_hash,
+                m.pak_path,
+                m.created_at.to_rfc3339(),
+                m.fact_count,
+                m.edge_count,
+                m.fact_id_min,
+                m.fact_id_max,
+                m.t_created_min.to_rfc3339(),
+                m.t_created_max.to_rfc3339(),
+                m.size_bytes,
+                m.blake3_hash,
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
@@ -131,33 +151,20 @@ mod tests {
         conn
     }
 
-    type EntryArgs = (
-        String,
-        DateTime<Utc>,
-        i64,
-        i64,
-        i64,
-        i64,
-        DateTime<Utc>,
-        DateTime<Utc>,
-        i64,
-        String,
-    );
-
-    fn make_entry(pak_path: &str) -> EntryArgs {
+    fn make_entry(pak_path: &str) -> NewArchiveManifest<'_> {
         let now = Utc::now();
-        (
-            pak_path.to_string(),
-            now,
-            10,
-            5,
-            1,
-            10,
-            now,
-            now,
-            1024,
-            "deadbeefdeadbeefdeadbeefdeadbeef".to_string(),
-        )
+        NewArchiveManifest {
+            pak_path,
+            created_at: now,
+            fact_count: 10,
+            edge_count: 5,
+            fact_id_min: 1,
+            fact_id_max: 10,
+            t_created_min: now,
+            t_created_max: now,
+            size_bytes: 1024,
+            blake3_hash: "deadbeefdeadbeefdeadbeefdeadbeef",
+        }
     }
 
     #[test]
@@ -167,33 +174,9 @@ mod tests {
 
         assert!(store.list().unwrap().is_empty());
 
-        let (
-            pak_path,
-            created_at,
-            fact_count,
-            edge_count,
-            fact_id_min,
-            fact_id_max,
-            t_created_min,
-            t_created_max,
-            size_bytes,
-            blake3_hash,
-        ) = make_entry("archives/2026-01.pak");
+        let entry = make_entry("archives/2026-01.pak");
 
-        let id = store
-            .insert(
-                &pak_path,
-                created_at,
-                fact_count,
-                edge_count,
-                fact_id_min,
-                fact_id_max,
-                t_created_min,
-                t_created_max,
-                size_bytes,
-                &blake3_hash,
-            )
-            .unwrap();
+        let id = store.insert(&entry).unwrap();
         assert!(id > 0);
 
         let entries = store.list().unwrap();
@@ -213,47 +196,12 @@ mod tests {
     fn insert_duplicate_pak_path_fails() {
         let conn = setup();
         let store = ArchiveManifestStore::new(&conn);
-        let (
-            pak_path,
-            created_at,
-            fact_count,
-            edge_count,
-            fact_id_min,
-            fact_id_max,
-            t_created_min,
-            t_created_max,
-            size_bytes,
-            blake3_hash,
-        ) = make_entry("archives/dup.pak");
+        let entry = make_entry("archives/dup.pak");
 
-        store
-            .insert(
-                &pak_path,
-                created_at,
-                fact_count,
-                edge_count,
-                fact_id_min,
-                fact_id_max,
-                t_created_min,
-                t_created_max,
-                size_bytes,
-                &blake3_hash,
-            )
-            .unwrap();
+        store.insert(&entry).unwrap();
 
         // Second insert with same path must fail (UNIQUE INDEX)
-        let result = store.insert(
-            &pak_path,
-            created_at,
-            fact_count,
-            edge_count,
-            fact_id_min,
-            fact_id_max,
-            t_created_min,
-            t_created_max,
-            size_bytes,
-            &blake3_hash,
-        );
+        let result = store.insert(&entry);
         assert!(result.is_err(), "duplicate pak_path should be rejected");
     }
 
@@ -262,33 +210,9 @@ mod tests {
         let conn = setup();
         let store = ArchiveManifestStore::new(&conn);
 
-        let (
-            pak_path,
-            created_at,
-            fact_count,
-            edge_count,
-            fact_id_min,
-            fact_id_max,
-            t_created_min,
-            t_created_max,
-            size_bytes,
-            blake3_hash,
-        ) = make_entry("archives/to_delete.pak");
+        let entry = make_entry("archives/to_delete.pak");
 
-        let id = store
-            .insert(
-                &pak_path,
-                created_at,
-                fact_count,
-                edge_count,
-                fact_id_min,
-                fact_id_max,
-                t_created_min,
-                t_created_max,
-                size_bytes,
-                &blake3_hash,
-            )
-            .unwrap();
+        let id = store.insert(&entry).unwrap();
 
         assert_eq!(store.list().unwrap().len(), 1);
 


### PR DESCRIPTION
## Summary

Resolves super-qa finding #367 (epic #258). `ArchiveManifestStore::insert` carried 10 positional parameters behind an `#[allow(clippy::too_many_arguments)]` suppression — ten same-typed `i64`/`DateTime<Utc>` arguments where a transposed `fact_id_min`/`fact_id_max` or `t_created_min`/`t_created_max` pair compiles silently and corrupts the manifest row.

- Introduce `NewArchiveManifest<'a>` parameter object with named fields (`Copy`; string fields borrow `&'a str`, so no caller allocation).
- `ArchiveManifestStore::insert` now takes `&NewArchiveManifest<'_>`; the `too_many_arguments` suppression is removed.
- Threaded through both `cold_storage.rs` call sites (`insert_archive_manifest`, `commit_archive_atomic`) and the three test helpers.

**Pure refactor: no behavior or schema change.**

### Scope note (sibling smell)
The brief asked to also collapse the sibling `#[allow(too_many_arguments)]` on `ColdStorage::commit_archive_atomic` / `insert_archive_manifest` **if it stays within the two scoped files**. It does not: those are `ColdStorage` *trait* methods whose signatures live in `storage/cold_storage.rs`, with the caller in `engine/archive.rs` and the conformance battery in `storage/conformance/cold.rs` — all out of scope. Those two suppressions are therefore left in place.

## Test plan

All gates run from the worktree, green:

| Gate | Result |
| ---- | ------ |
| `cargo fmt --all --check` | pass (clean) |
| `cargo build --workspace` | pass (0 errors; 1 pre-existing warning in untouched `consolidation.rs`) |
| `cargo test -p memory-engine` | pass — 1216 passed, 0 failed |
| `cargo test -p memory-engine --features archive` | pass — 1181 + sub-suites, 0 failed (exercises the changed archive-gated paths) |
| `cargo clippy --workspace --all-targets` | pass (exit 0; remaining warnings pre-existing, in untouched files) |
| `cargo clippy -p memory-engine --all-targets --features archive` | pass (exit 0; 0 diagnostics on changed files) |

Modified tests verified to run and pass: `insert_and_list_manifest`, `insert_duplicate_pak_path_fails`, `delete_manifest_entry`, `manifest_insert_list_oldest_first`, `manifest_round_trip_fields`, `commit_archive_atomic_rollback_on_mid_tx_error`.

Fixes #367