### PR TITLE
test(forgetting): cover edge cascade + graph reconcile + degree-weight on prune

### DIFF
--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -75,15 +75,6 @@ harness = false
 
 # --- integration tests (top-level ../../../tests/) — attached explicitly since this
 #     crate dir has no tests/ subdir for Cargo to auto-discover ---
-# The two-tier eval harness (#16): a multi-file binary rooted at tests/eval/main.rs.
-# Cargo auto-discovered it when the repo root was a package; after the bin/lib
-# restructure the core crate's dir has no tests/ subdir, so it must be attached
-# explicitly like every other top-level integration test below — otherwise the
-# whole conformance + quality suite silently stops building under `cargo test`.
-[[test]]
-name = "eval"
-path = "../../../tests/eval/main.rs"
-
 [[test]]
 name = "activity_stream_test"
 path = "../../../tests/activity_stream_test.rs"

--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -75,6 +75,15 @@ harness = false
 
 # --- integration tests (top-level ../../../tests/) — attached explicitly since this
 #     crate dir has no tests/ subdir for Cargo to auto-discover ---
+# The two-tier eval harness (#16): a multi-file binary rooted at tests/eval/main.rs.
+# Cargo auto-discovered it when the repo root was a package; after the bin/lib
+# restructure the core crate's dir has no tests/ subdir, so it must be attached
+# explicitly like every other top-level integration test below — otherwise the
+# whole conformance + quality suite silently stops building under `cargo test`.
+[[test]]
+name = "eval"
+path = "../../../tests/eval/main.rs"
+
 [[test]]
 name = "activity_stream_test"
 path = "../../../tests/activity_stream_test.rs"

--- a/memory-engine/lib/memory-engine/src/forgetting/policy.rs
+++ b/memory-engine/lib/memory-engine/src/forgetting/policy.rs
@@ -746,4 +746,198 @@ mod tests {
             "explicit override must win over the default exemption"
         );
     }
