### PR TITLE
fix(storage): EdgeStore::expire reports NotFound for a nonexistent edge id (rows-affected contract)

### DIFF
--- a/memory-engine/lib/memory-engine/src/storage/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/graph.rs
@@ -187,6 +187,15 @@ pub trait FactGraph: Send + Sync {
     // --- edges ---
     async fn insert_edge(&self, edge: &NewEdge) -> Result<i64>;
     async fn get_edge(&self, id: i64) -> Result<Edge>;
+    /// Soft-expire a single edge by setting its `t_expired`. Idempotency guard:
+    /// only an *active* edge is affected, so `Ok(())` always means this call
+    /// transitioned an active edge to expired.
+    ///
+    /// Returns [`MemoryError::NotFound`](crate::error::MemoryError::NotFound) if
+    /// no active edge with `id` exists (unknown id, or already expired) — the
+    /// write affected 0 rows. Mirrors [`expire_fact`](Self::expire_fact); a
+    /// backend MUST honor this rows-affected contract (the #632 conformance suite
+    /// pins it).
     async fn expire_edge(&self, id: i64, now: DateTime<Utc>) -> Result<()>;
     async fn expire_edges_by_fact(&self, fact_id: i64, now: DateTime<Utc>) -> Result<usize>;
     async fn list_all_edges(&self) -> Result<Vec<Edge>>;

--- a/memory-engine/lib/memory-engine/src/storage/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/graph.rs
@@ -194,8 +194,9 @@ pub trait FactGraph: Send + Sync {
     /// Returns [`MemoryError::NotFound`](crate::error::MemoryError::NotFound) if
     /// no active edge with `id` exists (unknown id, or already expired) — the
     /// write affected 0 rows. Mirrors [`expire_fact`](Self::expire_fact); a
-    /// backend MUST honor this rows-affected contract (the #632 conformance suite
-    /// pins it).
+    /// backend MUST honor this rows-affected contract. The `SQLite` impl honors
+    /// it; cross-backend conformance coverage (a `#632`-style arm) is a `#635`
+    /// follow-up.
     async fn expire_edge(&self, id: i64, now: DateTime<Utc>) -> Result<()>;
     async fn expire_edges_by_fact(&self, fact_id: i64, now: DateTime<Utc>) -> Result<usize>;
     async fn list_all_edges(&self) -> Result<Vec<Edge>>;

--- a/memory-engine/lib/memory-engine/src/store/edges.rs
+++ b/memory-engine/lib/memory-engine/src/store/edges.rs
@@ -79,14 +79,23 @@ impl<'a> EdgeStore<'a> {
 
     /// Expire an edge (soft-delete).
     ///
+    /// Idempotency guard (`t_expired IS NULL`): only an active edge is affected,
+    /// so a successful `Ok(())` always means *this* call transitioned an active
+    /// edge to expired. Mirrors [`FactStore::expire`](crate::store::facts::FactStore::expire).
+    ///
     /// # Errors
     ///
+    /// Returns `MemoryError::NotFound` if no active edge with `id` exists (the id
+    /// is unknown, or the edge was already expired) — the UPDATE affected 0 rows.
     /// Returns `MemoryError::Database` on SQL failure.
     pub fn expire(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
-        self.conn.execute(
-            "UPDATE edges SET t_expired = ?1 WHERE id = ?2",
+        let changed = self.conn.execute(
+            "UPDATE edges SET t_expired = ?1 WHERE id = ?2 AND t_expired IS NULL",
             params![now.to_rfc3339(), id],
         )?;
+        if changed == 0 {
+            return Err(MemoryError::NotFound(format!("edge {id}")));
+        }
         Ok(())
     }
 
@@ -396,6 +405,41 @@ mod tests {
         store.expire(id, Utc::now()).unwrap();
         let got = store.get(id).unwrap();
         assert!(got.t_expired.is_some());
+    }
+
+    #[test]
+    fn expire_nonexistent_edge_is_not_found() {
+        // #330: expiring an id that matches no row is an error, not a silent
+        // no-op. `Ok(())` must mean an edge was actually expired — mirroring
+        // `FactStore::expire`'s rows-affected contract.
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        let err = store
+            .expire(9999, Utc::now())
+            .expect_err("expiring a nonexistent edge id must return NotFound");
+        assert!(
+            matches!(err, MemoryError::NotFound(_)),
+            "expected MemoryError::NotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn expire_already_expired_edge_is_not_found() {
+        // The `t_expired IS NULL` guard makes re-expiring an already-expired
+        // edge a no-op at the SQL level, which the rows-affected check surfaces
+        // as NotFound — identical to `FactStore::expire`. This keeps `Ok(())`
+        // meaning "this call transitioned an active edge to expired".
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        let id = store.insert(&make_edge(1, 2, "test")).unwrap();
+        store.expire(id, Utc::now()).unwrap();
+        let err = store
+            .expire(id, Utc::now())
+            .expect_err("re-expiring an already-expired edge must return NotFound");
+        assert!(
+            matches!(err, MemoryError::NotFound(_)),
+            "expected MemoryError::NotFound, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`EdgeStore::expire` (and the `FactGraph::expire_edge` port it backs) executed its `UPDATE` and unconditionally returned `Ok(())`, discarding the affected-row count. Expiring an edge id that matched no row was an **undetected no-op** — callers got `Ok(())` even though nothing was expired, contradicting the invariant that a successful expire means an edge actually transitioned to expired. This diverged from every sibling write method (`FactStore::expire`, `expire_and_invalidate`, `update_base_importance`, `increment_access`) which all check rows-affected and return `MemoryError::NotFound` on 0 rows.

Fixes #330 (epic #258).

## Change

- **`store/edges.rs`** — `EdgeStore::expire` now mirrors `FactStore::expire` exactly: the `UPDATE` carries the `t_expired IS NULL` idempotency guard, and a 0-rows result returns `MemoryError::NotFound("edge {id}")`. Both an unknown id and an already-expired edge now surface as `NotFound`, so `Ok(())` reliably means *this* call expired an active edge. Doc updated.
- **`storage/graph.rs`** — documented the rows-affected `NotFound` contract on the `FactGraph::expire_edge` trait method (it previously had no per-method doc, unlike `expire_fact`), binding every backend — including the future `PgBackend` — to honor it.
- **`storage/sqlite/graph.rs`** — no change needed: the port wrapper is a pure passthrough that propagates whatever the store returns.

## Caller safety

No production code invokes the single-edge `expire_edge` today. Bulk edge expiry (conflict-resolution cascade, archive hard-delete) goes through `expire_edges_by_fact` / `hard_delete_edges_by_facts`, which return counts and are **untouched**. The only `expire_edge` callers are tests, so the stricter contract breaks no existing behavior — verified by grep across the whole `lib/` tree.

## Test plan (TDD)

Added two failing-first unit tests in `store/edges.rs`, watched them fail (old impl returned `Ok`), then implemented:
- `expire_nonexistent_edge_is_not_found` — expiring id `9999` (no row) → `NotFound`.
- `expire_already_expired_edge_is_not_found` — re-expiring an already-expired edge → `NotFound` (the idempotency guard).
- `expire_edge` (existing happy path) stays green.

## Full CI matrix (all green)

| Gate | Result |
| --- | --- |
| `cargo fmt --all` | clean |
| `cargo build --workspace` (default) | ok* |
| `cargo build --workspace --all-features` | ok |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | ok |
| `cargo test -p memory-engine --all-features` | ok (16 suites, 0 failed) |

\* The default-features build emits one pre-existing `unused_variable` warning in `storage/sqlite/consolidation.rs:662` (an `ann`-gated binding), unrelated to this change and present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)