### PR TITLE
test(mcp): add cargo-fuzz target for tools::dispatch untrusted-input entry

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,11 +25,17 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
+# `dispatch` is `async`; the dispatch target drives it on a reused
+# current-thread runtime, so only the `rt` feature is needed.
+tokio = { version = "1", features = ["rt"] }
 
 # Exercise the compressed-snapshot and HNSW restore branches as well as the
 # plain path, so the snapshot/restore targets cover every deserialization route.
 memory-engine = { path = "../memory-engine/lib/memory-engine", features = ["ann", "compress-gzip", "compress-zstd", "archive"] }
 memory-engine-embed = { path = "../memory-engine/lib/embed" }
+# Drives the MCP tool dispatcher (`tools::dispatch`), the server's primary
+# untrusted-input entry point (#321). The crate's lib.rs re-exports `tools`.
+memory-engine-mcp = { path = "../memory-engine/bin/mcp" }
 
 # Detach from the parent workspace: an empty `[workspace]` makes this its own
 # workspace root, so the repo-root `cargo build --workspace` ignores it.
@@ -83,6 +89,13 @@ bench = false
 [[bin]]
 name = "fts_query"
 path = "fuzz_targets/fts_query.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "dispatch"
+path = "fuzz_targets/dispatch.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/dispatch.rs
+++ b/fuzz/fuzz_targets/dispatch.rs
@@ -98,6 +98,10 @@ fn drive(name: &str, args: Map<String, Value>) {
     RT.with(|cell| {
         let mut slot = cell.borrow_mut();
         if slot.is_none() {
+            // rt-only is sufficient: every SQLite DB op goes through spawn_blocking,
+            // so no awaited path needs the tokio time/io driver. If a handler ever
+            // adds tokio::time/net, switch to enable_all() or this will produce
+            // spurious fuzz crashes.
             let Ok(rt) = tokio::runtime::Builder::new_current_thread().build() else {
                 return;
             };

--- a/fuzz/fuzz_targets/dispatch.rs
+++ b/fuzz/fuzz_targets/dispatch.rs
@@ -1,0 +1,129 @@
+//! Fuzz target for the MCP tool dispatcher (#321).
+//!
+//! `memory_engine_mcp::tools::dispatch` is the MCP server's primary
+//! untrusted-input entry point: every JSON-RPC `tools/call` lands here as a
+//! `(name, args)` pair that the server hands straight to the matching handler.
+//! The handlers do all the argument parsing/validation (`get_str`, `get_i64`,
+//! `parse_embedding`, `parse_declared_fingerprint`, datetime/importance/range
+//! checks, …) against a `serde_json::Map` the caller fully controls. The
+//! contract is total: any name + any argument object must resolve to
+//! `Ok(CallToolResult)` or `Err(ErrorData)` — never a panic (a panic in an
+//! embedded handler aborts the *consumer's* process, per the crate's
+//! no-`unwrap`/no-`unsafe` posture).
+//!
+//! `dispatch` is already `pub`, so no `#[cfg(fuzzing)]` seam is needed: the
+//! harness drives the real public entry point. It is `async`, so each iteration
+//! is driven on a reused current-thread Tokio runtime. Read-side handlers run
+//! against a fresh in-memory engine; write-side handlers that require an
+//! embedding provider / summary generator short-circuit on the `None` we pass
+//! (their validation still runs first, which is the surface we want).
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use memory_engine::{ActivityFilterConfig, MemoryEngine};
+use memory_engine_mcp::tools;
+use serde_json::{Map, Value};
+use std::cell::RefCell;
+
+/// Small embedding dimension — keeps engine setup cheap and lets a fuzzed
+/// `embedding` array of length 8 slip past the pre-allocation length gate
+/// (`parse_embedding`) into the deeper deserialize/identity-check paths.
+const DIM: usize = 8;
+
+/// Every tool name `dispatch` routes (plus one off-list name to drive the
+/// `unknown tool` arm). The first input byte selects which name to invoke, so
+/// the fuzzer can reach every handler's validation path rather than just one.
+const TOOL_NAMES: &[&str] = &[
+    "memory_ingest",
+    "memory_add_fact",
+    "memory_query",
+    "memory_resume_context",
+    "memory_list_due",
+    "memory_next_due_time",
+    "memory_explain_fact",
+    "memory_get_fact",
+    "memory_statistics",
+    "memory_flush_insights",
+    "memory_consolidate",
+    "memory_forget",
+    "memory_dump_state",
+    "memory_pin_fact",
+    "memory_unpin_fact",
+    "memory_replay_events",
+    "memory_fact_history",
+    "memory_bootstrap_session",
+    "memory_record_outcome",
+    "memory_outcome_counts",
+    "memory_record_activity",
+    "memory_checkpoint_session",
+    "memory_load_context",
+    "memory_dream_cycle",
+    "memory_apply_cycle_report",
+    "memory_get_recent_insights",
+    "memory_unknown_tool_name",
+];
+
+thread_local! {
+    // Reuse a single current-thread runtime across iterations: building a Tokio
+    // runtime per run is pure overhead that would dominate fuzz throughput.
+    static RT: RefCell<Option<tokio::runtime::Runtime>> = const { RefCell::new(None) };
+}
+
+fuzz_target!(|data: &[u8]| {
+    // First byte picks the tool name; the rest is the argument object. An empty
+    // input still drives `memory_ingest` (index 0) with empty args.
+    let (selector, json_bytes) = data
+        .split_first()
+        .map_or((0u8, data), |(b, rest)| (*b, rest));
+    let name = TOOL_NAMES[selector as usize % TOOL_NAMES.len()];
+
+    // Interpret the remainder as a JSON value; only an Object is a valid args map
+    // (the MCP framework only ever hands `dispatch` an object). Anything else —
+    // non-UTF-8, non-JSON, or a non-object JSON value — is uninteresting input.
+    let Ok(value) = serde_json::from_slice::<Value>(json_bytes) else {
+        return;
+    };
+    let Value::Object(args) = value else {
+        return;
+    };
+
+    drive(name, args);
+});
+
+/// Build a fresh in-memory engine and dispatch one tool call on the reused
+/// runtime. A fresh engine per run keeps iterations independent (a write from a
+/// prior input can't shift a later input's path) and an in-memory SQLite store
+/// makes construction cheap enough not to bottleneck the fuzzer.
+fn drive(name: &str, args: Map<String, Value>) {
+    RT.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if slot.is_none() {
+            let Ok(rt) = tokio::runtime::Builder::new_current_thread().build() else {
+                return;
+            };
+            *slot = Some(rt);
+        }
+        let rt = slot.as_ref().expect("runtime initialized above");
+
+        let Ok(engine) = MemoryEngine::builder(DIM).build() else {
+            return;
+        };
+
+        // No embedder / no summary generator: write handlers that need them
+        // reject *after* running their argument validation, which is exactly the
+        // untrusted-parse surface this target exercises. The result (Ok or Err)
+        // is discarded; only a panic constitutes a finding.
+        rt.block_on(async {
+            let _ = tools::dispatch(
+                name,
+                args,
+                &engine,
+                None,
+                None,
+                DIM,
+                &ActivityFilterConfig::default(),
+            )
+            .await;
+        });
+    });
+}

--- a/fuzz/fuzz_targets/dispatch.rs
+++ b/fuzz/fuzz_targets/dispatch.rs
@@ -33,6 +33,18 @@ const DIM: usize = 8;
 /// Every tool name `dispatch` routes (plus one off-list name to drive the
 /// `unknown tool` arm). The first input byte selects which name to invoke, so
 /// the fuzzer can reach every handler's validation path rather than just one.
+///
+/// `memory_dump_state` is **deliberately excluded**: it is the only dispatch
+/// handler with a filesystem side effect. On otherwise-valid (even empty) args
+/// it falls through to a temp-dir default path and `engine.dump_state()` writes
+/// a real dump file — so fuzzing it would create a file on *every* selection of
+/// that index, polluting the temp dir and throttling throughput across a long
+/// run, all while re-exercising parsing the rest of the corpus already covers.
+/// Its arg-parsing and path-validation are unit-tested directly in
+/// `memory-engine-mcp`'s `tests/dump_path_security.rs`, which is the right place
+/// for that surface. (`dump_state` is the *sole* filesystem-writing handler:
+/// every other write-side tool — bootstrap, consolidate, flush, checkpoint,
+/// dream-cycle — only touches the in-memory SQLite store.)
 const TOOL_NAMES: &[&str] = &[
     "memory_ingest",
     "memory_add_fact",
@@ -46,7 +58,6 @@ const TOOL_NAMES: &[&str] = &[
     "memory_flush_insights",
     "memory_consolidate",
     "memory_forget",
-    "memory_dump_state",
     "memory_pin_fact",
     "memory_unpin_fact",
     "memory_replay_events",
@@ -77,14 +88,25 @@ fuzz_target!(|data: &[u8]| {
         .map_or((0u8, data), |(b, rest)| (*b, rest));
     let name = TOOL_NAMES[selector as usize % TOOL_NAMES.len()];
 
-    // Interpret the remainder as a JSON value; only an Object is a valid args map
-    // (the MCP framework only ever hands `dispatch` an object). Anything else —
-    // non-UTF-8, non-JSON, or a non-object JSON value — is uninteresting input.
-    let Ok(value) = serde_json::from_slice::<Value>(json_bytes) else {
-        return;
-    };
-    let Value::Object(args) = value else {
-        return;
+    // Interpret the remainder as the args map. The MCP framework only ever hands
+    // `dispatch` an object, so only an Object (or *no* remainder at all) is a
+    // valid args shape.
+    //
+    // An empty remainder — a zero-length input or a lone selector byte — maps to
+    // an empty `Map`, so dispatch IS still called with empty args. That drives
+    // every handler's missing-required-argument validation, which a strict
+    // `from_slice` (it errors on empty input) would otherwise never reach.
+    //
+    // Any *non-empty* remainder that is not a JSON object — non-UTF-8, non-JSON,
+    // or a non-object JSON value (array/string/number/bool/null) — is
+    // uninteresting and skipped.
+    let args = if json_bytes.is_empty() {
+        Map::new()
+    } else {
+        match serde_json::from_slice::<Value>(json_bytes) {
+            Ok(Value::Object(args)) => args,
+            _ => return,
+        }
     };
 
     drive(name, args);


### PR DESCRIPTION
## Summary

Adds a `dispatch` cargo-fuzz target for `memory_engine_mcp::tools::dispatch`, the MCP server's **primary untrusted-input entry point**. Every JSON-RPC `tools/call` lands here as a caller-controlled `(name, args)` pair handed straight to a handler, which does all argument parsing/validation against a `serde_json::Map`. As an embedded library, a handler panic aborts the *consumer's* process, so the contract is total — any name + any args must resolve to `Ok(CallToolResult)` / `Err(ErrorData)`, never a panic.

## What it does

- Drives the **real public `dispatch`** (already `pub`, so no `#[cfg(fuzzing)]` seam is needed).
- First input byte selects the tool name from the full 26-handler list **+ one off-list name** to drive the `unknown tool` arm; the remainder is parsed as the JSON args object (only a JSON `Object` is dispatched — that is all the MCP framework ever hands `dispatch`).
- Each iteration runs against a **fresh in-memory `MemoryEngine`** (dim 8) on a **reused current-thread Tokio runtime** (`dispatch` is `async`). `None` embedder / `None` summary generator: write handlers that require them reject *after* running their argument validation, which is exactly the parse surface being exercised.

## Crate wiring

- Adds `memory-engine-mcp = { path = "../memory-engine/bin/mcp" }` and `tokio = { features = ["rt"] }` to the detached `fuzz` crate.
- Registers the `[[bin]]` target following the existing convention.
- **`parse_embedding`** (the optional second target) is a **private fn with no fuzz seam**, so a dedicated target is omitted rather than widening the public API; it is covered transitively through the `memory_add_fact` / `memory_query` dispatch paths.

## Verification

- `cargo +nightly fuzz build dispatch` — clean (nightly toolchain available; cargo-fuzz 0.13.2).
- Smoke run `cargo +nightly fuzz run dispatch -- -runs=3000` — 3000 runs, growing coverage (cov 243 / ft 415 / corp 77), **no crash, no panic**.
- `cargo build --workspace` — unaffected (0 errors). The fuzz crate stays detached (its empty `[workspace]` table); `cargo metadata` confirms the 4 workspace members exclude `memory-engine-fuzz`.

> Note: the `fuzz` crate is **detached from the workspace CI gate** (its own nightly/libFuzzer workspace), so this target is not built by `cargo build --workspace` in CI — tracked as #751.

Closes #321
Part of #256