### PR TITLE
test(storage): cover verify_archives error branches (missing file, hash mismatch, path traversal)

### DIFF
--- a/tests/archive_test.rs
+++ b/tests/archive_test.rs
@@ -194,6 +194,188 @@ async fn archive_returns_none_below_min_facts() {
     assert!(result.is_none(), "expected None for empty engine");
 }
 
+/// Archive ≥`min` facts into a single `.pak` and return `(engine, pak_path)`.
+///
+/// Adds `n` facts, forgets them all with an aggressive policy, then archives
+/// with a future cutoff so every expired fact qualifies. The returned engine
+/// holds exactly one manifest entry; `pak_path` is the absolute on-disk `.pak`.
+async fn archive_one_pak(engine: &MemoryEngine, n: usize) -> std::path::PathBuf {
+    let _ids = add_facts(engine, n).await;
+
+    let forget_policy = ForgetPolicy {
+        half_life_days: 0.0001,
+        min_importance: 1.0, // expire everything
+        ..ForgetPolicy::default()
+    };
+    let prune_stats = engine.forget(&forget_policy).await.unwrap();
+    assert!(
+        prune_stats.facts_expired >= n,
+        "expected >={n} expired, got {}",
+        prune_stats.facts_expired,
+    );
+
+    let archive_policy = ArchivePolicy {
+        expired_before: Utc::now() + Duration::hours(1),
+        min_facts: 1,
+    };
+    let stats = engine
+        .archive(&archive_policy)
+        .await
+        .unwrap()
+        .expect("should archive facts");
+    assert_eq!(stats.facts_archived, n);
+    assert!(stats.pak_path.exists(), "archived .pak must exist on disk");
+
+    // Baseline: an intact archive verifies OK. This pins the asymmetry the
+    // failure tests rely on — if `verify_archives` returned `ok=false`
+    // unconditionally, this assert (not just the negative ones) would fail.
+    let verify = engine.verify_archives().await.unwrap();
+    assert_eq!(verify.len(), 1);
+    assert!(
+        verify[0].ok,
+        "intact archive must verify OK, got error {:?}",
+        verify[0].error
+    );
+
+    stats.pak_path
+}
+
+/// #422 (file-not-found branch, `engine/archive.rs` `verify_archives`): a
+/// manifest row whose `.pak` no longer exists on disk must verify `ok == false`
+/// with a "file not found" error — never silently pass. Mutation check: if the
+/// `pak_path.exists()` guard were inverted (or the branch dropped), the removed
+/// file would fall into the I/O path and the `ok == false` / "file not found"
+/// assertions below would fail.
+#[tokio::test]
+async fn verify_archives_detects_missing_pak() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = open_file_engine(dir.path());
+
+    let pak_path = archive_one_pak(&engine, 150).await;
+
+    // Remove the `.pak` out from under the manifest row.
+    std::fs::remove_file(&pak_path).unwrap();
+    assert!(!pak_path.exists(), "precondition: .pak was removed");
+
+    let verify = engine.verify_archives().await.unwrap();
+    assert_eq!(verify.len(), 1, "manifest still has the one entry");
+    assert!(
+        !verify[0].ok,
+        "a missing .pak must verify as NOT ok, got ok=true"
+    );
+    let err = verify[0]
+        .error
+        .as_deref()
+        .expect("a failed verify must carry an error message");
+    assert!(
+        err.contains("file not found"),
+        "missing .pak must report 'file not found', got: {err:?}"
+    );
+}
+
+/// #422 (hash-mismatch branch, `engine/archive.rs` `verify_single_archive`): a
+/// `.pak` whose bytes were tampered with after archival must verify
+/// `ok == false` with a "hash mismatch" error. Flips a single byte in place so
+/// the file size is unchanged — this proves the integrity check is a content
+/// hash, not a length/existence check. Mutation check: if `verify_single_archive`
+/// ignored `verify_pak`'s `Ok(false)` arm (or compared lengths instead of
+/// hashes), the same-length corrupted file would pass and these asserts fail.
+#[tokio::test]
+async fn verify_archives_detects_tampered_pak() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = open_file_engine(dir.path());
+
+    let pak_path = archive_one_pak(&engine, 150).await;
+
+    // Corrupt one byte in place (size preserved → only the content hash moves).
+    let mut bytes = std::fs::read(&pak_path).unwrap();
+    assert!(!bytes.is_empty(), "precondition: .pak is non-empty");
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xFF;
+    std::fs::write(&pak_path, &bytes).unwrap();
+    assert_eq!(
+        std::fs::metadata(&pak_path).unwrap().len(),
+        bytes.len() as u64,
+        "tamper must preserve file length (proves hash, not length, is checked)"
+    );
+
+    let verify = engine.verify_archives().await.unwrap();
+    assert_eq!(verify.len(), 1, "manifest still has the one entry");
+    assert!(
+        !verify[0].ok,
+        "a tampered .pak must verify as NOT ok, got ok=true"
+    );
+    let err = verify[0]
+        .error
+        .as_deref()
+        .expect("a failed verify must carry an error message");
+    assert!(
+        err.contains("hash mismatch"),
+        "tampered .pak must report 'hash mismatch', got: {err:?}"
+    );
+}
+
+/// #422 / #292 (path-traversal guard, `engine/archive.rs` `verify_archives`):
+/// a manifest `pak_path` that escapes the archive directory via `..` must be
+/// rejected with "path traversal detected" BEFORE any filesystem access — the
+/// guard must fire ahead of the file-not-found branch. The legitimate write path
+/// only ever stores a separator-free `archive-<ts>.pak`, so a traversal path can
+/// only arrive from a tampered/restored DB; here we plant exactly such a row by
+/// writing the `SQLite` manifest table directly (the integration-tier analogue of
+/// the inline unit test's `raw_exec` injection, which is `pub(crate)`-only).
+///
+/// Mutation check: were the guard removed, `../outside/escape.pak` would resolve
+/// outside the archive dir, miss on disk, and surface "file not found" instead —
+/// so the asymmetric `error == "path traversal detected"` assert (distinct from
+/// the missing-file string) catches a dropped or reordered guard.
+#[tokio::test]
+async fn verify_archives_rejects_path_traversal_manifest_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Build the engine once so migrations create the schema (incl.
+    // `archive_manifest`), then drop it to release the file lock before we open
+    // a second connection to plant the malicious row.
+    {
+        let engine = open_file_engine(dir.path());
+        let _ids = add_facts(&engine, 1).await;
+    }
+
+    // Plant a `..` traversal manifest row directly via SQLite — the public API
+    // never produces such a path, and the crate-internal `raw_exec`/`storage()`
+    // seam is not reachable from an external integration test.
+    let evil_path = "../outside/escape.pak";
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO archive_manifest \
+             (pak_path, created_at, fact_count, edge_count, fact_id_min, \
+              fact_id_max, t_created_min, t_created_max, size_bytes, blake3_hash) \
+             VALUES (?1, '2026-01-01T00:00:00Z', 0, 0, 0, 0, \
+              '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 0, 'deadbeef')",
+            [evil_path],
+        )
+        .unwrap();
+    }
+
+    // Reopen the engine on the same DB and verify.
+    let engine = MemoryEngine::builder(DIM).path(&db_path).build().unwrap();
+
+    let verify = engine.verify_archives().await.unwrap();
+    assert_eq!(verify.len(), 1, "exactly one (malicious) manifest entry");
+    assert!(
+        !verify[0].ok,
+        "a `..` traversal manifest path must be flagged, not verified"
+    );
+    assert_eq!(
+        verify[0].error.as_deref(),
+        Some("path traversal detected"),
+        "the traversal must be caught by the containment guard, not fall \
+         through to the I/O (file-not-found) path"
+    );
+    assert_eq!(verify[0].pak_path, evil_path);
+}
+
 #[tokio::test]
 async fn archive_search_finds_archived_facts() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

