### PR TITLE
test(mcp): unit-test private parsers + proptest truncate & parse_embedding

### DIFF
--- a/memory-engine/bin/mcp/Cargo.toml
+++ b/memory-engine/bin/mcp/Cargo.toml
@@ -44,6 +44,7 @@ blake3 = "1"
 wiremock = "0.6"
 tempfile = "3"
 insta = { version = "1", features = ["yaml"] }
+proptest = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [lints.rust]

--- a/memory-engine/bin/mcp/src/depth.rs
+++ b/memory-engine/bin/mcp/src/depth.rs
@@ -524,19 +524,27 @@ mod tests {
     // --- Property-based tests (#471) ---
 
     proptest::proptest! {
-        /// `truncate` must never exceed `max` bytes and must always cut on a valid
-        /// UTF-8 char boundary, for *any* input string and any cap in 0..500. This
-        /// covers the contract the byte-boundary back-off loop exists to uphold —
-        /// slicing on a non-boundary would panic at runtime.
+        /// `truncate` must return the *longest valid char-boundary prefix* of `s`
+        /// that fits within `max` bytes, for *any* input string and any cap in
+        /// 0..500. Pinning prefix-maximality — not merely `len <= max` + boundary,
+        /// both of which an always-empty / off-by-one mutant would satisfy — is what
+        /// kills those mutants. The byte-boundary back-off loop exists precisely to
+        /// uphold this contract; slicing on a non-boundary would panic at runtime.
         #[test]
         fn truncate_respects_cap_and_char_boundary(s in ".*", max in 0_usize..500) {
             let out = truncate(&s, max);
             proptest::prop_assert!(out.len() <= max, "len {} > max {}", out.len(), max);
-            proptest::prop_assert!(
-                s.is_char_boundary(out.len()),
-                "output end {} is not a char boundary of the input",
-                out.len()
-            );
+            proptest::prop_assert!(s.starts_with(out), "output is not a prefix of input");
+            if s.len() <= max {
+                // Fits: returned verbatim, no truncation.
+                proptest::prop_assert_eq!(out, &s[..]);
+            } else {
+                // Truncated: the prefix is maximal — appending the next char of the
+                // input would overflow `max`, so we did not back off further than
+                // necessary.
+                let next = out.len() + s[out.len()..].chars().next().map_or(0, char::len_utf8);
+                proptest::prop_assert!(next > max, "backed off further than necessary");
+            }
         }
     }
 }

--- a/memory-engine/bin/mcp/src/depth.rs
+++ b/memory-engine/bin/mcp/src/depth.rs
@@ -520,4 +520,23 @@ mod tests {
         assert_eq!(timeline[0]["kind"], "Created");
         assert_eq!(timeline[1]["kind"], "BecameValid");
     }
+
+    // --- Property-based tests (#471) ---
+
+    proptest::proptest! {
+        /// `truncate` must never exceed `max` bytes and must always cut on a valid
+        /// UTF-8 char boundary, for *any* input string and any cap in 0..500. This
+        /// covers the contract the byte-boundary back-off loop exists to uphold —
+        /// slicing on a non-boundary would panic at runtime.
+        #[test]
+        fn truncate_respects_cap_and_char_boundary(s in ".*", max in 0_usize..500) {
+            let out = truncate(&s, max);
+            proptest::prop_assert!(out.len() <= max, "len {} > max {}", out.len(), max);
+            proptest::prop_assert!(
+                s.is_char_boundary(out.len()),
+                "output end {} is not a char boundary of the input",
+                out.len()
+            );
+        }
+    }
 }

