### PR TITLE
refactor(retrieval): curate search public surface (pub(crate) submodules + lib re-exports) and add SearchQuery builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ fn main() -> Result<(), MemoryError> {
     )?;
 
     // Query with hybrid search
-    use memory_engine::search::hybrid::{SearchQuery, SearchMode};
+    use memory_engine::search::{SearchQuery, SearchMode};
     let results = engine.query(&SearchQuery {
         text: Some("ownership data races".into()),
         embedding: Some(embedder.embed("ownership data races")?),

--- a/benches/search_bench.rs
+++ b/benches/search_bench.rs
@@ -26,9 +26,9 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::search::cosine_similarity;
-use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactRequest, FactType, ScopeQuery};
+use memory_engine::{SearchMode, SearchQuery};
 
 const DIM: usize = 128;
 
@@ -208,16 +208,7 @@ fn bench_vector_search(c: &mut Criterion) {
             b.iter(|| {
                 rt.block_on(async {
                     engine
-                        .query(&SearchQuery {
-                            text: None,
-                            embedding: Some(emb.clone()),
-                            mode: SearchMode::Vector,
-                            limit: 10,
-                            rerank_depth: None,
-                            valid_at: None,
-                            fact_type: None,
-                            scope: None,
-                        })
+                        .query(&SearchQuery::new(SearchMode::Vector, 10).embedding(emb.clone()))
                         .await
                         .unwrap();
                 });
@@ -244,16 +235,7 @@ fn bench_vector_search_dims(c: &mut Criterion) {
             b.iter(|| {
                 rt.block_on(async {
                     engine
-                        .query(&SearchQuery {
-                            text: None,
-                            embedding: Some(emb.clone()),
-                            mode: SearchMode::Vector,
-                            limit: 10,
-                            rerank_depth: None,
-                            valid_at: None,
-                            fact_type: None,
-                            scope: None,
-                        })
+                        .query(&SearchQuery::new(SearchMode::Vector, 10).embedding(emb.clone()))
                         .await
                         .unwrap();
                 });
@@ -278,16 +260,7 @@ fn bench_fts_search(c: &mut Criterion) {
             b.iter(|| {
                 rt.block_on(async {
                     engine
-                        .query(&SearchQuery {
-                            text: Some("Rust memory safety".into()),
-                            embedding: None,
-                            mode: SearchMode::Fts,
-                            limit: 10,
-                            rerank_depth: None,
-                            valid_at: None,
-                            fact_type: None,
-                            scope: None,
-                        })
+                        .query(&SearchQuery::new(SearchMode::Fts, 10).text("Rust memory safety"))
                         .await
                         .unwrap();
                 });
@@ -313,16 +286,11 @@ fn bench_hybrid_search(c: &mut Criterion) {
             b.iter(|| {
                 rt.block_on(async {
                     engine
-                        .query(&SearchQuery {
-                            text: Some("Rust memory".into()),
-                            embedding: Some(emb.clone()),
-                            mode: SearchMode::Hybrid,
-                            limit: 10,
-                            rerank_depth: None,
-                            valid_at: None,
-                            fact_type: None,
-                            scope: None,
-                        })
+                        .query(
+                            &SearchQuery::new(SearchMode::Hybrid, 10)
+                                .text("Rust memory")
+                                .embedding(emb.clone()),
+                        )
                         .await
                         .unwrap();
                 });
@@ -349,16 +317,11 @@ fn bench_scoped_search(c: &mut Criterion) {
         b.iter(|| {
             rt.block_on(async {
                 engine
-                    .query(&SearchQuery {
-                        text: Some("scoped fact".into()),
-                        embedding: Some(emb.clone()),
-                        mode: SearchMode::Hybrid,
-                        limit: 10,
-                        rerank_depth: None,
-                        valid_at: None,
-                        fact_type: None,
-                        scope: None,
-                    })
+                    .query(
+                        &SearchQuery::new(SearchMode::Hybrid, 10)
+                            .text("scoped fact")
+                            .embedding(emb.clone()),
+                    )
                     .await
                     .unwrap();
             });
@@ -369,16 +332,12 @@ fn bench_scoped_search(c: &mut Criterion) {
         b.iter(|| {
             rt.block_on(async {
                 engine
-                    .query(&SearchQuery {
-                        text: Some("scoped fact".into()),
-                        embedding: Some(emb.clone()),
-                        mode: SearchMode::Hybrid,
-                        limit: 10,
-                        rerank_depth: None,
-                        valid_at: None,
-                        fact_type: None,
-                        scope: Some(ScopeQuery::Exact("user:alice/project:alpha".into())),
-                    })
+                    .query(
+                        &SearchQuery::new(SearchMode::Hybrid, 10)
+                            .text("scoped fact")
+                            .embedding(emb.clone())
+                            .scope(ScopeQuery::Exact("user:alice/project:alpha".into())),
+                    )
                     .await
                     .unwrap();
             });
@@ -389,16 +348,12 @@ fn bench_scoped_search(c: &mut Criterion) {
         b.iter(|| {
             rt.block_on(async {
                 engine
-                    .query(&SearchQuery {
-                        text: Some("scoped fact".into()),
-                        embedding: Some(emb.clone()),
-                        mode: SearchMode::Hybrid,
-                        limit: 10,
-                        rerank_depth: None,
-                        valid_at: None,
-                        fact_type: None,
-                        scope: Some(ScopeQuery::Subtree("user:alice".into())),
-                    })
+                    .query(
+                        &SearchQuery::new(SearchMode::Hybrid, 10)
+                            .text("scoped fact")
+                            .embedding(emb.clone())
+                            .scope(ScopeQuery::Subtree("user:alice".into())),
+                    )
                     .await
                     .unwrap();
             });
@@ -463,16 +418,7 @@ fn bench_hnsw_search(c: &mut Criterion) {
             b.iter(|| {
                 rt.block_on(async {
                     engine
-                        .query(&SearchQuery {
-                            text: None,
-                            embedding: Some(emb.clone()),
-                            mode: SearchMode::Vector,
-                            limit: 10,
-                            rerank_depth: None,
-                            valid_at: None,
-                            fact_type: None,
-                            scope: None,
-                        })
+                        .query(&SearchQuery::new(SearchMode::Vector, 10).embedding(emb.clone()))
                         .await
                         .unwrap();
                 });

--- a/docs/advanced/extensibility.md
+++ b/docs/advanced/extensibility.md
@@ -179,7 +179,7 @@ Implementation example:
 
 ```rust
 use memory_engine::traits::Reranker;
-use memory_engine::search::hybrid::SearchResult;
+use memory_engine::search::SearchResult;
 
 struct CrossEncoderReranker {
     client: reqwest::blocking::Client,

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -84,7 +84,7 @@ let fact_id = engine.add_fact(
 ## 5. Query
 
 ```rust
-use memory_engine::search::hybrid::{SearchQuery, SearchMode};
+use memory_engine::search::{SearchQuery, SearchMode};
 
 let results = engine.query(&SearchQuery {
     text: Some("systems programming safety".into()),

--- a/docs/usage/querying-memory.md
+++ b/docs/usage/querying-memory.md
@@ -55,7 +55,7 @@ pub struct SearchResult {
 ## Basic example
 
 ```rust
-use memory_engine::search::hybrid::{SearchQuery, SearchMode};
+use memory_engine::search::{SearchQuery, SearchMode};
 
 let results = engine.query(&SearchQuery {
     text: Some("memory safety".into()),

--- a/examples/basic_roundtrip.rs
+++ b/examples/basic_roundtrip.rs
@@ -7,9 +7,9 @@
 use memory_engine::EmbeddingFingerprint;
 use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
-use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactRequest, EventType, FactType, NewEvent};
+use memory_engine::{SearchMode, SearchQuery};
 
 /// Zero-vector embedder for examples (no external model needed).
 struct DummyEmbedder;
@@ -78,16 +78,11 @@ async fn main() -> Result<(), MemoryError> {
 
     // 3. Query with hybrid search
     let results = engine
-        .query(&SearchQuery {
-            text: Some("Rust programming".into()),
-            embedding: Some(vec![0.1; 4]),
-            mode: SearchMode::Hybrid,
-            limit: 5,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(
+            &SearchQuery::new(SearchMode::Hybrid, 5)
+                .text("Rust programming")
+                .embedding(vec![0.1; 4]),
+        )
         .await?;
 
     println!("\nSearch results:");

--- a/examples/bi_temporal_query.rs
+++ b/examples/bi_temporal_query.rs
@@ -8,9 +8,9 @@ use chrono::{Duration, Utc};
 use memory_engine::EmbeddingFingerprint;
 use memory_engine::MemoryEngine;
 use memory_engine::error::MemoryError;
-use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactOptions, AddFactRequest, FactType};
+use memory_engine::{SearchMode, SearchQuery};
 
 struct DummyEmbedder;
 
@@ -90,16 +90,12 @@ async fn main() -> Result<(), MemoryError> {
 
     // Query: what's valid RIGHT NOW?
     let results_now = engine
-        .query(&SearchQuery {
-            text: Some("deadline meeting review".into()),
-            embedding: Some(vec![0.1; 4]),
-            mode: SearchMode::Hybrid,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: Some(now),
-            fact_type: None,
-            scope: None,
-        })
+        .query(
+            &SearchQuery::new(SearchMode::Hybrid, 10)
+                .text("deadline meeting review")
+                .embedding(vec![0.1; 4])
+                .valid_at(now),
+        )
         .await?;
 
     println!("Facts valid NOW ({}):", now.format("%Y-%m-%d"));
@@ -110,16 +106,12 @@ async fn main() -> Result<(), MemoryError> {
     // Query: what was valid 3 days ago?
     let past = now - Duration::days(3);
     let results_past = engine
-        .query(&SearchQuery {
-            text: Some("deadline meeting review".into()),
-            embedding: Some(vec![0.1; 4]),
-            mode: SearchMode::Hybrid,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: Some(past),
-            fact_type: None,
-            scope: None,
-        })
+        .query(
+            &SearchQuery::new(SearchMode::Hybrid, 10)
+                .text("deadline meeting review")
+                .embedding(vec![0.1; 4])
+                .valid_at(past),
+        )
         .await?;
 
     println!("\nFacts valid 3 days ago ({}):", past.format("%Y-%m-%d"));
@@ -130,16 +122,12 @@ async fn main() -> Result<(), MemoryError> {
     // Query: what will be valid in 2 weeks?
     let future = now + Duration::days(14);
     let results_future = engine
-        .query(&SearchQuery {
-            text: Some("deadline meeting review".into()),
-            embedding: Some(vec![0.1; 4]),
-            mode: SearchMode::Hybrid,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: Some(future),
-            fact_type: None,
-            scope: None,
-        })
+        .query(
+            &SearchQuery::new(SearchMode::Hybrid, 10)
+                .text("deadline meeting review")
+                .embedding(vec![0.1; 4])
+                .valid_at(future),
+        )
         .await?;
 
     println!("\nFacts valid in 2 weeks ({}):", future.format("%Y-%m-%d"));

--- a/memory-engine/bin/cli/src/commands/query.rs
+++ b/memory-engine/bin/cli/src/commands/query.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use memory_engine::MemoryQuery;
-use memory_engine::search::hybrid::MatchType;
 use memory_engine::traits::EmbeddingProvider;
+use memory_engine::{MatchType, MemoryQuery};
 use tabled::{Table, Tabled};
 
 use crate::commands::embedding_args::EmbeddingArgs;

--- a/memory-engine/bin/mcp/src/depth.rs
+++ b/memory-engine/bin/mcp/src/depth.rs
@@ -1,7 +1,7 @@
 use memory_engine::ResumeContext;
 use memory_engine::inspect_types::{FactExplanation, FactHistory};
-use memory_engine::search::hybrid::{QueryDiagnostics, SearchResult};
 use memory_engine::types::{Activity, Event, Fact, ProjectContext, SessionCheckpoint};
+use memory_engine::{QueryDiagnostics, SearchResult};
 use rmcp::model::ErrorData;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -422,7 +422,7 @@ mod tests {
 
     #[test]
     fn search_result_adds_score_and_match_type() {
-        use memory_engine::search::hybrid::MatchType;
+        use memory_engine::MatchType;
         let result = SearchResult {
             fact: make_test_fact(),
             score: 0.95,

--- a/memory-engine/bin/mcp/src/tools/mod.rs
+++ b/memory-engine/bin/mcp/src/tools/mod.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use memory_engine::ResumeConfig;
+use memory_engine::SearchMode;
 use memory_engine::bootstrap::{BootstrapConfig, KeywordExtractor};
 use memory_engine::engine::MemoryEngine;
 use memory_engine::inspect_types::{DumpFormat, FactExplanation, ReplayFilter, ReplayOrder};
-use memory_engine::search::hybrid::SearchMode;
 use memory_engine::traits::{
     ConsolidationConfig, EmbeddingProvider, ForgetPolicy, SummaryGenerator,
 };

--- a/memory-engine/lib/memory-engine/src/engine/query.rs
+++ b/memory-engine/lib/memory-engine/src/engine/query.rs
@@ -250,16 +250,12 @@ impl MemoryEngine {
 
         // hybrid_search already does its own 3x overfetch internally (line 87),
         // so we pass the raw limit here — no double inflation.
-        let search_query = SearchQuery {
-            text: query.text.clone(),
-            embedding: query.embedding.clone(),
-            mode,
-            limit,
-            rerank_depth: None,
-            valid_at: search_cutoff,
-            fact_type: query.fact_type,
-            scope: query.scope.clone(),
-        };
+        let mut search_query = SearchQuery::new(mode, limit);
+        search_query.text = query.text.clone();
+        search_query.embedding = query.embedding.clone();
+        search_query.valid_at = search_cutoff;
+        search_query.fact_type = query.fact_type;
+        search_query.scope = query.scope.clone();
 
         let (mut results, mut diagnostics) =
             port_hybrid_search(&*self.storage, &search_query, scope_ids).await?;

--- a/memory-engine/lib/memory-engine/src/engine/reconstruct.rs
+++ b/memory-engine/lib/memory-engine/src/engine/reconstruct.rs
@@ -747,16 +747,7 @@ mod tests {
                 );
             }
             let results = engine
-                .query(&SearchQuery {
-                    text: None,
-                    embedding: Some(vec![0.9_f32; DIM]),
-                    mode: SearchMode::Vector,
-                    limit: 5,
-                    rerank_depth: None,
-                    valid_at: None,
-                    fact_type: None,
-                    scope: None,
-                })
+                .query(&SearchQuery::new(SearchMode::Vector, 5).embedding(vec![0.9_f32; DIM]))
                 .await
                 .unwrap();
             assert_eq!(results.len(), 3, "all facts served from the rebuilt index");

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -212,16 +212,7 @@ async fn query_returns_results_after_adding_facts() {
         .await
         .unwrap();
 
-    let query = SearchQuery {
-        text: Some("Rust".into()),
-        embedding: None,
-        mode: SearchMode::Fts,
-        limit: 10,
-        rerank_depth: None,
-        valid_at: None,
-        fact_type: None,
-        scope: None,
-    };
+    let query = SearchQuery::new(SearchMode::Fts, 10).text("Rust");
     let results = engine.query(&query).await.unwrap();
     assert_eq!(results.len(), 1);
     assert!(results[0].fact.content.contains("Rust"));
@@ -267,16 +258,7 @@ async fn vector_query_ranks_closest_embedding_first() {
 
     // Query embedded as the "cats" axis — orthogonal to dogs/birds.
     let results = engine
-        .query(&SearchQuery {
-            text: None,
-            embedding: Some(embedder.axis("cats")),
-            mode: SearchMode::Vector,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Vector, 10).embedding(embedder.axis("cats")))
         .await
         .unwrap();
 
@@ -323,16 +305,7 @@ async fn vector_query_ranking_follows_query_axis() {
     }
 
     let results = engine
-        .query(&SearchQuery {
-            text: None,
-            embedding: Some(embedder.axis("dogs")),
-            mode: SearchMode::Vector,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Vector, 10).embedding(embedder.axis("dogs")))
         .await
         .unwrap();
 
@@ -1265,16 +1238,7 @@ async fn engine_concurrent_reads() {
         let e = engine.clone();
         handles.push(tokio::spawn(async move {
             let results = e
-                .query(&SearchQuery {
-                    text: Some("Rust".into()),
-                    embedding: None,
-                    mode: SearchMode::Fts,
-                    limit: 10,
-                    rerank_depth: None,
-                    valid_at: None,
-                    fact_type: None,
-                    scope: None,
-                })
+                .query(&SearchQuery::new(SearchMode::Fts, 10).text("Rust"))
                 .await
                 .unwrap();
             assert_eq!(results.len(), 1);
@@ -1290,16 +1254,7 @@ async fn engine_concurrent_reads() {
 // reader and the terminal check issue exactly the same query.
 #[cfg(test)]
 fn concurrent_probe_query() -> SearchQuery {
-    SearchQuery {
-        text: Some("Concurrent".into()),
-        embedding: None,
-        mode: SearchMode::Fts,
-        limit: 10,
-        rerank_depth: None,
-        valid_at: None,
-        fact_type: None,
-        scope: None,
-    }
+    SearchQuery::new(SearchMode::Fts, 10).text("Concurrent")
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1875,16 +1830,9 @@ async fn query_nonexistent_scope_returns_empty() {
         .unwrap();
 
     // Query with a scope path that doesn't exist
-    let query = SearchQuery {
-        text: Some("visible".into()),
-        embedding: None,
-        mode: SearchMode::Fts,
-        limit: 10,
-        rerank_depth: None,
-        valid_at: None,
-        fact_type: None,
-        scope: Some(ScopeQuery::Exact("nonexistent/scope".into())),
-    };
+    let query = SearchQuery::new(SearchMode::Fts, 10)
+        .text("visible")
+        .scope(ScopeQuery::Exact("nonexistent/scope".into()));
     let results = engine.query(&query).await.unwrap();
     assert!(
         results.is_empty(),
@@ -1966,16 +1914,7 @@ async fn list_due_returns_scheduled_facts() {
 
     // Future-dated facts should be invisible to regular search (no valid_at)
     let search = engine
-        .query(&SearchQuery {
-            text: Some("future check".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("future check"))
         .await
         .unwrap();
     assert!(
@@ -1985,16 +1924,7 @@ async fn list_due_returns_scheduled_facts() {
 
     // But past-due facts should be visible
     let search2 = engine
-        .query(&SearchQuery {
-            text: Some("check release".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("check release"))
         .await
         .unwrap();
     assert_eq!(search2.len(), 1, "past-due facts should appear in search");
@@ -2861,16 +2791,7 @@ async fn reranker_none_results_unchanged() {
         .unwrap();
 
     let results = engine
-        .query(&SearchQuery {
-            text: Some("fact".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("fact"))
         .await
         .unwrap();
 
@@ -2946,30 +2867,12 @@ async fn reranker_reverses_order() {
         .unwrap();
 
     let baseline = baseline_engine
-        .query(&SearchQuery {
-            text: Some("fact".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("fact"))
         .await
         .unwrap();
 
     let reranked = engine
-        .query(&SearchQuery {
-            text: Some("fact".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("fact"))
         .await
         .unwrap();
 
@@ -3018,16 +2921,7 @@ async fn reranker_skipped_for_vector_only_no_text() {
         .unwrap();
 
     let results = engine
-        .query(&SearchQuery {
-            text: None,
-            embedding: Some(vec![0.5; DIM]),
-            mode: SearchMode::Vector,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Vector, 10).embedding(vec![0.5; DIM]))
         .await
         .unwrap();
 
@@ -3075,16 +2969,7 @@ async fn reranker_applies_to_fts_only_mode() {
 
     // FTS-only with text → reranker should fire
     let results = engine
-        .query(&SearchQuery {
-            text: Some("fact".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("fact"))
         .await
         .unwrap();
 
@@ -3131,16 +3016,11 @@ async fn reranker_applies_to_vector_mode_with_text() {
 
     // Vector mode WITH text → reranker should fire
     let results = engine
-        .query(&SearchQuery {
-            text: Some("alpha".into()),
-            embedding: Some(vec![0.5; DIM]),
-            mode: SearchMode::Vector,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(
+            &SearchQuery::new(SearchMode::Vector, 10)
+                .text("alpha")
+                .embedding(vec![0.5; DIM]),
+        )
         .await
         .unwrap();
 
@@ -3178,16 +3058,11 @@ async fn rerank_depth_overfetches_then_truncates() {
     }
 
     let results = engine
-        .query(&SearchQuery {
-            text: Some("rerank test fact".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 3,
-            rerank_depth: Some(8),
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(
+            &SearchQuery::new(SearchMode::Fts, 3)
+                .text("rerank test fact")
+                .rerank_depth(8),
+        )
         .await
         .unwrap();
 
@@ -3241,16 +3116,7 @@ async fn reranker_error_propagates() {
         .unwrap();
 
     let result = engine
-        .query(&SearchQuery {
-            text: Some("test".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("test"))
         .await;
 
     assert!(result.is_err());
@@ -3309,16 +3175,7 @@ async fn rerank_depth_none_falls_back_to_limit() {
     }
 
     let results = engine
-        .query(&SearchQuery {
-            text: Some("limit test fact".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 5,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 5).text("limit test fact"))
         .await
         .unwrap();
 
@@ -3647,16 +3504,7 @@ async fn reranker_rejects_out_of_bounds_index() {
         .unwrap();
 
     let result = engine
-        .query(&SearchQuery {
-            text: Some("real".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("real"))
         .await;
 
     assert!(result.is_err(), "should reject out-of-bounds index");
@@ -3712,16 +3560,7 @@ async fn reranker_rejects_duplicates() {
         .unwrap();
 
     let result = engine
-        .query(&SearchQuery {
-            text: Some("dup".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("dup"))
         .await;
 
     assert!(result.is_err(), "should reject duplicates");
@@ -3778,16 +3617,7 @@ async fn reranker_allows_valid_subset() {
         .unwrap();
 
     let result = engine
-        .query(&SearchQuery {
-            text: Some("guard".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("guard"))
         .await;
 
     assert!(
@@ -3851,16 +3681,7 @@ async fn reranker_allows_filtering_subset() {
         .unwrap();
 
     let result = engine
-        .query(&SearchQuery {
-            text: Some("filterable".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("filterable"))
         .await;
 
     assert!(
@@ -3909,16 +3730,7 @@ async fn reranker_rejects_non_finite_score() {
         .unwrap();
 
     let result = engine
-        .query(&SearchQuery {
-            text: Some("score".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("score"))
         .await;
 
     assert!(result.is_err(), "should reject NaN score");
@@ -3984,16 +3796,7 @@ async fn reranker_rejects_output_too_long() {
         .unwrap();
 
     let result = engine
-        .query(&SearchQuery {
-            text: Some("length".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("length"))
         .await;
 
     assert!(result.is_err(), "should reject output longer than input");
@@ -4381,16 +4184,9 @@ async fn add_facts_batch_rollback_on_insert_failure() {
     assert!(result.is_err());
 
     // Verify rollback: no facts should be in the DB
-    let query = SearchQuery {
-        text: Some("rollback test".into()),
-        embedding: Some(vec![0.5; DIM]),
-        limit: 10,
-        mode: SearchMode::Hybrid,
-        rerank_depth: None,
-        valid_at: None,
-        fact_type: None,
-        scope: None,
-    };
+    let query = SearchQuery::new(SearchMode::Hybrid, 10)
+        .text("rollback test")
+        .embedding(vec![0.5; DIM]);
     let results = engine.query(&query).await.unwrap();
     assert!(
         results.is_empty(),

--- a/memory-engine/lib/memory-engine/src/lib.rs
+++ b/memory-engine/lib/memory-engine/src/lib.rs
@@ -146,7 +146,10 @@ pub use error::{
 };
 pub use inspect::types as inspect_types;
 pub use resume::{ResumeConfig, ResumeContext};
-pub use search::{MemoryQuery, QueryDiagnostics, QueryResponse};
+pub use search::{
+    MatchType, MemoryQuery, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult,
+    VectorSearchStrategy,
+};
 pub use store::UpcasterRegistry;
 pub use store::schema::CURRENT_SCHEMA_VERSION;
 pub use traits::{

--- a/memory-engine/lib/memory-engine/src/search/ann.rs
+++ b/memory-engine/lib/memory-engine/src/search/ann.rs
@@ -389,7 +389,7 @@ impl VectorSearchStrategy for HnswStrategy {
 
         // If HNSW widening couldn't satisfy, fall back to brute-force.
         if results.len() < limit {
-            return crate::search::vector_search(
+            return crate::search::vector::vector_search(
                 conn,
                 query_embedding,
                 self.embed_dim,

--- a/memory-engine/lib/memory-engine/src/search/hybrid.rs
+++ b/memory-engine/lib/memory-engine/src/search/hybrid.rs
@@ -13,8 +13,15 @@ use crate::types::{Fact, FactType};
 /// How to combine search sources.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchMode {
+    /// Lexical-only: FTS5 BM25 ranking over the query text. Requires `text`;
+    /// ignores any `embedding`. Best for exact-term and keyword recall.
     Fts,
+    /// Semantic-only: cosine similarity over the query `embedding`. Requires
+    /// `embedding`; ignores any `text`. Best for paraphrase and concept recall.
     Vector,
+    /// Both lexical and semantic, fused with Reciprocal Rank Fusion (see
+    /// [`rrf_merge`]). Uses whichever of `text`/`embedding` are present. The
+    /// default, balancing keyword precision with semantic recall.
     Hybrid,
 }
 
@@ -33,6 +40,22 @@ pub enum MatchType {
 }
 
 /// A unified search query across FTS5 and vector sources.
+///
+/// Construct with the fluent builder rather than a struct literal: the type is
+/// `#[non_exhaustive]`, so struct-literal construction is forbidden outside this
+/// crate. Start from [`SearchQuery::new`] (the two required fields — `mode` and
+/// `limit`) and chain the optional setters:
+///
+/// ```ignore
+/// let q = SearchQuery::new(SearchMode::Hybrid, 10)
+///     .text("rust ownership")
+///     .fact_type(FactType::Semantic);
+/// ```
+///
+/// This mirrors [`MemoryQuery`](crate::MemoryQuery)'s builder style and is
+/// misuse- and forward-compatibility-resistant: adding a field is a non-breaking
+/// change for callers, who never had to spell out the `None` defaults.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct SearchQuery {
     pub text: Option<String>,
@@ -46,6 +69,84 @@ pub struct SearchQuery {
     pub valid_at: Option<DateTime<Utc>>,
     pub fact_type: Option<FactType>,
     pub scope: Option<crate::types::ScopeQuery>,
+}
+
+impl SearchQuery {
+    /// Create a query for the given [`SearchMode`] and result `limit`.
+    ///
+    /// `mode` and `limit` are the only required parameters; all other filters
+    /// default to `None`. Refine the query with the chainable setters
+    /// ([`text`](Self::text), [`embedding`](Self::embedding), etc.).
+    #[must_use]
+    pub const fn new(mode: SearchMode, limit: usize) -> Self {
+        Self {
+            text: None,
+            embedding: None,
+            mode,
+            limit,
+            rerank_depth: None,
+            valid_at: None,
+            fact_type: None,
+            scope: None,
+        }
+    }
+
+    /// Set the FTS5 query text.
+    #[must_use]
+    pub fn text(mut self, text: impl Into<String>) -> Self {
+        self.text = Some(text.into());
+        self
+    }
+
+    /// Set the embedding vector for vector similarity search.
+    #[must_use]
+    pub fn embedding(mut self, embedding: Vec<f32>) -> Self {
+        self.embedding = Some(embedding);
+        self
+    }
+
+    /// Override the search mode.
+    #[must_use]
+    pub const fn mode(mut self, mode: SearchMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Override the result limit.
+    #[must_use]
+    pub const fn limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Set how many candidates to over-fetch for the reranker before truncating
+    /// to `limit`. Clamped to at least `limit` at query time.
+    #[must_use]
+    pub const fn rerank_depth(mut self, depth: usize) -> Self {
+        self.rerank_depth = Some(depth);
+        self
+    }
+
+    /// Set the point-in-time temporal cutoff.
+    #[must_use]
+    pub const fn valid_at(mut self, at: DateTime<Utc>) -> Self {
+        self.valid_at = Some(at);
+        self
+    }
+
+    /// Filter by fact type.
+    #[must_use]
+    pub const fn fact_type(mut self, fact_type: FactType) -> Self {
+        self.fact_type = Some(fact_type);
+        self
+    }
+
+    /// Filter by scope.
+    #[must_use]
+    pub fn scope(mut self, scope: crate::types::ScopeQuery) -> Self {
+        self.scope = Some(scope);
+        self
+    }
 }
 
 /// A search result with the full fact, combined score, and match source.
@@ -431,6 +532,46 @@ mod tests {
         conn
     }
 
+    #[test]
+    fn search_query_new_defaults_all_optionals_to_none() {
+        let q = SearchQuery::new(SearchMode::Hybrid, 7);
+        assert_eq!(q.mode, SearchMode::Hybrid);
+        assert_eq!(q.limit, 7);
+        assert!(q.text.is_none());
+        assert!(q.embedding.is_none());
+        assert!(q.rerank_depth.is_none());
+        assert!(q.valid_at.is_none());
+        assert!(q.fact_type.is_none());
+        assert!(q.scope.is_none());
+    }
+
+    #[test]
+    fn search_query_builder_chains_set_every_field() {
+        let at = chrono::Utc::now();
+        let q = SearchQuery::new(SearchMode::Fts, 3)
+            .text("rust")
+            .embedding(vec![1.0, 0.0, 0.0, 0.0])
+            .mode(SearchMode::Hybrid)
+            .limit(9)
+            .rerank_depth(20)
+            .valid_at(at)
+            .fact_type(FactType::Semantic)
+            .scope(crate::types::ScopeQuery::Exact("user:alice".into()));
+
+        assert_eq!(q.text.as_deref(), Some("rust"));
+        assert_eq!(q.embedding, Some(vec![1.0, 0.0, 0.0, 0.0]));
+        // `mode`/`limit` setters override the `new` arguments (last write wins).
+        assert_eq!(q.mode, SearchMode::Hybrid);
+        assert_eq!(q.limit, 9);
+        assert_eq!(q.rerank_depth, Some(20));
+        assert_eq!(q.valid_at, Some(at));
+        assert_eq!(q.fact_type, Some(FactType::Semantic));
+        assert_eq!(
+            q.scope,
+            Some(crate::types::ScopeQuery::Exact("user:alice".into()))
+        );
+    }
+
     fn make_fact_with(content: &str, embedding: Vec<f32>, fact_type: FactType) -> NewFact {
         NewFact {
             content: content.into(),
@@ -504,16 +645,9 @@ mod tests {
             SqliteBackend::from_pool(Arc::clone(&pool), Arc::new(UpcasterRegistry::new()));
 
         for mode in [SearchMode::Fts, SearchMode::Vector, SearchMode::Hybrid] {
-            let query = SearchQuery {
-                text: Some("rust".into()),
-                embedding: Some(vec![1.0, 0.0, 0.0, 0.0]),
-                mode,
-                limit: 10,
-                rerank_depth: None,
-                valid_at: None,
-                fact_type: None,
-                scope: None,
-            };
+            let query = SearchQuery::new(mode, 10)
+                .text("rust")
+                .embedding(vec![1.0, 0.0, 0.0, 0.0]);
 
             let (sync_results, sync_diag) = {
                 let conn = pool.read().unwrap();
@@ -653,16 +787,9 @@ mod tests {
             ))
             .unwrap();
 
-        let query = SearchQuery {
-            text: Some("Rust".into()),
-            embedding: Some(vec![1.0, 0.0, 0.0, 0.0]),
-            mode: SearchMode::Hybrid,
-            limit: 3,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        };
+        let query = SearchQuery::new(SearchMode::Hybrid, 3)
+            .text("Rust")
+            .embedding(vec![1.0, 0.0, 0.0, 0.0]);
 
         let (results, _diag) = hybrid_search(&conn, &query, DIM, None, &BruteForce).unwrap();
         assert!(!results.is_empty());
@@ -683,16 +810,7 @@ mod tests {
             .insert(&make_fact("Python language", vec![0.0, 1.0, 0.0, 0.0]))
             .unwrap();
 
-        let query = SearchQuery {
-            text: Some("Rust".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        };
+        let query = SearchQuery::new(SearchMode::Fts, 10).text("Rust");
 
         let (results, _diag) = hybrid_search(&conn, &query, DIM, None, &BruteForce).unwrap();
         assert_eq!(results.len(), 1);
@@ -710,16 +828,7 @@ mod tests {
             .insert(&make_fact("fact two", vec![0.0, 1.0, 0.0, 0.0]))
             .unwrap();
 
-        let query = SearchQuery {
-            text: None,
-            embedding: Some(vec![1.0, 0.0, 0.0, 0.0]),
-            mode: SearchMode::Vector,
-            limit: 1,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        };
+        let query = SearchQuery::new(SearchMode::Vector, 1).embedding(vec![1.0, 0.0, 0.0, 0.0]);
 
         let (results, _diag) = hybrid_search(&conn, &query, DIM, None, &BruteForce).unwrap();
         assert_eq!(results.len(), 1);
@@ -746,16 +855,9 @@ mod tests {
             ))
             .unwrap();
 
-        let query = SearchQuery {
-            text: Some("fact".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: Some(FactType::Semantic),
-            scope: None,
-        };
+        let query = SearchQuery::new(SearchMode::Fts, 10)
+            .text("fact")
+            .fact_type(FactType::Semantic);
 
         let (results, _diag) = hybrid_search(&conn, &query, DIM, None, &BruteForce).unwrap();
         assert_eq!(results.len(), 1);

--- a/memory-engine/lib/memory-engine/src/search/hybrid.rs
+++ b/memory-engine/lib/memory-engine/src/search/hybrid.rs
@@ -58,17 +58,21 @@ pub enum MatchType {
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct SearchQuery {
-    pub text: Option<String>,
-    pub embedding: Option<Vec<f32>>,
-    pub mode: SearchMode,
-    pub limit: usize,
+    // Fields are `pub(crate)`: external callers MUST use the builder
+    // (`SearchQuery::new(..)` + the chainable setters), which `#[non_exhaustive]`
+    // already enforces for construction. Intra-crate the engine still constructs
+    // via `new()` and writes fields directly (see `engine::query`).
+    pub(crate) text: Option<String>,
+    pub(crate) embedding: Option<Vec<f32>>,
+    pub(crate) mode: SearchMode,
+    pub(crate) limit: usize,
     /// How many candidates to pass to the reranker before truncating to `limit`.
     /// Clamped to at least `limit` — can only widen the candidate pool, never shrink it.
     /// When `None`, falls back to `limit` (no over-fetch).
-    pub rerank_depth: Option<usize>,
-    pub valid_at: Option<DateTime<Utc>>,
-    pub fact_type: Option<FactType>,
-    pub scope: Option<crate::types::ScopeQuery>,
+    pub(crate) rerank_depth: Option<usize>,
+    pub(crate) valid_at: Option<DateTime<Utc>>,
+    pub(crate) fact_type: Option<FactType>,
+    pub(crate) scope: Option<crate::types::ScopeQuery>,
 }
 
 impl SearchQuery {
@@ -243,7 +247,16 @@ pub fn rrf_merge(fts: &[(i64, f64)], vec: &[(i64, f32)], k: u32) -> Vec<(i64, f6
 /// Returns `MemoryError::Database` on query failure.
 /// Returns `MemoryError::EmbeddingDimension` if the query embedding or a stored
 /// embedding does not match the configured dimension during vector search.
-pub fn hybrid_search(
+//
+// Test-only oracle: the engine's live path is the async [`port_hybrid_search`]
+// (#631 Stage C); this synchronous twin survives only as the in-process
+// reference the `search` unit tests fuse against. It is `dead_code` in a release
+// build, so suppress the lint there rather than ship/widen it.
+#[cfg_attr(not(test), allow(dead_code))]
+// `search` is a crate-private module, so `pub(crate)` is the honest visibility;
+// the lint only fires because the module isn't `pub`.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn hybrid_search(
     conn: &Connection,
     query: &SearchQuery,
     embed_dim: usize,

--- a/memory-engine/lib/memory-engine/src/search/mod.rs
+++ b/memory-engine/lib/memory-engine/src/search/mod.rs
@@ -1,13 +1,13 @@
 //! Hybrid search: FTS5 (BM25) + vector (cosine) + Reciprocal Rank Fusion.
 
 #[cfg(feature = "ann")]
-pub mod ann;
-pub mod filter_sql;
-pub mod fts;
-pub mod hybrid;
-pub mod query;
-pub mod strategy;
-pub mod vector;
+pub(crate) mod ann;
+pub(crate) mod filter_sql;
+pub(crate) mod fts;
+pub(crate) mod hybrid;
+pub(crate) mod query;
+pub(crate) mod strategy;
+pub(crate) mod vector;
 
 #[cfg(feature = "ann")]
 pub use ann::HnswStrategy;

--- a/memory-engine/lib/memory-engine/src/search/mod.rs
+++ b/memory-engine/lib/memory-engine/src/search/mod.rs
@@ -9,17 +9,34 @@ pub(crate) mod query;
 pub(crate) mod strategy;
 pub(crate) mod vector;
 
-#[cfg(feature = "ann")]
-pub use ann::HnswStrategy;
-pub use filter_sql::FilterSql;
-pub use fts::{FtsResult, fts_count_expired, fts_search, fts_search_filtered};
+// --- Genuinely-public surface (re-exported at the crate root by `lib.rs`) ---
+//
+// These are the only `pub` items the `search` module exposes. Everything else
+// below is an impl-internal helper kept `pub(crate)` so it stays reachable from
+// other engine modules without leaking onto the public API (#365).
 pub use hybrid::{
-    MatchType, QueryDiagnostics, QueryResponse, RRF_K, SearchMode, SearchQuery, SearchResult,
-    hybrid_search, rrf_merge,
+    MatchType, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult,
 };
 pub use query::MemoryQuery;
-pub use strategy::{BruteForce, SearchConfig, VectorSearchStrategy};
-pub use vector::{VectorResult, cosine_similarity, vector_search, vector_search_filtered};
+pub use strategy::VectorSearchStrategy;
+
+// `SearchConfig` and `cosine_similarity` are not part of the engine's facade
+// API, but the top-level benches/tests (which compile as separate crates and
+// therefore cannot see `pub(crate)`) consume them via `memory_engine::search::*`.
+// They are kept `pub` for those out-of-crate consumers only.
+pub use strategy::SearchConfig;
+pub use vector::cosine_similarity;
+
+// --- Impl-internal helpers: crate-private, never reachable as `memory_engine::search::*` ---
+//
+// Only the helpers that engine modules reach through the `crate::search::*`
+// facade path are re-exported here; the rest are addressed via their
+// `crate::search::<submodule>::*` paths (e.g. `fts::fts_search`,
+// `strategy::BruteForce`, `ann::HnswStrategy`), so a flat re-export would be a
+// dead import.
+pub(crate) use filter_sql::FilterSql;
+pub(crate) use fts::{fts_count_expired, fts_search_filtered};
+pub(crate) use vector::vector_search_filtered;
 
 /// Serialize an optional scope-ID slice to a JSON string for use as a SQL
 /// parameter in `json_each(?N)` expressions.

--- a/memory-engine/lib/memory-engine/src/search/strategy.rs
+++ b/memory-engine/lib/memory-engine/src/search/strategy.rs
@@ -62,7 +62,15 @@ pub trait VectorSearchStrategy: Send + Sync {
 ///
 /// This is the default strategy and serves as the correctness oracle when
 /// testing approximate strategies.
-pub struct BruteForce;
+//
+// Crate-internal test oracle: only the `search` unit tests construct it (the
+// engine's live vector path uses `vector_search` / `HnswStrategy` directly), so
+// it is `dead_code` in a release build — suppress there rather than widen it.
+#[cfg_attr(not(test), allow(dead_code))]
+// `search` is a crate-private module, so `pub(crate)` is the honest visibility;
+// the lint only fires because the module isn't `pub`.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct BruteForce;
 
 impl VectorSearchStrategy for BruteForce {
     fn search(

--- a/memory-engine/lib/memory-engine/src/search/vector.rs
+++ b/memory-engine/lib/memory-engine/src/search/vector.rs
@@ -25,13 +25,20 @@ pub struct VectorResult {
 ///
 /// Kept equal to the default [`SearchConfig::ann_threshold`](crate::search::strategy::SearchConfig)
 /// (50,000) — the documented fact count at which ANN should take over.
-pub const BRUTE_FORCE_WARN_THRESHOLD: usize = 50_000;
+// `search` is a crate-private module, so `pub(crate)` is the honest visibility;
+// the `redundant_pub_crate` lint fires only because nothing here is `pub`, but
+// the marker documents intent (vs widening to `pub` to dodge the lint).
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) const BRUTE_FORCE_WARN_THRESHOLD: usize = 50_000;
 
 /// Whether a brute-force candidate set is large enough to warrant the scaling
 /// warning. Split out as a pure predicate so the boundary is unit-testable
 /// without materializing a 50k-fact corpus.
+// `pub(crate)` is honest (crate-private module); `#[allow]` keeps the lint quiet
+// without widening visibility.
+#[allow(clippy::redundant_pub_crate)]
 #[must_use]
-pub const fn brute_force_scan_is_oversized(candidates: usize) -> bool {
+pub(crate) const fn brute_force_scan_is_oversized(candidates: usize) -> bool {
     candidates > BRUTE_FORCE_WARN_THRESHOLD
 }
 
@@ -75,7 +82,16 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 ///
 /// Returns `MemoryError::Database` on query failure, or
 /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
-pub fn vector_search(
+//
+// The live SQLite path goes through `vector_search_filtered`; this unfiltered
+// convenience wrapper is reached only by the `ann` brute-force fallback and by
+// tests, so it is `dead_code` in a no-`ann` release build — suppress the lint
+// there rather than widen visibility.
+#[cfg_attr(not(any(test, feature = "ann")), allow(dead_code))]
+// `search` is a crate-private module, so `pub(crate)` is the honest visibility;
+// the lint only fires because the module isn't `pub`.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn vector_search(
     conn: &Connection,
     query_embedding: &[f32],
     embed_dim: usize,

--- a/memory-engine/lib/memory-engine/src/search/vector.rs
+++ b/memory-engine/lib/memory-engine/src/search/vector.rs
@@ -25,13 +25,13 @@ pub struct VectorResult {
 ///
 /// Kept equal to the default [`SearchConfig::ann_threshold`](crate::search::strategy::SearchConfig)
 /// (50,000) — the documented fact count at which ANN should take over.
-pub(crate) const BRUTE_FORCE_WARN_THRESHOLD: usize = 50_000;
+pub const BRUTE_FORCE_WARN_THRESHOLD: usize = 50_000;
 
 /// Whether a brute-force candidate set is large enough to warrant the scaling
 /// warning. Split out as a pure predicate so the boundary is unit-testable
 /// without materializing a 50k-fact corpus.
 #[must_use]
-pub(crate) const fn brute_force_scan_is_oversized(candidates: usize) -> bool {
+pub const fn brute_force_scan_is_oversized(candidates: usize) -> bool {
     candidates > BRUTE_FORCE_WARN_THRESHOLD
 }
 

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/search_index.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/search_index.rs
@@ -146,7 +146,9 @@ mod tests {
     use super::super::SqliteBackend;
     use crate::error::MemoryError;
     use crate::pool::ConnectionPool;
-    use crate::search::{fts_count_expired, fts_search, vector_search};
+    use crate::search::fts::fts_search;
+    use crate::search::fts_count_expired;
+    use crate::search::vector::vector_search;
     use crate::storage::{FactFilter, SearchIndex};
     use crate::store::facts::FactStore;
     use crate::store::upcaster::UpcasterRegistry;

--- a/tests/ann_recall_test.rs
+++ b/tests/ann_recall_test.rs
@@ -14,9 +14,9 @@ use std::collections::HashSet;
 use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::search::SearchConfig;
-use memory_engine::search::hybrid::{SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactRequest, FactType};
+use memory_engine::{SearchMode, SearchQuery};
 
 const DIM: usize = 32;
 const N: usize = 5_000;
@@ -102,16 +102,7 @@ async fn hnsw_recall_at_k_exceeds_threshold() {
     let mut recalls = Vec::new();
     for query_text in &queries {
         let query_emb = embedder.embed(query_text).unwrap();
-        let query = SearchQuery {
-            text: None,
-            embedding: Some(query_emb),
-            mode: SearchMode::Vector,
-            limit: K,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        };
+        let query = SearchQuery::new(SearchMode::Vector, K).embedding(query_emb);
 
         let bf_results = engine_bf.query(&query).await.unwrap();
         let ann_results = engine_ann.query(&query).await.unwrap();

--- a/tests/archive_test.rs
+++ b/tests/archive_test.rs
@@ -267,7 +267,7 @@ async fn archive_search_finds_archived_facts() {
     for r in &response.results {
         assert_eq!(
             r.match_type,
-            memory_engine::search::hybrid::MatchType::Archive,
+            memory_engine::MatchType::Archive,
             "expected MatchType::Archive for all results"
         );
     }

--- a/tests/eval/conformance/scope_isolation.rs
+++ b/tests/eval/conformance/scope_isolation.rs
@@ -3,7 +3,7 @@
 //! Verifies that scope-based queries enforce strict isolation:
 //! facts in one scope never leak into queries targeting another scope.
 
-use memory_engine::search::query::MemoryQuery;
+use memory_engine::MemoryQuery;
 use memory_engine::types::FactType;
 
 use crate::helpers::{add_scoped_fact, eval_engine};

--- a/tests/eval/conformance/temporal_consistency.rs
+++ b/tests/eval/conformance/temporal_consistency.rs
@@ -6,7 +6,7 @@
 
 use chrono::{Duration, Utc};
 
-use memory_engine::search::query::MemoryQuery;
+use memory_engine::MemoryQuery;
 use memory_engine::types::{AddFactOptions, EventType, FactType, NewEvent};
 
 use crate::helpers::{add_fact_with_opts, days_ago, eval_engine};

--- a/tests/eval/quality/retrieval.rs
+++ b/tests/eval/quality/retrieval.rs
@@ -5,8 +5,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use memory_engine::search::hybrid::MatchType;
-use memory_engine::search::query::MemoryQuery;
+use memory_engine::MatchType;
+use memory_engine::MemoryQuery;
 use memory_engine::traits::EmbeddingProvider;
 
 use crate::corpus::{CorpusQuery, golden_corpus};
@@ -25,7 +25,7 @@ struct QueryMetrics {
 async fn run_fts_query(
     engine: &memory_engine::engine::MemoryEngine,
     query: &CorpusQuery,
-) -> (Vec<i64>, memory_engine::search::hybrid::QueryDiagnostics) {
+) -> (Vec<i64>, memory_engine::QueryDiagnostics) {
     let mut mq = MemoryQuery::new().text(query.text).limit(20);
 
     if let Some(scope) = query.scope {

--- a/tests/roundtrip_test.rs
+++ b/tests/roundtrip_test.rs
@@ -4,9 +4,9 @@ use chrono::Utc;
 use memory_engine::EmbeddingFingerprint;
 use memory_engine::engine::MemoryEngine;
 use memory_engine::error::Result;
-use memory_engine::search::hybrid::{MatchType, SearchMode, SearchQuery};
 use memory_engine::traits::EmbeddingProvider;
 use memory_engine::types::{AddFactRequest, EventType, FactType, NewEvent};
+use memory_engine::{MatchType, SearchMode, SearchQuery};
 
 /// Mock embedder that returns a vector pointing in the direction
 /// determined by a simple hash of the text, so different texts
@@ -111,16 +111,7 @@ async fn full_roundtrip() {
 
     // 3. Query via FTS — "Rust" should match facts 1 and 2
     let fts_results = engine
-        .query(&SearchQuery {
-            text: Some("Rust".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Fts, 10).text("Rust"))
         .await
         .unwrap();
     assert_eq!(fts_results.len(), 2);
@@ -130,16 +121,7 @@ async fn full_roundtrip() {
     // 4. Query via vector — use the embedding of "Rust systems programming"
     let query_emb = embedder.embed("Rust systems programming").unwrap();
     let vec_results = engine
-        .query(&SearchQuery {
-            text: None,
-            embedding: Some(query_emb),
-            mode: SearchMode::Vector,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(&SearchQuery::new(SearchMode::Vector, 10).embedding(query_emb))
         .await
         .unwrap();
     assert!(!vec_results.is_empty());
@@ -152,16 +134,11 @@ async fn full_roundtrip() {
     // 5. Query via hybrid — combine text and embedding
     let hybrid_emb = embedder.embed("Rust programming language").unwrap();
     let hybrid_results = engine
-        .query(&SearchQuery {
-            text: Some("Rust".into()),
-            embedding: Some(hybrid_emb),
-            mode: SearchMode::Hybrid,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: None,
-            scope: None,
-        })
+        .query(
+            &SearchQuery::new(SearchMode::Hybrid, 10)
+                .text("Rust")
+                .embedding(hybrid_emb),
+        )
         .await
         .unwrap();
     assert!(!hybrid_results.is_empty());
@@ -177,16 +154,11 @@ async fn full_roundtrip() {
 
     // 6. Verify fact_type filter
     let semantic_only = engine
-        .query(&SearchQuery {
-            text: Some("Rust".into()),
-            embedding: None,
-            mode: SearchMode::Fts,
-            limit: 10,
-            rerank_depth: None,
-            valid_at: None,
-            fact_type: Some(FactType::Semantic),
-            scope: None,
-        })
+        .query(
+            &SearchQuery::new(SearchMode::Fts, 10)
+                .text("Rust")
+                .fact_type(FactType::Semantic),
+        )
         .await
         .unwrap();
     assert!(


### PR DESCRIPTION
Part of #257, #499.

## #365 — module visibility
The search submodules (`ann`, `filter_sql`, `fts`, `hybrid`, `query`, `strategy`, `vector`) were `pub mod`, exposing impl-internal paths (`search::hybrid::fts_search`, `cosine_similarity`, `rrf_merge`, …) to downstream crates and letting them bypass the curated re-export layer. They are now `pub(crate) mod`, and the genuinely-public types are flat-re-exported at the crate root in `lib.rs`: added `MatchType`, `SearchMode`, `SearchQuery`, `SearchResult`, and the `VectorSearchStrategy` trait alongside the existing `MemoryQuery`/`QueryDiagnostics`/`QueryResponse`.

All downstream importers move from impl paths to the curated crate-root path:
- `bin/cli/src/commands/query.rs`, `bin/mcp/src/{tools/mod.rs, depth.rs}`
- the in-crate `tests/`, `benches/`, `examples/` consumers

Two free items in the now-private `vector` module switch `pub(crate)` → `pub` to satisfy `clippy::redundant_pub_crate` (they stay crate-only via the private module — no downstream visibility change).

## #364 — SearchQuery builder
`SearchQuery` was a fully-public struct built via struct literal, forcing every call site to spell out the `None` defaults and to recompile-break on every field addition — inconsistent with `MemoryQuery`. Added `#[non_exhaustive]` (forbids external struct-literal construction) plus a fluent builder mirroring `MemoryQuery`'s style:

```rust
SearchQuery::new(mode, limit)
    .text(...).embedding(...).mode(...).limit(...)
    .rerank_depth(...).valid_at(...).fact_type(...).scope(...)
```

All construction sites migrated (engine production paths + ~40 test/bench/example sites).

## #499 doc sub-finding
Documented each `SearchMode` variant (`Fts`/`Vector`/`Hybrid`).

## Gate (whole workspace — public API + bin imports changed)
- `cargo fmt` ✓
- `cargo build --workspace` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓ (clean)
- `cargo test --workspace` ✓ (1597 passed, 6 pre-existing ignored)

## Reviewer notes
- Engine production sites (`engine/query.rs`) build via `SearchQuery::new()` then assign the already-`Option` fields directly (same-crate, `#[non_exhaustive]` does not restrict intra-crate field writes), because the `Some`-wrapping setters cannot express a conditional `Option` like `valid_at: search_cutoff`. Test/example sites use the fluent chain.
- ⚠️ `bin/mcp/src/tools/mod.rs` is also being edited by a concurrent session in the primary checkout; a textual conflict on the single import line may surface at merge.

Closes #364
Closes #365