+
+    /// #312: the prune → graph-reconcile composition. Every prior prune test runs
+    /// against an EMPTY `MemoryGraph`, so neither the SQL edge cascade
+    /// (`prune_atomic` → `EdgeStore::expire_by_fact`) nor the in-memory reconcile
+    /// loop (`graph.write().remove_edges_by_fact`) is ever exercised end-to-end.
+    /// This seeds edges in BOTH the `SQLite` `EdgeStore` (via the port) and the
+    /// `MemoryGraph` (mirroring the DB), prunes a low-importance victim, and
+    /// asserts the cascade fires in both projections while a non-victim edge
+    /// survives untouched.
+    #[tokio::test]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one cohesive composition test: seed (facts+edges in DB and graph), \
+                  prune, then assert the cascade across both the SQLite and in-memory \
+                  projections — splitting it would scatter the shared fixture"
+    )]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the read guard is intentionally held across the closing assertion \
+                  block; this is a single-threaded test with no contention"
+    )]
+    async fn prune_cascades_edges_and_reconciles_graph() {
+        use crate::graph::EdgeData;
+        use crate::types::{NewEdge, NewFact};
+
+        let now = Utc::now();
+        let old_time = now - Duration::days(200);
+        let embed_dim = 4;
+
+        let backend = std::sync::Arc::new(SqliteBackend::from_pool(
+            std::sync::Arc::new(ConnectionPool::open_memory(embed_dim).unwrap()),
+            std::sync::Arc::new(UpcasterRegistry::new()),
+        ));
+        let storage: std::sync::Arc<dyn StorageBackend> = backend.clone();
+
+        // Seed a fact with the shared embed dim + scope. Built fresh per call so
+        // each fact can vary its type/importance/recency.
+        let make_fact = |content: &str, hash: &str, fact_type, base, accessed| NewFact {
+            content: content.into(),
+            content_hash: hash.into(),
+            embedding: vec![0.1; embed_dim],
+            fact_type,
+            t_created: old_time,
+            t_expired: None,
+            t_valid: None,
+            t_invalid: None,
+            source_event_id: None,
+            scope_id: 1,
+            base_importance: base,
+            access_count: 0,
+            last_accessed: accessed,
+            metadata: serde_json::json!({}),
+            is_pinned: false,
+        };
+
+        // Victim: Episodic, ancient, near-zero importance → guaranteed pruned.
+        let victim = storage
+            .insert_fact(&make_fact(
+                "victim",
+                "h-victim",
+                FactType::Episodic,
+                0.01,
+                old_time,
+            ))
+            .await
+            .unwrap();
+        // Survivor: Semantic (decay-exempt) → immune to the prune. Adjacent to the
+        // victim (edge cascades) AND to the bystander (edge must survive).
+        let survivor = storage
+            .insert_fact(&make_fact(
+                "survivor",
+                "h-surv",
+                FactType::Semantic,
+                0.9,
+                now,
+            ))
+            .await
+            .unwrap();
+        // Bystander: Semantic, only adjacent to the survivor — its edge must be
+        // untouched by the victim's cascade.
+        let bystander = storage
+            .insert_fact(&make_fact(
+                "bystander",
+                "h-by",
+                FactType::Semantic,
+                0.9,
+                now,
+            ))
+            .await
+            .unwrap();
+
+        // Mirror two edges into BOTH SQLite and the in-memory graph:
+        //   e_cascade:  victim   → survivor   (must expire when victim is pruned)
+        //   e_keep:     survivor → bystander  (neither endpoint pruned → survives)
+        let new_edge = |src, tgt| NewEdge {
+            source_fact_id: src,
+            target_fact_id: tgt,
+            relation_type: "related".into(),
+            weight: 1.0,
+            scope_id: 1,
+            t_created: old_time,
+            t_expired: None,
+        };
+        let e_cascade = storage
+            .insert_edge(&new_edge(victim, survivor))
+            .await
+            .unwrap();
+        let e_keep = storage
+            .insert_edge(&new_edge(survivor, bystander))
+            .await
+            .unwrap();
+
+        let graph = parking_lot::RwLock::new(MemoryGraph::new());
+        {
+            let mut g = graph.write();
+            g.add_edge(
+                victim,
+                survivor,
+                EdgeData {
+                    edge_id: e_cascade,
+                    relation_type: "related".into(),
+                    weight: 1.0,
+                },
+            );
+            g.add_edge(
+                survivor,
+                bystander,
+                EdgeData {
+                    edge_id: e_keep,
+                    relation_type: "related".into(),
+                    weight: 1.0,
+                },
+            );
+        }
+
+        // Pre-conditions: the graph mirrors the two seeded edges.
+        assert_eq!(graph.read().degree(victim), 1, "victim starts connected");
+        assert_eq!(
+            graph.read().degree(survivor),
+            2,
+            "survivor bridges victim and bystander"
+        );
+
+        let policy = ForgetPolicy {
+            min_importance: 0.3,
+            ..ForgetPolicy::default()
+        };
+        let (stats, expired) = prune(&storage, &graph, &policy, now).await.unwrap();
+
+        // Only the victim is pruned (survivor + bystander are decay-exempt Semantic).
+        assert_eq!(stats.facts_evaluated, 3);
+        assert_eq!(stats.facts_expired, 1, "only the episodic victim expires");
+        assert_eq!(expired, vec![victim]);
+
+        // (a) SQLite cascade: the victim's edge is expired, the other edge stays active.
+        let active_edges = storage.list_active_edges().await.unwrap();
+        let active_ids: std::collections::HashSet<i64> =
+            active_edges.iter().map(|e| e.id).collect();
+        assert!(
+            !active_ids.contains(&e_cascade),
+            "victim's edge must be expired in SQLite (cascade)"
+        );
+        assert!(
+            active_ids.contains(&e_keep),
+            "survivor↔bystander edge must remain active in SQLite"
+        );
+        // It is soft-deleted, not hard-deleted: still present with t_expired set.
+        let cascaded = storage.get_edge(e_cascade).await.unwrap();
+        assert!(
+            cascaded.t_expired.is_some(),
+            "cascaded edge is soft-deleted (t_expired set), not removed"
+        );
+
+        // (b) In-memory reconcile loop ran + (c) the surviving adjacent fact keeps
+        // its non-victim edge in the graph. Scope the read guard tightly so it is
+        // released immediately after the assertions (no contention held to fn end).
+        {
+            let g = graph.read();
+            // (b) The victim is fully disconnected.
+            assert_eq!(g.degree(victim), 0, "in-memory graph reconciled the victim");
+            assert!(
+                g.neighbors(victim).is_empty(),
+                "victim has no outgoing neighbors after reconcile"
+            );
+            // (c) The cascade is scoped to the victim, not a blanket wipe.
+            assert_eq!(
+                g.degree(survivor),
+                1,
+                "survivor keeps exactly its bystander edge (victim edge gone)"
+            );
+            assert_eq!(g.neighbors(survivor), vec![bystander]);
+            assert_eq!(g.degree(bystander), 1);
+        }
+    }
 }

