### PR TITLE
test(storage): cover FactState branches, determine_state priority, build_graph_context, fact_history Expired

### DIFF
--- a/memory-engine/lib/memory-engine/src/inspect/explain.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/explain.rs
@@ -160,7 +160,12 @@ mod tests {
 
     /// #314: a `t_invalid` that is strictly in the *future* must NOT invalidate —
     /// `is_temporally_due` keeps the fact `Due` (it also has a past `t_valid`).
-    /// This pins the `t_invalid <= now` boundary so a `<` / `<=` flip is caught.
+    ///
+    /// Note: a strictly-future `t_invalid` behaves identically under `<` and `<=`,
+    /// so this case alone does NOT discriminate the `t_invalid <= now` boundary
+    /// (the flip is silently accepted). The exact-boundary case
+    /// [`determine_state_t_invalid_at_now_is_invalidated`] pins the `<=` vs `<`
+    /// distinction; this one only covers the "clearly future ⇒ still Due" branch.
     #[test]
     fn determine_state_future_t_invalid_is_not_invalidated() {
         let now = Utc::now();
@@ -173,6 +178,27 @@ mod tests {
             matches!(state, FactState::Due { .. }),
             "future t_invalid must stay Due, got {state:?}"
         );
+    }
+
+    /// #314: the exact `t_invalid == now` boundary classifies as `Invalidated`,
+    /// pinning the `t_invalid <= now` comparison against a `<=` → `<` flip.
+    ///
+    /// This is the discriminating case the strictly-future test above cannot reach:
+    /// under the live `<=` the fact is `Invalidated { t_invalid: now }`; under a
+    /// mutated `<` the `t_invalid` branch is skipped and — with `t_valid` left
+    /// `None`, so `is_temporally_due` is false — the fact falls through to `Active`.
+    /// Asserting the exact `Invalidated { t_invalid }` (not just the variant) also
+    /// guards the threaded instant.
+    #[test]
+    fn determine_state_t_invalid_at_now_is_invalidated() {
+        let now = Utc::now();
+        let mut fact = baseline_fact(now);
+        // `t_valid` stays None: a `<=` → `<` flip would route to Active (not Due),
+        // making the boundary failure unambiguous.
+        fact.t_invalid = Some(now);
+
+        let state = determine_state(&fact, now);
+        assert_eq!(state, FactState::Invalidated { t_invalid: now });
     }
 
     /// #314: `t_expired` set without a `quarantine` metadata marker → `Unknown`.

--- a/memory-engine/lib/memory-engine/src/inspect/explain.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/explain.rs
@@ -339,6 +339,70 @@ mod tests {
         assert_eq!(ctx.component_size, 4);
     }
 
+    /// #459 / #901: documents the CURRENT behaviour that `build_graph_context`
+    /// returns the **entire weakly-connected component**, NOT the immediate
+    /// (distance-1) neighbours — and that this is *inconsistent* with `degree`,
+    /// which counts only distance-1 in+out edges.
+    ///
+    /// The star fixture in [`build_graph_context_with_neighbors`] cannot expose
+    /// this: in a star every component member is also a distance-1 neighbour of
+    /// the centre, so component-membership and immediate-neighbourhood coincide.
+    /// Here a deliberately **transitive** chain `A(10) -> B(20) -> C(30)` queried
+    /// from `A` separates them: `C` is distance-2 from `A` (NOT an immediate
+    /// neighbour), yet it appears in `neighbor_ids` because the helper walks the
+    /// whole component. `degree(A) == 1` (only the `A->B` edge) confirms the
+    /// distance-1 vs whole-component divergence.
+    ///
+    /// This asserts reality (the whole-component behaviour) rather than hiding it.
+    /// The degree-vs-component inconsistency — and whether `neighbor_ids` should
+    /// instead be the distance-1 neighbour set to match `degree` — is a
+    /// production design decision tracked in collateral issue #901; this test must
+    /// be updated to assert the distance-1 set if/when that fix lands.
+    #[test]
+    fn build_graph_context_returns_whole_component_not_immediate_neighbours() {
+        let mut graph = MemoryGraph::new();
+        let edge = |edge_id| EdgeData {
+            edge_id,
+            relation_type: "supports".into(),
+            weight: 1.0,
+        };
+        // Transitive chain: A(10) -> B(20) -> C(30). C is distance-2 from A.
+        graph.add_edge(10, 20, edge(1));
+        graph.add_edge(20, 30, edge(2));
+
+        let ctx = build_graph_context(&graph, 10);
+
+        // `degree` is distance-1 in+out: A has only the single outgoing `A->B`.
+        assert_eq!(ctx.degree, 1, "A has exactly one distance-1 edge (A->B)");
+
+        // `neighbor_ids` is the WHOLE component minus A — so it INCLUDES the
+        // transitive distance-2 node C(30), proving it is not the distance-1 set.
+        assert_eq!(
+            ctx.neighbor_ids,
+            vec![20, 30],
+            "whole connected component (incl. transitive C=30), NOT immediate neighbours"
+        );
+        // Non-vacuous guard: the transitive node is the load-bearing assertion —
+        // a distance-1-only implementation (matching `degree`) would omit 30.
+        assert!(
+            ctx.neighbor_ids.contains(&30),
+            "transitive distance-2 node C(30) must be present under current whole-component behaviour"
+        );
+
+        // The divergence made explicit: neighbour-set size (2) exceeds degree (1).
+        assert!(
+            ctx.neighbor_ids.len() > ctx.degree,
+            "component-derived neighbour set is broader than the distance-1 degree (tracked in #901)"
+        );
+
+        assert_eq!(
+            ctx.component_size,
+            ctx.neighbor_ids.len() + 1,
+            "neighbours + the fact itself"
+        );
+        assert_eq!(ctx.component_size, 3);
+    }
+
     /// #459: a node present in the graph but with no edges has degree 0, no
     /// neighbours, and a component of just itself — the asymmetric counterpart to
     /// the connected case above (guards `component_size` against a stray +1).

--- a/memory-engine/lib/memory-engine/src/inspect/explain.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/explain.rs
@@ -101,12 +101,322 @@ pub fn fact_history_from_fact(fact_id: i64, fact: &Fact) -> FactHistory {
 mod tests {
     use super::*;
     use crate::engine::MemoryEngine;
+    use crate::graph::{EdgeData, MemoryGraph};
     use crate::traits::EmbeddingProvider;
     use crate::types::{AddFactOptions, AddFactRequest, EventType, FactType, NewEvent};
     use chrono::Duration;
     use std::sync::Arc;
 
     const DIM: usize = 4;
+
+    /// A neutral, *active* baseline fact: no expiry, no valid-time, not pinned.
+    ///
+    /// Tests for [`determine_state`] / [`fact_history_from_fact`] mutate exactly the
+    /// one or two timestamp/flag fields under test on top of this baseline, so each
+    /// assertion isolates a single classifier branch. `determine_state` and
+    /// `fact_history_from_fact` are pure over a `Fact`, so a hand-built struct is
+    /// the most direct, least-coupled way to drive every branch — including the
+    /// past-`t_invalid` and `t_expired` states the engine's `add_fact` entry points
+    /// cannot set.
+    fn baseline_fact(now: DateTime<Utc>) -> Fact {
+        Fact {
+            id: 1,
+            content: "baseline".into(),
+            content_hash: "0".repeat(32),
+            embedding: vec![0.0; DIM],
+            fact_type: FactType::Semantic,
+            t_created: now,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            base_importance: 0.5,
+            access_count: 0,
+            last_accessed: now,
+            metadata: serde_json::json!({}),
+            scope_id: 1,
+            is_pinned: false,
+            importance_score: 0.5,
+            surfaced_at: None,
+        }
+    }
+
+    // --- #314 / #458: determine_state branch + priority coverage -----------
+
+    /// #314: a fact with a *past* `t_invalid` (and no `t_expired`, not pinned)
+    /// classifies as `Invalidated`, and the exact `t_invalid` instant is threaded
+    /// through unchanged. The asserted instant is deliberately offset from both
+    /// `now` and `t_created` so a wrong field (e.g. echoing `now`) would fail.
+    #[test]
+    fn determine_state_invalidated_branch() {
+        let now = Utc::now();
+        let t_invalid = now - Duration::hours(3);
+        let mut fact = baseline_fact(now);
+        fact.t_invalid = Some(t_invalid);
+
+        let state = determine_state(&fact, now);
+        assert_eq!(state, FactState::Invalidated { t_invalid });
+    }
+
+    /// #314: a `t_invalid` that is strictly in the *future* must NOT invalidate —
+    /// `is_temporally_due` keeps the fact `Due` (it also has a past `t_valid`).
+    /// This pins the `t_invalid <= now` boundary so a `<` / `<=` flip is caught.
+    #[test]
+    fn determine_state_future_t_invalid_is_not_invalidated() {
+        let now = Utc::now();
+        let mut fact = baseline_fact(now);
+        fact.t_valid = Some(now - Duration::hours(1));
+        fact.t_invalid = Some(now + Duration::hours(1));
+
+        let state = determine_state(&fact, now);
+        assert!(
+            matches!(state, FactState::Due { .. }),
+            "future t_invalid must stay Due, got {state:?}"
+        );
+    }
+
+    /// #314: `t_expired` set without a `quarantine` metadata marker → `Unknown`.
+    #[test]
+    fn determine_state_expired_unknown_reason() {
+        let now = Utc::now();
+        let mut fact = baseline_fact(now);
+        fact.t_expired = Some(now - Duration::hours(1));
+
+        let state = determine_state(&fact, now);
+        assert_eq!(
+            state,
+            FactState::Expired {
+                reason: ExpiredReason::Unknown
+            }
+        );
+    }
+
+    /// #314: `t_expired` set WITH a `quarantine` metadata marker → `Quarantined`.
+    /// Paired with the `Unknown` case above so a constant-return bug (always one
+    /// reason) is caught by the asymmetry.
+    #[test]
+    fn determine_state_expired_quarantined_reason() {
+        let now = Utc::now();
+        let mut fact = baseline_fact(now);
+        fact.t_expired = Some(now - Duration::hours(1));
+        fact.metadata = serde_json::json!({ "quarantine": "dream-cycle" });
+
+        let state = determine_state(&fact, now);
+        assert_eq!(
+            state,
+            FactState::Expired {
+                reason: ExpiredReason::Quarantined
+            }
+        );
+    }
+
+    /// #458: priority `Pinned > Due` — a pinned fact whose `t_valid` is in the past
+    /// (so it would otherwise be `Due`) classifies as `Pinned`. Catches a chain
+    /// re-order that put the `is_temporally_due` check before `is_pinned`.
+    #[test]
+    fn determine_state_pinned_beats_due() {
+        let now = Utc::now();
+        let mut fact = baseline_fact(now);
+        fact.is_pinned = true;
+        fact.t_valid = Some(now - Duration::hours(1));
+
+        let state = determine_state(&fact, now);
+        assert_eq!(state, FactState::Pinned);
+    }
+
+    /// #458: priority `Expired > Pinned` — an expired *and* pinned fact classifies
+    /// as `Expired`, not `Pinned`. Catches a chain re-order that ran `is_pinned`
+    /// before the `t_expired` check.
+    #[test]
+    fn determine_state_expired_beats_pinned() {
+        let now = Utc::now();
+        let mut fact = baseline_fact(now);
+        fact.t_expired = Some(now - Duration::hours(1));
+        fact.is_pinned = true;
+
+        let state = determine_state(&fact, now);
+        assert_eq!(
+            state,
+            FactState::Expired {
+                reason: ExpiredReason::Unknown
+            }
+        );
+    }
+
+    /// #458: priority `Expired > Invalidated` — a fact that is both expired and
+    /// past-`t_invalid` classifies as `Expired`. Catches a chain re-order that put
+    /// the `t_invalid` check first.
+    #[test]
+    fn determine_state_expired_beats_invalidated() {
+        let now = Utc::now();
+        let mut fact = baseline_fact(now);
+        fact.t_expired = Some(now - Duration::hours(1));
+        fact.t_invalid = Some(now - Duration::hours(2));
+
+        let state = determine_state(&fact, now);
+        assert_eq!(
+            state,
+            FactState::Expired {
+                reason: ExpiredReason::Unknown
+            }
+        );
+    }
+
+    /// #458: priority `Invalidated > Pinned` — a pinned fact whose `t_invalid` is in
+    /// the past classifies as `Invalidated`, not `Pinned`. Catches a chain re-order
+    /// that put `is_pinned` before the `t_invalid` check.
+    #[test]
+    fn determine_state_invalidated_beats_pinned() {
+        let now = Utc::now();
+        let t_invalid = now - Duration::hours(2);
+        let mut fact = baseline_fact(now);
+        fact.t_invalid = Some(t_invalid);
+        fact.is_pinned = true;
+
+        let state = determine_state(&fact, now);
+        assert_eq!(state, FactState::Invalidated { t_invalid });
+    }
+
+    // --- #459: build_graph_context with a connected fact (degree > 0) ------
+
+    /// #459: a fact with >= 1 edge yields a non-trivial graph context — the
+    /// existing tests only ever exercise degree-0 isolated facts. Builds a known
+    /// star (center `10` linked to `20`, `30`, `40`) so degree, the *sorted*
+    /// neighbour set, and the `component_size == neighbors + 1` formula are all
+    /// asserted against distinct, hand-computed values.
+    #[test]
+    fn build_graph_context_with_neighbors() {
+        let mut graph = MemoryGraph::new();
+        let edge = |edge_id| EdgeData {
+            edge_id,
+            relation_type: "supports".into(),
+            weight: 1.0,
+        };
+        // Insert targets out of order so a missing sort would surface.
+        graph.add_edge(10, 40, edge(1)); // outgoing
+        graph.add_edge(10, 20, edge(2)); // outgoing
+        graph.add_edge(30, 10, edge(3)); // incoming — degree counts both directions
+
+        let ctx = build_graph_context(&graph, 10);
+
+        assert_eq!(ctx.degree, 3, "2 outgoing + 1 incoming");
+        assert_eq!(
+            ctx.neighbor_ids,
+            vec![20, 30, 40],
+            "all in/out neighbours, ascending"
+        );
+        assert_eq!(
+            ctx.component_size,
+            ctx.neighbor_ids.len() + 1,
+            "neighbours + the fact itself"
+        );
+        assert_eq!(ctx.component_size, 4);
+    }
+
+    /// #459: a node present in the graph but with no edges has degree 0, no
+    /// neighbours, and a component of just itself — the asymmetric counterpart to
+    /// the connected case above (guards `component_size` against a stray +1).
+    #[test]
+    fn build_graph_context_isolated_present_node() {
+        let mut graph = MemoryGraph::new();
+        // Give the graph some unrelated structure, then probe a disconnected node.
+        graph.add_edge(
+            1,
+            2,
+            EdgeData {
+                edge_id: 1,
+                relation_type: "r".into(),
+                weight: 1.0,
+            },
+        );
+        graph.ensure_node(99);
+
+        let ctx = build_graph_context(&graph, 99);
+        assert_eq!(ctx.degree, 0);
+        assert!(ctx.neighbor_ids.is_empty());
+        assert_eq!(ctx.component_size, 1);
+    }
+
+    // --- #460: fact_history Expired timeline entry -------------------------
+
+    /// #460: a fact with `t_expired` set yields a timeline that **includes** the
+    /// `Expired` event — the existing `fact_history_*` tests never set `t_expired`,
+    /// so this branch was uncovered. Realistic, chronological timestamps here.
+    #[test]
+    fn fact_history_includes_expired_entry() {
+        let now = Utc::now();
+        let t_created = now - Duration::hours(10);
+        let t_valid = now - Duration::hours(8);
+        let t_invalid = now - Duration::hours(4);
+        let t_expired = now - Duration::hours(1);
+
+        let mut fact = baseline_fact(now);
+        fact.t_created = t_created;
+        fact.t_valid = Some(t_valid);
+        fact.t_invalid = Some(t_invalid);
+        fact.t_expired = Some(t_expired);
+
+        let history = fact_history_from_fact(42, &fact);
+        assert_eq!(history.fact_id, 42);
+        assert_eq!(history.timeline.len(), 4);
+
+        // The Expired entry is present and carries `t_expired` verbatim — a missing
+        // `if let Some(t_expired)` push, or echoing the wrong timestamp, fails here.
+        let expired_entry = history
+            .timeline
+            .iter()
+            .find(|e| matches!(e.kind, HistoryEventKind::Expired))
+            .expect("Expired entry present");
+        assert_eq!(expired_entry.timestamp, t_expired);
+    }
+
+    /// #460: the timeline is sorted **ascending** by timestamp regardless of the
+    /// fixed push order (`Created → BecameValid → BecameInvalid → Expired`). To make
+    /// the `sort_by_key` load-bearing — and not silently satisfied because the push
+    /// order already happens to be chronological — `t_created` is deliberately the
+    /// *latest* instant, so a dropped sort would leave `Created` at index 0 and the
+    /// kind-vector assertion would fail.
+    #[test]
+    fn fact_history_sort_is_load_bearing() {
+        let base = Utc::now() - Duration::hours(20);
+        // Chronological order: valid < invalid < expired < created (created last).
+        let t_valid = base + Duration::hours(1);
+        let t_invalid = base + Duration::hours(2);
+        let t_expired = base + Duration::hours(3);
+        let t_created = base + Duration::hours(9);
+
+        let mut fact = baseline_fact(Utc::now());
+        fact.t_created = t_created;
+        fact.t_valid = Some(t_valid);
+        fact.t_invalid = Some(t_invalid);
+        fact.t_expired = Some(t_expired);
+
+        let history = fact_history_from_fact(7, &fact);
+        assert_eq!(history.timeline.len(), 4);
+
+        // Sorted by timestamp, `Created` (latest) must land LAST — the inverse of
+        // the push order, so a dropped sort flips this assertion.
+        let kinds: Vec<&HistoryEventKind> = history.timeline.iter().map(|e| &e.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                &HistoryEventKind::BecameValid,
+                &HistoryEventKind::BecameInvalid,
+                &HistoryEventKind::Expired,
+                &HistoryEventKind::Created,
+            ],
+            "timeline must be sorted ascending by timestamp, not push order"
+        );
+
+        // Timestamps are non-decreasing.
+        assert!(
+            history
+                .timeline
+                .windows(2)
+                .all(|w| w[0].timestamp <= w[1].timestamp),
+            "timeline must be sorted ascending"
+        );
+    }
 
     struct FakeEmbed;
     impl EmbeddingProvider for FakeEmbed {


### PR DESCRIPTION
## Summary

Wave 2 of the **#258 area:storage** super-qa sweep. Four findings flagged zero-coverage branches in `memory-engine/lib/memory-engine/src/inspect/explain.rs`. This PR adds 11 inline unit tests that drive the pure classifier/derivation functions directly with hand-built `Fact` / `MemoryGraph` fixtures — the least-coupled way to reach lifecycle states the engine `add_fact` entry points cannot set (e.g. a past `t_invalid`, or a `t_expired` soft-deleted row). Every new test is **mutation-checked** to be non-vacuous (see Test plan).

No production code changed — tests only.

## Per-issue coverage

### #314 — `FactState::Expired` and `::Invalidated` branches (was zero coverage through the classifier)
- `determine_state_invalidated_branch` — past `t_invalid` → `Invalidated`, threading the exact instant through (offset from `now`/`t_created` so echoing the wrong field fails).
- `determine_state_future_t_invalid_is_not_invalidated` — a future `t_invalid` stays `Due` (boundary guard).
- `determine_state_expired_unknown_reason` / `determine_state_expired_quarantined_reason` — `t_expired` with/without the `quarantine` metadata marker, paired so a constant-return bug is caught by the asymmetry.

> Note: the **Expired** half was already covered end-to-end as collateral by the DreamCycle quarantine tests (`tests/dream_cycle_test.rs`, `engine/cycle/apply.rs`); these add the *direct, classifier-level* Expired coverage plus the still-uncovered **Invalidated** branch.

### #458 — `determine_state` priority-order invariants (`Expired > Invalidated > Pinned > Due > Active`)
Each test combines two competing conditions so a chain re-order fails:
- `determine_state_pinned_beats_due`, `determine_state_expired_beats_pinned`, `determine_state_expired_beats_invalidated`, `determine_state_invalidated_beats_pinned`.

### #459 — `build_graph_context` with degree > 0 (existing tests only ever used degree-0 isolated facts)
- `build_graph_context_with_neighbors` — a known in/out star (center linked to three nodes, one incoming) asserts `degree`, the *sorted* neighbour set, and `component_size == neighbors + 1` against distinct hand-computed values (targets inserted out of order so a dropped sort surfaces).
- `build_graph_context_isolated_present_node` — asymmetric counterpart: a present-but-edgeless node has degree 0, no neighbours, component of 1.

### #460 — `fact_history` Expired timeline entry (existing `fact_history_*` tests never set `t_expired`)
- `fact_history_includes_expired_entry` — the Expired entry is present and carries `t_expired` verbatim.
- `fact_history_sort_is_load_bearing` — deliberately makes `t_created` the *latest* instant so the ascending `sort_by_key` must move `Created` to the end; a dropped sort flips the kind order and fails (the existing chronological-input tests can't catch this).

## Test plan (all 5 CI gates green)

| Gate | Result |
| ---- | ------ |
| `cargo fmt --all` | ✅ clean |
| `cargo build --workspace` | ✅ (2 pre-existing dead_code/unused warnings, unrelated to `explain.rs`) |
| `cargo build --workspace --all-features` | ✅ |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | ✅ No issues found |
| `cargo test -p memory-engine --all-features` | ✅ 1408 passed, 71 ignored |

**Non-vacuity (mutation checks performed locally, then reverted):**
- Reordering the priority chain (pinned moved to top) → `expired_beats_pinned` + `invalidated_beats_pinned` FAIL.
- Dropping `sort_by_key` in `fact_history_from_fact` → `fact_history_sort_is_load_bearing` FAILS (Created stays first).
- Removing `sort_unstable` in `build_graph_context` → `build_graph_context_with_neighbors` FAILS (`[30,20,40]` ≠ `[20,30,40]`).

Fixes #314, Fixes #458, Fixes #459, Fixes #460