### PR TITLE
refactor(mcp): EventType/Outcome parsing via core FromStr SSOT

### DIFF
--- a/memory-engine/bin/mcp/src/tools/mod.rs
+++ b/memory-engine/bin/mcp/src/tools/mod.rs
@@ -683,11 +683,27 @@ fn parse_search_mode(s: &str) -> Result<SearchMode, ErrorData> {
 /// it. The core parser is complete (it accepts every variant); this boundary gate
 /// preserves the schema contract without re-implementing the variant mapping.
 fn parse_event_type(s: &str) -> Result<EventType, ValidationError> {
-    match s.parse() {
-        Ok(EventType::OutcomeSignal) | Err(_) => {
-            Err(ValidationError::UnknownEventType(s.to_owned()))
-        }
-        Ok(et) => Ok(et),
+    // The system-only-reject arm and the unparseable arm share a body, but keeping
+    // them separate is deliberate: it documents the two distinct rejection reasons
+    // and keeps the `EventType` match exhaustive (no `Ok(_)` catch-all), so a new
+    // variant forces a deliberate allow/reject decision here at compile time.
+    #[allow(clippy::match_same_arms)]
+    match s.parse::<EventType>() {
+        // User-facing types — accepted at the MCP ingest/replay boundary. These are
+        // exactly the variants the `ingest` / `replay` JSON schemas advertise.
+        Ok(
+            et @ (EventType::Interaction
+            | EventType::ToolCall
+            | EventType::MemoryOp
+            | EventType::SystemEvent),
+        ) => Ok(et),
+        // System-generated only — emitted internally by `record_outcome`, never
+        // user-ingestible; the schemas deliberately omit it.
+        Ok(EventType::OutcomeSignal) => Err(ValidationError::UnknownEventType(s.to_owned())),
+        // NOTE: intentionally NO catch-all `Ok(_)`. Adding a new `EventType` variant
+        // must force a deliberate allow/reject decision here — the compiler flags
+        // the non-exhaustive match instead of silently making it user-ingestible.
+        Err(_) => Err(ValidationError::UnknownEventType(s.to_owned())),
     }
 }
 

--- a/memory-engine/bin/mcp/src/tools/mod.rs
+++ b/memory-engine/bin/mcp/src/tools/mod.rs
@@ -671,13 +671,23 @@ fn parse_search_mode(s: &str) -> Result<SearchMode, ErrorData> {
     }
 }
 
+/// Parse an MCP `event_type` tool parameter into the core [`EventType`].
+///
+/// Delegates to core's canonical [`EventType::from_str`] (the single source of
+/// truth, #353/#678), so casing is reconciled across surfaces: the JSON schemas
+/// advertise `PascalCase` (`"Interaction"`), but `snake_case` is also accepted.
+///
+/// One MCP-specific narrowing: [`EventType::OutcomeSignal`] is **rejected** here.
+/// It is a system-generated event (emitted by `record_outcome`), not a
+/// user-ingestible type — the `ingest` / `replay` JSON schemas deliberately omit
+/// it. The core parser is complete (it accepts every variant); this boundary gate
+/// preserves the schema contract without re-implementing the variant mapping.
 fn parse_event_type(s: &str) -> Result<EventType, ValidationError> {
-    match s {
-        "Interaction" => Ok(EventType::Interaction),
-        "ToolCall" => Ok(EventType::ToolCall),
-        "MemoryOp" => Ok(EventType::MemoryOp),
-        "SystemEvent" => Ok(EventType::SystemEvent),
-        other => Err(ValidationError::UnknownEventType(other.to_owned())),
+    match s.parse() {
+        Ok(EventType::OutcomeSignal) | Err(_) => {
+            Err(ValidationError::UnknownEventType(s.to_owned()))
+        }
+        Ok(et) => Ok(et),
     }
 }
 
@@ -1736,16 +1746,18 @@ async fn handle_bootstrap_session(
 // Phase 5a: Outcome tracking handlers
 // ---------------------------------------------------------------------------
 
+/// Parse an MCP `outcome` tool parameter into the core [`Outcome`].
+///
+/// Delegates to core's canonical [`Outcome::from_str`] (the single source of
+/// truth, #353/#678), so casing is reconciled across surfaces: the JSON schema
+/// advertises `PascalCase` (`"Positive"`), but lowercase is also accepted.
 fn parse_outcome(s: &str) -> Result<Outcome, ErrorData> {
-    match s {
-        "Positive" => Ok(Outcome::Positive),
-        "Negative" => Ok(Outcome::Negative),
-        "Neutral" => Ok(Outcome::Neutral),
-        other => Err(ErrorData::invalid_params(
-            format!("invalid outcome: {other} (expected Positive, Negative, or Neutral)"),
+    s.parse().map_err(|_| {
+        ErrorData::invalid_params(
+            format!("invalid outcome: {s} (expected Positive, Negative, or Neutral)"),
             None,
-        )),
-    }
+        )
+    })
 }
 
 async fn handle_record_outcome(
@@ -1999,9 +2011,9 @@ async fn handle_get_recent_insights(
 mod tests {
     use super::{
         default_dump_name, default_dump_path, get_usize, parse_consolidate_config, parse_embedding,
-        parse_fact_type, validate_dump_path,
+        parse_event_type, parse_fact_type, parse_outcome, validate_dump_path,
     };
-    use memory_engine::types::FactType;
+    use memory_engine::types::{EventType, FactType, Outcome};
     use serde_json::json;
     use std::collections::HashSet;
 
@@ -2078,6 +2090,69 @@ mod tests {
         // ValidationError is a thiserror enum; the offending token is preserved
         // in its Display string.
         assert!(err.to_string().contains("wisdom"), "{err}");
+    }
+
+    #[test]
+    fn parse_event_type_accepts_schema_pascal_case() {
+        // The JSON schemas advertise these four PascalCase tokens — all must parse.
+        assert_eq!(
+            parse_event_type("Interaction").unwrap(),
+            EventType::Interaction
+        );
+        assert_eq!(parse_event_type("ToolCall").unwrap(), EventType::ToolCall);
+        assert_eq!(parse_event_type("MemoryOp").unwrap(), EventType::MemoryOp);
+        assert_eq!(
+            parse_event_type("SystemEvent").unwrap(),
+            EventType::SystemEvent
+        );
+    }
+
+    #[test]
+    fn parse_event_type_reconciles_snake_case() {
+        // After delegating to core's canonical FromStr, the MCP surface also
+        // accepts the snake_case casing (#353/#678 reconciliation).
+        assert_eq!(parse_event_type("tool_call").unwrap(), EventType::ToolCall);
+        assert_eq!(
+            parse_event_type("interaction").unwrap(),
+            EventType::Interaction
+        );
+    }
+
+    #[test]
+    fn parse_event_type_rejects_outcome_signal() {
+        // OutcomeSignal is a system-generated event, deliberately omitted from the
+        // ingest/replay JSON schemas. Even though core's FromStr parses it, the MCP
+        // boundary must keep rejecting it (with the token preserved).
+        let err = parse_event_type("OutcomeSignal").unwrap_err();
+        assert!(err.to_string().contains("OutcomeSignal"), "{err}");
+    }
+
+    #[test]
+    fn parse_event_type_rejects_unknown_preserving_token() {
+        let err = parse_event_type("WisdomOp").unwrap_err();
+        assert!(err.to_string().contains("WisdomOp"), "{err}");
+    }
+
+    #[test]
+    fn parse_outcome_accepts_schema_pascal_case() {
+        // The JSON schema advertises PascalCase tokens — these must parse.
+        assert_eq!(parse_outcome("Positive").unwrap(), Outcome::Positive);
+        assert_eq!(parse_outcome("Negative").unwrap(), Outcome::Negative);
+        assert_eq!(parse_outcome("Neutral").unwrap(), Outcome::Neutral);
+    }
+
+    #[test]
+    fn parse_outcome_reconciles_lowercase() {
+        // After delegating to core's canonical FromStr, lowercase also parses.
+        assert_eq!(parse_outcome("positive").unwrap(), Outcome::Positive);
+        assert_eq!(parse_outcome("neutral").unwrap(), Outcome::Neutral);
+    }
+
+    #[test]
+    fn parse_outcome_rejects_unknown_preserving_token() {
+        let err = parse_outcome("mixed").unwrap_err();
+        // ErrorData carries the offending token in its message.
+        assert!(err.message.contains("mixed"), "{}", err.message);
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/types/events.rs
+++ b/memory-engine/lib/memory-engine/src/types/events.rs
@@ -1,7 +1,9 @@
 use std::fmt;
+use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Type of event in the append-only log.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -13,6 +15,72 @@ pub enum EventType {
     /// Outcome feedback signal for a fact (positive, negative, or neutral).
     /// Payload carries `{"fact_id": i64, "outcome": "Positive"|"Negative"|"Neutral"}`.
     OutcomeSignal,
+}
+
+impl fmt::Display for EventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Interaction => write!(f, "interaction"),
+            Self::ToolCall => write!(f, "tool_call"),
+            Self::MemoryOp => write!(f, "memory_op"),
+            Self::SystemEvent => write!(f, "system_event"),
+            Self::OutcomeSignal => write!(f, "outcome_signal"),
+        }
+    }
+}
+
+/// Error returned when a string does not name a known [`EventType`] variant.
+///
+/// Carries the offending token so callers can surface an actionable message.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("unknown event type: {0}")]
+pub struct ParseEventTypeError(pub String);
+
+impl FromStr for EventType {
+    type Err = ParseEventTypeError;
+
+    /// Canonical, case-insensitive parse of the `EventType` variant names.
+    ///
+    /// This is the **single source of truth** for the string→`EventType` mapping
+    /// shared by every consumer surface (the MCP server's `ingest` / `replay`
+    /// tool parameters). Mirroring [`FactType::from_str`](crate::types::FactType::from_str),
+    /// it is intentionally lenient on casing so it accepts both wire conventions
+    /// present in the codebase: [`Display`] emits `snake_case` (`"interaction"`),
+    /// while serde-derive and the MCP JSON-schema enums use `PascalCase`
+    /// (`"Interaction"`). Parsing reconciles both to one canonical enum;
+    /// [`EventType::to_string`] remains the canonical output.
+    ///
+    /// It accepts **all** variants, including [`EventType::OutcomeSignal`] — a
+    /// complete parser that round-trips with `Display`. Surfaces that must reject
+    /// system-generated types (e.g. the MCP `ingest` tool, whose JSON schema
+    /// advertises only the four user-ingestible types) apply their own gate after
+    /// this parse rather than relying on an incomplete mapping.
+    ///
+    /// Note: this is orthogonal to the serde `Deserialize` derive (which stays
+    /// `PascalCase`) and to the strict, exact-match DB serialization in
+    /// `store::events` — that path must round-trip bytes verbatim, so it does not
+    /// share this lenient casing.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Zero-allocation, case-insensitive match. The multi-word variants admit
+        // two spellings — the `PascalCase` wire form (`"ToolCall"`, the JSON-schema
+        // / serde-derive convention) and the `snake_case` [`Display`] form
+        // (`"tool_call"`) — so both casings AND `Display::to_string` round-trip.
+        if s.eq_ignore_ascii_case("Interaction") {
+            Ok(Self::Interaction)
+        } else if s.eq_ignore_ascii_case("ToolCall") || s.eq_ignore_ascii_case("tool_call") {
+            Ok(Self::ToolCall)
+        } else if s.eq_ignore_ascii_case("MemoryOp") || s.eq_ignore_ascii_case("memory_op") {
+            Ok(Self::MemoryOp)
+        } else if s.eq_ignore_ascii_case("SystemEvent") || s.eq_ignore_ascii_case("system_event") {
+            Ok(Self::SystemEvent)
+        } else if s.eq_ignore_ascii_case("OutcomeSignal")
+            || s.eq_ignore_ascii_case("outcome_signal")
+        {
+            Ok(Self::OutcomeSignal)
+        } else {
+            Err(ParseEventTypeError(s.to_owned()))
+        }
+    }
 }
 
 /// Outcome of using a fact — consumer-supplied feedback signal.
@@ -33,6 +101,39 @@ impl fmt::Display for Outcome {
             Self::Positive => write!(f, "positive"),
             Self::Negative => write!(f, "negative"),
             Self::Neutral => write!(f, "neutral"),
+        }
+    }
+}
+
+/// Error returned when a string does not name a known [`Outcome`] variant.
+///
+/// Carries the offending token so callers can surface an actionable message.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("unknown outcome: {0}")]
+pub struct ParseOutcomeError(pub String);
+
+impl FromStr for Outcome {
+    type Err = ParseOutcomeError;
+
+    /// Canonical, case-insensitive parse of the `Outcome` variant names.
+    ///
+    /// The **single source of truth** for the string→`Outcome` mapping shared by
+    /// every consumer surface (the MCP server's `record_outcome` tool parameter).
+    /// Mirroring [`FactType::from_str`](crate::types::FactType::from_str), it is
+    /// lenient on casing so it accepts both the `PascalCase` wire form the MCP
+    /// JSON schema advertises (`"Positive"`) and the `snake_case`/lowercase
+    /// [`Display`] form (`"positive"`); [`Outcome::to_string`] round-trips through
+    /// it. Parsing reconciles every casing to one canonical enum.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Zero-allocation case-insensitive match (no temporary lowercased String).
+        if s.eq_ignore_ascii_case("positive") {
+            Ok(Self::Positive)
+        } else if s.eq_ignore_ascii_case("negative") {
+            Ok(Self::Negative)
+        } else if s.eq_ignore_ascii_case("neutral") {
+            Ok(Self::Neutral)
+        } else {
+            Err(ParseOutcomeError(s.to_owned()))
         }
     }
 }
