### PR TITLE
fix(retrieval): bound + revalidate snapshot edge set in MemoryGraph::from_snapshot

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -362,6 +362,12 @@ impl MemoryEngine {
 
         let conn = pool.read()?;
         let current_fp = snapshot::read_fingerprint(&conn)?;
+        // Referential-validation set (#257): the live set of active fact ids, used
+        // below to reject any snapshot edge whose endpoint references a fact that
+        // does not exist (a phantom-node injection). Queried once from the same
+        // authoritative connection that validated the fingerprint, so it reflects
+        // exactly the facts `load_from_db` would honor via the SQLite foreign key.
+        let active_fact_ids = crate::store::facts::active_fact_ids(&conn)?;
         drop(conn);
 
         if header.fingerprint != current_fp {
@@ -390,7 +396,7 @@ impl MemoryEngine {
         // Bound + revalidate the snapshot edge set (#412, #499). On any violation,
         // discard the (rebuildable) sidecar and fall back to a full rebuild from
         // the authoritative DB rather than failing the open.
-        let graph = match MemoryGraph::from_snapshot(&payload.graph) {
+        let graph = match MemoryGraph::from_snapshot(&payload.graph, &active_fact_ids) {
             Ok(g) => g,
             Err(e) => {
                 tracing::warn!(

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -369,7 +369,37 @@ impl MemoryEngine {
             return Ok(None);
         }
 
-        let graph = MemoryGraph::from_snapshot(&payload.graph);
+        // Defense in depth (#412): the fingerprint now matches the live DB, so the
+        // sidecar's edge list MUST hold exactly `active_edge_count` edges. A
+        // different length is an internally-inconsistent (corrupt/tampered) sidecar
+        // — turn the count fingerprint into an explicit bound and discard rather
+        // than trust it. `active_edge_count` is non-negative in practice (a COUNT),
+        // and `usize::try_from` of a negative value falls through to the mismatch
+        // branch, so a malformed fingerprint also rejects.
+        let expected_edges = usize::try_from(current_fp.active_edge_count).ok();
+        if expected_edges != Some(payload.graph.edges.len()) {
+            tracing::warn!(
+                snapshot_edges = payload.graph.edges.len(),
+                db_active_edges = current_fp.active_edge_count,
+                "snapshot edge count disagrees with the validated DB fingerprint, \
+                 discarding sidecar and rebuilding from the database"
+            );
+            return Ok(None);
+        }
+
+        // Bound + revalidate the snapshot edge set (#412, #499). On any violation,
+        // discard the (rebuildable) sidecar and fall back to a full rebuild from
+        // the authoritative DB rather than failing the open.
+        let graph = match MemoryGraph::from_snapshot(&payload.graph) {
+            Ok(g) => g,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "snapshot graph failed edge revalidation, rebuilding from the database"
+                );
+                return Ok(None);
+            }
+        };
         let scope_tree = ScopeTree::from_snapshot(&payload.scope_tree);
         Ok(Some((graph, scope_tree, payload.hnsw)))
     }

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -362,18 +362,23 @@ impl MemoryEngine {
 
         let conn = pool.read()?;
         let current_fp = snapshot::read_fingerprint(&conn)?;
-        // Referential-validation set (#257): the live set of active fact ids, used
-        // below to reject any snapshot edge whose endpoint references a fact that
-        // does not exist (a phantom-node injection). Queried once from the same
-        // authoritative connection that validated the fingerprint, so it reflects
-        // exactly the facts `load_from_db` would honor via the SQLite foreign key.
-        let active_fact_ids = crate::store::facts::active_fact_ids(&conn)?;
-        drop(conn);
 
         if header.fingerprint != current_fp {
             tracing::info!("snapshot stale (fingerprint mismatch), falling back to full rebuild");
             return Ok(None);
         }
+
+        // Referential-validation set (#257): the live set of *existing* fact ids
+        // (any `t_expired`), used below to reject any snapshot edge whose endpoint
+        // references a fact that does not exist (a phantom-node injection). This is
+        // the same population `load_from_db` honors via the SQLite foreign key — all
+        // facts, not active-only: an active edge can legitimately point at an expired
+        // fact (see `existing_fact_ids` / `MemoryGraph::from_snapshot`). Queried once
+        // from the authoritative connection that validated the fingerprint, *after*
+        // the fingerprint check (perf #499): on the common stale-snapshot path the
+        // early return above skips this full-table scan entirely.
+        let existing_fact_ids = crate::store::facts::existing_fact_ids(&conn)?;
+        drop(conn);
 
         // Defense in depth (#412): the fingerprint now matches the live DB, so the
         // sidecar's edge list MUST hold exactly `active_edge_count` edges. A
@@ -396,7 +401,7 @@ impl MemoryEngine {
         // Bound + revalidate the snapshot edge set (#412, #499). On any violation,
         // discard the (rebuildable) sidecar and fall back to a full rebuild from
         // the authoritative DB rather than failing the open.
-        let graph = match MemoryGraph::from_snapshot(&payload.graph, &active_fact_ids) {
+        let graph = match MemoryGraph::from_snapshot(&payload.graph, &existing_fact_ids) {
             Ok(g) => g,
             Err(e) => {
                 tracing::warn!(

--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -303,16 +303,28 @@ impl MemoryGraph {
     }
 
     /// Rebuild graph from a snapshot, bounding and revalidating the edge set
-    /// against the live set of active fact ids.
+    /// against the live set of *existing* fact ids.
     ///
     /// The `.snapshot` sidecar is an untrusted input: its blake3 checksum is
     /// *unkeyed* (a corruption check, not an authenticity control), so a local
     /// actor able to write the sidecar — or plain on-disk corruption — can present
     /// a structurally-invalid edge list. This builds the same edge-only graph as
-    /// [`load_from_db`](Self::load_from_db), and is now **at least as strict** as
-    /// that path: `load_from_db` reads edges whose endpoints the `SQLite` foreign
-    /// key guarantees to exist, and this requires the same of every snapshot edge
-    /// via the `active_fact_ids` set the caller queries from the authoritative DB.
+    /// [`load_from_db`](Self::load_from_db) and validates against **exactly**
+    /// `load_from_db`'s trust boundary — neither looser nor stricter.
+    ///
+    /// That boundary is the `edges.source_fact_id/target_fact_id REFERENCES
+    /// facts(id)` foreign key, which `load_from_db` relies on to guarantee every
+    /// loaded edge's endpoints *exist*. Crucially, the FK guarantees existence, not
+    /// activeness: `SQLite` foreign keys cannot be conditional on `t_expired`, and an
+    /// active edge legitimately references an *expired* fact (the conflict-resolution
+    /// `contradicts` edge `new → old` is created active while `old` is expired in the
+    /// same transaction; the dream-cycle `supersedes` edge `synthetic → src` stays
+    /// active while every source is expired). The validation therefore checks every
+    /// endpoint against the `existing_fact_ids` set (`SELECT id FROM facts`, any
+    /// `t_expired`) — **all** facts, not active-only. Validating against the
+    /// active-only set would be *stricter* than `load_from_db` and would falsely
+    /// reject a snapshot that faithfully mirrors a real rebuild, defeating the
+    /// snapshot optimization for a needless DB rebuild.
     ///
     /// Three defense-in-depth gates (#257, #412, #499):
     ///
@@ -329,22 +341,23 @@ impl MemoryGraph {
     ///    is structurally impossible (corruption or tamper); reject it. This is a
     ///    cheap pre-filter for gate 3.
     /// 3. **Referential validation** (#257) — every edge `source`/`target` MUST be
-    ///    present in `active_fact_ids` (the live `SELECT id FROM facts WHERE
-    ///    t_expired IS NULL` set). A positive-but-absent endpoint is a phantom-node
-    ///    injection: it would otherwise materialize a node for a fact that does not
-    ///    exist. This mirrors the FK guarantee `load_from_db` enjoys and closes the
-    ///    gap the positivity check alone left open.
+    ///    present in `existing_fact_ids` (the live `SELECT id FROM facts` set, any
+    ///    `t_expired`). A positive-but-absent endpoint is a phantom-node injection:
+    ///    it would otherwise materialize a node for a fact that does not exist. This
+    ///    mirrors the FK guarantee `load_from_db` enjoys — existence, not activeness
+    ///    — and closes the gap the positivity check alone left open, without
+    ///    over-rejecting the legitimate active-edge-to-expired-fact case.
     ///
     /// # Errors
     ///
     /// Returns [`MemoryError::Internal`](crate::error::MemoryError::Internal) when
     /// the edge count exceeds the cap, any edge carries a non-positive
     /// `source`/`target`/`edge_id`, or any edge `source`/`target` is absent from
-    /// `active_fact_ids`. The caller treats this as "discard the sidecar and
+    /// `existing_fact_ids`. The caller treats this as "discard the sidecar and
     /// rebuild from the authoritative database"; it never panics.
     pub(crate) fn from_snapshot(
         snap: &crate::engine::snapshot::GraphSnapshot,
-        active_fact_ids: &HashSet<i64>,
+        existing_fact_ids: &HashSet<i64>,
     ) -> Result<Self> {
         check_edge_count_bound(snap.edges.len())?;
 
@@ -361,12 +374,15 @@ impl MemoryGraph {
                     target = edge.target,
                 )));
             }
-            // Gate 3: referential validation — both endpoints must reference an
-            // active fact. A positive-but-absent id is a phantom-node injection.
-            if !active_fact_ids.contains(&edge.source) || !active_fact_ids.contains(&edge.target) {
+            // Gate 3: referential validation — both endpoints must reference a fact
+            // that EXISTS (active or expired), matching the FK target `load_from_db`
+            // trusts. A positive-but-absent id is a phantom-node injection.
+            if !existing_fact_ids.contains(&edge.source)
+                || !existing_fact_ids.contains(&edge.target)
+            {
                 return Err(crate::error::MemoryError::Internal(format!(
                     "snapshot edge {edge_id} references a fact id absent from the \
-                     active set (source={source}, target={target}); discarding \
+                     existing-fact set (source={source}, target={target}); discarding \
                      sidecar and rebuilding from the database",
                     edge_id = edge.edge_id,
                     source = edge.source,
@@ -674,7 +690,7 @@ mod tests {
     #[test]
     fn from_snapshot_accepts_valid_edges() {
         // Baseline: a well-formed snapshot (positive ids, within the cap, all
-        // endpoints present in the active fact set) builds the graph faithfully —
+        // endpoints present in the existing fact set) builds the graph faithfully —
         // the revalidation does not reject good data.
         let snap = crate::engine::snapshot::GraphSnapshot {
             edges: vec![
@@ -694,24 +710,56 @@ mod tests {
                 },
             ],
         };
-        let active: HashSet<i64> = [10, 20, 30].into_iter().collect();
-        let g = MemoryGraph::from_snapshot(&snap, &active).expect("valid snapshot must build");
+        let existing: HashSet<i64> = [10, 20, 30].into_iter().collect();
+        let g = MemoryGraph::from_snapshot(&snap, &existing).expect("valid snapshot must build");
         assert_eq!(g.edge_count(), 2);
         assert_eq!(g.neighbors(10), vec![20]);
         assert_eq!(g.neighbors(20), vec![30]);
     }
 
     #[test]
+    fn from_snapshot_accepts_edge_to_expired_fact() {
+        // #257 regression guard: the validation set is the set of facts that
+        // *exist* (active OR expired) — exactly `load_from_db`'s FK trust boundary,
+        // NOT the stricter active-only set. `load_from_db` loads every active edge,
+        // and an active edge legitimately references an expired fact (e.g. the
+        // dream-cycle `supersedes` edge `synthetic → src`, where the source is
+        // expired in the same cycle, or the conflict `contradicts` edge `new → old`
+        // where `old` is expired). Here the endpoint `20` models a fact that exists
+        // but is expired: it is present in `existing` (the `SELECT id FROM facts`
+        // set), so the snapshot edge that mirrors what `load_from_db` would load MUST
+        // be accepted — never falsely rejected into a needless full DB rebuild.
+        let snap = crate::engine::snapshot::GraphSnapshot {
+            edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
+                edge_id: 1,
+                source: 10, // active synthetic
+                target: 20, // existing-but-EXPIRED source
+                relation_type: "supersedes".into(),
+                weight: 1.0,
+            }],
+        };
+        // `20` exists (expired facts are still in `SELECT id FROM facts`).
+        let existing: HashSet<i64> = [10, 20].into_iter().collect();
+        let g = MemoryGraph::from_snapshot(&snap, &existing)
+            .expect("an active edge to an existing-but-expired fact must be accepted");
+        assert_eq!(g.edge_count(), 1);
+        assert_eq!(g.neighbors(10), vec![20]);
+    }
+
+    #[test]
     fn from_snapshot_rejects_phantom_node_reference() {
         // #257 (true referential validation): an edge endpoint that is *positive*
-        // but absent from the live active fact set is a phantom-node injection —
+        // but absent from the live existing-fact set is a phantom-node injection —
         // the positivity pre-filter alone cannot catch it. The snapshot path must
-        // be at least as strict as `load_from_db` (whose endpoints are guaranteed
-        // present by the DB foreign key), so such an edge is rejected with a typed
-        // error rather than silently materializing a node that does not exist.
-        let active: HashSet<i64> = [10, 20].into_iter().collect();
+        // be as strict as `load_from_db` (whose endpoints are guaranteed present by
+        // the DB foreign key), so such an edge is rejected with a typed error rather
+        // than silently materializing a node that does not exist. Note: the set is
+        // existing facts (active OR expired), so this rejection is for a *truly
+        // nonexistent* id, not merely an expired one (see
+        // `from_snapshot_accepts_edge_to_expired_fact`).
+        let existing: HashSet<i64> = [10, 20].into_iter().collect();
 
-        // Phantom target (30 not active).
+        // Phantom target (30 does not exist).
         let snap_target = crate::engine::snapshot::GraphSnapshot {
             edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
                 edge_id: 1,
@@ -723,13 +771,13 @@ mod tests {
         };
         assert!(
             matches!(
-                MemoryGraph::from_snapshot(&snap_target, &active),
+                MemoryGraph::from_snapshot(&snap_target, &existing),
                 Err(crate::error::MemoryError::Internal(_))
             ),
-            "positive-but-absent target must be rejected as a phantom node"
+            "positive-but-nonexistent target must be rejected as a phantom node"
         );
 
-        // Phantom source (99 not active).
+        // Phantom source (99 does not exist).
         let snap_source = crate::engine::snapshot::GraphSnapshot {
             edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
                 edge_id: 1,
@@ -741,10 +789,10 @@ mod tests {
         };
         assert!(
             matches!(
-                MemoryGraph::from_snapshot(&snap_source, &active),
+                MemoryGraph::from_snapshot(&snap_source, &existing),
                 Err(crate::error::MemoryError::Internal(_))
             ),
-            "positive-but-absent source must be rejected as a phantom node"
+            "positive-but-nonexistent source must be rejected as a phantom node"
         );
     }
 
@@ -755,8 +803,8 @@ mod tests {
         // cannot reference a real fact — it is a dangling/absent-node reference
         // (corruption or tamper) and must be rejected with a typed error, not
         // silently materialized into a phantom node. The cheap positivity check
-        // fires before the set membership lookup, so an empty active set suffices.
-        let active: HashSet<i64> = HashSet::new();
+        // fires before the set membership lookup, so an empty existing set suffices.
+        let existing: HashSet<i64> = HashSet::new();
         for (source, target) in [(0, 20), (-1, 20), (10, 0), (10, -5)] {
             let snap = crate::engine::snapshot::GraphSnapshot {
                 edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
@@ -769,7 +817,7 @@ mod tests {
             };
             assert!(
                 matches!(
-                    MemoryGraph::from_snapshot(&snap, &active),
+                    MemoryGraph::from_snapshot(&snap, &existing),
                     Err(crate::error::MemoryError::Internal(_))
                 ),
                 "non-positive endpoint ({source}, {target}) must be rejected"
@@ -780,8 +828,8 @@ mod tests {
     #[test]
     fn from_snapshot_rejects_nonpositive_edge_id() {
         // An edge_id is a SQLite rowid too; <= 0 signals a corrupt/tampered
-        // edge record. Endpoints are valid + active so only the edge_id triggers.
-        let active: HashSet<i64> = [10, 20].into_iter().collect();
+        // edge record. Endpoints are valid + existing so only the edge_id triggers.
+        let existing: HashSet<i64> = [10, 20].into_iter().collect();
         let snap = crate::engine::snapshot::GraphSnapshot {
             edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
                 edge_id: 0,
@@ -792,7 +840,7 @@ mod tests {
             }],
         };
         assert!(matches!(
-            MemoryGraph::from_snapshot(&snap, &active),
+            MemoryGraph::from_snapshot(&snap, &existing),
             Err(crate::error::MemoryError::Internal(_))
         ));
     }

--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -13,20 +13,18 @@ use crate::store::edges::EdgeStore;
 ///
 /// Defense in depth (CWE-400 / CWE-770). [`MemoryGraph::from_snapshot`] iterates
 /// the deserialized `snap.edges` and, per edge, allocates a petgraph edge plus up
-/// to two nodes and two `HashMap` entries. The on-disk size of the sidecar is
-/// already gated by `MAX_SNAPSHOT_BYTES` (512 MiB) and serde's cautious
-/// preallocation bounds in-band length prefixes, so a *small* crafted file cannot
-/// force a giant allocation. This cap is the residual guard for a sidecar that is
-/// large-but-under-the-byte-cap yet still claims an implausible edge count — and
-/// it makes the bound on `from_snapshot` explicit rather than implicit. It is
-/// chosen consistent with `MAX_SNAPSHOT_BYTES`: a 512 MiB sidecar of `MessagePack`
-/// edge records cannot encode anywhere near 50M edges, so this never rejects a
-/// legitimate corpus.
+/// to two nodes and two `HashMap` entries.
 ///
-/// The primary, tighter bound is the call-site cross-check against the
-/// already-validated `DbFingerprint::active_edge_count` (see
-/// `MemoryEngine::try_load_snapshot`); this constant is the floor that holds even
-/// without a fingerprint in hand.
+/// This 50M cap is a **cheap, fingerprint-less function-level invariant — not the
+/// primary runtime defense.** At runtime it is subsumed twice over: the on-disk
+/// sidecar is already gated by `MAX_SNAPSHOT_BYTES` (512 MiB, which bounds a
+/// `MessagePack` edge stream to an ~9.4M-edge ceiling — well under this cap), and
+/// the sole caller (`MemoryEngine::try_load_snapshot`) additionally cross-checks
+/// the edge count against the already-validated `DbFingerprint::active_edge_count`
+/// and discards on any disagreement. This constant is therefore the residual guard
+/// that still holds for a caller with **no fingerprint in hand**, and it makes the
+/// bound on `from_snapshot` explicit rather than implicit. It is chosen consistent
+/// with `MAX_SNAPSHOT_BYTES`, so it never rejects a legitimate corpus.
 const MAX_SNAPSHOT_EDGES: usize = 50_000_000;
 
 /// Reject a snapshot edge count that exceeds [`MAX_SNAPSHOT_EDGES`].
@@ -304,41 +302,72 @@ impl MemoryGraph {
         GraphSnapshot { edges }
     }
 
-    /// Rebuild graph from a snapshot, bounding and revalidating the edge set.
+    /// Rebuild graph from a snapshot, bounding and revalidating the edge set
+    /// against the live set of active fact ids.
     ///
     /// The `.snapshot` sidecar is an untrusted input: its blake3 checksum is
     /// *unkeyed* (a corruption check, not an authenticity control), so a local
     /// actor able to write the sidecar — or plain on-disk corruption — can present
     /// a structurally-invalid edge list. This builds the same edge-only graph as
-    /// [`load_from_db`](Self::load_from_db), but with two defense-in-depth gates
-    /// (#412, #499):
+    /// [`load_from_db`](Self::load_from_db), and is now **at least as strict** as
+    /// that path: `load_from_db` reads edges whose endpoints the `SQLite` foreign
+    /// key guarantees to exist, and this requires the same of every snapshot edge
+    /// via the `active_fact_ids` set the caller queries from the authoritative DB.
+    ///
+    /// Three defense-in-depth gates (#257, #412, #499):
     ///
     /// 1. **Count bound** — reject more than [`MAX_SNAPSHOT_EDGES`] edges before
     ///    any per-edge allocation (CWE-400 / CWE-770: unbounded petgraph/`HashMap`
-    ///    growth at cold start). The caller applies a tighter cross-check against
-    ///    the validated `DbFingerprint::active_edge_count`; this is the floor that
-    ///    holds with no fingerprint in hand.
-    /// 2. **Endpoint revalidation** — every `source`, `target`, and `edge_id` is a
+    ///    growth at cold start). This is a cheap, fingerprint-less function-level
+    ///    invariant, *not* the primary runtime defense: at runtime the on-disk
+    ///    `MAX_SNAPSHOT_BYTES` byte cap (512 MiB, an ~9.4M-edge ceiling for
+    ///    `MessagePack` edge records) plus the caller's tighter cross-check against
+    ///    the validated `DbFingerprint::active_edge_count` already subsume it. It
+    ///    is the floor that still holds for a caller with no fingerprint in hand.
+    /// 2. **Endpoint positivity** — every `source`, `target`, and `edge_id` is a
     ///    `SQLite` rowid and is therefore strictly positive. A non-positive value
-    ///    is a dangling/absent-node reference that cannot correspond to a real fact
-    ///    or edge; reject rather than silently materialize a phantom node.
+    ///    is structurally impossible (corruption or tamper); reject it. This is a
+    ///    cheap pre-filter for gate 3.
+    /// 3. **Referential validation** (#257) — every edge `source`/`target` MUST be
+    ///    present in `active_fact_ids` (the live `SELECT id FROM facts WHERE
+    ///    t_expired IS NULL` set). A positive-but-absent endpoint is a phantom-node
+    ///    injection: it would otherwise materialize a node for a fact that does not
+    ///    exist. This mirrors the FK guarantee `load_from_db` enjoys and closes the
+    ///    gap the positivity check alone left open.
     ///
     /// # Errors
     ///
     /// Returns [`MemoryError::Internal`](crate::error::MemoryError::Internal) when
-    /// the edge count exceeds the cap or any edge carries a non-positive
-    /// `source`/`target`/`edge_id`. The caller treats this as "discard the sidecar
-    /// and rebuild from the authoritative database"; it never panics.
-    pub(crate) fn from_snapshot(snap: &crate::engine::snapshot::GraphSnapshot) -> Result<Self> {
+    /// the edge count exceeds the cap, any edge carries a non-positive
+    /// `source`/`target`/`edge_id`, or any edge `source`/`target` is absent from
+    /// `active_fact_ids`. The caller treats this as "discard the sidecar and
+    /// rebuild from the authoritative database"; it never panics.
+    pub(crate) fn from_snapshot(
+        snap: &crate::engine::snapshot::GraphSnapshot,
+        active_fact_ids: &HashSet<i64>,
+    ) -> Result<Self> {
         check_edge_count_bound(snap.edges.len())?;
 
         let mut graph = Self::new();
         for edge in &snap.edges {
+            // Gate 2: cheap structural pre-filter — rowids are strictly positive.
             if edge.source <= 0 || edge.target <= 0 || edge.edge_id <= 0 {
                 return Err(crate::error::MemoryError::Internal(format!(
-                    "snapshot edge {edge_id} references a non-positive endpoint \
-                     (source={source}, target={target}); discarding sidecar and \
-                     rebuilding from the database",
+                    "snapshot edge {edge_id} carries a non-positive rowid \
+                     (source={source}, target={target}, edge_id={edge_id}); \
+                     discarding sidecar and rebuilding from the database",
+                    edge_id = edge.edge_id,
+                    source = edge.source,
+                    target = edge.target,
+                )));
+            }
+            // Gate 3: referential validation — both endpoints must reference an
+            // active fact. A positive-but-absent id is a phantom-node injection.
+            if !active_fact_ids.contains(&edge.source) || !active_fact_ids.contains(&edge.target) {
+                return Err(crate::error::MemoryError::Internal(format!(
+                    "snapshot edge {edge_id} references a fact id absent from the \
+                     active set (source={source}, target={target}); discarding \
+                     sidecar and rebuilding from the database",
                     edge_id = edge.edge_id,
                     source = edge.source,
                     target = edge.target,
@@ -644,8 +673,9 @@ mod tests {
 
     #[test]
     fn from_snapshot_accepts_valid_edges() {
-        // Baseline: a well-formed snapshot (positive ids, within the cap) builds
-        // the graph faithfully — the revalidation does not reject good data.
+        // Baseline: a well-formed snapshot (positive ids, within the cap, all
+        // endpoints present in the active fact set) builds the graph faithfully —
+        // the revalidation does not reject good data.
         let snap = crate::engine::snapshot::GraphSnapshot {
             edges: vec![
                 crate::engine::snapshot::GraphEdgeSnapshot {
@@ -664,10 +694,58 @@ mod tests {
                 },
             ],
         };
-        let g = MemoryGraph::from_snapshot(&snap).expect("valid snapshot must build");
+        let active: HashSet<i64> = [10, 20, 30].into_iter().collect();
+        let g = MemoryGraph::from_snapshot(&snap, &active).expect("valid snapshot must build");
         assert_eq!(g.edge_count(), 2);
         assert_eq!(g.neighbors(10), vec![20]);
         assert_eq!(g.neighbors(20), vec![30]);
+    }
+
+    #[test]
+    fn from_snapshot_rejects_phantom_node_reference() {
+        // #257 (true referential validation): an edge endpoint that is *positive*
+        // but absent from the live active fact set is a phantom-node injection —
+        // the positivity pre-filter alone cannot catch it. The snapshot path must
+        // be at least as strict as `load_from_db` (whose endpoints are guaranteed
+        // present by the DB foreign key), so such an edge is rejected with a typed
+        // error rather than silently materializing a node that does not exist.
+        let active: HashSet<i64> = [10, 20].into_iter().collect();
+
+        // Phantom target (30 not active).
+        let snap_target = crate::engine::snapshot::GraphSnapshot {
+            edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
+                edge_id: 1,
+                source: 10,
+                target: 30,
+                relation_type: "x".into(),
+                weight: 1.0,
+            }],
+        };
+        assert!(
+            matches!(
+                MemoryGraph::from_snapshot(&snap_target, &active),
+                Err(crate::error::MemoryError::Internal(_))
+            ),
+            "positive-but-absent target must be rejected as a phantom node"
+        );
+
+        // Phantom source (99 not active).
+        let snap_source = crate::engine::snapshot::GraphSnapshot {
+            edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
+                edge_id: 1,
+                source: 99,
+                target: 20,
+                relation_type: "x".into(),
+                weight: 1.0,
+            }],
+        };
+        assert!(
+            matches!(
+                MemoryGraph::from_snapshot(&snap_source, &active),
+                Err(crate::error::MemoryError::Internal(_))
+            ),
+            "positive-but-absent source must be rejected as a phantom node"
+        );
     }
 
     #[test]
@@ -676,7 +754,9 @@ mod tests {
         // rowids and are always positive. An edge whose source/target is <= 0
         // cannot reference a real fact — it is a dangling/absent-node reference
         // (corruption or tamper) and must be rejected with a typed error, not
-        // silently materialized into a phantom node.
+        // silently materialized into a phantom node. The cheap positivity check
+        // fires before the set membership lookup, so an empty active set suffices.
+        let active: HashSet<i64> = HashSet::new();
         for (source, target) in [(0, 20), (-1, 20), (10, 0), (10, -5)] {
             let snap = crate::engine::snapshot::GraphSnapshot {
                 edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
@@ -689,7 +769,7 @@ mod tests {
             };
             assert!(
                 matches!(
-                    MemoryGraph::from_snapshot(&snap),
+                    MemoryGraph::from_snapshot(&snap, &active),
                     Err(crate::error::MemoryError::Internal(_))
                 ),
                 "non-positive endpoint ({source}, {target}) must be rejected"
@@ -700,7 +780,8 @@ mod tests {
     #[test]
     fn from_snapshot_rejects_nonpositive_edge_id() {
         // An edge_id is a SQLite rowid too; <= 0 signals a corrupt/tampered
-        // edge record.
+        // edge record. Endpoints are valid + active so only the edge_id triggers.
+        let active: HashSet<i64> = [10, 20].into_iter().collect();
         let snap = crate::engine::snapshot::GraphSnapshot {
             edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
                 edge_id: 0,
@@ -711,7 +792,7 @@ mod tests {
             }],
         };
         assert!(matches!(
-            MemoryGraph::from_snapshot(&snap),
+            MemoryGraph::from_snapshot(&snap, &active),
             Err(crate::error::MemoryError::Internal(_))
         ));
     }

--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -8,6 +8,41 @@ use rusqlite::Connection;
 use crate::error::Result;
 use crate::store::edges::EdgeStore;
 
+/// Hard upper bound on the number of edges accepted from a single snapshot
+/// sidecar (50M).
+///
+/// Defense in depth (CWE-400 / CWE-770). [`MemoryGraph::from_snapshot`] iterates
+/// the deserialized `snap.edges` and, per edge, allocates a petgraph edge plus up
+/// to two nodes and two `HashMap` entries. The on-disk size of the sidecar is
+/// already gated by `MAX_SNAPSHOT_BYTES` (512 MiB) and serde's cautious
+/// preallocation bounds in-band length prefixes, so a *small* crafted file cannot
+/// force a giant allocation. This cap is the residual guard for a sidecar that is
+/// large-but-under-the-byte-cap yet still claims an implausible edge count — and
+/// it makes the bound on `from_snapshot` explicit rather than implicit. It is
+/// chosen consistent with `MAX_SNAPSHOT_BYTES`: a 512 MiB sidecar of `MessagePack`
+/// edge records cannot encode anywhere near 50M edges, so this never rejects a
+/// legitimate corpus.
+///
+/// The primary, tighter bound is the call-site cross-check against the
+/// already-validated `DbFingerprint::active_edge_count` (see
+/// `MemoryEngine::try_load_snapshot`); this constant is the floor that holds even
+/// without a fingerprint in hand.
+const MAX_SNAPSHOT_EDGES: usize = 50_000_000;
+
+/// Reject a snapshot edge count that exceeds [`MAX_SNAPSHOT_EDGES`].
+///
+/// Extracted as a free function so the bound is unit-testable without
+/// materializing tens of millions of edge descriptors.
+fn check_edge_count_bound(count: usize) -> Result<()> {
+    if count > MAX_SNAPSHOT_EDGES {
+        return Err(crate::error::MemoryError::Internal(format!(
+            "snapshot edge count {count} exceeds the maximum of {MAX_SNAPSHOT_EDGES}; \
+             discarding sidecar and rebuilding from the database"
+        )));
+    }
+    Ok(())
+}
+
 /// Edge weight stored in the petgraph `DiGraph`.
 #[derive(Debug, Clone)]
 pub struct EdgeData {
@@ -269,10 +304,46 @@ impl MemoryGraph {
         GraphSnapshot { edges }
     }
 
-    /// Rebuild graph from a snapshot (same logic as `load_from_db`).
-    pub(crate) fn from_snapshot(snap: &crate::engine::snapshot::GraphSnapshot) -> Self {
+    /// Rebuild graph from a snapshot, bounding and revalidating the edge set.
+    ///
+    /// The `.snapshot` sidecar is an untrusted input: its blake3 checksum is
+    /// *unkeyed* (a corruption check, not an authenticity control), so a local
+    /// actor able to write the sidecar — or plain on-disk corruption — can present
+    /// a structurally-invalid edge list. This builds the same edge-only graph as
+    /// [`load_from_db`](Self::load_from_db), but with two defense-in-depth gates
+    /// (#412, #499):
+    ///
+    /// 1. **Count bound** — reject more than [`MAX_SNAPSHOT_EDGES`] edges before
+    ///    any per-edge allocation (CWE-400 / CWE-770: unbounded petgraph/`HashMap`
+    ///    growth at cold start). The caller applies a tighter cross-check against
+    ///    the validated `DbFingerprint::active_edge_count`; this is the floor that
+    ///    holds with no fingerprint in hand.
+    /// 2. **Endpoint revalidation** — every `source`, `target`, and `edge_id` is a
+    ///    `SQLite` rowid and is therefore strictly positive. A non-positive value
+    ///    is a dangling/absent-node reference that cannot correspond to a real fact
+    ///    or edge; reject rather than silently materialize a phantom node.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Internal`](crate::error::MemoryError::Internal) when
+    /// the edge count exceeds the cap or any edge carries a non-positive
+    /// `source`/`target`/`edge_id`. The caller treats this as "discard the sidecar
+    /// and rebuild from the authoritative database"; it never panics.
+    pub(crate) fn from_snapshot(snap: &crate::engine::snapshot::GraphSnapshot) -> Result<Self> {
+        check_edge_count_bound(snap.edges.len())?;
+
         let mut graph = Self::new();
         for edge in &snap.edges {
+            if edge.source <= 0 || edge.target <= 0 || edge.edge_id <= 0 {
+                return Err(crate::error::MemoryError::Internal(format!(
+                    "snapshot edge {edge_id} references a non-positive endpoint \
+                     (source={source}, target={target}); discarding sidecar and \
+                     rebuilding from the database",
+                    edge_id = edge.edge_id,
+                    source = edge.source,
+                    target = edge.target,
+                )));
+            }
             graph.add_edges_from_iter(
                 edge.source,
                 edge.target,
@@ -281,7 +352,7 @@ impl MemoryGraph {
                 edge.weight,
             );
         }
-        graph
+        Ok(graph)
     }
 
     /// Shared edge-insertion kernel used by `load_from_db` and `from_snapshot`.
@@ -569,6 +640,97 @@ mod tests {
         assert_eq!(e.target, 3);
         assert_eq!(e.relation_type, "survivor");
         assert!((e.weight - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn from_snapshot_accepts_valid_edges() {
+        // Baseline: a well-formed snapshot (positive ids, within the cap) builds
+        // the graph faithfully — the revalidation does not reject good data.
+        let snap = crate::engine::snapshot::GraphSnapshot {
+            edges: vec![
+                crate::engine::snapshot::GraphEdgeSnapshot {
+                    edge_id: 1,
+                    source: 10,
+                    target: 20,
+                    relation_type: "supplements".into(),
+                    weight: 0.5,
+                },
+                crate::engine::snapshot::GraphEdgeSnapshot {
+                    edge_id: 2,
+                    source: 20,
+                    target: 30,
+                    relation_type: "related".into(),
+                    weight: 1.0,
+                },
+            ],
+        };
+        let g = MemoryGraph::from_snapshot(&snap).expect("valid snapshot must build");
+        assert_eq!(g.edge_count(), 2);
+        assert_eq!(g.neighbors(10), vec![20]);
+        assert_eq!(g.neighbors(20), vec![30]);
+    }
+
+    #[test]
+    fn from_snapshot_rejects_nonpositive_endpoint() {
+        // #499 (graph/data-integrity-trusts-snapshot-edges): fact ids are SQLite
+        // rowids and are always positive. An edge whose source/target is <= 0
+        // cannot reference a real fact — it is a dangling/absent-node reference
+        // (corruption or tamper) and must be rejected with a typed error, not
+        // silently materialized into a phantom node.
+        for (source, target) in [(0, 20), (-1, 20), (10, 0), (10, -5)] {
+            let snap = crate::engine::snapshot::GraphSnapshot {
+                edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
+                    edge_id: 1,
+                    source,
+                    target,
+                    relation_type: "x".into(),
+                    weight: 1.0,
+                }],
+            };
+            assert!(
+                matches!(
+                    MemoryGraph::from_snapshot(&snap),
+                    Err(crate::error::MemoryError::Internal(_))
+                ),
+                "non-positive endpoint ({source}, {target}) must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn from_snapshot_rejects_nonpositive_edge_id() {
+        // An edge_id is a SQLite rowid too; <= 0 signals a corrupt/tampered
+        // edge record.
+        let snap = crate::engine::snapshot::GraphSnapshot {
+            edges: vec![crate::engine::snapshot::GraphEdgeSnapshot {
+                edge_id: 0,
+                source: 10,
+                target: 20,
+                relation_type: "x".into(),
+                weight: 1.0,
+            }],
+        };
+        assert!(matches!(
+            MemoryGraph::from_snapshot(&snap),
+            Err(crate::error::MemoryError::Internal(_))
+        ));
+    }
+
+    #[test]
+    fn from_snapshot_rejects_over_cap_edge_count() {
+        // Defense-in-depth bound: a snapshot claiming more edges than
+        // MAX_SNAPSHOT_EDGES is rejected before any per-edge allocation, so a
+        // tampered sidecar cannot drive unbounded petgraph/HashMap growth at
+        // cold start (CWE-400/770). We assert the *length gate* fires using a
+        // tiny stand-in cap via the testable kernel, without allocating 50M
+        // edges.
+        // The cap is generously large; materializing cap+1 edge descriptors is
+        // infeasible, so we exercise the bound-check kernel directly: exactly the
+        // cap is accepted, one over is rejected.
+        assert!(check_edge_count_bound(MAX_SNAPSHOT_EDGES).is_ok());
+        let err = check_edge_count_bound(MAX_SNAPSHOT_EDGES + 1)
+            .expect_err("over-cap edge count must be rejected");
+        assert!(matches!(err, crate::error::MemoryError::Internal(_)));
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -66,20 +66,33 @@ fn content_hash(content: &str) -> String {
     hash.to_hex()[..32].to_string()
 }
 
-/// Collect the set of active fact ids (`SELECT id FROM facts WHERE t_expired IS
-/// NULL`).
+/// Collect the set of **existing** fact ids (`SELECT id FROM facts`, any
+/// `t_expired`).
 ///
 /// A free function — it needs neither a configured `embed_dim` nor a full
 /// [`FactStore`], only the id column — used by snapshot referential validation
-/// (#257) to reject any edge endpoint that does not reference a live fact (a
-/// phantom-node injection). The returned set is exactly the population whose
-/// edges the `SQLite` foreign key would honor on a full `load_from_db` rebuild.
+/// (#257) to reject any edge endpoint that does not reference a fact that exists
+/// (a phantom-node injection).
+///
+/// This set is *exactly* the population whose edges the `SQLite` foreign key
+/// (`edges.source_fact_id/target_fact_id REFERENCES facts(id)`) honors on a full
+/// [`load_from_db`](crate::graph::MemoryGraph::load_from_db) rebuild — and that
+/// is *all* facts, not just active ones. `load_from_db` loads every *active edge*
+/// (`edges.t_expired IS NULL`), and an active edge can legitimately point at an
+/// *expired* fact: the conflict-resolution `contradicts` edge `new → old` is
+/// created active in the same transaction the `old` fact is expired, and the
+/// dream-cycle `supersedes` edge `synthetic → src` stays active while every
+/// source `src` is expired. The FK guarantees the endpoint fact *exists*, never
+/// that it is active (`SQLite` FKs cannot be conditional on `t_expired`).
+/// Restricting this set to active-only would therefore be *stricter* than
+/// `load_from_db`'s trust boundary and would falsely reject a snapshot that
+/// faithfully mirrors a real rebuild.
 ///
 /// # Errors
 ///
 /// Returns `MemoryError::Database` on query failure.
-pub fn active_fact_ids(conn: &Connection) -> Result<std::collections::HashSet<i64>> {
-    let mut stmt = conn.prepare("SELECT id FROM facts WHERE t_expired IS NULL")?;
+pub fn existing_fact_ids(conn: &Connection) -> Result<std::collections::HashSet<i64>> {
+    let mut stmt = conn.prepare("SELECT id FROM facts")?;
     let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
     let mut ids = std::collections::HashSet::new();
     for row in rows {
@@ -1426,6 +1439,40 @@ mod tests {
             scope_id: 1,
             is_pinned: false,
         }
+    }
+
+    /// #257 regression: the snapshot referential-validation set MUST include
+    /// **expired** facts, because that is exactly the fact population
+    /// `MemoryGraph::load_from_db` trusts. `load_from_db` loads every *active*
+    /// edge (`edges.t_expired IS NULL`), and an active edge can legitimately point
+    /// at an *expired* fact — e.g. the conflict-resolution `contradicts` edge
+    /// `new → old` (the old fact is expired in the same transaction the edge is
+    /// created) and the dream-cycle `supersedes` edge `synthetic → src` (every
+    /// source is expired). The `edges.source_fact_id/target_fact_id REFERENCES
+    /// facts(id)` foreign key guarantees the endpoint fact *exists*, not that it is
+    /// active (`SQLite` FKs cannot be conditional on `t_expired`). Validating against
+    /// the active-only set would therefore be *stricter* than `load_from_db` and
+    /// would falsely reject a snapshot that faithfully mirrors a real rebuild.
+    #[test]
+    fn existing_fact_ids_includes_expired_facts() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+
+        let active_id = store.insert(&make_fact("active", vec![0.1; DIM])).unwrap();
+        let expired_id = store.insert(&make_fact("expired", vec![0.2; DIM])).unwrap();
+        store.expire(expired_id, Utc::now()).unwrap();
+
+        let ids = existing_fact_ids(&conn).unwrap();
+        assert!(
+            ids.contains(&active_id),
+            "the active fact must be in the validation set"
+        );
+        assert!(
+            ids.contains(&expired_id),
+            "the EXPIRED fact must also be in the validation set: load_from_db's \
+             active edges can reference it, so excluding it would falsely reject a \
+             legitimate snapshot edge (the #257 over-strict regression)"
+        );
     }
 
     /// #659: `count_active` counts exactly the rows `list_active` would return

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -66,6 +66,28 @@ fn content_hash(content: &str) -> String {
     hash.to_hex()[..32].to_string()
 }
 
+/// Collect the set of active fact ids (`SELECT id FROM facts WHERE t_expired IS
+/// NULL`).
+///
+/// A free function — it needs neither a configured `embed_dim` nor a full
+/// [`FactStore`], only the id column — used by snapshot referential validation
+/// (#257) to reject any edge endpoint that does not reference a live fact (a
+/// phantom-node injection). The returned set is exactly the population whose
+/// edges the `SQLite` foreign key would honor on a full `load_from_db` rebuild.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on query failure.
+pub fn active_fact_ids(conn: &Connection) -> Result<std::collections::HashSet<i64>> {
+    let mut stmt = conn.prepare("SELECT id FROM facts WHERE t_expired IS NULL")?;
+    let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+    let mut ids = std::collections::HashSet::new();
+    for row in rows {
+        ids.insert(row?);
+    }
+    Ok(ids)
+}
+
 #[allow(dead_code)] // complete CRUD API — not all methods called through engine facade yet
 impl<'a> FactStore<'a> {
     /// Create a new `FactStore` borrowing the given connection.


### PR DESCRIPTION
## Summary

Hardens `MemoryGraph::from_snapshot` against an untrusted `.snapshot` sidecar. The sidecar's blake3 checksum is *unkeyed* (corruption check, not authenticity), so a local actor able to write it — or on-disk corruption — can present a structurally invalid edge list. `from_snapshot` previously iterated `snap.edges` with no cap and trusted every field, allowing unbounded petgraph/`HashMap` growth at cold start (CWE-400/770) and phantom nodes from dangling endpoints.

## Changes

Two defense-in-depth gates:

1. **Count bound** — `from_snapshot` rejects more than `MAX_SNAPSHOT_EDGES` (50M, consistent with `MAX_SNAPSHOT_BYTES`) before any per-edge allocation. The engine call site (`try_load_snapshot`) applies the tighter cross-check: the fingerprint is already validated against the live DB, so the sidecar's edge count MUST equal `DbFingerprint::active_edge_count`; any mismatch discards the sidecar and rebuilds from the authoritative DB.
2. **Endpoint revalidation (#499)** — every `source`/`target`/`edge_id` is a SQLite rowid and is strictly positive; a non-positive value is a dangling/absent-node reference that cannot map to a real fact and is rejected.

`from_snapshot` now returns `Result` and surfaces a typed `MemoryError::Internal` on violation (never panics). The single caller treats the error as "discard the rebuildable sidecar and rebuild from the DB", so engine open stays robust (graceful degradation, not a hard open failure).

## Tests (TDD)

New unit tests in `memory_graph.rs`: valid-edge baseline, non-positive endpoint rejection (4 cases), non-positive `edge_id` rejection, and the over-cap bound kernel. All assert the typed `MemoryError::Internal`.

## Gate

- `cargo clippy -p memory-engine --all-targets --all-features -- -D warnings` — clean
- `cargo test -p memory-engine` — 1234 passed
- `cargo test -p memory-engine --features ann` — 1264 passed

Closes #412. Part of #257, #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)