### PR TITLE
fix(temporal): re-validate old fact is active inside resolve_conflict_atomic (TOCTOU #335)

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/conflict.rs
+++ b/memory-engine/lib/memory-engine/src/engine/conflict.rs
@@ -47,11 +47,13 @@ impl MemoryEngine {
     ///   — the candidate `new_fact` exceeds the size bound enforced by
     ///   `check_new_fact`. Checked before the arbiter is called.
     /// - [`MemoryError::NotFound`](crate::error::MemoryError::NotFound) — `old_id`
-    ///   is missing or already expired. The lookup itself retrieves expired facts;
-    ///   an already-expired `old_id` is rejected later by the `t_expired IS NULL`
-    ///   guard in the atomic expire step (which changes zero rows), while a missing
-    ///   `old_id` is rejected at lookup. The two are indistinguishable to the
-    ///   caller (both yield `NotFound`).
+    ///   is missing or already expired. The lookup itself retrieves expired facts,
+    ///   so an already-expired `old_id` is rejected later, *inside the atomic
+    ///   transaction*: `Update`/`Delete` change zero rows under their
+    ///   `t_expired IS NULL` expiry, and `Add` re-validates `old_id` is still
+    ///   active before creating its edge (the #335 read→write TOCTOU guard). A
+    ///   missing `old_id` is rejected at lookup. All cases are indistinguishable to
+    ///   the caller (each yields `NotFound`).
     /// - Propagates any error returned by the [`ConflictArbiter`] or the
     ///   underlying database operations.
     ///

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -1153,6 +1153,45 @@ async fn resolve_conflict_double_delete_on_expired_returns_not_found() {
     );
 }
 
+/// #335 (TOCTOU): the arbiter decides on the `old_fact` read *before* the atomic
+/// write opens its transaction. If `old_id` is expired concurrently in that
+/// window, an `Add` decision would otherwise create a `supplements` edge against
+/// a now-expired fact. The in-transaction re-validation must reject it instead.
+/// (`get_fact` returns expired rows, so the candidate still reaches the arbiter;
+/// the guard fires inside `resolve_conflict_atomic`.)
+#[tokio::test]
+async fn resolve_conflict_add_on_expired_old_fact_returns_not_found() {
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let old_id = insert_raw_fact(&engine, &make_new_fact("original", vec![0.5; DIM])).await;
+
+    // Expire old_id — stands in for a concurrent Delete landing before our Add's write.
+    engine
+        .resolve_conflict(
+            &FixedArbiter {
+                decision: CrudDecision::Delete,
+            },
+            old_id,
+            &make_new_fact("concurrent expiry", vec![0.5; DIM]),
+        )
+        .await
+        .unwrap();
+
+    // Add against the now-expired old_id must be rejected by the in-tx re-validation.
+    let result = engine
+        .resolve_conflict(
+            &FixedArbiter {
+                decision: CrudDecision::Add,
+            },
+            old_id,
+            &make_new_fact("supplement", vec![0.5; DIM]),
+        )
+        .await;
+    assert!(
+        matches!(result, Err(MemoryError::NotFound(_))),
+        "Add against an expired old_id must be rejected (TOCTOU #335), got {result:?}"
+    );
+}
+
 // --- #435: Delete cascade removes DB edges and in-memory graph edge ---
 
 #[tokio::test]

--- a/memory-engine/lib/memory-engine/src/storage/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/graph.rs
@@ -369,6 +369,15 @@ pub trait FactGraph: Send + Sync {
     /// the write, which would duplicate the fact). Every *other* `Err` variant preserves
     /// the byte-identical guarantee (nothing was written).
     ///
+    /// **Re-validation (TOCTOU, #335):** the arbiter `decision` was made
+    /// engine-side from an `old_id` read *before* this call opened its
+    /// transaction. Implementations MUST re-validate that `old_id` is still active
+    /// *inside* the transaction and return `MemoryError::NotFound` if it was
+    /// expired concurrently in that window — an `Add` must not create a
+    /// `supplements` edge pointing at an already-expired fact. (The `Update` and
+    /// `Delete` arms re-validate implicitly via their `WHERE t_expired IS NULL`
+    /// expiry, which changes zero rows on an already-expired fact.)
+    ///
     /// # Returns
     ///
     /// `(new_fact_id, edge_id)` — both `Some` for `Add`/`Update`, both `None` for

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
@@ -896,6 +896,17 @@ impl FactGraph for SqliteBackend {
                     CrudDecision::Noop => Ok((None, None)),
                     CrudDecision::Add => {
                         let tx = conn.unchecked_transaction()?;
+                        // #335 (TOCTOU): the arbiter decided on `old_id` as read
+                        // BEFORE this transaction opened. Re-validate it is still
+                        // active here; if it was expired concurrently in that window,
+                        // reject rather than create a `supplements` edge pointing at
+                        // an already-expired fact. (The Update/Delete arms self-guard
+                        // via `expire_and_invalidate`'s `WHERE t_expired IS NULL`.)
+                        if !FactStore::new(&tx, dim).is_active(old_id)? {
+                            return Err(crate::error::MemoryError::NotFound(format!(
+                                "fact {old_id} is no longer active (expired since arbitration)"
+                            )));
+                        }
                         let new_id = FactStore::new(&tx, dim).insert(&new_fact)?;
                         // "supplements" edge: new → old
                         let edge_id = EdgeStore::new(&tx).insert(&NewEdge {
@@ -1974,6 +1985,59 @@ mod tests {
             be.list_active_facts(None).await.unwrap().len(),
             1,
             "rollback must leave exactly the original active fact"
+        );
+    }
+
+    /// #335 (TOCTOU): an `Add` whose `old_id` was expired *after* the arbiter
+    /// decided (but before this transaction) must be rejected with `NotFound`
+    /// rather than create a `supplements` edge against an already-expired fact.
+    /// The in-transaction re-validation is what closes the race.
+    #[tokio::test]
+    async fn resolve_conflict_atomic_add_on_expired_old_rejects() {
+        let pool = seeded(&[fact("old", [0.1; DIM])]);
+        let be = backend(Arc::clone(&pool));
+        let old_id = be.list_active_facts(None).await.unwrap()[0].id;
+
+        // Expire old_id first — stands in for a concurrent Delete landing in the
+        // read→write window.
+        be.resolve_conflict_atomic(
+            crate::traits::CrudDecision::Delete,
+            old_id,
+            &fact("ignored", [0.0; DIM]),
+            "",
+            1.0,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+
+        // Add against the now-expired old_id must be rejected.
+        let err = be
+            .resolve_conflict_atomic(
+                crate::traits::CrudDecision::Add,
+                old_id,
+                &fact("supplement", [0.5; DIM]),
+                "supplements",
+                1.0,
+                Utc::now(),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::NotFound(_)),
+            "Add against an expired old_id must be NotFound (TOCTOU #335), got {err:?}"
+        );
+
+        // Byte-identical on error: the rejected Add wrote nothing — no supplement
+        // fact (old is expired ⇒ zero active facts) and no edge.
+        assert_eq!(
+            be.list_active_facts(None).await.unwrap().len(),
+            0,
+            "the rejected Add must not have inserted a supplement fact"
+        );
+        assert!(
+            be.list_active_edges().await.unwrap().is_empty(),
+            "the rejected Add must not have created a supplements edge"
         );
     }
 


### PR DESCRIPTION
Part of epic **#259** (area:temporal super-qa). Wave 3 — the one needs-design finding.

## The bug (#335 TOCTOU)
`MemoryEngine::resolve_conflict` reads `old_fact` (`block_read`) → arbitrates → writes via `resolve_conflict_atomic` (`block_write`). A concurrent writer can expire `old_id` in that read→write window. The **`Add`** arm created a `supplements` edge against `old_id` with no re-check, so a concurrently-expired fact would gain a dangling edge against an already-expired target. (Update/Delete already self-guard via `expire_and_invalidate`'s `WHERE t_expired IS NULL`.)

## The fix (you chose: re-validate inside the atomic transaction)
In `SqliteBackend::resolve_conflict_atomic`'s `Add` arm, re-validate `old_id` is still active **inside the transaction** via `FactStore::is_active` (the guard added for the sibling #409 read→write gap) → return `NotFound` if expired since arbitration, writing nothing.

**Why this is airtight:** the write connection is a single exclusive `parking_lot::Mutex<Connection>` per `block_write`, so any concurrent expiry serializes fully before or after ours — the in-tx `is_active` either sees it (reject) or runs first (edge against a then-active fact, later cascade-expired normally). No residual in-tx race.

**Error choice:** reuse `NotFound` (uniform with Update/Delete; caller recovery is identical) rather than a new `StaleConflict` variant. Contract documented on the `FactGraph::resolve_conflict_atomic` trait method + the engine's `resolve_conflict` `# Errors`. `PgBackend` has no `resolve_conflict_atomic` impl yet (#634/#635), so it inherits the contract doc only.

## Tests (TDD red→green)
- engine-level: `resolve_conflict_add_on_expired_old_fact_returns_not_found` — full path (get_fact returns the expired row, the atomic guard fires).
- backend-level: `resolve_conflict_atomic_add_on_expired_old_rejects` — asserts the rejected Add writes nothing (byte-identical-on-error).

## Review
Adversarial concurrency-correctness subagent: **CLEAN** — verified no residual in-tx race (exclusive `Mutex<Connection>`), no HNSW desync on the error path (`?` short-circuits before the post-commit notify), byte-identical-on-error holds, no over-firing on a legitimately-active `old_id`.

## Verification
- `cargo test --all-features` — 1408 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo doc -D rustdoc::broken_intra_doc_links` — no errors in touched files

Closes #335