### PR TITLE
test(storage): cover dump_sqlite live-database + null-byte path guards

### DIFF
--- a/memory-engine/lib/memory-engine/src/inspect/dump.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/dump.rs
@@ -990,9 +990,6 @@ mod tests {
     #[tokio::test]
     async fn dump_sqlite_rejects_null_byte_path() {
         use crate::store::schema::{init_schema, open_connection};
-        use std::ffi::OsString;
-        use std::os::unix::ffi::OsStringExt;
-        use std::path::PathBuf;
 
         let dir = tempfile::tempdir().unwrap();
         let source = dir.path().join("source.db");
@@ -1001,11 +998,10 @@ mod tests {
 
         // Build a target path *inside* the temp dir with an interior NUL byte in
         // the leaf name, so only the NUL — not a missing parent dir — can be the
-        // cause of any rejection. Assemble the bytes directly (`<dir>/out\0.db`)
-        // so the NUL is preserved verbatim through to `dump_sqlite`.
-        let mut raw: Vec<u8> = dir.path().as_os_str().to_os_string().into_vec();
-        raw.extend_from_slice(b"/out\0.db");
-        let bad_path = PathBuf::from(OsString::from_vec(raw));
+        // cause of any rejection. A NUL is a valid `char`, so the literal leaf
+        // `"out\0.db"` carries the byte verbatim through `join` into
+        // `dump_sqlite`.
+        let bad_path = dir.path().join("out\0.db");
         assert!(
             bad_path.as_os_str().as_encoded_bytes().contains(&0),
             "the constructed bad path must actually contain a NUL byte"
@@ -1027,6 +1023,12 @@ mod tests {
         let good_path = dir.path().join("out.db");
         dump_sqlite(&conn, &good_path)
             .expect("an otherwise-identical path without a NUL byte must dump cleanly");
+
+        // Drop the live source connection before verifying the dump: the
+        // verification reopen below must observe the published file without
+        // racing the still-open writer handle on the same temp dir (avoids any
+        // SQLite lock-contention / sidecar-file flakiness).
+        drop(conn);
         rusqlite::Connection::open_with_flags(
             &good_path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,

--- a/memory-engine/lib/memory-engine/src/inspect/dump.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/dump.rs
@@ -893,8 +893,8 @@ mod tests {
     /// regression here could silently corrupt the live DB on a re-dump.
     ///
     /// The guard is gated on `is_file_backed` (an in-memory `open_memory()` conn
-    /// never reaches it — see #463's short-circuit note), so this test opens a
-    /// real on-disk connection. Non-vacuous: deleting the guard would let
+    /// has db path `:memory:`, so it never reaches the guard), so this test opens
+    /// a real on-disk connection. Non-vacuous: deleting the guard would let
     /// `VACUUM INTO` proceed against the source, so this returns `Ok` (or a
     /// different error) and fails the exact-variant `matches!` below.
     #[tokio::test]
@@ -970,14 +970,18 @@ mod tests {
     /// NUL byte must be rejected, never reaching `VACUUM INTO` (where a NUL would
     /// otherwise risk truncating the SQL string fed to `SQLite`). On current main
     /// the rejection surfaces as `MemoryError::Io` (`ErrorKind::InvalidInput`):
-    /// the `std::fs::symlink_metadata(path)` probe — which runs for *every*
-    /// connection, file-backed or not (it is not behind the `is_file_backed`
-    /// short-circuit) — fails first because the OS rejects a NUL in a path, and
-    /// that I/O error is mapped to `MemoryError::Io`. (This is the live behavior
-    /// after the #836 `VACUUM INTO`-into-a-server-minted-temp refactor: the
-    /// surviving in-function NUL check at the `VACUUM INTO` site now guards the
-    /// *server-minted* temp path, which can never carry caller-supplied NULs, so
-    /// the caller-path NUL is caught earlier and typed as `Io`, not `Internal`.)
+    /// the rejection is defense-in-depth across the path-touching syscalls that
+    /// run before `VACUUM INTO` — `canonicalize` (file-backed conns),
+    /// `symlink_metadata`, and the final `persist` rename — each of which the OS
+    /// refuses on a NUL-bearing path, mapping to `MemoryError::Io`. A NUL-byte
+    /// caller path is therefore rejected as `Io` / `InvalidInput` before the NUL
+    /// can reach `VACUUM INTO`; the exact probe that fires first is an
+    /// implementation detail, not part of the contract. (This is the live
+    /// behavior after the #836 `VACUUM INTO`-into-a-server-minted-temp refactor:
+    /// the surviving in-function NUL check at the `VACUUM INTO` site now guards
+    /// only the *server-minted* temp path, which can never carry caller-supplied
+    /// NULs, so the caller-path NUL is caught earlier and typed as `Io`, not
+    /// `Internal`.)
     ///
     /// Non-vacuous: a path *without* a NUL byte at the same nonexistent leaf is
     /// accepted (the dump succeeds), so the assertion fails if the NUL is not
@@ -1011,8 +1015,9 @@ mod tests {
         assert!(
             matches!(result, Err(MemoryError::Io(ref e))
                 if e.kind() == std::io::ErrorKind::InvalidInput),
-            "a NUL-byte dump path must be rejected (current main: as \
-             MemoryError::Io / InvalidInput, from the symlink_metadata probe), \
+            "a NUL-byte dump path must be rejected as \
+             MemoryError::Io / InvalidInput before the NUL can reach VACUUM INTO \
+             (defense-in-depth across canonicalize / symlink_metadata / persist), \
              got {result:?}"
         );
 

--- a/memory-engine/lib/memory-engine/src/inspect/dump.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/dump.rs
@@ -886,6 +886,149 @@ mod tests {
         );
     }
 
+    /// #315 data-safety guard: `dump_sqlite` must refuse to overwrite the live
+    /// database file. With a file-backed connection, the source DB path and the
+    /// dump target canonicalize to the same file, so the guard
+    /// (`DumpTargetIsLiveDatabase`) must fire *before* `VACUUM INTO` runs — a
+    /// regression here could silently corrupt the live DB on a re-dump.
+    ///
+    /// The guard is gated on `is_file_backed` (an in-memory `open_memory()` conn
+    /// never reaches it — see #463's short-circuit note), so this test opens a
+    /// real on-disk connection. Non-vacuous: deleting the guard would let
+    /// `VACUUM INTO` proceed against the source, so this returns `Ok` (or a
+    /// different error) and fails the exact-variant `matches!` below.
+    #[tokio::test]
+    async fn dump_sqlite_refuses_to_overwrite_live_db() {
+        use crate::store::schema::{init_schema, open_connection};
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.db");
+        let source_str = source.to_str().unwrap();
+
+        let conn = open_connection(source_str).unwrap();
+        init_schema(&conn).unwrap();
+
+        // Dump target == the live source file (both canonicalize to the same path).
+        let result = dump_sqlite(&conn, &source);
+
+        assert!(
+            matches!(
+                result,
+                Err(MemoryError::Conflict(
+                    ConflictError::DumpTargetIsLiveDatabase
+                ))
+            ),
+            "dumping onto the live database file must be refused with \
+             DumpTargetIsLiveDatabase, got {result:?}"
+        );
+
+        // The source DB must be intact and unmodified by the refused dump:
+        // it is still a valid SQLite database that opens read-only.
+        rusqlite::Connection::open_with_flags(&source, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .expect("the live database must remain a valid SQLite file after the refusal");
+    }
+
+    /// #315 corollary: a symlink that *resolves* to the live database must also
+    /// be refused — `canonicalize` follows the link, so the guard compares the
+    /// resolved target against the resolved source and still catches it. This
+    /// proves the guard is not bypassable by indirection (a direct same-path
+    /// test alone would pass even if the guard compared raw, un-canonicalized
+    /// paths). Non-vacuous: a guard that skipped canonicalization on the target
+    /// would treat the symlink as a distinct path and let the dump clobber the
+    /// live DB through the link.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dump_sqlite_refuses_symlink_resolving_to_live_db() {
+        use crate::store::schema::{init_schema, open_connection};
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.db");
+        let source_str = source.to_str().unwrap();
+
+        let conn = open_connection(source_str).unwrap();
+        init_schema(&conn).unwrap();
+
+        // A symlink whose referent is the live database file.
+        let link = dir.path().join("alias.db");
+        std::os::unix::fs::symlink(&source, &link).unwrap();
+
+        let result = dump_sqlite(&conn, &link);
+
+        assert!(
+            matches!(
+                result,
+                Err(MemoryError::Conflict(
+                    ConflictError::DumpTargetIsLiveDatabase
+                ))
+            ),
+            "a symlink resolving to the live database must be refused with \
+             DumpTargetIsLiveDatabase, got {result:?}"
+        );
+    }
+
+    /// #463 null-byte path guard: a dump target whose path contains an interior
+    /// NUL byte must be rejected, never reaching `VACUUM INTO` (where a NUL would
+    /// otherwise risk truncating the SQL string fed to `SQLite`). On current main
+    /// the rejection surfaces as `MemoryError::Io` (`ErrorKind::InvalidInput`):
+    /// the `std::fs::symlink_metadata(path)` probe — which runs for *every*
+    /// connection, file-backed or not (it is not behind the `is_file_backed`
+    /// short-circuit) — fails first because the OS rejects a NUL in a path, and
+    /// that I/O error is mapped to `MemoryError::Io`. (This is the live behavior
+    /// after the #836 `VACUUM INTO`-into-a-server-minted-temp refactor: the
+    /// surviving in-function NUL check at the `VACUUM INTO` site now guards the
+    /// *server-minted* temp path, which can never carry caller-supplied NULs, so
+    /// the caller-path NUL is caught earlier and typed as `Io`, not `Internal`.)
+    ///
+    /// Non-vacuous: a path *without* a NUL byte at the same nonexistent leaf is
+    /// accepted (the dump succeeds), so the assertion fails if the NUL is not
+    /// what triggers the rejection.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dump_sqlite_rejects_null_byte_path() {
+        use crate::store::schema::{init_schema, open_connection};
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+        use std::path::PathBuf;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.db");
+        let conn = open_connection(source.to_str().unwrap()).unwrap();
+        init_schema(&conn).unwrap();
+
+        // Build a target path *inside* the temp dir with an interior NUL byte in
+        // the leaf name, so only the NUL — not a missing parent dir — can be the
+        // cause of any rejection. Assemble the bytes directly (`<dir>/out\0.db`)
+        // so the NUL is preserved verbatim through to `dump_sqlite`.
+        let mut raw: Vec<u8> = dir.path().as_os_str().to_os_string().into_vec();
+        raw.extend_from_slice(b"/out\0.db");
+        let bad_path = PathBuf::from(OsString::from_vec(raw));
+        assert!(
+            bad_path.as_os_str().as_encoded_bytes().contains(&0),
+            "the constructed bad path must actually contain a NUL byte"
+        );
+
+        let result = dump_sqlite(&conn, &bad_path);
+        assert!(
+            matches!(result, Err(MemoryError::Io(ref e))
+                if e.kind() == std::io::ErrorKind::InvalidInput),
+            "a NUL-byte dump path must be rejected (current main: as \
+             MemoryError::Io / InvalidInput, from the symlink_metadata probe), \
+             got {result:?}"
+        );
+
+        // Control: the SAME leaf without the NUL byte is accepted and produces a
+        // valid SQLite dump. This makes the rejection above attributable to the
+        // NUL specifically, not to anything else about the path or connection.
+        let good_path = dir.path().join("out.db");
+        dump_sqlite(&conn, &good_path)
+            .expect("an otherwise-identical path without a NUL byte must dump cleanly");
+        rusqlite::Connection::open_with_flags(
+            &good_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .expect("the NUL-free dump must be a valid SQLite database");
+    }
+
     /// `tmp_path` must build a `.tmp` sibling next to a normal target path.
     #[test]
     fn tmp_path_builds_sibling_for_normal_path() {


### PR DESCRIPTION
Adds regression coverage for the two untested `dump_sqlite` data-safety guards in `inspect/dump.rs`, from epic #258 (Wave 2). Test-only PR — no production code touched.

## Per-issue coverage

### #315 — live-database safety guard
`dump_sqlite` canonicalizes the source DB path and the dump target and refuses (`ConflictError::DumpTargetIsLiveDatabase`) when they resolve to the same file, preventing a re-dump from clobbering the live database. The guard is gated on `is_file_backed`, so an in-memory connection never reaches it.

- **`dump_sqlite_refuses_to_overwrite_live_db`** — opens a *file-backed* connection at `source.db`, dumps onto that same path, asserts the exact `DumpTargetIsLiveDatabase` variant, and verifies the source DB stays a valid SQLite file (was not partially overwritten).
- **`dump_sqlite_refuses_symlink_resolving_to_live_db`** (unix) — corollary proving `canonicalize` follows a symlink, so the guard catches a symlink whose referent is the live DB (not bypassable by indirection; a guard comparing raw paths would miss it).

### #463 — null-byte path guard
A dump target with an interior NUL byte must be rejected before reaching `VACUUM INTO`.

- **`dump_sqlite_rejects_null_byte_path`** (unix) — feeds a `<tempdir>/out\0.db` target (interior NUL, valid parent dir) and asserts the rejection, plus a NUL-free control dump to attribute the failure to the NUL specifically.

**Variant deviation (current main):** the original finding expected `MemoryError::Internal`. After the #836 refactor (`VACUUM INTO` into a server-minted temp), the surviving in-function NUL check guards the *server-minted* temp path, which can never carry a caller NUL. A caller-path NUL is now caught earlier by the unconditional `std::fs::symlink_metadata(path)` probe and typed as **`MemoryError::Io` (`ErrorKind::InvalidInput`)**. The test asserts the live behavior and documents why.

## Test plan
All five CI-matrix gates run from the worktree, all green:

1. `cargo fmt --all` — clean
2. `cargo build --workspace` — Finished, no errors
3. `cargo build --workspace --all-features` — Finished, no errors
4. `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
5. `cargo test -p memory-engine --all-features` — ok, 1331 passed / 0 failed (+ all sub-suites green)

Each key assertion was **mutation-checked**: asserting the wrong error variant, or that the guard returns `Ok`, makes the corresponding test fail — confirming non-vacuity.

Fixes #315, Fixes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)