### PR TITLE
test(mcp): replace brittle hardcoded tool-count with lower-bound + uniqueness invariant

### DIFF
--- a/memory-engine/bin/mcp/tests/tool_roundtrip.rs
+++ b/memory-engine/bin/mcp/tests/tool_roundtrip.rs
@@ -957,7 +957,7 @@ async fn unknown_tool_returns_error() {
 /// useless below them). Uniqueness (no duplicate names, hence no silent gaps from
 /// a copy-paste collision) is covered by `all_tool_definitions_have_unique_names`.
 #[test]
-fn all_tool_definitions_are_unique_and_nonempty() {
+fn all_tool_definitions_meet_p0_floor() {
     /// P0 floor: the minimum viable tool set the MCP server must expose.
     const P0_FLOOR: usize = 10;
     let defs = tools::all_tool_definitions();

--- a/memory-engine/bin/mcp/tests/tool_roundtrip.rs
+++ b/memory-engine/bin/mcp/tests/tool_roundtrip.rs
@@ -948,13 +948,23 @@ async fn unknown_tool_returns_error() {
 // Tool definitions
 // ---------------------------------------------------------------------------
 
+/// Invariant check on the tool registry, deliberately *not* an exact-count
+/// assertion (#470). A hardcoded `== 26` false-positives on every legitimate
+/// tool addition or removal, even when the list stays internally consistent.
+///
+/// Instead we assert the structural intent: the registry is non-empty and stays
+/// at or above the P0 floor (the 10 P0 tools are load-bearing — the MCP server is
+/// useless below them). Uniqueness (no duplicate names, hence no silent gaps from
+/// a copy-paste collision) is covered by `all_tool_definitions_have_unique_names`.
 #[test]
-fn all_tool_definitions_returns_26() {
+fn all_tool_definitions_are_unique_and_nonempty() {
+    /// P0 floor: the minimum viable tool set the MCP server must expose.
+    const P0_FLOOR: usize = 10;
     let defs = tools::all_tool_definitions();
-    assert_eq!(
-        defs.len(),
-        26,
-        "expected 10 P0 + 5 P1 + 3 P2 + 2 Phase 5a outcome + 3 activity stream + 3 cognitive (#225) tools"
+    assert!(
+        defs.len() >= P0_FLOOR,
+        "tool registry dropped below the P0 floor ({P0_FLOOR}): got {}",
+        defs.len()
     );
 }
 


### PR DESCRIPTION
## What

`memory-engine/bin/mcp/tests/tool_roundtrip.rs` had a test `all_tool_definitions_returns_26` asserting `defs.len() == 26`. That hardcoded count false-positives on **every** legitimate tool addition or removal — even when the registry is internally consistent — forcing a no-signal test edit each time.

## Change

Replace the exact-count assertion with a structural invariant, and rename the test to reveal intent:

**Before**
```rust
#[test]
fn all_tool_definitions_returns_26() {
    let defs = tools::all_tool_definitions();
    assert_eq!(
        defs.len(),
        26,
        "expected 10 P0 + 5 P1 + 3 P2 + 2 Phase 5a outcome + 3 activity stream + 3 cognitive (#225) tools"
    );
}
```

**After**
```rust
#[test]
fn all_tool_definitions_are_unique_and_nonempty() {
    /// P0 floor: the minimum viable tool set the MCP server must expose.
    const P0_FLOOR: usize = 10;
    let defs = tools::all_tool_definitions();
    assert!(
        defs.len() >= P0_FLOOR,
        "tool registry dropped below the P0 floor ({P0_FLOOR}): got {}",
        defs.len()
    );
}
```

The non-empty / `>= P0_FLOOR` lower bound still catches a registry that has been gutted, without pinning a count that changes legitimately. The companion uniqueness guard `all_tool_definitions_have_unique_names` (which catches duplicate/colliding names, hence silent gaps) is **kept intact**.

## Gate

- `cargo test -p memory-engine-mcp --test tool_roundtrip` — 34 passed
- `cargo test -p memory-engine-mcp` — 167 passed
- `cargo clippy -p memory-engine-mcp --all-targets` — 0 errors (2 pre-existing storage warnings #843, outside this crate)
- `cargo fmt --check` — clean
- `cargo build --workspace` — 0 errors

Closes #470
Part of #256