### PR TITLE
test(mcp): wiremock coverage for HttpSummaryGenerator response auto-detection

### DIFF
--- a/memory-engine/bin/mcp/tests/summary_integration.rs
+++ b/memory-engine/bin/mcp/tests/summary_integration.rs
@@ -1,0 +1,129 @@
+//! wiremock-based coverage for `HttpSummaryGenerator`'s response auto-detection.
+//!
+//! `HttpSummaryGenerator::summarize` POSTs to an `OpenAI`-compatible chat endpoint
+//! and then auto-detects which of two response shapes it got back, plus two error
+//! shapes. The four branches exercised here, one per test:
+//!
+//! 1. `OpenAI`:      `{ "choices": [{ "message": { "content": "..." } }] }` → `Ok`
+//! 2. `Ollama`:      `{ "message": { "content": "..." } }`                  → `Ok`
+//! 3. Embedded error: a 200 carrying `{ "error": { ... } }`                → `Err`
+//! 4. Unknown shape:  a 200 matching neither extractor                     → `Err`
+//!    (the error message includes the raw response body).
+//!
+//! `HttpSummaryGenerator` (like `HttpEmbeddingProvider`) wraps a
+//! `reqwest::blocking::Client`, which builds its own internal tokio runtime. Both
+//! constructing it and calling `summarize` from inside an async runtime would panic
+//! ("cannot start a runtime from within a runtime"), so the whole construct-and-call
+//! is offloaded onto `spawn_blocking` and only the `Result` is `.await`ed back — the
+//! same discipline as `embedding_integration.rs`.
+
+use memory_engine::error::MemoryError;
+use memory_engine::traits::{SummarizableContent, SummaryGenerator};
+use memory_engine_mcp::summary::HttpSummaryGenerator;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Mount a single POST `/v1/chat/completions` mock returning `body` with status 200,
+/// then build an `HttpSummaryGenerator` aimed at it and run one `summarize` call.
+///
+/// Construction and the blocking call both happen on `spawn_blocking` (the blocking
+/// reqwest client cannot live on the async runtime thread). One throwaway item is fed;
+/// the parsing under test is independent of the request payload.
+async fn summarize_against(body: serde_json::Value) -> Result<String, MemoryError> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let endpoint = format!("{}/v1/chat/completions", server.uri());
+    tokio::task::spawn_blocking(move || {
+        let generator = HttpSummaryGenerator::new(endpoint, "test-model".to_string(), None, 5)
+            .expect("client builds");
+        let embedding = [0.0_f32; 4];
+        let items = [SummarizableContent::new("alpha fact", &embedding)];
+        generator.summarize(&items)
+    })
+    .await
+    .expect("spawn_blocking join")
+}
+
+// ---------------------------------------------------------------------------
+// Branch 1: OpenAI format — choices[0].message.content
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn openai_format_extracts_content() {
+    let result = summarize_against(json!({
+        "choices": [{ "message": { "content": "summary text" } }]
+    }))
+    .await;
+
+    assert_eq!(result.expect("OpenAI branch yields Ok"), "summary text");
+}
+
+// ---------------------------------------------------------------------------
+// Branch 2: Ollama format — message.content
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ollama_format_extracts_content() {
+    let result = summarize_against(json!({
+        "message": { "content": "summary text" }
+    }))
+    .await;
+
+    assert_eq!(result.expect("Ollama branch yields Ok"), "summary text");
+}
+
+// ---------------------------------------------------------------------------
+// Branch 3: embedded API error in a 200 response — { "error": { ... } }
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn embedded_api_error_is_rejected() {
+    let result = summarize_against(json!({
+        "error": { "message": "rate limited" }
+    }))
+    .await;
+
+    let err = result.expect_err("embedded-error branch yields Err");
+    let msg = err.to_string();
+    // `MemoryError::Internal` renders as "internal error: {0}"; the embedded-error
+    // branch sets {0} = "summary API returned error: {serialized error object}".
+    assert!(
+        msg.contains("summary API returned error:"),
+        "error message should name the embedded-API-error branch, got: {msg}"
+    );
+    // The serialized error object is forwarded so the operator sees the provider's reason.
+    assert!(
+        msg.contains("rate limited"),
+        "error message should forward the provider's reason, got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Branch 4: unknown shape (neither choices nor message) — Err includes the body
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn unknown_shape_errors_with_body() {
+    let result = summarize_against(json!({
+        "unexpected": "payload"
+    }))
+    .await;
+
+    let err = result.expect_err("unknown-shape branch yields Err");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cannot extract summary from response:"),
+        "error message should name the no-extractor branch, got: {msg}"
+    );
+    // The branch echoes the raw response body so the operator can see what arrived.
+    assert!(
+        msg.contains("\"unexpected\":\"payload\""),
+        "error message should echo the unparseable response body, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

`HttpSummaryGenerator::summarize` (`memory-engine/bin/mcp/src/summary.rs`) auto-detects the chat-completion response shape and rejects two error cases, but the only existing inline test asserted that the system prompt is non-empty — none of the parsing logic was exercised.

Adds `memory-engine/bin/mcp/tests/summary_integration.rs`: one `wiremock` 200 response per branch, asserting against the **real** extraction result and error strings (read from `summary.rs`, not guessed).

## Branches covered (one test each)

| # | Response body | Branch in `summarize` | Assertion |
|---|---|---|---|
| 1 | `{"choices":[{"message":{"content":"summary text"}}]}` | OpenAI `choices[0].message.content` | `Ok("summary text")` |
| 2 | `{"message":{"content":"summary text"}}` | Ollama `message.content` | `Ok("summary text")` |
| 3 | `{"error":{"message":"rate limited"}}` | embedded API error in a 200 | `Err`, message contains `summary API returned error:` and `rate limited` |
| 4 | `{"unexpected":"payload"}` | neither extractor matched | `Err`, message contains `cannot extract summary from response:` and echoes the body |

Errors are matched on `MemoryError::Internal`'s `Display` (`internal error: {0}`), so assertions are substring checks against the actual `{0}` strings in `summary.rs`.

## Notes

- `HttpSummaryGenerator` wraps a `reqwest::blocking::Client`, which builds its own tokio runtime; constructing and calling it from inside the async test runtime would panic. Construction + the `summarize` call are offloaded onto `spawn_blocking`, mirroring `embedding_integration.rs`.
- `wiremock` was already a dev-dependency of the mcp crate — no new dependency added.

## Gate
- `cargo test -p memory-engine-mcp` — 171 passed (incl. 4 new)
- `cargo clippy -p memory-engine-mcp --all-targets` — clean (only the pre-existing storage warnings, #843)
- `cargo fmt --check` clean; `cargo build --workspace` green

Closes #469
Part of #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)