### PR TITLE
refactor(forgetting): batch importance_score materialization into one UPDATE

### DIFF
--- a/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
@@ -990,10 +990,9 @@ impl FactGraph for SqliteBackend {
                 let fact_store = FactStore::new(&tx, dim);
                 let edge_store = EdgeStore::new(&tx);
 
-                // Materialize importance scores for every active fact.
-                for &(id, score) in &scored {
-                    fact_store.update_importance_score(id, score)?;
-                }
+                // Materialize importance scores for every active fact in one
+                // bulk UPDATE (#392) instead of an N+1 per-row loop.
+                fact_store.update_importance_scores_bulk(&scored)?;
                 // Expire the sub-threshold set + cascade edge expiry.
                 for &fact_id in &to_expire {
                     fact_store.expire(fact_id, now)?;

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -871,15 +871,19 @@ impl<'a> FactStore<'a> {
     /// `update_importance_score` calls (one prepared-statement exec + one
     /// B-tree write each) into one `json_each`-driven UPDATE, regardless of
     /// corpus size. Behaviorally identical to the loop: only the ids present in
-    /// `scores` are touched — rows outside the payload are left untouched. The
-    /// `WHERE id IN (...)` guard restricts the UPDATE to the scored ids; without
-    /// it the correlated subquery yields NULL for every unmatched row, which the
-    /// `importance_score REAL NOT NULL` column rejects (the whole statement errors
-    /// and rolls back).
+    /// `scores` are touched — rows outside the payload are left untouched. This
+    /// is an `UPDATE ... FROM json_each(?1)` join (`SQLite` 3.33+): the payload is
+    /// parsed exactly once and index-joined to `facts` on
+    /// `facts.id = CAST(s.key AS INTEGER)`, so the cost is O(N) in the batch
+    /// size — no per-row re-scan of the JSON. The join condition *is* the
+    /// restriction: a fact with no matching `json_each` row is simply not joined,
+    /// hence not updated (no NULL is ever produced for the `NOT NULL`
+    /// `importance_score` column).
     ///
     /// `scores` is serialized as a JSON object mapping the id (as a string key,
-    /// which is what `json_each.key` yields) to its score; the `IN`-subquery
-    /// casts the TEXT key back to INTEGER so i64 ids round-trip correctly.
+    /// which is what `json_each.key` yields) to its score; the join casts the
+    /// TEXT key back to INTEGER (`CAST(s.key AS INTEGER)`) so i64 ids round-trip
+    /// correctly.
     ///
     /// Every score is validated finite *before* any SQL runs: `serde_json` maps a
     /// non-finite `f64` (`NaN` / `±Infinity`) to JSON `null`, which `json_each`
@@ -925,10 +929,9 @@ impl<'a> FactStore<'a> {
         let payload = serde_json::to_string(&serde_json::Value::Object(map))?;
         self.conn.execute(
             "UPDATE facts \
-             SET importance_score = ( \
-                 SELECT value FROM json_each(?1) WHERE key = CAST(facts.id AS TEXT) \
-             ) \
-             WHERE id IN (SELECT CAST(key AS INTEGER) FROM json_each(?1))",
+             SET importance_score = s.value \
+             FROM json_each(?1) AS s \
+             WHERE facts.id = CAST(s.key AS INTEGER)",
             params![payload],
         )?;
         Ok(())
@@ -2440,16 +2443,16 @@ mod tests {
         }
     }
 
-    /// #392: the bulk `importance_score` materialization (one `json_each`
-    /// UPDATE) must be byte-for-byte equivalent to the old per-row loop:
+    /// #392: the bulk `importance_score` materialization (one
+    /// `UPDATE ... FROM json_each` join) must be behavior-equivalent to the old
+    /// per-row loop:
     /// (a) it sets exactly the scored subset,
-    /// (b) it leaves an UNSCORED row untouched (the `WHERE id IN (...)` guard
-    ///     restricts the UPDATE to scored ids; without it the correlated subquery
-    ///     yields NULL for unmatched rows, which the `NOT NULL` column rejects —
-    ///     the whole statement would error and roll back),
+    /// (b) it leaves an UNSCORED row untouched (the FROM-join condition
+    ///     `facts.id = CAST(s.key AS INTEGER)` is the restriction: a fact with no
+    ///     matching `json_each` row is not joined, hence not updated — no NULL is
+    ///     ever produced for the `NOT NULL` column),
     /// (c) i64 ids round-trip the `json_each` TEXT key cast (a large id catches
-    ///     a TEXT/INTEGER mismatch in the `CAST(... AS TEXT)` / `CAST(key AS
-    ///     INTEGER)` pairing), and
+    ///     a TEXT/INTEGER mismatch in the `CAST(s.key AS INTEGER)` join key), and
     /// (d) an empty slice is a no-op.
     #[test]
     fn update_importance_scores_bulk_sets_subset_and_round_trips_ids() {

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -871,24 +871,52 @@ impl<'a> FactStore<'a> {
     /// `update_importance_score` calls (one prepared-statement exec + one
     /// B-tree write each) into one `json_each`-driven UPDATE, regardless of
     /// corpus size. Behaviorally identical to the loop: only the ids present in
-    /// `scores` are touched — rows outside the payload are left untouched (the
-    /// `WHERE id IN (...)` guard; without it the correlated subquery would NULL
-    /// every unmatched row).
+    /// `scores` are touched — rows outside the payload are left untouched. The
+    /// `WHERE id IN (...)` guard restricts the UPDATE to the scored ids; without
+    /// it the correlated subquery yields NULL for every unmatched row, which the
+    /// `importance_score REAL NOT NULL` column rejects (the whole statement errors
+    /// and rolls back).
     ///
     /// `scores` is serialized as a JSON object mapping the id (as a string key,
     /// which is what `json_each.key` yields) to its score; the `IN`-subquery
     /// casts the TEXT key back to INTEGER so i64 ids round-trip correctly.
+    ///
+    /// Every score is validated finite *before* any SQL runs: `serde_json` maps a
+    /// non-finite `f64` (`NaN` / `±Infinity`) to JSON `null`, which `json_each`
+    /// would then yield as NULL and the UPDATE would try to write into the
+    /// `NOT NULL` column — aborting the entire enclosing transaction. The guard is
+    /// validate-all-then-execute: a single non-finite entry rejects the whole
+    /// batch with [`ConflictError::PolicyParameter`](crate::error::ConflictError::PolicyParameter)
+    /// and leaves **all** rows untouched. (Defense in depth: today's callers feed
+    /// provably-finite `compute_importance` output, so this is unreachable — but it
+    /// converts a latent opaque DB-constraint abort into a clean, typed error.)
     ///
     /// An empty slice is a no-op and returns `Ok(())` (no degenerate statement
     /// runs).
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure (or `MemoryError` from
-    /// JSON serialization, which cannot fail for the `id -> f64` map built here).
+    /// Returns [`MemoryError::Conflict`](crate::error::MemoryError::Conflict) wrapping
+    /// [`ConflictError::PolicyParameter`](crate::error::ConflictError::PolicyParameter)
+    /// if any score is non-finite (the statement does not run). Returns
+    /// `MemoryError::Database` on SQL failure (or `MemoryError` from JSON
+    /// serialization, which cannot fail for the finite `id -> f64` map built here).
     pub fn update_importance_scores_bulk(&self, scores: &[(i64, f64)]) -> Result<()> {
         if scores.is_empty() {
             return Ok(());
+        }
+        // Validate-all-then-execute: a non-finite score would serialize to JSON
+        // `null` and write NULL into the `NOT NULL` importance_score column,
+        // aborting the enclosing transaction. Reject the whole batch up front so a
+        // bad entry leaves every row untouched.
+        for &(id, score) in scores {
+            if !score.is_finite() {
+                return Err(MemoryError::Conflict(
+                    crate::error::ConflictError::PolicyParameter(format!(
+                        "importance score must be finite, got {score} for fact {id}"
+                    )),
+                ));
+            }
         }
         let mut map = serde_json::Map::with_capacity(scores.len());
         for &(id, score) in scores {
@@ -2415,8 +2443,10 @@ mod tests {
     /// #392: the bulk `importance_score` materialization (one `json_each`
     /// UPDATE) must be byte-for-byte equivalent to the old per-row loop:
     /// (a) it sets exactly the scored subset,
-    /// (b) it leaves an UNSCORED row untouched (the `WHERE id IN (...)` guard —
-    ///     a naive correlated subquery would NULL-out every unmatched row),
+    /// (b) it leaves an UNSCORED row untouched (the `WHERE id IN (...)` guard
+    ///     restricts the UPDATE to scored ids; without it the correlated subquery
+    ///     yields NULL for unmatched rows, which the `NOT NULL` column rejects —
+    ///     the whole statement would error and roll back),
     /// (c) i64 ids round-trip the `json_each` TEXT key cast (a large id catches
     ///     a TEXT/INTEGER mismatch in the `CAST(... AS TEXT)` / `CAST(key AS
     ///     INTEGER)` pairing), and
@@ -2462,6 +2492,48 @@ mod tests {
         assert!((fs.get(b).unwrap().importance_score - 0.5).abs() < f64::EPSILON);
         assert!((fs.get(c).unwrap().importance_score - 0.33).abs() < f64::EPSILON);
         assert!((fs.get(big_id).unwrap().importance_score - 0.99).abs() < f64::EPSILON);
+    }
+
+    /// #392 hardening: a non-finite score (`NaN` / `±Infinity`) is rejected up
+    /// front with `ConflictError::PolicyParameter` and leaves **all** rows
+    /// untouched. `serde_json` would otherwise map the non-finite `f64` to JSON
+    /// `null`, writing NULL into the `importance_score REAL NOT NULL` column and
+    /// aborting the enclosing transaction — so this proves validate-all-then-
+    /// execute: the bad batch errors cleanly and no row mutates.
+    #[test]
+    fn update_importance_scores_bulk_rejects_non_finite_leaves_rows_untouched() {
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let conn = setup();
+            let fs = FactStore::new(&conn, DIM);
+
+            // Two facts, each seeded at base_importance 0.5 by `insert`.
+            let a = fs.insert(&make_fact("fact a", vec![0.1; DIM])).unwrap();
+            let b = fs.insert(&make_fact("fact b", vec![0.2; DIM])).unwrap();
+
+            // A batch mixing a valid score for `a` with a non-finite score for `b`.
+            // The whole batch must be rejected before any UPDATE runs.
+            let err = fs
+                .update_importance_scores_bulk(&[(a, 0.11), (b, bad)])
+                .expect_err("non-finite score must be rejected");
+            assert!(
+                matches!(
+                    err,
+                    MemoryError::Conflict(crate::error::ConflictError::PolicyParameter(_))
+                ),
+                "expected ConflictError::PolicyParameter, got {err:?}"
+            );
+
+            // Validate-all-then-execute: BOTH rows keep their seeded 0.5 — even
+            // `a`, whose score was valid, must be left untouched.
+            assert!(
+                (fs.get(a).unwrap().importance_score - 0.5).abs() < f64::EPSILON,
+                "valid-scored row must be untouched when the batch is rejected"
+            );
+            assert!(
+                (fs.get(b).unwrap().importance_score - 0.5).abs() < f64::EPSILON,
+                "non-finite-scored row must be untouched"
+            );
+        }
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -865,6 +865,47 @@ impl<'a> FactStore<'a> {
         Ok(())
     }
 
+    /// Bulk-update materialized importance scores in a single statement.
+    ///
+    /// Collapses what the prune path used to do as an N+1 loop of per-row
+    /// `update_importance_score` calls (one prepared-statement exec + one
+    /// B-tree write each) into one `json_each`-driven UPDATE, regardless of
+    /// corpus size. Behaviorally identical to the loop: only the ids present in
+    /// `scores` are touched — rows outside the payload are left untouched (the
+    /// `WHERE id IN (...)` guard; without it the correlated subquery would NULL
+    /// every unmatched row).
+    ///
+    /// `scores` is serialized as a JSON object mapping the id (as a string key,
+    /// which is what `json_each.key` yields) to its score; the `IN`-subquery
+    /// casts the TEXT key back to INTEGER so i64 ids round-trip correctly.
+    ///
+    /// An empty slice is a no-op and returns `Ok(())` (no degenerate statement
+    /// runs).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure (or `MemoryError` from
+    /// JSON serialization, which cannot fail for the `id -> f64` map built here).
+    pub fn update_importance_scores_bulk(&self, scores: &[(i64, f64)]) -> Result<()> {
+        if scores.is_empty() {
+            return Ok(());
+        }
+        let mut map = serde_json::Map::with_capacity(scores.len());
+        for &(id, score) in scores {
+            map.insert(id.to_string(), serde_json::json!(score));
+        }
+        let payload = serde_json::to_string(&serde_json::Value::Object(map))?;
+        self.conn.execute(
+            "UPDATE facts \
+             SET importance_score = ( \
+                 SELECT value FROM json_each(?1) WHERE key = CAST(facts.id AS TEXT) \
+             ) \
+             WHERE id IN (SELECT CAST(key AS INTEGER) FROM json_each(?1))",
+            params![payload],
+        )?;
+        Ok(())
+    }
+
     /// Shallow-merge a JSON object `patch` into a fact's `metadata` column.
     ///
     /// Existing keys are overwritten by colliding patch keys; other keys are
@@ -2369,6 +2410,58 @@ mod tests {
                 "SQL LIMIT {cap} must equal Rust .take({cap}) (same order)"
             );
         }
+    }
+
+    /// #392: the bulk `importance_score` materialization (one `json_each`
+    /// UPDATE) must be byte-for-byte equivalent to the old per-row loop:
+    /// (a) it sets exactly the scored subset,
+    /// (b) it leaves an UNSCORED row untouched (the `WHERE id IN (...)` guard —
+    ///     a naive correlated subquery would NULL-out every unmatched row),
+    /// (c) i64 ids round-trip the `json_each` TEXT key cast (a large id catches
+    ///     a TEXT/INTEGER mismatch in the `CAST(... AS TEXT)` / `CAST(key AS
+    ///     INTEGER)` pairing), and
+    /// (d) an empty slice is a no-op.
+    #[test]
+    fn update_importance_scores_bulk_sets_subset_and_round_trips_ids() {
+        let conn = setup();
+        let fs = FactStore::new(&conn, DIM);
+
+        // Three autoincrement facts (ids 1, 2, 3), each seeded at base_importance
+        // 0.5 by `insert`.
+        let a = fs.insert(&make_fact("fact a", vec![0.1; DIM])).unwrap();
+        let b = fs.insert(&make_fact("fact b", vec![0.2; DIM])).unwrap();
+        let c = fs.insert(&make_fact("fact c", vec![0.3; DIM])).unwrap();
+
+        // A fourth fact carrying a large i64 id, to exercise the json_each key
+        // cast on a value that would mismatch under a sloppy TEXT/INTEGER pairing.
+        let big_id: i64 = 9_007_199_254_740_993; // 2^53 + 1
+        let d = fs.insert(&make_fact("fact d", vec![0.4; DIM])).unwrap();
+        conn.execute("UPDATE facts SET id = ?1 WHERE id = ?2", params![big_id, d])
+            .unwrap();
+
+        // Score a SUBSET: a, c, and the large-id fact — but NOT b.
+        fs.update_importance_scores_bulk(&[(a, 0.11), (c, 0.33), (big_id, 0.99)])
+            .unwrap();
+
+        // (a) exactly the scored rows take their new values.
+        assert!((fs.get(a).unwrap().importance_score - 0.11).abs() < f64::EPSILON);
+        assert!((fs.get(c).unwrap().importance_score - 0.33).abs() < f64::EPSILON);
+        // (c) the large id round-trips the cast and is updated.
+        assert!((fs.get(big_id).unwrap().importance_score - 0.99).abs() < f64::EPSILON);
+
+        // (b) the unscored row b keeps its seeded base_importance (0.5) — the
+        // bulk UPDATE must not zero/NULL rows outside the payload.
+        assert!(
+            (fs.get(b).unwrap().importance_score - 0.5).abs() < f64::EPSILON,
+            "unscored fact must be left untouched"
+        );
+
+        // (d) an empty slice changes nothing and returns Ok.
+        fs.update_importance_scores_bulk(&[]).unwrap();
+        assert!((fs.get(a).unwrap().importance_score - 0.11).abs() < f64::EPSILON);
+        assert!((fs.get(b).unwrap().importance_score - 0.5).abs() < f64::EPSILON);
+        assert!((fs.get(c).unwrap().importance_score - 0.33).abs() < f64::EPSILON);
+        assert!((fs.get(big_id).unwrap().importance_score - 0.99).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## What

The prune path materialized `importance_score` with an N+1 loop of single-row UPDATEs inside `prune_atomic` (`storage/sqlite/graph.rs`): one prepared-statement exec + one B-tree write per active fact. For a 100k-fact store that is 100k statement executions per prune.

This replaces the loop with a single `json_each`-driven bulk UPDATE — one statement regardless of corpus size:

```sql
UPDATE facts
SET importance_score = (SELECT value FROM json_each(?1) WHERE key = CAST(facts.id AS TEXT))
WHERE id IN (SELECT CAST(key AS INTEGER) FROM json_each(?1))
```

## Why it's correct

Behavior-identical to the loop, guarded by a new TDD test (`update_importance_scores_bulk_sets_subset_and_round_trips_ids`):

- (a) sets exactly the scored subset;
- (b) an unscored row is left **untouched** — the `WHERE id IN (...)` guard; without it the correlated subquery would NULL every unmatched row;
- (c) i64 ids round-trip the `json_each` TEXT key cast (a large id, 2^53+1, catches a TEXT/INTEGER mismatch — the issue body's suggested SQL omitted `CAST(key AS INTEGER)`);
- (d) an empty slice is a no-op returning `Ok(())` (early return, no degenerate statement).

The per-row `update_importance_score` is **retained** — still used by the single-fact callers (`graph.rs:219`, `consolidation/dedup.rs:260`).

## Gate

`cargo fmt --check`, `cargo build --workspace`, `cargo test --workspace` (1702 passed), `cargo clippy --workspace --all-targets --all-features -- -D warnings` — all green.

Closes #392
Part of #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)