--- a/tests/eval/quality/forgetting.rs
+++ b/tests/eval/quality/forgetting.rs
@@ -5,10 +5,12 @@
 
 use std::collections::HashMap;
 
+use chrono::Utc;
 use memory_engine::ForgetPolicy;
-use memory_engine::types::{AddFactOptions, FactType};
+use memory_engine::traits::EmbeddingProvider;
+use memory_engine::types::{AddFactOptions, AddFactRequest, EventType, FactType, NewEvent};
 
-use crate::helpers::{add_fact_with_opts, days_ago, eval_engine};
+use crate::helpers::{TestEmbedder, add_fact_with_opts, days_ago, eval_engine};
 
 #[tokio::test]
 async fn ebbinghaus_decay_ordering_old_before_young() {
@@ -261,5 +263,143 @@ async fn pin_immunity_survives_aggressive_forget() {
     assert!(
         unpinned.t_expired.is_some(),
         "unpinned fact with low importance should be expired under aggressive policy"
+    );
+}
+
+/// #312: end-to-end exercise of the `graph_degree_weight` survival signal.
+///
+/// Two Episodic facts with EQUAL `base_importance`, EQUAL age, and EQUAL access
+/// count differ only in graph connectivity: one is the hub of a co-session clique
+/// (high degree), the other is isolated (degree 0). Under a threshold tuned between
+/// their scores, the graph-degree term is the sole differentiator — the connected
+/// fact must survive while the isolated one is pruned.
+///
+/// Every prior forgetting test runs with an empty graph (every fact's degree is 0,
+/// so the 3rd of 4 scoring signals never moves the needle); this is the gap #312
+/// flagged. The clique is built through the real engine API (`ingest` +
+/// `link_session_facts`), so the in-memory graph the prune walk reads is populated
+/// the same way production populates it.
+#[tokio::test]
+async fn well_connected_fact_survives_prune() {
+    let engine = eval_engine();
+    let embedder: std::sync::Arc<dyn EmbeddingProvider> = std::sync::Arc::new(TestEmbedder);
+
+    // One session whose facts will be wired into a co-session clique.
+    let session = "sess-hub";
+    let event = NewEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::Interaction,
+        payload: serde_json::json!({"k": "v"}),
+        source: "test".to_string(),
+        session_id: Some(session.to_string()),
+        scope_id: 1,
+        origin_node_id: "node-1".to_string(),
+        sequence_id: 1,
+        created_at: None,
+    };
+    let event_id = engine.ingest(&event).await.expect("ingest event");
+
+    // Shared decay profile: ancient + never accessed, so recency/frequency are
+    // identical for the hub and the isolated fact and cannot mask the degree term.
+    let aged = || AddFactOptions {
+        base_importance: Some(0.3),
+        t_created: Some(days_ago(100)),
+        last_accessed: Some(days_ago(100)),
+        ..Default::default()
+    };
+
+    // Hub: Episodic (so it CAN decay), linked to the session event so
+    // `link_session_facts` connects it.
+    let hub_id = engine
+        .add_fact(
+            &AddFactRequest {
+                content: "Hub fact connected to many others in its session".to_string(),
+                fact_type: FactType::Episodic,
+                source_event_id: Some(event_id),
+                scope: None,
+                opts: Some(aged()),
+            },
+            embedder.clone(),
+            None,
+        )
+        .await
+        .expect("add hub");
+
+    // Two Semantic neighbours (decay-exempt → they survive, keeping the hub's
+    // degree stable through the prune) sharing the same session as the hub.
+    for i in 0..2 {
+        engine
+            .add_fact(
+                &AddFactRequest {
+                    content: format!("Neighbour {i} sharing the hub's session"),
+                    fact_type: FactType::Semantic,
+                    source_event_id: Some(event_id),
+                    scope: None,
+                    opts: Some(AddFactOptions {
+                        base_importance: Some(0.9),
+                        ..Default::default()
+                    }),
+                },
+                embedder.clone(),
+                None,
+            )
+            .await
+            .expect("add neighbour");
+    }
+
+    // Isolated fact: same type/importance/age as the hub, but NOT linked to any
+    // session — it never gains a co-session edge, so its degree stays 0.
+    let isolated_id = add_fact_with_opts(
+        &engine,
+        "Isolated fact with no graph connections at all",
+        FactType::Episodic,
+        None,
+        aged(),
+    )
+    .await;
+
+    // Build the co-session clique. Hub + 2 neighbours → the hub gains 4 directed
+    // edges (in+out to each neighbour); the isolated fact gains none.
+    let created = engine
+        .link_session_facts(session, None)
+        .await
+        .expect("link session facts");
+    assert!(created > 0, "co-session edges must have been created");
+
+    // Sanity: the degree signal is actually non-trivial for the hub and zero for
+    // the isolated fact — otherwise the test would pass for the wrong reason.
+    assert!(
+        engine.graph_degree(hub_id) >= 2,
+        "hub must be well-connected, got degree {}",
+        engine.graph_degree(hub_id)
+    );
+    assert_eq!(
+        engine.graph_degree(isolated_id),
+        0,
+        "isolated fact must have no edges"
+    );
+
+    // Computed scores (default weights recency=0.3, freq=0.2, graph=0.3, base=0.2):
+    //   isolated (deg 0): 0.3·2^(-100/69) + 0 + 0          + 0.2·0.3 ≈ 0.170
+    //   hub      (deg 4): 0.3·2^(-100/69) + 0 + 0.3·0.409  + 0.2·0.3 ≈ 0.293
+    // A threshold strictly between them isolates the graph-degree term as the
+    // decisive survival signal.
+    let policy = ForgetPolicy {
+        min_importance: 0.23,
+        ..ForgetPolicy::default()
+    };
+    let _stats = engine.forget(&policy).await.expect("forget failed");
+
+    let hub = engine.get_fact(hub_id).await.expect("get hub");
+    let isolated = engine.get_fact(isolated_id).await.expect("get isolated");
+
+    assert!(
+        isolated.t_expired.is_some(),
+        "the isolated fact (degree 0) must be pruned under the threshold"
+    );
+    assert!(
+        hub.t_expired.is_none(),
+        "the well-connected fact must survive — its graph-degree signal lifts it \
+         above the threshold despite equal base importance, age, and access"
     );
 }


