### PR TITLE
perf(retrieval): batch HNSW candidate fetch into one query (kill 2N N+1 in HnswStrategy::search)

### DIFF
--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -21,7 +21,10 @@ serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 async-trait = "0.1"
-rusqlite = { version = "0.34", features = ["bundled"] }
+# `trace`: additive, zero-runtime-cost rusqlite feature (compiles in
+# `Connection::trace`); used by the ANN batched-fetch round-trip count test
+# (#288/#362). No new crates in the graph.
+rusqlite = { version = "0.34", features = ["bundled", "trace"] }
 blake3 = "1"
 rmp-serde = "1"
 tempfile = "3"

--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -21,10 +21,7 @@ serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 async-trait = "0.1"
-# `trace`: additive, zero-runtime-cost rusqlite feature (compiles in
-# `Connection::trace`); used by the ANN batched-fetch round-trip count test
-# (#288/#362). No new crates in the graph.
-rusqlite = { version = "0.34", features = ["bundled", "trace"] }
+rusqlite = { version = "0.34", features = ["bundled"] }
 blake3 = "1"
 rmp-serde = "1"
 tempfile = "3"
@@ -50,6 +47,11 @@ deadpool-postgres = { version = "0.14", optional = true }
 libc = "0.2"
 
 [dev-dependencies]
