### PR TITLE
chore(temporal): address #501 low/info survivors (docs + idempotency tests)

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/conflict.rs
+++ b/memory-engine/lib/memory-engine/src/engine/conflict.rs
@@ -40,9 +40,46 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Returns `MemoryError::NotFound` if the old fact doesn't exist.
-    /// Propagates errors from the arbiter or database operations.
+    /// - [`MemoryError::ReadOnly`] — the engine was opened in read-only mode.
+    /// - [`MemoryError::Conflict`] wrapping [`ConflictError::PayloadTooLarge`] —
+    ///   the candidate `new_fact` exceeds the size bound enforced by
+    ///   [`check_new_fact`](crate::limits::check_new_fact). Checked before the
+    ///   arbiter is called.
+    /// - [`MemoryError::NotFound`] — `old_id` is missing or already expired. The
+    ///   lookup itself retrieves expired facts; an already-expired `old_id` is
+    ///   rejected later by the `t_expired IS NULL` guard in the atomic expire step
+    ///   (which changes zero rows), while a missing `old_id` is rejected at lookup.
+    ///   The two are indistinguishable to the caller (both yield `NotFound`).
+    /// - Propagates any error returned by the [`ConflictArbiter`] or the
+    ///   underlying database operations.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use memory_engine::{MemoryEngine, NewFact, FactType, Fact, Result};
+    /// use memory_engine::traits::{ConflictArbiter, CrudDecision};
+    ///
+    /// struct AlwaysUpdate;
+    /// impl ConflictArbiter for AlwaysUpdate {
+    ///     fn arbitrate(&self, _old: &Fact, _new: &Fact) -> Result<CrudDecision> {
+    ///         Ok(CrudDecision::Update)
+    ///     }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let engine = MemoryEngine::builder(4).build()?;
+    ///
+    ///     // Suppose `old_id` was obtained from a prior `add_fact` or `ingest` call.
+    ///     let old_id: i64 = 1;
+    ///     let candidate = NewFact::builder("updated content", vec![0.1; 4], FactType::Semantic)
+    ///         .build();
+    ///
+    ///     let resolution = engine.resolve_conflict(&AlwaysUpdate, old_id, &candidate).await?;
+    ///     println!("decision: {:?}, new fact id: {:?}", resolution.decision, resolution.new_fact_id);
+    ///     Ok(())
+    /// }
+    /// ```
     // One match dispatches the 4 CRUD decisions; splitting per-arm helpers would
     // scatter the persist→graph-mirror ordering invariant across functions.
     #[allow(clippy::too_many_lines)]

