### PR TITLE
refactor(temporal): extract shared expire-cascade closure in resolve_conflict_atomic

### DIFF
--- a/memory-engine/lib/memory-engine/src/storage/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/graph.rs
@@ -332,8 +332,8 @@ pub trait FactGraph: Send + Sync {
     ) -> Result<Vec<(i64, i64, i64)>>;
 
     /// Atomically execute an arbitrated conflict-resolution write plan in ONE
-    /// transaction — the verbatim single-tx body of the former
-    /// `crate::conflict::temporal::resolve_conflict`, moved below the seam.
+    /// transaction — the former conflict-resolution path, now encapsulated below
+    /// the storage seam.
     ///
     /// The consumer [`ConflictArbiter`](crate::traits::ConflictArbiter) decision is
     /// made engine-side **before** this call; this method performs only the DB

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
@@ -852,8 +852,7 @@ impl FactGraph for SqliteBackend {
         .await
     }
 
-    // ATOMIC WRITE — arbitrated conflict resolution in ONE transaction (verbatim
-    // single-tx body of the former conflict::temporal::resolve_conflict). Restores the
+    // ATOMIC WRITE — arbitrated conflict resolution in ONE transaction. Restores the
     // all-or-nothing semantics the #631 cutover lost when it decomposed this into
     // separate per-call port transactions (a mid-sequence failure could leave an old
     // fact expired+invalidated with no inserted successor = silent data loss).
@@ -882,6 +881,16 @@ impl FactGraph for SqliteBackend {
                 // unchecked_transaction: we own the write connection exclusively here,
                 // so there is no risk of nesting. All writes for the decision commit
                 // atomically (or roll back together on any error).
+                // Shared cascade used by Update and Delete: expire+invalidate the
+                // old fact (bi-temporal: both columns) then cascade-expire its edges.
+                // Extracted as a closure so dim/old_id/now are captured from the
+                // surrounding scope rather than threaded as arguments.
+                let cascade_expire = |tx: &rusqlite::Transaction| -> Result<()> {
+                    FactStore::new(tx, dim).expire_and_invalidate(old_id, now)?;
+                    EdgeStore::new(tx).expire_by_fact(old_id, now)?;
+                    Ok(())
+                };
+
                 match decision {
                     CrudDecision::Noop => Ok((None, None)),
                     CrudDecision::Add => {
@@ -902,15 +911,11 @@ impl FactGraph for SqliteBackend {
                     }
                     CrudDecision::Update => {
                         let tx = conn.unchecked_transaction()?;
-                        // Expire + invalidate old fact (bi-temporal: both columns).
-                        FactStore::new(&tx, dim).expire_and_invalidate(old_id, now)?;
-                        // Cascade: expire all edges involving the old fact.
-                        let edge_store = EdgeStore::new(&tx);
-                        edge_store.expire_by_fact(old_id, now)?;
+                        cascade_expire(&tx)?;
                         // Insert the replacement fact.
                         let new_id = FactStore::new(&tx, dim).insert(&new_fact)?;
                         // "contradicts" edge: new → old
-                        let edge_id = edge_store.insert(&NewEdge {
+                        let edge_id = EdgeStore::new(&tx).insert(&NewEdge {
                             source_fact_id: new_id,
                             target_fact_id: old_id,
                             relation_type: relation.clone(),
@@ -924,8 +929,7 @@ impl FactGraph for SqliteBackend {
                     }
                     CrudDecision::Delete => {
                         let tx = conn.unchecked_transaction()?;
-                        FactStore::new(&tx, dim).expire_and_invalidate(old_id, now)?;
-                        EdgeStore::new(&tx).expire_by_fact(old_id, now)?;
+                        cascade_expire(&tx)?;
                         tx.commit()?;
                         Ok((None, None))
                     }


### PR DESCRIPTION
Part of epic **#259** (area:temporal super-qa). Wave 2, PR-4. Behavior-preserving.

## Finding #399 (re-targeted)
The 2026-06-01 snapshot described 3 duplicated tx-arms in `src/conflict/temporal.rs`. Since #628/#631 that logic moved below the storage seam into `SqliteBackend::resolve_conflict_atomic` (`storage/sqlite/graph.rs`). The engine-level duplication is gone; what remained was the `Update`/`Delete` arms repeating `expire_and_invalidate(old_id) + expire_by_fact(old_id)`.

Extracted into a local `cascade_expire` closure (captures `dim`/`old_id`/`now` from scope — all `Copy`). Per-arm SQL sequence is **byte-identical**; the only structural change is `EdgeStore::new(&tx)` constructed fresh for the Update edge-insert instead of reused (a zero-cost reference wrapper). The atomicity tests are unchanged and green.

## Collateral cleanup
Dropped dead `crate::conflict::temporal` module references from two backend comments (`storage/graph.rs` trait doc + `storage/sqlite/graph.rs` impl comment) — that module was absorbed by the #628 cutover and no longer exists. Found during #259 review (the engine-side copy was already fixed in #887).

## Verification
- `cargo test -p memory-engine --all-features` — 1400 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

Closes #399