### PR TITLE
test(storage): cover SummaryStore::for_each/list_all and ScopeStore::for_each

### DIFF
--- a/memory-engine/lib/memory-engine/src/store/scopes.rs
+++ b/memory-engine/lib/memory-engine/src/store/scopes.rs
@@ -304,4 +304,89 @@ mod tests {
         let err = store.ensure_path(&long_label).unwrap_err();
         assert!(matches!(err, MemoryError::Conflict(_)));
     }
+
+    #[test]
+    fn for_each_on_seeded_store_visits_only_root() {
+        // `migrate` seeds the root scope, so a fresh store is never truly empty —
+        // the smallest possible state is exactly the root (id=1).
+        let conn = setup();
+        let store = ScopeStore::new(&conn);
+        let mut visited = Vec::new();
+        store
+            .for_each(|s| {
+                visited.push(s);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(visited.len(), 1);
+        assert_eq!(visited[0].id, 1);
+        assert_eq!(visited[0].label, "root");
+        assert!(visited[0].parent_id.is_none());
+        assert_eq!(visited[0].depth, 0);
+    }
+
+    #[test]
+    fn for_each_visits_every_scope_exactly_once_in_id_order() {
+        let conn = setup();
+        let store = ScopeStore::new(&conn);
+        // Distinct labels at distinct depths so a swap or dropped row is caught.
+        let leaf = store
+            .ensure_path("user:michael/machine:desktop/project:memory-engine")
+            .unwrap();
+
+        let mut visited = Vec::new();
+        store
+            .for_each(|s| {
+                visited.push((s.id, s.label, s.depth, s.parent_id));
+                Ok(())
+            })
+            .unwrap();
+
+        // for_each must agree with list_all (the same SELECT ... ORDER BY id),
+        // and cover root + the three created nodes.
+        let expected: Vec<_> = store
+            .list_all()
+            .unwrap()
+            .into_iter()
+            .map(|s| (s.id, s.label, s.depth, s.parent_id))
+            .collect();
+        assert_eq!(visited, expected);
+
+        // Pin the exact ordered shape so an out-of-order scan or missing node fails:
+        // root, then the chain in insertion/id order with ascending depths.
+        assert_eq!(
+            visited,
+            vec![
+                (1, "root".to_string(), 0, None),
+                (2, "user:michael".to_string(), 1, Some(1)),
+                (3, "machine:desktop".to_string(), 2, Some(2)),
+                (4, "project:memory-engine".to_string(), 3, Some(3)),
+            ]
+        );
+        // The leaf id returned by ensure_path is the last visited node.
+        assert_eq!(visited.last().unwrap().0, leaf);
+    }
+
+    #[test]
+    fn for_each_propagates_callback_error_and_stops_iteration() {
+        let conn = setup();
+        let store = ScopeStore::new(&conn);
+        store.ensure_path("a/b/c").unwrap(); // root + 3 => 4 scopes total
+
+        // Fail on the second visited scope: proves the error surfaces AND that
+        // the remaining scopes are not visited.
+        let mut seen = 0_usize;
+        let err = store
+            .for_each(|_| {
+                seen += 1;
+                if seen == 2 {
+                    Err(MemoryError::NotFound("boom".to_string()))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::NotFound(msg) if msg == "boom"));
+        assert_eq!(seen, 2, "iteration must stop at the failing callback");
+    }
 }

--- a/memory-engine/lib/memory-engine/src/store/summaries.rs
+++ b/memory-engine/lib/memory-engine/src/store/summaries.rs
@@ -360,4 +360,123 @@ mod tests {
         let err = store.get(999).unwrap_err();
         assert!(matches!(err, MemoryError::NotFound(_)));
     }
+
+    #[test]
+    fn list_all_empty_store_returns_empty() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        assert!(store.list_all().unwrap().is_empty());
+    }
+
+    #[test]
+    fn list_all_returns_every_summary_in_id_order() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        // Insert across levels with asymmetric source ids so each content string
+        // is distinct — a tuple-swap or dropped row would change the sequence.
+        let id1 = store
+            .insert(&make_summary(ConsolidationLevel::Local, vec![1]))
+            .unwrap();
+        let id2 = store
+            .insert(&make_summary(ConsolidationLevel::Cluster, vec![2, 3]))
+            .unwrap();
+        let id3 = store
+            .insert(&make_summary(ConsolidationLevel::Global, vec![4, 5, 6]))
+            .unwrap();
+
+        let all = store.list_all().unwrap();
+        // All three rows, regardless of level (list_all is not level-filtered).
+        assert_eq!(all.len(), 3);
+        // ORDER BY id ASC — assert the exact ordered id sequence so a reorder
+        // (e.g. DESC) would fail.
+        assert_eq!(
+            all.iter().map(|s| s.id).collect::<Vec<_>>(),
+            vec![id1, id2, id3]
+        );
+        // Content/level travel with the right row — asymmetric so a swap is caught.
+        assert_eq!(all[0].level, ConsolidationLevel::Local);
+        assert_eq!(all[0].source_fact_ids, vec![1]);
+        assert_eq!(all[1].level, ConsolidationLevel::Cluster);
+        assert_eq!(all[1].source_fact_ids, vec![2, 3]);
+        assert_eq!(all[2].level, ConsolidationLevel::Global);
+        assert_eq!(all[2].source_fact_ids, vec![4, 5, 6]);
+    }
+
+    #[test]
+    fn for_each_visits_every_summary_exactly_once_in_order() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        let id1 = store
+            .insert(&make_summary(ConsolidationLevel::Local, vec![1]))
+            .unwrap();
+        let id2 = store
+            .insert(&make_summary(ConsolidationLevel::Cluster, vec![2, 3]))
+            .unwrap();
+        let id3 = store
+            .insert(&make_summary(ConsolidationLevel::Global, vec![4, 5, 6]))
+            .unwrap();
+
+        let mut visited = Vec::new();
+        store
+            .for_each(|s| {
+                visited.push((s.id, s.level, s.source_fact_ids));
+                Ok(())
+            })
+            .unwrap();
+
+        // Exactly-once and ORDER BY id ASC: the full ordered tuple sequence.
+        assert_eq!(
+            visited,
+            vec![
+                (id1, ConsolidationLevel::Local, vec![1]),
+                (id2, ConsolidationLevel::Cluster, vec![2, 3]),
+                (id3, ConsolidationLevel::Global, vec![4, 5, 6]),
+            ]
+        );
+    }
+
+    #[test]
+    fn for_each_on_empty_store_never_calls_callback() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        let mut calls = 0_usize;
+        store
+            .for_each(|_| {
+                calls += 1;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(calls, 0);
+    }
+
+    #[test]
+    fn for_each_propagates_callback_error_and_stops_iteration() {
+        let conn = setup();
+        let store = SummaryStore::new(&conn, 4);
+        store
+            .insert(&make_summary(ConsolidationLevel::Local, vec![1]))
+            .unwrap();
+        store
+            .insert(&make_summary(ConsolidationLevel::Cluster, vec![2]))
+            .unwrap();
+        store
+            .insert(&make_summary(ConsolidationLevel::Global, vec![3]))
+            .unwrap();
+
+        // Fail on the second visited row: proves the error surfaces AND that
+        // iteration halts (the third row is never seen).
+        let mut seen = 0_usize;
+        let err = store
+            .for_each(|_| {
+                seen += 1;
+                if seen == 2 {
+                    Err(MemoryError::NotFound("boom".to_string()))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+        assert!(matches!(err, MemoryError::NotFound(msg) if msg == "boom"));
+        assert_eq!(seen, 2, "iteration must stop at the failing callback");
+    }
 }


### PR DESCRIPTION
## Summary

Adds direct unit-test coverage for three previously-untested store-level iterators that are load-bearing for the export and Phase 5 DreamCycle pipelines. Part of epic #258 (Wave 2). Tests only — no production code changed.

## Per-issue coverage

### #483 — `SummaryStore::list_all` + `for_each`
- `list_all_empty_store_returns_empty` — empty store yields an empty vec
- `list_all_returns_every_summary_in_id_order` — every row across all levels in ascending id order; asymmetric `source_fact_ids`/levels so a row swap or reorder is caught
- `for_each_visits_every_summary_exactly_once_in_order` — exactly-once visitation, asserted as the full ordered tuple sequence
- `for_each_on_empty_store_never_calls_callback` — zero callback invocations on an empty store
- `for_each_propagates_callback_error_and_stops_iteration` — fails on the 2nd visited row, asserts the error surfaces AND the 3rd row is never visited

### #484 — `ScopeStore::for_each`
- `for_each_on_seeded_store_visits_only_root` — a freshly-migrated store seeds the root node; for_each visits exactly that one node
- `for_each_visits_every_scope_exactly_once_in_id_order` — exactly-once in id order; cross-checked against `list_all` and pinned to the exact ordered `(id, label, depth, parent_id)` shape
- `for_each_propagates_callback_error_and_stops_iteration` — error propagation + iteration halt

## Non-vacuity (mutation-verified)

The ordering and error-propagation assertions were mutation-checked before commit:
- flipping the `for_each` `ORDER BY id ASC` → `DESC` makes the ordering tests (summaries + scopes) fail
- swallowing the callback error (`f(x)?` → `let _ = f(x)`) makes the error-propagation test fail

## Test plan — full CI matrix, all green

1. `cargo fmt --all` — clean (no diff)
2. `cargo build --workspace` — Finished, ok
3. `cargo build --workspace --all-features` — Finished, ok
4. `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Finished, no warnings
5. `cargo test -p memory-engine --all-features` — ok; 1336 lib unit tests passed (8 new), 0 failed

Fixes #483, Fixes #484