### PR TITLE
refactor(storage): str_to_fact_type/str_to_event_type return a parse error, not NotFound, for invalid variants

### DIFF
--- a/memory-engine/lib/memory-engine/src/store/events.rs
+++ b/memory-engine/lib/memory-engine/src/store/events.rs
@@ -36,6 +36,18 @@ pub const fn event_type_to_str(et: &EventType) -> &'static str {
 /// #560), **not** [`MemoryError::NotFound`] — `NotFound` means "the requested row
 /// is absent", a semantically distinct, recoverable condition (#366). The message
 /// embeds the offending token verbatim for diagnostics.
+///
+/// What a *read-path* caller sees, end-to-end: the read site ([`row_to_event`])
+/// boxes this `Internal` into `rusqlite::Error::FromSqlConversionFailure`, which
+/// re-maps to [`MemoryError::Database`] via its `#[from]`. So the surfaced
+/// top-level variant is `Database` (a *data* error — the correct class for corrupt
+/// stored data, and crucially **not** `NotFound`, the conflation #366 reported),
+/// with this `Internal` preserved as the boxed source. The `Internal` value here
+/// is therefore the directly-observable error only for a *direct* caller; the read
+/// path re-classifies it to `Database`. Both surfaced behaviors are covered by
+/// tests (`corrupt_event_type_read_path_surfaces_database_not_notfound` for the
+/// end-to-end path, `str_to_event_type_rejects_unknown_as_internal` for the direct
+/// call).
 fn str_to_event_type(s: &str) -> Result<EventType> {
     match s {
         "Interaction" => Ok(EventType::Interaction),
@@ -390,6 +402,53 @@ mod tests {
         let store = EventStore::new(&conn, &registry);
         let err = store.get(999).unwrap_err();
         assert!(matches!(err, MemoryError::NotFound(_)));
+    }
+
+    /// #366 end-to-end (read path): corrupt the stored `event_type` of a real row,
+    /// then read it back through the normal `EventStore::get` path and assert the
+    /// **actual user-visible** `MemoryError`.
+    ///
+    /// The isolated [`str_to_event_type_rejects_unknown_as_internal`] test below
+    /// only exercises the private helper; the production caller (`row_to_event`)
+    /// boxes its error into `rusqlite::Error::FromSqlConversionFailure`, which
+    /// re-maps to [`MemoryError::Database`] via its `#[from]`. So the helper's
+    /// `Internal` never reaches a read-path caller as the top-level variant.
+    ///
+    /// What #366 actually demanded — *do not surface [`MemoryError::NotFound`] for
+    /// a corrupt enum* — is met end-to-end: the surfaced variant is `Database` (a
+    /// data error, the correct class for corrupt stored data), distinct from
+    /// `NotFound`, with `Internal("corrupt stored event_type: …")` preserved as the
+    /// boxed source. Unlike `facts`, the `events.event_type` column has **no** CHECK
+    /// constraint, so this corruption is reachable through a plain UPDATE.
+    #[test]
+    fn corrupt_event_type_read_path_surfaces_database_not_notfound() {
+        let conn = setup();
+        let registry = UpcasterRegistry::new();
+        let store = EventStore::new(&conn, &registry);
+        let id = store.insert(&make_event("p", None)).unwrap();
+        conn.execute(
+            "UPDATE events SET event_type = 'bogus' WHERE id = ?1",
+            params![id],
+        )
+        .unwrap();
+
+        let err = store.get(id).unwrap_err();
+        // The user-visible top-level variant is Database (the helper's Internal is
+        // boxed by FromSqlConversionFailure and re-mapped via `#[from]`).
+        assert!(
+            matches!(err, MemoryError::Database(_)),
+            "read-path corrupt event_type must surface Database, got {err:?}"
+        );
+        // #366's actual harm — surfacing NotFound for a corrupt enum — is gone.
+        assert!(
+            !matches!(err, MemoryError::NotFound(_)),
+            "a corrupt stored event_type must never read back as NotFound (#366), got {err:?}"
+        );
+        // The diagnostic helper message survives as the boxed source.
+        assert!(
+            err.to_string().contains("corrupt stored event_type"),
+            "the diagnostic message must be preserved through the box, got {err}"
+        );
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/store/events.rs
+++ b/memory-engine/lib/memory-engine/src/store/events.rs
@@ -26,6 +26,16 @@ pub const fn event_type_to_str(et: &EventType) -> &'static str {
     }
 }
 
+/// Parse an `event_type` string read back from the store into the core
+/// [`EventType`].
+///
+/// Values are written via [`event_type_to_str`], so a token that names no known
+/// variant is **data-integrity corruption** (the `event_type` column was tampered
+/// with or otherwise corrupted), not a missing row. It maps to
+/// [`MemoryError::Internal`] (a terminal "this shouldn't happen" / corrupt state,
+/// #560), **not** [`MemoryError::NotFound`] — `NotFound` means "the requested row
+/// is absent", a semantically distinct, recoverable condition (#366). The message
+/// embeds the offending token verbatim for diagnostics.
 fn str_to_event_type(s: &str) -> Result<EventType> {
     match s {
         "Interaction" => Ok(EventType::Interaction),
@@ -33,8 +43,8 @@ fn str_to_event_type(s: &str) -> Result<EventType> {
         "MemoryOp" => Ok(EventType::MemoryOp),
         "SystemEvent" => Ok(EventType::SystemEvent),
         "OutcomeSignal" => Ok(EventType::OutcomeSignal),
-        other => Err(MemoryError::NotFound(format!(
-            "unknown event type: {other}"
+        other => Err(MemoryError::Internal(format!(
+            "corrupt stored event_type: {other}"
         ))),
     }
 }
@@ -380,6 +390,29 @@ mod tests {
         let store = EventStore::new(&conn, &registry);
         let err = store.get(999).unwrap_err();
         assert!(matches!(err, MemoryError::NotFound(_)));
+    }
+
+    #[test]
+    fn str_to_event_type_rejects_unknown_as_internal() {
+        // An `event_type` string read back from the DB that names no known
+        // variant is a data-integrity failure (the store wrote it via
+        // `event_type_to_str`, so a value that does not parse means the row is
+        // corrupt) — NOT a missing-row condition. It must map to
+        // `MemoryError::Internal`, never `MemoryError::NotFound` (#366).
+        let err = str_to_event_type("Bogus").unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Internal(_)),
+            "expected Internal, got {err:?}"
+        );
+        // The message stays greppable: it carries the offending token verbatim.
+        assert!(
+            err.to_string().contains("Bogus"),
+            "message must include the offending string, got {err}"
+        );
+        assert!(
+            !matches!(err, MemoryError::NotFound(_)),
+            "an unparseable stored enum is not a NotFound condition"
+        );
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -55,9 +55,17 @@ pub const fn fact_type_to_str(ft: &FactType) -> &'static str {
 /// here. Stored values are written as `snake_case` via [`fact_type_to_str`]; the
 /// canonical parser accepts that (and is case-insensitive), so the DB round-trip
 /// is unaffected.
+///
+/// A value that does not parse is therefore **data-integrity corruption**, not a
+/// missing row: the store always writes a canonical token, so an unparseable one
+/// means the `fact_type` column was tampered with or otherwise corrupted. It maps
+/// to [`MemoryError::Internal`] (a terminal "this shouldn't happen" / corrupt
+/// state, #560), **not** [`MemoryError::NotFound`] — `NotFound` means "the
+/// requested row is absent", a semantically distinct, recoverable condition
+/// (#366). The message embeds the offending token verbatim for diagnostics.
 fn str_to_fact_type(s: &str) -> Result<FactType> {
     s.parse::<FactType>()
-        .map_err(|e| MemoryError::NotFound(e.to_string()))
+        .map_err(|e| MemoryError::Internal(format!("corrupt stored fact_type: {e}")))
 }
 
 /// Compute blake3 hex hash of content, truncated to first 32 characters (128 bits).
@@ -1439,6 +1447,29 @@ mod tests {
             scope_id: 1,
             is_pinned: false,
         }
+    }
+
+    #[test]
+    fn str_to_fact_type_rejects_unknown_as_internal() {
+        // A `fact_type` string read back from the DB that names no known variant
+        // is a data-integrity failure (the store wrote it via `fact_type_to_str`,
+        // so a value that does not parse means the row is corrupt) — NOT a
+        // missing-row condition. It must map to `MemoryError::Internal`, never
+        // `MemoryError::NotFound` (#366).
+        let err = str_to_fact_type("bogus").unwrap_err();
+        assert!(
+            matches!(err, MemoryError::Internal(_)),
+            "expected Internal, got {err:?}"
+        );
+        // The message stays greppable: it carries the offending token verbatim.
+        assert!(
+            err.to_string().contains("bogus"),
+            "message must include the offending string, got {err}"
+        );
+        assert!(
+            !matches!(err, MemoryError::NotFound(_)),
+            "an unparseable stored enum is not a NotFound condition"
+        );
     }
 
     /// #257 regression: the snapshot referential-validation set MUST include

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -63,6 +63,22 @@ pub const fn fact_type_to_str(ft: &FactType) -> &'static str {
 /// state, #560), **not** [`MemoryError::NotFound`] — `NotFound` means "the
 /// requested row is absent", a semantically distinct, recoverable condition
 /// (#366). The message embeds the offending token verbatim for diagnostics.
+///
+/// What a *read-path* caller sees, end-to-end: the read sites ([`row_to_fact`],
+/// [`row_to_scoring_row`]) box this `Internal` into
+/// `rusqlite::Error::FromSqlConversionFailure`, which re-maps to
+/// [`MemoryError::Database`] via its `#[from]`. So the surfaced top-level variant
+/// is `Database` (a *data* error — the correct class for corrupt stored data, and
+/// crucially **not** `NotFound`, which is exactly the conflation #366 reported),
+/// with this `Internal` preserved as the boxed source for diagnostics. The
+/// `Internal` value here is therefore the directly-observable error only for a
+/// *direct* caller of this helper; the read path re-classifies it to `Database`.
+/// On the `SQLite` backend a `CHECK(fact_type IN (…))` constraint additionally makes
+/// this arm unreachable through ordinary SQL — it fires only on genuine on-disk
+/// tampering or a backend without that constraint. Both surfaced behaviors are
+/// covered by tests (`corrupt_fact_type_read_path_surfaces_database_not_notfound`
+/// for the end-to-end path, `str_to_fact_type_rejects_unknown_as_internal` for the
+/// direct call).
 fn str_to_fact_type(s: &str) -> Result<FactType> {
     s.parse::<FactType>()
         .map_err(|e| MemoryError::Internal(format!("corrupt stored fact_type: {e}")))
@@ -1447,6 +1463,66 @@ mod tests {
             scope_id: 1,
             is_pinned: false,
         }
+    }
+
+    /// #366 end-to-end (read path): corrupt the stored `fact_type` of a real row,
+    /// then read it back through the normal `FactStore::get` path and assert the
+    /// **actual user-visible** `MemoryError`.
+    ///
+    /// This is the test that proves the #366 fix where a user can observe it — the
+    /// isolated [`str_to_fact_type_rejects_unknown_as_internal`] test below only
+    /// exercises the private helper, but every production caller (`row_to_fact`,
+    /// `row_to_scoring_row`) boxes the helper's error into
+    /// `rusqlite::Error::FromSqlConversionFailure`, which re-maps to
+    /// [`MemoryError::Database`] via its `#[from]`. So the helper's `Internal`
+    /// never reaches a read-path caller as the top-level variant.
+    ///
+    /// What #366 actually demanded — *do not surface [`MemoryError::NotFound`] for
+    /// a corrupt enum* (which lets a caller matching `NotFound` mistake a corrupt
+    /// store for "no such fact") — is met **end-to-end**: the surfaced variant is
+    /// `Database`, a data error, which is the semantically correct class for
+    /// corrupt stored data, and is distinct from `NotFound`. The diagnostic
+    /// `Internal("corrupt stored fact_type: …")` is preserved as the boxed source.
+    ///
+    /// Note the `SQLite` schema carries `CHECK(fact_type IN (…))`, so this corruption
+    /// is unreachable through ordinary SQL — the test must
+    /// `PRAGMA ignore_check_constraints` to simulate genuine on-disk tampering or a
+    /// backend without the constraint (the exact scenario the helper guards).
+    #[test]
+    fn corrupt_fact_type_read_path_surfaces_database_not_notfound() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let id = store.insert(&make_fact("p", vec![0.0; DIM])).unwrap();
+        // The `CHECK(fact_type IN (...))` constraint rejects a bad value on a plain
+        // UPDATE; bypass it to simulate genuine on-disk corruption / a non-CHECK
+        // backend — the only way `str_to_fact_type`'s corrupt arm is reachable.
+        conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+            .unwrap();
+        conn.execute(
+            "UPDATE facts SET fact_type = 'bogus' WHERE id = ?1",
+            params![id],
+        )
+        .unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+            .unwrap();
+
+        let err = store.get(id).unwrap_err();
+        // The user-visible top-level variant is Database (the helper's Internal is
+        // boxed by FromSqlConversionFailure and re-mapped via `#[from]`).
+        assert!(
+            matches!(err, MemoryError::Database(_)),
+            "read-path corrupt fact_type must surface Database, got {err:?}"
+        );
+        // #366's actual harm — surfacing NotFound for a corrupt enum — is gone.
+        assert!(
+            !matches!(err, MemoryError::NotFound(_)),
+            "a corrupt stored fact_type must never read back as NotFound (#366), got {err:?}"
+        );
+        // The diagnostic helper message survives as the boxed source.
+        assert!(
+            err.to_string().contains("corrupt stored fact_type"),
+            "the diagnostic message must be preserved through the box, got {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`str_to_fact_type` (`store/facts.rs`) and `str_to_event_type` (`store/events.rs`) run on the **read path**, deserializing the `fact_type` / `event_type` column back from the database. Both classified an unparseable value as `MemoryError::NotFound`.

That conflates two unrelated error classes. `NotFound` means *"the requested row is absent"* — a recoverable, expected condition a caller may branch on. But these strings are written by `fact_type_to_str` / `event_type_to_str`, so a value that does **not** parse cannot be a missing row: it is **data-integrity corruption** (the column was tampered with, or a write/read invariant broke). Mapping it to `NotFound` lets a caller matching `NotFound` silently treat a corrupt store as "no such fact".

## Change (per issue)

- **#366** — Map both parse seams to `MemoryError::Internal` instead of `NotFound`.
  - `store/facts.rs::str_to_fact_type` → `Internal("corrupt stored fact_type: {e}")`
  - `store/events.rs::str_to_event_type` → `Internal("corrupt stored event_type: {other}")`

### Why `Internal`, not a new `InvalidData`/`Corruption` variant

Per the **#560** typed-error arc, `Internal` is the documented home for *"a bug or corrupted state the caller cannot meaningfully recover from"* — terminal, propagate-don't-`match`. A corrupt stored enum has **no per-value recovery** (no caller can act differently per offending string), so #560's "one variant per *recoverable* cause" rule argues **against** adding a dedicated `InvalidData`/`Corruption` variant here. `error.rs` is therefore intentionally untouched; this is a pure read-path semantic fix scoped to the two store modules. The message stays greppable, embedding the offending token verbatim.

The legitimate row-absent `NotFound` (e.g. `EventStore::get` / `FactStore::get` on a missing id) is unchanged — only the parse seam moves. No existing test asserted `NotFound` from these parse paths (the one `NotFound` test, `events::get_not_found`, is the genuine missing-row path and stays).

## Test plan (TDD)

Added one focused unit test per seam (red→green): asserts `Internal` (not `NotFound`) and that the message contains the offending token.

| Gate | Result |
| --- | --- |
| `cargo fmt --all` | clean |
| `cargo build --workspace` (default features) | exit 0 |
| `cargo build --workspace --all-features` | exit 0 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | No issues found |
| `cargo test -p memory-engine --all-features` | 1378 passed, 71 ignored |

Fixes #366