--- a/memory-engine/bin/mcp/src/tools/mod.rs
+++ b/memory-engine/bin/mcp/src/tools/mod.rs
@@ -2066,9 +2066,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_embedding_wrong_length_rejected_before_alloc() {
+    fn parse_embedding_rejects_wrong_length() {
         // #294: a wrong-length array is rejected on its *length* BEFORE any
-        // `Vec<f32>` materialization (pre-alloc DoS guard, CWE-400/770).
+        // `Vec<f32>` materialization (pre-alloc DoS guard, CWE-400/770). This
+        // test only verifies *that* a wrong-length array is rejected with an
+        // informative message; the BEFORE-alloc ordering is enforced by the code
+        // (length check precedes the `Vec` build) and documented there.
         let args = emb_args(json!(vec![0.1_f32; 16]));
         let err = parse_embedding(&args, 8).unwrap_err();
         assert!(
@@ -2111,12 +2114,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn parse_event_type_rejects_unknown_preserving_token() {
-        let err = parse_event_type("Telepathy").unwrap_err();
-        // ValidationError preserves the offending token in its Display string.
-        assert!(err.to_string().contains("Telepathy"), "{err}");
-    }
+    // `parse_event_type_rejects_unknown_preserving_token` lives in the #353 block above.
 
     // --- parse_outcome (#317) ---
 
@@ -2127,11 +2125,7 @@ mod tests {
         assert_eq!(parse_outcome("Neutral").unwrap(), Outcome::Neutral);
     }
 
-    #[test]
-    fn parse_outcome_rejects_unknown_preserving_token() {
-        let err = parse_outcome("Mixed").unwrap_err();
-        assert!(err.message.contains("Mixed"), "{}", err.message);
-    }
+    // `parse_outcome_rejects_unknown_preserving_token` lives in the #353 block above.
 
     // --- get_datetime (#317) ---
 

--- a/memory-engine/bin/mcp/src/tools/mod.rs
+++ b/memory-engine/bin/mcp/src/tools/mod.rs
@@ -2026,8 +2026,9 @@ async fn handle_get_recent_insights(
 #[cfg(test)]
 mod tests {
     use super::{
-        default_dump_name, default_dump_path, get_usize, parse_consolidate_config, parse_embedding,
-        parse_event_type, parse_fact_type, parse_outcome, validate_dump_path,
+        default_dump_name, default_dump_path, get_datetime, get_usize, parse_consolidate_config,
+        parse_embedding, parse_event_type, parse_fact_type, parse_outcome, require_f64_if_present,
+        validate_dump_path,
     };
     use memory_engine::types::{EventType, FactType, Outcome};
     use serde_json::json;
@@ -2082,6 +2083,110 @@ mod tests {
         // A present-but-non-array value is malformed input, not a silent None.
         let args = emb_args(json!("not-an-array"));
         assert!(parse_embedding(&args, 8).is_err());
+    }
+
+    #[test]
+    fn parse_embedding_non_numeric_element_rejected() {
+        // #317: a correctly-sized array whose elements are not all numeric passes
+        // the length gate but fails the `Vec<f32>` deserialization — it must be a
+        // typed error, not a silent coercion.
+        let args = emb_args(json!([0.0, "oops", 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]));
+        let err = parse_embedding(&args, 8).unwrap_err();
+        assert!(err.message.contains("invalid embedding"), "{}", err.message);
+    }
+
+    // --- parse_event_type (#317) ---
+
+    #[test]
+    fn parse_event_type_accepts_known_variants() {
+        assert_eq!(
+            parse_event_type("Interaction").unwrap(),
+            EventType::Interaction
+        );
+        assert_eq!(parse_event_type("ToolCall").unwrap(), EventType::ToolCall);
+        assert_eq!(parse_event_type("MemoryOp").unwrap(), EventType::MemoryOp);
+        assert_eq!(
+            parse_event_type("SystemEvent").unwrap(),
+            EventType::SystemEvent
+        );
+    }
+
+    #[test]
+    fn parse_event_type_rejects_unknown_preserving_token() {
+        let err = parse_event_type("Telepathy").unwrap_err();
+        // ValidationError preserves the offending token in its Display string.
+        assert!(err.to_string().contains("Telepathy"), "{err}");
+    }
+
+    // --- parse_outcome (#317) ---
+
+    #[test]
+    fn parse_outcome_accepts_known_variants() {
+        assert_eq!(parse_outcome("Positive").unwrap(), Outcome::Positive);
+        assert_eq!(parse_outcome("Negative").unwrap(), Outcome::Negative);
+        assert_eq!(parse_outcome("Neutral").unwrap(), Outcome::Neutral);
+    }
+
+    #[test]
+    fn parse_outcome_rejects_unknown_preserving_token() {
+        let err = parse_outcome("Mixed").unwrap_err();
+        assert!(err.message.contains("Mixed"), "{}", err.message);
+    }
+
+    // --- get_datetime (#317) ---
+
+    #[test]
+    fn get_datetime_absent_is_ok_none() {
+        let args = cfg_args(&[]);
+        assert!(get_datetime(&args, "timestamp").unwrap().is_none());
+    }
+
+    #[test]
+    fn get_datetime_valid_iso_round_trips() {
+        let args = cfg_args(&[("timestamp", json!("2026-06-26T12:00:00Z"))]);
+        let dt = get_datetime(&args, "timestamp").unwrap().expect("present");
+        assert_eq!(dt.to_rfc3339(), "2026-06-26T12:00:00+00:00");
+    }
+
+    #[test]
+    fn get_datetime_malformed_non_empty_rejected() {
+        // A present, non-empty, but unparseable ISO string is malformed input — it
+        // must surface as an invalid-params error rather than silently defaulting.
+        let args = cfg_args(&[("timestamp", json!("not-a-timestamp"))]);
+        let err = get_datetime(&args, "timestamp").unwrap_err();
+        assert!(err.message.contains("invalid timestamp"), "{}", err.message);
+    }
+
+    // --- require_f64_if_present (#317) ---
+
+    #[test]
+    fn require_f64_if_present_absent_is_ok_none() {
+        let args = cfg_args(&[]);
+        assert!(
+            require_f64_if_present(&args, "half_life_days")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn require_f64_if_present_numeric_value_passes() {
+        let args = cfg_args(&[("half_life_days", json!(42.0))]);
+        let v = require_f64_if_present(&args, "half_life_days").unwrap();
+        assert_eq!(v, Some(42.0));
+    }
+
+    #[test]
+    fn require_f64_if_present_string_value_rejected() {
+        // The exact regression this guard exists for: a numeric-looking *string*
+        // (`"1"`) must be rejected, not silently coerced or dropped to the default.
+        let args = cfg_args(&[("half_life_days", json!("1"))]);
+        let err = require_f64_if_present(&args, "half_life_days").unwrap_err();
+        assert!(
+            err.message.contains("half_life_days must be a number"),
+            "{}",
+            err.message
+        );
     }
 
     #[test]
@@ -2355,6 +2460,28 @@ mod tests {
             assert_eq!(p.extension().and_then(|e| e.to_str()), Some("json"));
             let name = p.file_name().and_then(|n| n.to_str()).unwrap();
             assert!(name.starts_with("memory-dump-"), "unexpected name: {name}");
+        }
+    }
+
+    // --- Property-based tests (#471) ---
+
+    proptest::proptest! {
+        /// Round-trip: any fixed-dimension `Vec<f32>` of finite values serializes to
+        /// a JSON array, parses back through `parse_embedding(args, D)`, and equals
+        /// the input bit-for-bit. serde_json widens each f32 to f64 for the JSON text
+        /// and narrows on the way back; that round-trip is exact for every finite f32
+        /// (f64 represents all f32 values losslessly), so a strict equality check is
+        /// the right contract. Non-finite values are excluded — serde_json cannot
+        /// represent NaN/±inf as JSON numbers (they would serialize to null).
+        #[test]
+        fn parse_embedding_round_trips_fixed_dim(
+            v in proptest::collection::vec(proptest::num::f32::NORMAL | proptest::num::f32::ZERO | proptest::num::f32::SUBNORMAL, 8..=8)
+        ) {
+            let args = emb_args(json!(v));
+            let got = parse_embedding(&args, 8)
+                .expect("a finite, correctly-sized array must parse")
+                .expect("present");
+            proptest::prop_assert_eq!(got, v);
         }
     }
 


### PR DESCRIPTION
## Summary

Fills the test gaps in the MCP server's private parsers and adds the first property-based tests to the crate.

### #317 — unit tests for uncovered private parsers (`tools/mod.rs`)

The `#[cfg(test)] mod tests` block already covered `parse_fact_type`, `parse_consolidate_config`, and `default_dump*`. This adds happy- and error-path unit tests for the parsers that had none:

- `parse_event_type` — every known variant → `Ok`; an unknown string → `Err` (offending token preserved).
- `parse_outcome` — every known variant → `Ok`; an unknown string → `Err` (token preserved).
- `parse_embedding` — a correctly-sized array with a **non-numeric element** passes the length gate but fails `Vec<f32>` deserialization → `Err` (the wrong-length and non-array cases were already covered).
- `get_datetime` — absent → `Ok(None)`; valid ISO → round-trips; a **malformed-but-non-empty** ISO string → `Err`.
- `require_f64_if_present` — absent → `Ok(None)`; numeric → `Ok(Some)`; `Value::String("1")` present → `Err` (the exact silent-fallback regression this guard exists for).

### #471 — property-based tests with `proptest`

- **`depth::truncate`** (`depth.rs`): for any `s: String` and any `max in 0..500`, `truncate(&s, max)` satisfies `output.len() <= max` **and** `s.is_char_boundary(output.len())` — the invariant the byte back-off loop upholds (a non-boundary slice would panic).
- **`parse_embedding` round-trip** (`tools/mod.rs`): any fixed-dim (`D = 8`) `Vec<f32>` of finite values serializes to JSON, parses back through `parse_embedding(&map, D)`, and equals the input bit-for-bit. serde_json widens each f32 to f64 for the JSON text and narrows back; that round-trip is exact for every finite f32 (f64 represents all f32 losslessly), so strict equality is the correct contract. Non-finite values are excluded (serde_json cannot encode NaN/±inf as JSON numbers).

`proptest = "1"` added to `[dev-dependencies]`.

## Gate

- `cargo test -p memory-engine-mcp` — 180 passed (lib suite: 57 passed, including all new unit tests + both proptests).
- `cargo clippy -p memory-engine-mcp --all-targets` — clean (the 2 remaining warnings are the pre-existing `memory-engine` lib storage warnings, #843).
- `cargo fmt --check` — clean.
- `cargo build --workspace` — green.
- `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok (proptest introduces no new advisory or license issue).

Closes #317
Closes #471
Part of #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)