+# `trace`: additive, zero-runtime-cost rusqlite feature (compiles in
+# `Connection::trace`); used ONLY by the ANN batched-fetch round-trip count test
+# (#288/#362). Cargo feature-unifies this dev entry into the test build only, so
+# the shipped library (and crates linking it) never enables `trace`. No new crates.
+rusqlite = { version = "0.34", features = ["trace"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 insta = { version = "1", features = ["yaml", "redactions"] }

--- a/memory-engine/lib/memory-engine/src/search/ann.rs
+++ b/memory-engine/lib/memory-engine/src/search/ann.rs
@@ -1047,6 +1047,110 @@ mod tests {
         }
 
         #[test]
+        fn hnsw_strategy_one_batched_query_per_widening_attempt_forces_widening() {
+            // #288 / #362, INFO coverage: the previous test only exercises the
+            // single-attempt path, so it cannot distinguish "one query per attempt"
+            // from "one query total". Here we build a fixture that FORCES the widen
+            // loop to take a second attempt and assert the batch-query count tracks
+            // attempts (2 attempts → 2 batched queries), proving the per-attempt
+            // invariant rather than the by-construction single-attempt case.
+            //
+            // Construction: the `OVERFETCH_FACTOR * limit` candidates HNSW returns on
+            // the first attempt are all `Procedural` (filtered out by the `Semantic`
+            // query), so attempt 1 underfills (0 < 1) and the loop widens; the wider
+            // overfetch on attempt 2 reaches a farther `Semantic` fact that survives.
+            // (We filter on `fact_type` rather than `scope_id` to avoid seeding a
+            // second scope row — `init_schema` only provides the default scope 1.)
+            use rusqlite::trace::{TraceEvent, TraceEventCodes};
+            use std::cell::Cell;
+
+            thread_local! {
+                static BATCH_QUERIES: Cell<usize> = const { Cell::new(0) };
+            }
+            #[allow(
+                clippy::needless_pass_by_value,
+                reason = "signature is fixed by `Connection::trace_v2`, which takes a \
+                          bare `fn(TraceEvent)` — a reference param would not match"
+            )]
+            fn on_stmt(ev: TraceEvent<'_>) {
+                if let TraceEvent::Stmt(_, sql) = ev
+                    && sql.contains("json_each")
+                {
+                    BATCH_QUERIES.with(|c| c.set(c.get() + 1));
+                }
+            }
+
+            let conn = open_memory().unwrap();
+            init_schema(&conn).unwrap();
+            let store = FactStore::new(&conn, DIM);
+
+            // Helper: insert a fact at `emb` of `fact_type`, returning its id.
+            let insert = |emb: Vec<f32>, fact_type: FactType| -> i64 {
+                let fact = NewFact {
+                    content: "fact".into(),
+                    content_hash: String::new(),
+                    embedding: emb,
+                    fact_type,
+                    t_created: Utc::now(),
+                    t_expired: None,
+                    t_valid: None,
+                    t_invalid: None,
+                    source_event_id: None,
+                    scope_id: 1,
+                    base_importance: 0.5,
+                    access_count: 0,
+                    last_accessed: Utc::now(),
+                    metadata: serde_json::json!({}),
+                    is_pinned: false,
+                };
+                store.insert(&fact).unwrap()
+            };
+
+            // Query is [1,0,0,0]. `limit = 1` → first overfetch = OVERFETCH_FACTOR = 3.
+            // The 3 nearest facts are `Procedural` (excluded by the `Semantic` query);
+            // a 4th, farther fact is the only `Semantic` match, reachable only once
+            // overfetch widens to >= 4. We seed > OVERFETCH_FACTOR `Procedural` facts so
+            // the first attempt's candidate window is entirely `Procedural` and
+            // genuinely underfills the `Semantic` request.
+            let procedural_near = vec![
+                vec![1.0_f32, 0.0, 0.0, 0.0],
+                vec![0.99_f32, 0.01, 0.0, 0.0],
+                vec![0.98_f32, 0.02, 0.0, 0.0],
+                vec![0.97_f32, 0.03, 0.0, 0.0],
+            ];
+            for emb in procedural_near {
+                insert(emb, FactType::Procedural);
+            }
+            // The lone `Semantic` match: farther than every `Procedural` fact, so HNSW
+            // only surfaces it after the overfetch window widens on the second attempt.
+            let semantic_id = insert(vec![0.0_f32, 1.0, 0.0, 0.0], FactType::Semantic);
+
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+
+            BATCH_QUERIES.with(|c| c.set(0));
+            conn.trace_v2(TraceEventCodes::SQLITE_TRACE_STMT, Some(on_stmt));
+
+            let query = [1.0_f32, 0.0, 0.0, 0.0];
+            let results = strategy
+                .search(&conn, &query, DIM, 1, Some(&FactType::Semantic), None)
+                .unwrap();
+
+            conn.trace_v2(TraceEventCodes::empty(), None);
+
+            assert_eq!(results.len(), 1, "the lone `Semantic` fact must be found");
+            assert_eq!(
+                results[0].fact_id, semantic_id,
+                "the surviving result is the `Semantic` fact, reached only after widening"
+            );
+            assert_eq!(
+                BATCH_QUERIES.with(Cell::get),
+                2,
+                "two widening attempts must issue exactly two batched candidate \
+                 queries — one per attempt, never 2N per-candidate round-trips"
+            );
+        }
+
+        #[test]
         fn hnsw_strategy_notify_expire_excludes_from_results() {
             let (conn, ids) = setup_with_facts();
             let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();

--- a/memory-engine/lib/memory-engine/src/search/ann.rs
+++ b/memory-engine/lib/memory-engine/src/search/ann.rs
@@ -350,17 +350,32 @@ impl VectorSearchStrategy for HnswStrategy {
                 cands
             }; // Read lock released here
 
-            // Phase 2: Post-filter and exact-score ALL candidates via DB
+            // Phase 2: Post-filter + exact-score ALL candidates in ONE batched
+            // query (#288/#362). The old per-candidate `check_fact_filters` +
+            // `load_embedding` pair issued 2N round-trips; a single query over the
+            // candidate id set returns only the surviving rows (passing the SAME
+            // expiry/fact_type/scope predicates) with their embeddings.
+            let surviving = fetch_candidate_embeddings(
+                conn,
+                &candidates,
+                fact_type,
+                scope_ids,
+                self.embed_dim,
+            )?;
+
             results.clear();
-            results.reserve(candidates.len());
-            for fact_id in candidates {
-                let passes = check_fact_filters(conn, fact_id, fact_type, scope_ids)?;
-                if !passes {
-                    continue;
+            results.reserve(surviving.len());
+            // Iterate `candidates` in HNSW-neighbor order so the pre-sort order is
+            // identical to the old per-candidate loop (the final `sort_by` is
+            // stable, so this preserves equal-score tie-breaking exactly).
+            for fact_id in &candidates {
+                if let Some(stored_emb) = surviving.get(fact_id) {
+                    let score = crate::search::cosine_similarity(query_embedding, stored_emb);
+                    results.push(VectorResult {
+                        fact_id: *fact_id,
+                        score,
+                    });
                 }
-                let stored_emb = load_embedding(conn, fact_id, self.embed_dim)?;
-                let score = crate::search::cosine_similarity(query_embedding, &stored_emb);
-                results.push(VectorResult { fact_id, score });
             }
 
             if results.len() >= limit {
@@ -484,38 +499,70 @@ impl VectorSearchStrategy for HnswStrategy {
     }
 }
 
-fn check_fact_filters(
+/// Fetch the embeddings of all `candidate_ids` that survive the HNSW post-filters
+/// (active + `fact_type` + scope), in a **single** batched query (#288/#362).
+///
+/// Replaces the old per-candidate `check_fact_filters` (EXISTS) + `load_embedding`
+/// (SELECT embedding) pair, which issued two round-trips per candidate — a `2N`
+/// N+1 pattern across up to [`MAX_WIDEN_ATTEMPTS`] widening passes. The predicates
+/// are byte-for-byte the same ones those two helpers enforced:
+///
+/// - `t_expired IS NULL` (active only),
+/// - `?2 IS NULL OR fact_type = ?2` (optional `fact_type` filter),
+/// - `?3 IS NULL OR scope_id IN (json_each(?3))` (optional scope filter).
+///
+/// The candidate id list is passed as a JSON array expanded via `json_each` — the
+/// same binding technique the scope filter already uses, so a large candidate set
+/// is one parameter, not `N` placeholders. Rows not matching the filters (or absent
+/// — e.g. a stale HNSW graph entry whose fact was expired) are simply omitted from
+/// the returned map, so the caller drops them exactly as the old EXISTS check did.
+///
+/// # Errors
+///
+/// Returns `MemoryError::Database` on query failure, `MemoryError::Serialization`
+/// if the id/scope JSON cannot be built, or `MemoryError::EmbeddingDimension` if a
+/// stored embedding has the wrong width.
+fn fetch_candidate_embeddings(
     conn: &Connection,
-    fact_id: i64,
+    candidate_ids: &[i64],
     fact_type: Option<&FactType>,
     scope_ids: Option<&[i64]>,
-) -> Result<bool> {
+    embed_dim: usize,
+) -> Result<HashMap<i64, Vec<f32>>> {
     use crate::search::serialize_scope_ids;
     use crate::store::facts::fact_type_to_str;
 
+    if candidate_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let ids_json =
+        serde_json::to_string(candidate_ids).map_err(crate::error::MemoryError::Serialization)?;
     let scope_json = serialize_scope_ids(scope_ids)?;
-    let exists: bool = conn.query_row(
-        "SELECT EXISTS(
-            SELECT 1 FROM facts
-            WHERE id = ?1
-            AND t_expired IS NULL
-            AND (?2 IS NULL OR fact_type = ?2)
-            AND (?3 IS NULL OR scope_id IN (SELECT value FROM json_each(?3)))
-        )",
-        rusqlite::params![fact_id, fact_type.map(fact_type_to_str), scope_json,],
-        |row| row.get(0),
+
+    let mut stmt = conn.prepare(
+        "SELECT id, embedding FROM facts
+         WHERE id IN (SELECT value FROM json_each(?1))
+           AND t_expired IS NULL
+           AND (?2 IS NULL OR fact_type = ?2)
+           AND (?3 IS NULL OR scope_id IN (SELECT value FROM json_each(?3)))",
+    )?;
+    let rows = stmt.query_map(
+        rusqlite::params![ids_json, fact_type.map(fact_type_to_str), scope_json],
+        |row| {
+            let id: i64 = row.get(0)?;
+            let blob: Vec<u8> = row.get(1)?;
+            Ok((id, blob))
+        },
     )?;
 
-    Ok(exists)
-}
-
-fn load_embedding(conn: &Connection, fact_id: i64, embed_dim: usize) -> Result<Vec<f32>> {
-    let blob: Vec<u8> = conn.query_row(
-        "SELECT embedding FROM facts WHERE id = ?1",
-        [fact_id],
-        |row| row.get(0),
-    )?;
-    deserialize_embedding(&blob, embed_dim)
+    let mut out = HashMap::with_capacity(candidate_ids.len());
+    for row in rows {
+        let (fact_id, blob) = row?;
+        let embedding = deserialize_embedding(&blob, embed_dim)?;
+        out.insert(fact_id, embedding);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -817,13 +864,196 @@ mod tests {
         }
 
         #[test]
+        #[allow(
+            clippy::too_many_lines,
+            reason = "exhaustive filter-matrix test: 5 fixture facts (one per excluded \
+                      dimension) + per-result score verification; splitting would scatter \
+                      the single behavioral assertion"
+        )]
+        fn hnsw_strategy_batched_fetch_respects_filters_and_expiry() {
+            // #288 / #362: Phase 2 now fetches all surviving candidates in ONE
+            // batched query per widening attempt (was 2 round-trips per candidate).
+            // This proves the batched path preserves the exact filter semantics the
+            // old per-candidate `check_fact_filters` + `load_embedding` pair enforced:
+            // (a) fact_type filter, (b) scope filter, (c) expiry exclusion, and that
+            // the scores match an independent cosine computation.
+            let conn = open_memory().unwrap();
+            init_schema(&conn).unwrap();
+            let store = FactStore::new(&conn, DIM);
+
+            // scope 1 (root) exists by default; create scope 2 for the wrong-scope fact
+            // (facts.scope_id has a FK to scopes.id).
+            let scope_store = crate::store::scopes::ScopeStore::new(&conn);
+            let scope2 = scope_store.insert(1, "other", 1).unwrap().id;
+
+            let make =
+                |content: &str, emb: Vec<f32>, ft: FactType, scope: i64, expired: bool| -> i64 {
+                    let fact = NewFact {
+                        content: content.into(),
+                        content_hash: String::new(),
+                        embedding: emb,
+                        fact_type: ft,
+                        t_created: Utc::now(),
+                        t_expired: if expired { Some(Utc::now()) } else { None },
+                        t_valid: None,
+                        t_invalid: None,
+                        source_event_id: None,
+                        scope_id: scope,
+                        base_importance: 0.5,
+                        access_count: 0,
+                        last_accessed: Utc::now(),
+                        metadata: serde_json::json!({}),
+                        is_pinned: false,
+                    };
+                    store.insert(&fact).unwrap()
+                };
+
+            // Near-query semantic facts in scope 1 (the wanted matches).
+            let near_a = make(
+                "near a",
+                vec![1.0, 0.0, 0.0, 0.0],
+                FactType::Semantic,
+                1,
+                false,
+            );
+            let near_b = make(
+                "near b",
+                vec![0.9, 0.1, 0.0, 0.0],
+                FactType::Semantic,
+                1,
+                false,
+            );
+            // Same scope/type but must be filtered OUT by expiry.
+            let expired = make(
+                "expired",
+                vec![0.95, 0.05, 0.0, 0.0],
+                FactType::Semantic,
+                1,
+                true,
+            );
+            // Wrong fact_type — excluded by the fact_type filter.
+            let wrong_type = make(
+                "wrong type",
+                vec![0.98, 0.02, 0.0, 0.0],
+                FactType::Episodic,
+                1,
+                false,
+            );
+            // Wrong scope — excluded by the scope filter.
+            let wrong_scope = make(
+                "wrong scope",
+                vec![0.97, 0.03, 0.0, 0.0],
+                FactType::Semantic,
+                scope2,
+                false,
+            );
+
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+            // The HNSW build scans `t_expired IS NULL`, so `expired` was never indexed;
+            // re-insert its (still-active-in-graph) embedding so a stale graph entry
+            // could surface it — the batched query's `t_expired IS NULL` must still drop it.
+            strategy
+                .notify_insert(expired, &[0.95_f32, 0.05, 0.0, 0.0])
+                .unwrap();
+
+            let query = [1.0_f32, 0.0, 0.0, 0.0];
+            let results = strategy
+                .search(&conn, &query, DIM, 2, Some(&FactType::Semantic), Some(&[1]))
+                .unwrap();
+
+            let found: Vec<i64> = results.iter().map(|r| r.fact_id).collect();
+            assert!(
+                found.contains(&near_a) && found.contains(&near_b),
+                "both in-scope, in-type, active facts must be returned, got {found:?}"
+            );
+            assert!(
+                !found.contains(&expired),
+                "expired fact must be excluded by t_expired IS NULL"
+            );
+            assert!(
+                !found.contains(&wrong_type),
+                "wrong fact_type must be excluded by the fact_type filter"
+            );
+            assert!(
+                !found.contains(&wrong_scope),
+                "wrong scope must be excluded by the scope filter"
+            );
+
+            // Scores must equal an independent cosine computation over the stored vector.
+            for r in &results {
+                let blob: Vec<u8> = conn
+                    .query_row(
+                        "SELECT embedding FROM facts WHERE id = ?1",
+                        [r.fact_id],
+                        |row| row.get(0),
+                    )
+                    .unwrap();
+                let emb = deserialize_embedding(&blob, DIM).unwrap();
+                let expected = crate::search::cosine_similarity(&query, &emb);
+                assert!(
+                    (r.score - expected).abs() < f32::EPSILON,
+                    "score for {} must match cosine, got {} expected {expected}",
+                    r.fact_id,
+                    r.score
+                );
+            }
+        }
+
+        #[test]
+        fn hnsw_strategy_one_batched_query_per_widening_attempt() {
+            // #288 / #362: the batched candidate fetch must issue exactly ONE
+            // candidate query (the `json_each` batch) per widening attempt — never
+            // 2N per-candidate round-trips. We trace SQL statements during `search`
+            // and count those that touch the batch query (identified by `json_each`).
+            use rusqlite::trace::{TraceEvent, TraceEventCodes};
+            use std::cell::Cell;
+
+            // `trace_v2` takes a bare `fn` pointer (no captures), so the counter
+            // lives in a thread-local the callback bumps. Single-threaded test.
+            thread_local! {
+                static BATCH_QUERIES: Cell<usize> = const { Cell::new(0) };
+            }
+            #[allow(
+                clippy::needless_pass_by_value,
+                reason = "signature is fixed by `Connection::trace_v2`, which takes a \
+                          bare `fn(TraceEvent)` — a reference param would not match"
+            )]
+            fn on_stmt(ev: TraceEvent<'_>) {
+                if let TraceEvent::Stmt(_, sql) = ev
+                    && sql.contains("json_each")
+                {
+                    BATCH_QUERIES.with(|c| c.set(c.get() + 1));
+                }
+            }
+
+            let (conn, _ids) = setup_with_facts();
+            let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
+
+            BATCH_QUERIES.with(|c| c.set(0));
+            conn.trace_v2(TraceEventCodes::SQLITE_TRACE_STMT, Some(on_stmt));
+
+            // A request the index can satisfy without widening: limit 2 over 3 facts,
+            // no filters → first attempt yields >= limit, loop breaks after one pass.
+            let query = [1.0_f32, 0.0, 0.0, 0.0];
+            let results = strategy.search(&conn, &query, DIM, 2, None, None).unwrap();
+
+            conn.trace_v2(TraceEventCodes::empty(), None);
+            assert_eq!(results.len(), 2, "search must satisfy the request");
+            assert_eq!(
+                BATCH_QUERIES.with(Cell::get),
+                1,
+                "exactly one batched candidate query per widening attempt (1 attempt here)"
+            );
+        }
+
+        #[test]
         fn hnsw_strategy_notify_expire_excludes_from_results() {
             let (conn, ids) = setup_with_facts();
             let strategy = HnswStrategy::build_from_db(&conn, DIM).unwrap();
 
             // Tombstone in HNSW index
             strategy.notify_expire(ids[0]);
-            // Also expire in DB so check_fact_filters excludes it
+            // Also expire in DB so the batched candidate fetch excludes it
             conn.execute(
                 "UPDATE facts SET t_expired = datetime('now') WHERE id = ?1",
                 [ids[0]],

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
@@ -237,14 +237,14 @@ impl SqliteBackend {
     /// this is always `false` (brute-force).
     ///
     /// The extra guard `filter_is_hnsw_compatible` ensures the filter does not
-    /// carry predicates that HNSW's `check_fact_filters` cannot honour (pinned,
+    /// carry predicates that HNSW's batched candidate fetch cannot honour (pinned,
     /// metadata, ids, non-Active temporal). In those cases the richer brute-force
     /// SQL path is used so no result is incorrectly included or excluded.
     #[cfg(feature = "ann")]
     fn should_use_hnsw(&self, filter: &crate::storage::FactFilter) -> bool {
         use crate::storage::TemporalFilter;
         // Replication of `engine/mod.rs:379-387` + filter-compatibility guard.
-        // HNSW's `check_fact_filters` only handles:
+        // HNSW's batched candidate fetch only handles:
         //   t_expired IS NULL  +  fact_type  +  scope_ids
         // Any extra dimension (pinned, metadata, ids, non-Active temporal) must
         // fall through to the full brute-force SQL path.

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/search_index.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/search_index.rs
@@ -68,20 +68,20 @@ impl SearchIndex for SqliteBackend {
                     .expect("should_use_hnsw() is true only when hnsw is Some"),
             );
             // The read guard (`conn`) must be held for the entire HNSW search because
-            // per-candidate DB reads (`check_fact_filters`, `load_embedding`) all use
-            // the same connection. Dropping it early would require a separate `pool.read()`
-            // per candidate, which is both more expensive and semantically inconsistent.
+            // the batched candidate fetch (one query per widening attempt) uses the
+            // same connection. Dropping it early would require a separate `pool.read()`
+            // per attempt, which is both more expensive and semantically inconsistent.
             #[allow(
                 clippy::significant_drop_tightening,
                 reason = "conn guard must outlive the HNSW search; early drop would \
-                          require a separate connection per candidate lookup"
+                          require a separate connection per candidate-fetch query"
             )]
             let out = tokio::task::spawn_blocking(move || {
                 use crate::search::strategy::VectorSearchStrategy as _;
                 let conn = pool.read()?;
-                // `HnswStrategy::search` post-filters each HNSW candidate via
-                // `check_fact_filters` (t_expired IS NULL + fact_type + scope_id),
-                // then exact-scores via `load_embedding` — all inside the closure.
+                // `HnswStrategy::search` post-filters + exact-scores all HNSW
+                // candidates in ONE batched query per widening attempt (#288/#362):
+                // `t_expired IS NULL` + fact_type + scope_id, then cosine in Rust.
                 let results =
                     hnsw.search(&conn, &q, dim, k, fact_type.as_ref(), scope_ids.as_deref())?;
                 // Widen f32 → f64 at the backend boundary (value-exact, order-preserving).
@@ -713,7 +713,7 @@ mod hnsw_tests {
             .unwrap();
         assert_eq!(hnsw_result.len(), 2, "HNSW must return 2 results");
 
-        // IDs and scores must match exactly (HNSW exact-rescores via load_embedding).
+        // IDs and scores must match exactly (HNSW exact-rescores via the batched fetch).
         assert_eq!(
             hnsw_result.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
             oracle.iter().map(|(id, _)| *id).collect::<Vec<_>>(),


### PR DESCRIPTION
## What

Phase 2 of `HnswStrategy::search` issued **two SQLite round-trips per HNSW candidate** — `check_fact_filters` (an `EXISTS` query) then `load_embedding` (a `SELECT embedding`). With `overfetch = limit * OVERFETCH_FACTOR` candidates and up to `MAX_WIDEN_ATTEMPTS` widening passes, that is a `2N` N+1 pattern (e.g. limit 50 + one widening → `2 * 150 = 300` round-trips before the brute-force fallback).

This replaces the per-candidate pair with a **single batched query per widening attempt**:

```sql
SELECT id, embedding FROM facts
WHERE id IN (SELECT value FROM json_each(?1))
  AND t_expired IS NULL
  AND (?2 IS NULL OR fact_type = ?2)
  AND (?3 IS NULL OR scope_id IN (SELECT value FROM json_each(?3)))
```

Surviving rows land in a `HashMap<i64, Vec<f32>>` (built by the new `fetch_candidate_embeddings`), then candidates are cosine-scored in Rust.

## Semantics preserved

- **Filter predicates** are byte-for-byte the ones the two removed helpers enforced: active (`t_expired IS NULL`), optional `fact_type`, optional scope. A candidate absent from the result set (filtered out, or a stale HNSW graph entry whose fact was expired) is dropped exactly as the old `EXISTS` check did.
- **Ranking/order** is unchanged: scoring iterates `candidates` in HNSW-neighbor order, so the pre-sort order matches the old loop, and the final `sort_by` is stable → equal-score tie-breaking is identical.
- The widening loop re-runs the batched query each attempt on the (larger) candidate set, as before.

The now-unused `check_fact_filters` / `load_embedding` are removed (grep-confirmed they had no other callers; stale references in `storage/sqlite/{mod,search_index}.rs` comments updated).

## Tests (TDD, `--features ann`)

- `hnsw_strategy_batched_fetch_respects_filters_and_expiry` — 5-fact fixture (one per excluded dimension: wrong fact_type, wrong scope, expired) proves the batched path returns only the in-scope/in-type/active facts and that each score equals an independent cosine computation. This test **passed against the old code too** — it pins the semantics across the refactor.
- `hnsw_strategy_one_batched_query_per_widening_attempt` — uses `Connection::trace_v2` to count statements touching the batch query; asserts exactly **one** per widening attempt. Against the old code this counted **3** (one per candidate), confirming the N+1; now it is **1**.

The trace assertion needs `rusqlite`'s `trace` feature — added to the existing `bundled`. It is additive and **adds no new crate to the dependency graph** (verified with `cargo deny check`).

## Gate

- `cargo fmt --check` ✅
- `cargo clippy -p memory-engine --all-targets --all-features -- -D warnings` ✅ (clean)
- `cargo test -p memory-engine` ✅ (1230) and `--features ann` ✅ (1262)
- `cargo deny check` ✅

### Note for reviewers

`cargo clippy --features ann` (without `--all-features`) surfaces a **pre-existing** `dead_code` error for `break_facts_table` in `storage/conformance/factory.rs` — reproduced on a clean `origin/main` checkout, unrelated to this change, and masked by the CI `--all-features` gate where the method is used. Filing as collateral, not folded in.

Closes #288, Closes #362. Part of #257.