### PR TITLE
test(mcp): handle_forget negative-path coverage

### DIFF
--- a/memory-engine/bin/mcp/tests/tools.rs
+++ b/memory-engine/bin/mcp/tests/tools.rs
@@ -218,7 +218,11 @@ async fn test_forget_invalid_override_key() {
         &memory_engine::ActivityFilterConfig::default(),
     )
     .await;
-    assert!(result.is_err());
+    // An unknown FactType key surfaces as `INVALID_PARAMS` via the
+    // `parse_fact_type` -> `ValidationError::UnknownFactType` -> `ErrorData`
+    // conversion (matching the sibling `test_forget_validation_error`).
+    let err = result.unwrap_err();
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
 }
 
 #[tokio::test]
@@ -238,7 +242,9 @@ async fn test_forget_non_object_overrides() {
         &memory_engine::ActivityFilterConfig::default(),
     )
     .await;
-    assert!(array_result.is_err());
+    let array_err = array_result.unwrap_err();
+    assert_eq!(array_err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(array_err.message.contains("must be a JSON object"));
 
     // A JSON string is likewise rejected.
     let string_result = tools::dispatch(
@@ -251,7 +257,9 @@ async fn test_forget_non_object_overrides() {
         &memory_engine::ActivityFilterConfig::default(),
     )
     .await;
-    assert!(string_result.is_err());
+    let string_err = string_result.unwrap_err();
+    assert_eq!(string_err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(string_err.message.contains("must be a JSON object"));
 }
 
 // ---------------------------------------------------------------------------

--- a/memory-engine/bin/mcp/tests/tools.rs
+++ b/memory-engine/bin/mcp/tests/tools.rs
@@ -197,6 +197,63 @@ async fn test_forget_with_overrides() {
     assert!(v["facts_evaluated"].is_number());
 }
 
+// #497 sub-finding #6: the handler validates `half_life_overrides` keys via
+// `parse_fact_type` and rejects non-object values, but only the happy path was
+// covered. These two tests close that negative-path gap.
+
+#[tokio::test]
+async fn test_forget_invalid_override_key() {
+    let (engine, _dir) = test_engine();
+    add_test_fact(&engine, "some fact").await;
+
+    // An override key that is not a valid FactType must fail fact-type parsing
+    // rather than being silently ignored or panicking.
+    let result = tools::dispatch(
+        "memory_forget",
+        args(&[("half_life_overrides", json!({"NotARealType": 30.0}))]),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    )
+    .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_forget_non_object_overrides() {
+    let (engine, _dir) = test_engine();
+    add_test_fact(&engine, "some fact").await;
+
+    // A JSON array for `half_life_overrides` must hit the must-be-a-JSON-object
+    // validation error.
+    let array_result = tools::dispatch(
+        "memory_forget",
+        args(&[("half_life_overrides", json!([30.0]))]),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    )
+    .await;
+    assert!(array_result.is_err());
+
+    // A JSON string is likewise rejected.
+    let string_result = tools::dispatch(
+        "memory_forget",
+        args(&[("half_life_overrides", json!("Episodic"))]),
+        &engine,
+        None,
+        None,
+        3,
+        &memory_engine::ActivityFilterConfig::default(),
+    )
+    .await;
+    assert!(string_result.is_err());
+}
+
 // ---------------------------------------------------------------------------
 // Consolidate
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the #497 sub-finding #6 coverage gap.

The MCP `handle_forget` handler (`memory-engine/bin/mcp/src/tools/handlers/p1.rs`) already validates `half_life_overrides`:
- invalid override keys are rejected via `parse_fact_type` (fact-type parse error);
- a non-object `half_life_overrides` value returns the must-be-a-JSON-object validation error.

Only the happy path (`Episodic: 30.0`) was tested. This adds the missing negative-path coverage in `memory-engine/bin/mcp/tests/tools.rs`:
- `test_forget_invalid_override_key` — a `NotARealType` key must error;
- `test_forget_non_object_overrides` — a JSON array and a JSON string must each error.

Behavior-preserving, test-only. Both paths confirmed genuinely validated by the handler (no real gap). Note #497 is closed at the #255 epic wrap-up.

Part of #255