### PR TITLE
refactor(temporal): extract Fact::from_new_for_arbiter + document arbiter-input contract

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/conflict.rs
+++ b/memory-engine/lib/memory-engine/src/engine/conflict.rs
@@ -64,8 +64,7 @@ impl MemoryEngine {
         // free-function transaction).
         let old_fact = self.storage.get_fact(old_id).await?;
 
-        // Build a temporary Fact from NewFact for the arbiter (it needs both as
-        // Fact). Ported verbatim from `crate::conflict::temporal::resolve_conflict`.
+        // Build a temporary Fact from NewFact for the arbiter (it needs both as Fact).
         let new_as_fact = crate::types::Fact::from_new_for_arbiter(new_fact);
 
         // CONSUMER TRAIT — the main loop drives this; left exactly as-is (rule 5).

--- a/memory-engine/lib/memory-engine/src/engine/conflict.rs
+++ b/memory-engine/lib/memory-engine/src/engine/conflict.rs
@@ -23,6 +23,21 @@ impl MemoryEngine {
     /// Delegates the decision to the consumer-provided [`ConflictArbiter`].
     /// Graph is updated only after the persistence operations succeed.
     ///
+    /// **Arbiter input caveat:** the `new_fact` passed to
+    /// [`ConflictArbiter::arbitrate`] is a pre-insert synthetic `Fact` built via
+    /// [`Fact::from_new_for_arbiter`](crate::types::Fact). Its `id` is always `0`
+    /// (not yet assigned by the DB) and `importance_score` is the
+    /// [`Fact::UNSCORED_IMPORTANCE`](crate::types::Fact::UNSCORED_IMPORTANCE)
+    /// sentinel (`0.5`), NOT the eventual stored score. Arbiters must rely on
+    /// `content`, `fact_type`, `base_importance`, and `metadata` — never on `id`
+    /// or `importance_score`.
+    ///
+    /// **Graph/DB consistency:** the in-memory graph is updated only after the DB
+    /// commit succeeds. A panic in the small window between the commit and the
+    /// graph mirror leaves the graph and DB transiently diverged for the rest of
+    /// the session; the next `open()` recovers the graph via
+    /// `MemoryGraph::load_from_db`.
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
@@ -51,26 +66,7 @@ impl MemoryEngine {
 
         // Build a temporary Fact from NewFact for the arbiter (it needs both as
         // Fact). Ported verbatim from `crate::conflict::temporal::resolve_conflict`.
-        let new_as_fact = crate::types::Fact {
-            id: 0, // placeholder, not yet inserted
-            content: new_fact.content.clone(),
-            content_hash: new_fact.content_hash.clone(),
-            embedding: new_fact.embedding.clone(),
-            fact_type: new_fact.fact_type,
-            t_created: new_fact.t_created,
-            t_expired: new_fact.t_expired,
-            t_valid: new_fact.t_valid,
-            t_invalid: new_fact.t_invalid,
-            source_event_id: new_fact.source_event_id,
-            scope_id: new_fact.scope_id,
-            base_importance: new_fact.base_importance,
-            access_count: new_fact.access_count,
-            last_accessed: new_fact.last_accessed,
-            metadata: new_fact.metadata.clone(),
-            is_pinned: new_fact.is_pinned,
-            importance_score: crate::types::Fact::UNSCORED_IMPORTANCE,
-            surfaced_at: None,
-        };
+        let new_as_fact = crate::types::Fact::from_new_for_arbiter(new_fact);
 
         // CONSUMER TRAIT — the main loop drives this; left exactly as-is (rule 5).
         let decision = arbiter.arbitrate(&old_fact, &new_as_fact)?;

--- a/memory-engine/lib/memory-engine/src/traits.rs
+++ b/memory-engine/lib/memory-engine/src/traits.rs
@@ -190,16 +190,17 @@ pub trait DeltaProposer: Send + Sync {
 pub trait ConflictArbiter: Send + Sync {
     /// Decide how to resolve a conflict between an existing and a new fact.
     ///
-    /// # Warning: `importance_score` on `new_fact` is a placeholder
-    ///
-    /// When called from [`MemoryEngine::resolve_conflict`](crate::MemoryEngine::resolve_conflict),
-    /// `new_fact` is a temporary [`Fact`] constructed from a [`NewFact`](crate::types::NewFact)
-    /// before it has been persisted or scored. Its `importance_score` field is hardcoded
-    /// to [`Fact::UNSCORED_IMPORTANCE`](crate::types::Fact::UNSCORED_IMPORTANCE) and does
-    /// **not** reflect the fact's actual computed importance. Implementations that branch on
-    /// `new_fact.importance_score` will always see that sentinel.
-    /// Use `new_fact.base_importance` (the caller-supplied raw importance) instead if you need
-    /// a signal for the incoming fact's weight.
+    /// **Arbiter input caveat:** when called from
+    /// [`MemoryEngine::resolve_conflict`](crate::MemoryEngine::resolve_conflict),
+    /// `new_fact` is a pre-insert synthetic [`Fact`] built via
+    /// [`Fact::from_new_for_arbiter`](crate::types::Fact) from a
+    /// [`NewFact`](crate::types::NewFact) before it has been persisted or scored.
+    /// Its `id` is always `0` (not yet assigned by the DB) and `importance_score`
+    /// is always the
+    /// [`Fact::UNSCORED_IMPORTANCE`](crate::types::Fact::UNSCORED_IMPORTANCE)
+    /// sentinel (`0.5`), NOT the eventual stored score. Implementations must rely
+    /// on `content`, `fact_type`, `base_importance`, and `metadata` — never on
+    /// `id` or `importance_score`.
     ///
     /// # Errors
     ///

--- a/memory-engine/lib/memory-engine/src/types/facts.rs
+++ b/memory-engine/lib/memory-engine/src/types/facts.rs
@@ -168,6 +168,39 @@ impl Fact {
     /// unscored candidate.
     pub const UNSCORED_IMPORTANCE: f64 = 0.5;
 
+    /// Build a transient, pre-insert [`Fact`] from a [`NewFact`] to hand to
+    /// [`ConflictArbiter::arbitrate`](crate::traits::ConflictArbiter::arbitrate).
+    ///
+    /// `id` is `0` (not yet assigned by the DB) and `importance_score` is the
+    /// [`Self::UNSCORED_IMPORTANCE`] sentinel — NOT the eventual stored score.
+    /// All other fields are copied verbatim from `nf`.
+    ///
+    /// **Arbiter input caveat:** the returned `Fact` is synthetic. Arbiters must
+    /// rely on `content`, `fact_type`, `base_importance`, and `metadata` — never
+    /// on `id` (always `0`) or `importance_score` (always the sentinel `0.5`).
+    pub(crate) fn from_new_for_arbiter(nf: &NewFact) -> Self {
+        Self {
+            id: 0, // placeholder, not yet inserted
+            content: nf.content.clone(),
+            content_hash: nf.content_hash.clone(),
+            embedding: nf.embedding.clone(),
+            fact_type: nf.fact_type,
+            t_created: nf.t_created,
+            t_expired: nf.t_expired,
+            t_valid: nf.t_valid,
+            t_invalid: nf.t_invalid,
+            source_event_id: nf.source_event_id,
+            scope_id: nf.scope_id,
+            base_importance: nf.base_importance,
+            access_count: nf.access_count,
+            last_accessed: nf.last_accessed,
+            metadata: nf.metadata.clone(),
+            is_pinned: nf.is_pinned,
+            importance_score: Self::UNSCORED_IMPORTANCE,
+            surfaced_at: None,
+        }
+    }
+
     /// Whether this fact is **temporally due** at `now`: it has a concrete
     /// valid-time start that has arrived (`t_valid` is `Some` and `<= now`) and is
     /// not yet bi-temporally invalidated (`t_invalid` is `None` or strictly after


### PR DESCRIPTION
Part of epic **#259** (area:temporal super-qa). Wave 1, PR-1.

The conflict-resolution path (`MemoryEngine::resolve_conflict`) builds a transient `Fact` from a `NewFact` to hand to the consumer `ConflictArbiter`. This bundles three findings that all concern that synthetic fact — a coherent, **behavior-preserving** unit.

## Findings addressed
- **#398** (refactor) — extract the 18-line inline field-copy into `Fact::from_new_for_arbiter`. Field-for-field identical to the prior block (verified). The `importance_score = UNSCORED_IMPORTANCE` sentinel is **deliberately preserved**, not seeded from `base_importance`: synthetic pre-insert facts carry this sentinel by convention (cf. `consolidation/cluster.rs`), and the arbiter already receives the real `base_importance`.
- **#372** (docs) — document the arbiter-input caveat on `resolve_conflict` and mirror it on `ConflictArbiter::arbitrate`: `new_fact` is a pre-insert synthetic (`id == 0`, `importance_score ==` sentinel, NOT the stored score). The prior trait warning covered only `importance_score`; this also documents `id == 0`.
- **#417** (docs) — document the graph/DB eventual-consistency invariant: the in-memory graph is mirrored only after the DB commit; a panic in that window leaves them transiently diverged, recovered on next `open()` via `MemoryGraph::load_from_db`.

## Reconciliation note
The 2026-06-01 super-qa snapshot analyzed `src/conflict/temporal.rs` with a *"hardcoded 0.5"*. Since #628/#631/#254, that path moved to `src/engine/conflict.rs` and the literal is now the named `Fact::UNSCORED_IMPORTANCE` sentinel. The findings' optional *"seed from importance"* suggestion is **declined** — it would break the established sentinel convention. This PR documents and encapsulates the convention instead.

## Verification
- `cargo test --workspace` — green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

Closes #372
Closes #398
Closes #417