### PR DESCRIPTION
Closes the #312 coverage gap. The `prune` → in-memory reconcile loop and the `graph_degree_weight` survival signal were untested **end-to-end** because every prior prune test ran against an **empty** `MemoryGraph` (degree always 0, no edges to cascade). The constituent primitives — `EdgeStore::expire_by_fact`, `MemoryGraph::remove_edges_by_fact`, `prune_atomic` atomicity — were each independently tested; only their *composition* was uncovered.

## Tests added

**Unit** — `forgetting/policy.rs::prune_cascades_edges_and_reconciles_graph`
Seeds edges in BOTH the SQLite `EdgeStore` (via the storage port) and the in-memory `MemoryGraph`, prunes a low-importance Episodic victim adjacent to a decay-exempt Semantic survivor, and asserts:
- (a) the victim's edge is **soft-expired** in SQLite (`t_expired` set, still present), while a non-victim edge stays active;
- (b) `graph.degree(victim) == 0` after prune — the in-memory reconcile loop ran;
- (c) the surviving adjacent fact retains its non-victim edge in **both** projections (cascade is scoped to the victim, not a blanket wipe).

**Integration** — `tests/eval/quality/forgetting.rs::well_connected_fact_survives_prune`
Two Episodic facts with **equal** `base_importance`, age, and access count differ only in graph connectivity: one is the hub of a co-session clique (built through the real engine API — `ingest` + `link_session_facts`), the other isolated. Under a threshold tuned strictly between their computed scores, the well-connected fact survives while the isolated one is pruned — isolating `graph_degree_weight` as the decisive signal, exercised end-to-end.

## Canary result

**Both tests pass on current behavior — no product bug found.** `prune` cascades edges, reconciles the in-memory graph, and the degree signal influences survival exactly as designed. Verified under both default features and `--all-features` (the `ann` HNSW `notify_expire` path in `prune_atomic`).

## Collateral: re-attach the orphaned eval harness

While wiring the integration test I found the entire two-tier eval harness (`tests/eval/main.rs` — 56 conformance + quality tests, including the 4 pre-existing `forgetting` tests) was **not being built or run** by `cargo test --workspace`. Cargo auto-discovered it when the repo root was a package; the bin/lib restructure left the core crate's directory without a `tests/` subdir, so the harness silently stopped compiling. Added a `[[test]] name = "eval"` target (`path = "../../../tests/eval/main.rs"`) mirroring the other explicitly-attached top-level integration tests. Without this the new #312 integration test would not run at all. The harness compiles and passes clean (56 passed, 3 `#[ignore]` Phase-5 skeletons).

## Gate (CI-exact, all green)

- `cargo fmt --all --check` ✅
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (0 failures; eval harness 56 passed / 3 ignored)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅

No production code change. No `unwrap`/`expect` in lib code (the `#[cfg(test)]` module is exempt).

Closes #312
Part of #255