`verify_archives()` had integration coverage for the happy path only — `archive_lifecycle_roundtrip` asserts `verify[0].ok == true` on a valid, intact `.pak`. Its three failure branches in `engine/archive.rs` were untested at the integration tier. This PR adds three non-vacuous `#[tokio::test]`s (behind `#![cfg(feature = "archive")]`) in `tests/archive_test.rs`. Pure test addition; no production change.

## Per-issue coverage (#422)

- **`verify_archives_detects_missing_pak`** (file-not-found branch): archive 150 facts, `std::fs::remove_file` the `.pak`, then assert `verify[0].ok == false` and the error contains `"file not found"`. Covers the `pak_path.exists() == false` arm.
- **`verify_archives_detects_tampered_pak`** (hash-mismatch branch): archive, flip a single byte in place (file length preserved), then assert `ok == false` with `"hash mismatch"`. The length-preserving tamper proves the integrity check is a content hash, not a length/existence check, exercising the `verify_single_archive` `Ok(false)` arm.
- **`verify_archives_rejects_path_traversal_manifest_row`** (path-traversal guard, #292): plant a `../outside/escape.pak` manifest row directly via SQLite (the legitimate write path never produces a traversal path, and the crate-internal `raw_exec`/`is_within_archive_dir` seam is `pub(crate)`-only and unreachable from an external integration test), then assert the row is flagged with `"path traversal detected"` **before** any filesystem access. Integration-tier analogue of the existing inline `#292` unit test.

A shared `archive_one_pak` helper drives the archive flow and asserts the **intact** baseline verifies `ok == true`, anchoring the asymmetry the negative cases depend on.

## Test quality

Each assertion pins a distinct, asymmetric expected error string so a predicate flip or dropped/reordered branch is caught — e.g. removing the traversal guard would surface `"file not found"` (the wrong string) instead. Mutation-checked locally: corrupting the expected strings (`"path traversal detected"` → sentinel, `"hash mismatch"` → sentinel) reliably fails the corresponding tests, confirming they are not vacuous.

## Test plan — full CI matrix, all green

1. `cargo fmt --all` — clean
2. `cargo build --workspace` — 0 errors
3. `cargo build --workspace --all-features` — ok
4. `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no issues
5. `cargo test -p memory-engine --all-features` — all suites pass; `archive_test` = 7 passed (4 existing + 3 new), 0 failed

Fixes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)