--- a/memory-engine/lib/memory-engine/src/engine/conflict.rs
+++ b/memory-engine/lib/memory-engine/src/engine/conflict.rs
@@ -40,16 +40,18 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// - [`MemoryError::ReadOnly`] — the engine was opened in read-only mode.
-    /// - [`MemoryError::Conflict`] wrapping [`ConflictError::PayloadTooLarge`] —
-    ///   the candidate `new_fact` exceeds the size bound enforced by
-    ///   [`check_new_fact`](crate::limits::check_new_fact). Checked before the
-    ///   arbiter is called.
-    /// - [`MemoryError::NotFound`] — `old_id` is missing or already expired. The
-    ///   lookup itself retrieves expired facts; an already-expired `old_id` is
-    ///   rejected later by the `t_expired IS NULL` guard in the atomic expire step
-    ///   (which changes zero rows), while a missing `old_id` is rejected at lookup.
-    ///   The two are indistinguishable to the caller (both yield `NotFound`).
+    /// - [`MemoryError::ReadOnly`](crate::error::MemoryError::ReadOnly) — the
+    ///   engine was opened in read-only mode.
+    /// - [`MemoryError::Conflict`](crate::error::MemoryError::Conflict) wrapping
+    ///   [`ConflictError::PayloadTooLarge`](crate::error::ConflictError::PayloadTooLarge)
+    ///   — the candidate `new_fact` exceeds the size bound enforced by
+    ///   `check_new_fact`. Checked before the arbiter is called.
+    /// - [`MemoryError::NotFound`](crate::error::MemoryError::NotFound) — `old_id`
+    ///   is missing or already expired. The lookup itself retrieves expired facts;
+    ///   an already-expired `old_id` is rejected later by the `t_expired IS NULL`
+    ///   guard in the atomic expire step (which changes zero rows), while a missing
+    ///   `old_id` is rejected at lookup. The two are indistinguishable to the
+    ///   caller (both yield `NotFound`).
     /// - Propagates any error returned by the [`ConflictArbiter`] or the
     ///   underlying database operations.
     ///

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -1094,8 +1094,6 @@ async fn resolve_conflict_nonexistent_fact_returns_not_found() {
 /// takes, so the two are indistinguishable at that layer).
 #[tokio::test]
 async fn resolve_conflict_double_update_on_expired_returns_not_found() {
-    use crate::error::MemoryError;
-
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let old_id = insert_raw_fact(&engine, &make_new_fact("original", vec![0.5; DIM])).await;
     let arbiter = FixedArbiter {
@@ -1125,8 +1123,6 @@ async fn resolve_conflict_double_update_on_expired_returns_not_found() {
 /// Same idempotency guard for the `Delete` decision.
 #[tokio::test]
 async fn resolve_conflict_double_delete_on_expired_returns_not_found() {
-    use crate::error::MemoryError;
-
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let old_id = insert_raw_fact(&engine, &make_new_fact("to_delete", vec![0.5; DIM])).await;
     let arbiter = FixedArbiter {

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -1087,6 +1087,76 @@ async fn resolve_conflict_nonexistent_fact_returns_not_found() {
     );
 }
 
+/// A second `resolve_conflict(Update)` on an already-expired `old_id` returns
+/// `NotFound`. The guard is NOT `get_fact` — that retrieves expired rows fine —
+/// it's `expire_and_invalidate`'s `WHERE id = ? AND t_expired IS NULL`, which
+/// changes zero rows on an already-expired fact (the same path a missing fact
+/// takes, so the two are indistinguishable at that layer).
+#[tokio::test]
+async fn resolve_conflict_double_update_on_expired_returns_not_found() {
+    use crate::error::MemoryError;
+
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let old_id = insert_raw_fact(&engine, &make_new_fact("original", vec![0.5; DIM])).await;
+    let arbiter = FixedArbiter {
+        decision: CrudDecision::Update,
+    };
+
+    // First Update — expires the old fact and inserts a successor.
+    engine
+        .resolve_conflict(
+            &arbiter,
+            old_id,
+            &make_new_fact("replacement", vec![0.5; DIM]),
+        )
+        .await
+        .unwrap();
+
+    // Second Update on the SAME (now-expired) old_id — must return NotFound.
+    let result = engine
+        .resolve_conflict(&arbiter, old_id, &make_new_fact("second", vec![0.5; DIM]))
+        .await;
+    assert!(
+        matches!(result, Err(MemoryError::NotFound(_))),
+        "expected NotFound on already-expired fact, got {result:?}"
+    );
+}
+
+/// Same idempotency guard for the `Delete` decision.
+#[tokio::test]
+async fn resolve_conflict_double_delete_on_expired_returns_not_found() {
+    use crate::error::MemoryError;
+
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let old_id = insert_raw_fact(&engine, &make_new_fact("to_delete", vec![0.5; DIM])).await;
+    let arbiter = FixedArbiter {
+        decision: CrudDecision::Delete,
+    };
+
+    // First Delete — expires the fact.
+    engine
+        .resolve_conflict(
+            &arbiter,
+            old_id,
+            &make_new_fact("irrelevant", vec![0.5; DIM]),
+        )
+        .await
+        .unwrap();
+
+    // Second Delete on the SAME (now-expired) old_id — must return NotFound.
+    let result = engine
+        .resolve_conflict(
+            &arbiter,
+            old_id,
+            &make_new_fact("irrelevant", vec![0.5; DIM]),
+        )
+        .await;
+    assert!(
+        matches!(result, Err(MemoryError::NotFound(_))),
+        "expected NotFound on already-expired fact, got {result:?}"
+    );
+}
+
 // --- #435: Delete cascade removes DB edges and in-memory graph edge ---
 
 #[tokio::test]

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -526,7 +526,11 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::NotFound` if no rows affected (already expired or absent).
+    /// Returns `MemoryError::NotFound` if no rows are affected. This covers two
+    /// indistinguishable cases by design: the fact does not exist at all, or it
+    /// was already expired (`t_expired IS NOT NULL`). The SQL `WHERE` clause
+    /// filters on `t_expired IS NULL`, so both produce zero changed rows and map
+    /// to the same `NotFound` error.
     pub fn expire_and_invalidate(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
         let now_str = now.to_rfc3339();
         let changed = self.conn.execute(

--- a/memory-engine/lib/memory-engine/src/types/facts.rs
+++ b/memory-engine/lib/memory-engine/src/types/facts.rs
@@ -175,6 +175,11 @@ impl Fact {
     /// [`Self::UNSCORED_IMPORTANCE`] sentinel — NOT the eventual stored score.
     /// All other fields are copied verbatim from `nf`.
     ///
+    /// **Clone is intentional:** the trait signature takes `&Fact`, so an owned
+    /// value must be built from the borrowed `NewFact`. The fields cloned
+    /// (`content`, `content_hash`, `embedding`, `metadata`) are string/vec
+    /// payloads with no cheaper alternative at this call site.
+    ///
     /// **Arbiter input caveat:** the returned `Fact` is synthetic. Arbiters must
     /// rely on `content`, `fact_type`, `base_importance`, and `metadata` — never
     /// on `id` (always `0`) or `importance_score` (always the sentinel `0.5`).


### PR DESCRIPTION
Part of epic **#259** (area:temporal super-qa). Wave 2, PR-5. Docs + 2 tests; behavior-preserving.

Addresses the 5 surviving low/info items in #501 (the fn-length and FixedArbiter-duplication items were already resolved upstream):

1. **`resolve_conflict` `# Errors`** — enumerate concrete variants (`ReadOnly`, `Conflict(PayloadTooLarge)`, `NotFound`) + a `no_run` doc-example. The `NotFound` bullet is precise about mechanism: `get_fact` retrieves expired rows; the guard that rejects an already-expired `old_id` is `expire_and_invalidate`'s `WHERE t_expired IS NULL` (adversarial-review fix — the first draft implied `get_fact` was the gate).
2. **`expire_and_invalidate` doc** — document that `NotFound` covers missing OR already-expired (indistinguishable, by the same WHERE guard).
3. **`from_new_for_arbiter`** — note the clone is intentional (the trait takes `&Fact`).
4. **double-expiry idempotency tests** — Update + Delete on an already-expired `old_id` → `NotFound`.

## Verification
- `cargo test -p memory-engine --all-features` (+ `--doc`) — green
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

Closes #501