@@ -114,6 +215,143 @@ mod tests {
         assert_eq!(Outcome::Positive.to_string(), "positive");
         assert_eq!(Outcome::Negative.to_string(), "negative");
         assert_eq!(Outcome::Neutral.to_string(), "neutral");
+    }
+
+    // --- EventType FromStr (canonical string parse, shared by MCP surfaces) ---
+
+    #[test]
+    fn event_type_from_str_accepts_pascal_case() {
+        // PascalCase is the serde-derive / MCP-JSON-schema wire form.
+        assert_eq!(
+            "Interaction".parse::<EventType>().unwrap(),
+            EventType::Interaction
+        );
+        assert_eq!(
+            "ToolCall".parse::<EventType>().unwrap(),
+            EventType::ToolCall
+        );
+        assert_eq!(
+            "MemoryOp".parse::<EventType>().unwrap(),
+            EventType::MemoryOp
+        );
+        assert_eq!(
+            "SystemEvent".parse::<EventType>().unwrap(),
+            EventType::SystemEvent
+        );
+        // The parser is complete: it accepts the system-generated variant too.
+        // Surfaces that must reject it (the MCP `ingest` tool) gate after parsing.
+        assert_eq!(
+            "OutcomeSignal".parse::<EventType>().unwrap(),
+            EventType::OutcomeSignal
+        );
+    }
+
+    #[test]
+    fn event_type_from_str_accepts_snake_case_display_form() {
+        // The Display form (snake_case) must also parse so to_string round-trips.
+        assert_eq!(
+            "tool_call".parse::<EventType>().unwrap(),
+            EventType::ToolCall
+        );
+        assert_eq!(
+            "memory_op".parse::<EventType>().unwrap(),
+            EventType::MemoryOp
+        );
+        assert_eq!(
+            "system_event".parse::<EventType>().unwrap(),
+            EventType::SystemEvent
+        );
+        assert_eq!(
+            "outcome_signal".parse::<EventType>().unwrap(),
+            EventType::OutcomeSignal
+        );
+    }
+
+    #[test]
+    fn event_type_from_str_is_case_insensitive() {
+        assert_eq!(
+            "INTERACTION".parse::<EventType>().unwrap(),
+            EventType::Interaction
+        );
+        assert_eq!(
+            "toolcall".parse::<EventType>().unwrap(),
+            EventType::ToolCall
+        );
+        assert_eq!(
+            "MEMORY_OP".parse::<EventType>().unwrap(),
+            EventType::MemoryOp
+        );
+    }
+
+    #[test]
+    fn event_type_from_str_rejects_unknown_preserving_token() {
+        let err = "WisdomOp".parse::<EventType>().unwrap_err();
+        // The unknown token is preserved in the error for actionable messages.
+        assert!(err.to_string().contains("WisdomOp"));
+    }
+
+    #[test]
+    fn event_type_from_str_rejects_surrounding_whitespace() {
+        // The parser is intentionally strict on whitespace — it does not trim.
+        assert!(" Interaction".parse::<EventType>().is_err());
+        assert!("ToolCall ".parse::<EventType>().is_err());
+        assert!("".parse::<EventType>().is_err());
+    }
+
+    #[test]
+    fn event_type_display_round_trips_through_from_str() {
+        for et in [
+            EventType::Interaction,
+            EventType::ToolCall,
+            EventType::MemoryOp,
+            EventType::SystemEvent,
+            EventType::OutcomeSignal,
+        ] {
+            assert_eq!(et.to_string().parse::<EventType>().unwrap(), et);
+        }
+    }
+
+    // --- Outcome FromStr (canonical string parse, shared by MCP) ---
+
+    #[test]
+    fn outcome_from_str_accepts_pascal_case() {
+        // PascalCase is the MCP-JSON-schema wire form.
+        assert_eq!("Positive".parse::<Outcome>().unwrap(), Outcome::Positive);
+        assert_eq!("Negative".parse::<Outcome>().unwrap(), Outcome::Negative);
+        assert_eq!("Neutral".parse::<Outcome>().unwrap(), Outcome::Neutral);
+    }
+
+    #[test]
+    fn outcome_from_str_accepts_lowercase_display_form() {
+        assert_eq!("positive".parse::<Outcome>().unwrap(), Outcome::Positive);
+        assert_eq!("negative".parse::<Outcome>().unwrap(), Outcome::Negative);
+        assert_eq!("neutral".parse::<Outcome>().unwrap(), Outcome::Neutral);
+    }
+
+    #[test]
+    fn outcome_from_str_is_case_insensitive() {
+        assert_eq!("POSITIVE".parse::<Outcome>().unwrap(), Outcome::Positive);
+        assert_eq!("nEgAtIvE".parse::<Outcome>().unwrap(), Outcome::Negative);
+    }
+
+    #[test]
+    fn outcome_from_str_rejects_unknown_preserving_token() {
+        let err = "mixed".parse::<Outcome>().unwrap_err();
+        assert!(err.to_string().contains("mixed"));
+    }
+
+    #[test]
+    fn outcome_from_str_rejects_surrounding_whitespace() {
+        assert!(" positive".parse::<Outcome>().is_err());
+        assert!("Neutral ".parse::<Outcome>().is_err());
+        assert!("".parse::<Outcome>().is_err());
+    }
+
+    #[test]
+    fn outcome_display_round_trips_through_from_str() {
+        for o in [Outcome::Positive, Outcome::Negative, Outcome::Neutral] {
+            assert_eq!(o.to_string().parse::<Outcome>().unwrap(), o);
+        }
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/types/events.rs
+++ b/memory-engine/lib/memory-engine/src/types/events.rs
@@ -124,6 +124,12 @@ impl FromStr for Outcome {
     /// JSON schema advertises (`"Positive"`) and the `snake_case`/lowercase
     /// [`Display`] form (`"positive"`); [`Outcome::to_string`] round-trips through
     /// it. Parsing reconciles every casing to one canonical enum.
+    ///
+    /// Note: this is orthogonal to the strict DB serialization — the serde
+    /// `Deserialize` derive and the exact-match outcome-count SQL in
+    /// `storage::sqlite::event_log` (matching `"positive"`/`"negative"`/`"neutral"`
+    /// verbatim) do NOT route through this `FromStr`. The "SSOT" claim is therefore
+    /// scoped to the consumer-facing parse boundary, not the persistence path.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Zero-allocation case-insensitive match (no temporary lowercased String).
         if s.eq_ignore_ascii_case("positive") {


### PR DESCRIPTION
## Summary

Extends the #678 `FromStr`-in-core single-source-of-truth pattern (already applied to `FactType`) to `EventType` and `Outcome`. The MCP `parse_event_type` / `parse_outcome` were hand-rolled exact-match `match` statements duplicating the string→enum mapping; they now delegate to canonical core `FromStr` impls.

## Changes

**Core lib (`types/events.rs`)**
- Add case-insensitive `FromStr` for `EventType` and `Outcome`, mirroring `FactType::from_str`. They accept the PascalCase wire form the JSON schemas advertise **and** the snake_case/lowercase `Display` form, so `to_string` round-trips.
- Add a `Display` impl for `EventType` (it had none) so the round-trip holds.
- `EventType::from_str` is **complete** — it parses `OutcomeSignal` too; an incomplete parser that cannot round-trip `Display` is a latent bug.
- New error types `ParseEventTypeError` / `ParseOutcomeError` preserve the offending token, like `ParseFactTypeError`.
- These lenient consumer parsers stay **orthogonal** to the strict, exact-match DB serialization in `store::events` (which must round-trip bytes verbatim) and to the serde derives — same separation `FactType` documents.

**MCP (`tools/mod.rs`)**
- `parse_event_type` / `parse_outcome` now delegate via `s.parse()`, preserving their existing error types (`ValidationError::UnknownEventType`, the outcome `ErrorData`) and messages.
- `parse_event_type` keeps one MCP-specific narrowing: it **rejects `OutcomeSignal`** (a system-generated event, deliberately omitted from the ingest/replay JSON schemas) at the boundary, so the schema contract is unchanged. The core parser is complete; the boundary gate enforces the surface policy.

## Tests
- Core: 10 new unit tests (PascalCase / snake_case Display form / case-insensitivity / whitespace-strictness / unknown-token-preserved / Display↔FromStr round-trip) for both `EventType` and `Outcome`.
- MCP: 7 new unit tests for the delegating `parse_event_type` / `parse_outcome`, including the `OutcomeSignal`-rejected-at-boundary case.

## Gate
- `cargo test -p memory-engine -p memory-engine-mcp` — all green
- `cargo clippy -p memory-engine -p memory-engine-mcp --all-targets` — clean (only the 2 pre-existing `consolidation.rs`/`sqlite/mod.rs` storage warnings tracked as #843)
- `cargo fmt --check` — clean
- `cargo build --workspace` — clean

Closes #353. Part of #256.