### PR TITLE
docs(core): fix broken+private intra-doc links crate-wide + add rustdoc CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,25 @@ jobs:
       - name: cargo clippy (deny warnings)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  docs:
+    name: Docs (intra-doc links)
+    runs-on: ubuntu-latest
+    # Deny broken AND public->private intra-doc links. `cargo test --doc` does not
+    # catch broken *links* (only failing doc examples), so this is a distinct gate.
+    # Scoped to the `memory-engine` core crate for now; the cli/mcp/embed crates
+    # still carry residual broken links (tracked separately) before the gate can
+    # widen to `--workspace`.
+    env:
+      RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo doc (default features)
+        run: cargo doc --no-deps -p memory-engine
+      - name: cargo doc (all features)
+        run: cargo doc --no-deps -p memory-engine --all-features
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,6 @@ src/
   resume/             # 4-tier cognitive boot (pinned → importance → due → recent)
   bootstrap/          # Claude Code JSONL session import
   inspect/            # Debugging APIs (explain, replay, dump, restore, statistics)
-  async_engine.rs     # AsyncMemoryEngine (tokio, feature-gated)
 tests/                # Integration tests
 benches/              # Criterion benchmarks
 examples/             # 3 runnable examples

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -51,7 +51,6 @@ Source lives in `src/`. Each module owns its domain:
 - `resume/` — 4-tier cognitive boot: pinned → high_importance → due → recent.
 - `bootstrap/` — Parse Claude Code JSONL session logs into historical facts.
 - `inspect/` — Debugging APIs: `explain_fact`, `fact_history`, `replay_events`, `dump_state`, `statistics`.
-- `async_engine.rs` — `AsyncMemoryEngine` via `tokio::spawn_blocking` (feature-gated).
 
 Tests in `tests/` (6 integration tests), benchmarks in `benches/`, examples in `examples/` (3).
 

--- a/memory-engine/lib/memory-engine/src/bootstrap/filter.rs
+++ b/memory-engine/lib/memory-engine/src/bootstrap/filter.rs
@@ -51,7 +51,7 @@ impl EpisodeCategory {
     /// the adjacent `session_outcome` convention (`"failure"`/`"success"`/…)
     /// and decouples the stored schema from the Rust variant names, so a variant
     /// rename can no longer silently alter stored data (#334). Round-trips via
-    /// [`EpisodeCategory::from_str`].
+    /// `EpisodeCategory::from_str`.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {

--- a/memory-engine/lib/memory-engine/src/bootstrap/metrics.rs
+++ b/memory-engine/lib/memory-engine/src/bootstrap/metrics.rs
@@ -34,13 +34,13 @@ pub struct BootstrapConfig {
     /// stops (#293). Bounds the per-stream I/O against a hostile or corrupt
     /// `.jsonl` of many in-bounds lines; the reader is wrapped in
     /// [`std::io::Read::take`]. `0` = no per-stream limit. Defaults to
-    /// [`crate::bootstrap::parse::DEFAULT_MAX_SESSION_BYTES`] (256 MiB).
+    /// `DEFAULT_MAX_SESSION_BYTES` (256 MiB).
     pub max_session_bytes: u64,
     /// Maximum number of parsed entries retained from a single session before
     /// parsing stops with a truncation `warn` (#293). Bounds the in-memory
     /// entry `Vec` — and every downstream linear pass — against an entry-count
     /// flood. `0` = no entry-count limit. Defaults to
-    /// [`crate::bootstrap::parse::DEFAULT_MAX_ENTRIES`] (1,000,000).
+    /// `DEFAULT_MAX_ENTRIES` (1,000,000).
     pub max_entries: usize,
 }
 

--- a/memory-engine/lib/memory-engine/src/bootstrap/redact.rs
+++ b/memory-engine/lib/memory-engine/src/bootstrap/redact.rs
@@ -635,7 +635,7 @@ pub fn redact_text(text: &str) -> (String, Vec<Finding>) {
 ///
 /// Use this on a controlled corpus where the secret-holder can enumerate their
 /// own secrets: it closes the bare-hex / arbitrary-low-entropy gaps the
-/// signature detectors cannot (see [`detect_denylist`]). The `denylist` values
+/// signature detectors cannot (see `detect_denylist`). The `denylist` values
 /// are supplied at runtime from a gitignored source — never committed.
 ///
 /// `redact_text(text)` == `redact_text_with_denylist(text, &[])`.

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -29,11 +29,11 @@ impl MemoryEngine {
     ///
     /// The in-memory graph is a *derived cache* of the active edge set: the DB
     /// is the source of truth and the cache is rebuilt from it on every `open`
-    /// ([`crate::graph::MemoryGraph::load_from_db`]). After the atomic commit
+    /// (`MemoryGraph::load_from_db`). After the atomic commit
     /// succeeds, the archived facts' nodes are removed in place under a single
     /// graph write guard — an O(N) prune held across no `.await`, so it is
     /// atomic with respect to any other graph mutator.
-    /// [`crate::graph::MemoryGraph::remove_node`] is
+    /// `MemoryGraph::remove_node` is
     /// loop-safe: petgraph's swap-remove relocates the former last node into the
     /// freed slot, and `remove_node` re-indexes `node_map` for that displaced
     /// node, so surviving nodes keep resolving to their correct indices across

--- a/memory-engine/lib/memory-engine/src/engine/cognitive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cognitive.rs
@@ -206,7 +206,7 @@ impl MemoryEngine {
     /// fact-writes and the cycle can fire on the same trigger.
     ///
     /// On entry, under a single write-lock acquisition, this compares
-    /// [`FactStore::max_caller_written_fact_id`] against the persisted cursor
+    /// `FactStore::max_caller_written_fact_id` against the persisted cursor
     /// `last_caller_write_fact_id`:
     ///
     /// - **New caller writes** (`max > cursor`): advance the cursor to `max` and return

--- a/memory-engine/lib/memory-engine/src/engine/cycle/llm_impl.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cycle/llm_impl.rs
@@ -41,7 +41,7 @@ const METHOD_VERSION: &str = "llm-proposer-v1";
 /// construct one per `run_dream_cycle` call. The `Arc`s let the async `run` offload
 /// each (possibly blocking HTTP) `propose`/`embed` call to the blocking pool via
 /// `spawn_blocking` — keeping the executor unblocked and a `reqwest::blocking`
-/// provider nested-runtime-safe. See the [module docs](self) for the safety rails.
+/// provider nested-runtime-safe. See the module docs for the safety rails.
 ///
 /// # Injecting the backend
 ///

--- a/memory-engine/lib/memory-engine/src/engine/graph.rs
+++ b/memory-engine/lib/memory-engine/src/engine/graph.rs
@@ -21,8 +21,8 @@ impl MemoryEngine {
     /// Create `co_session` edges between all active facts sharing a session.
     ///
     /// Edges are bidirectional (A→B and B→A), with weight
-    /// [`CO_SESSION_WEIGHT`](Self::CO_SESSION_WEIGHT) and
-    /// `scope_id =` [`CO_SESSION_SCOPE_ID`](Self::CO_SESSION_SCOPE_ID)
+    /// `CO_SESSION_WEIGHT` and
+    /// `scope_id = CO_SESSION_SCOPE_ID`
     /// (root — cross-scope by nature). Idempotent: calling twice for the same
     /// session does not create duplicate edges.
     ///

--- a/memory-engine/lib/memory-engine/src/engine/ingest.rs
+++ b/memory-engine/lib/memory-engine/src/engine/ingest.rs
@@ -84,7 +84,7 @@ impl MemoryEngine {
     /// Unlike [`add_fact`](Self::add_fact), this performs no embedding (the vector is
     /// given) — the caller supplies the **declared** identity of the model that produced
     /// it (#615, §Design.3). That declared fingerprint is treated exactly like a live
-    /// provider's: [`record_if_absent`](crate::store::embedding_meta::record_if_absent)
+    /// provider's: `record_if_absent`
     /// records it on a fresh store (so a precomputed-only workflow can bootstrap an
     /// identity) and compares it (full-tuple `Eq`) against the stored identity on a
     /// populated one, hard-rejecting a mismatch. This closes the same-dim foreign-vector

--- a/memory-engine/lib/memory-engine/src/engine/inspect.rs
+++ b/memory-engine/lib/memory-engine/src/engine/inspect.rs
@@ -101,7 +101,7 @@ impl MemoryEngine {
     /// This means the graph context may reflect a slightly older snapshot than the
     /// database state under concurrent writes. This trade-off is intentional for
     /// an informational API: the graph snapshot is taken via
-    /// [`inspect::explain::build_graph_context`] before the DB read.
+    /// `inspect::explain::build_graph_context` before the DB read.
     pub async fn explain_fact(&self, id: i64) -> Result<crate::inspect::FactExplanation> {
         use crate::inspect::explain;
         use crate::inspect::types::FactProvenance;
@@ -180,14 +180,14 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns [`MemoryError::Io`] on filesystem failure.
-    /// Returns [`MemoryError::Conflict`] if the target path resolves to the live database.
-    /// Returns [`MemoryError::Database`] on SQL failure.
-    /// Returns [`MemoryError::Serialization`] for the JSON formats if snapshot
+    /// Returns [`MemoryError::Io`](crate::MemoryError::Io) on filesystem failure.
+    /// Returns [`MemoryError::Conflict`](crate::MemoryError::Conflict) if the target path resolves to the live database.
+    /// Returns [`MemoryError::Database`](crate::MemoryError::Database) on SQL failure.
+    /// Returns [`MemoryError::Serialization`](crate::MemoryError::Serialization) for the JSON formats if snapshot
     /// serialization fails.
-    /// Returns [`MemoryError::NotImplemented`] if a compression format is used
+    /// Returns [`MemoryError::NotImplemented`](crate::MemoryError::NotImplemented) if a compression format is used
     /// without the corresponding feature enabled.
-    /// Returns [`MemoryError::ReadOnly`] for the `Sqlite` format if the engine
+    /// Returns [`MemoryError::ReadOnly`](crate::MemoryError::ReadOnly) for the `Sqlite` format if the engine
     /// was opened read-only (the `VACUUM INTO` backup acquires the write lock).
     pub async fn dump_state(&self, format: &crate::inspect::DumpFormat) -> Result<()> {
         self.ensure_open()?;

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -52,7 +52,7 @@ mod equivalence;
 
 /// Which [`StorageBackend`] implementation backs the engine.
 ///
-/// Resolved once in [`MemoryEngine::open_storage`]. The in-process
+/// Resolved once in `MemoryEngine::open_storage`. The in-process
 /// [`SqliteBackend`] is the default and only variant today; epic #628 adds a
 /// `Postgres` arm (#634).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -511,7 +511,7 @@ impl MemoryEngine {
     ///
     /// After #631 the engine no longer holds the pool/HNSW, so snapshot assembly
     /// (DB fingerprint + HNSW) lives below the port; this hands the engine's two
-    /// projections down via [`StorageBackend::write_engine_snapshot`] and marks the
+    /// projections down via [`SchemaManager::write_engine_snapshot`](crate::storage::SchemaManager::write_engine_snapshot) and marks the
     /// engine flushed so `Drop` won't warn.
     ///
     /// Unlike [`close`](Self::close) this needs no `&mut`, so a **shared owner**
@@ -526,7 +526,7 @@ impl MemoryEngine {
     /// reconstruction (#742): the in-memory HNSW it would serialize was built at the
     /// old dimension, while the DB (and thus the sidecar's fingerprint/`embed_dim`
     /// header) is now `D′`. The reopen at `D′` rebuilds the index from the DB anyway
-    /// (the `embed_dim` header gate at [`snapshot::load_from_file`] already rejects a
+    /// (the `embed_dim` header gate at `snapshot::load_from_file` already rejects a
     /// stale-dim sidecar), and under `ann` the assembly would otherwise *fail*
     /// re-reading the now-`D′` `facts.embedding` at the old dim. Short-circuiting
     /// avoids that spurious error and the wasted work. The consumer can still flush +

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -52,7 +52,7 @@ mod equivalence;
 
 /// Which [`StorageBackend`] implementation backs the engine.
 ///
-/// Resolved once in `MemoryEngine::open_storage`. The in-process
+/// Resolved once in `MemoryEngine::open_from_config`. The in-process
 /// [`SqliteBackend`] is the default and only variant today; epic #628 adds a
 /// `Postgres` arm (#634).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/memory-engine/lib/memory-engine/src/engine/outcome.rs
+++ b/memory-engine/lib/memory-engine/src/engine/outcome.rs
@@ -16,13 +16,13 @@ impl MemoryEngine {
     /// Appends an [`EventType::OutcomeSignal`] event to the event log with
     /// payload `{"fact_id": <id>, "outcome": "<variant>"}`. The fact must
     /// exist (active or expired); recording on a nonexistent fact returns
-    /// [`MemoryError::NotFound`].
+    /// [`MemoryError::NotFound`](crate::MemoryError::NotFound).
     ///
     /// # Errors
     ///
-    /// - [`MemoryError::NotFound`] if `fact_id` does not exist.
-    /// - [`MemoryError::ReadOnly`] if the engine is read-only.
-    /// - [`MemoryError::Database`] on insert failure.
+    /// - [`MemoryError::NotFound`](crate::MemoryError::NotFound) if `fact_id` does not exist.
+    /// - [`MemoryError::ReadOnly`](crate::MemoryError::ReadOnly) if the engine is read-only.
+    /// - [`MemoryError::Database`](crate::MemoryError::Database) on insert failure.
     pub async fn record_outcome(&self, fact_id: i64, outcome: Outcome) -> Result<i64> {
         // Validate fact exists via the port — propagate DB errors as-is,
         // only remap NotFound for a clearer message.
@@ -56,8 +56,8 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// - [`MemoryError::NotFound`] if `fact_id` does not exist.
-    /// - [`MemoryError::Database`] on query failure.
+    /// - [`MemoryError::NotFound`](crate::MemoryError::NotFound) if `fact_id` does not exist.
+    /// - [`MemoryError::Database`](crate::MemoryError::Database) on query failure.
     pub async fn get_outcome_counts(&self, fact_id: i64) -> Result<OutcomeCounts> {
         // Validate fact exists (consistent with record_outcome) — propagate NotFound.
         self.storage.get_fact(fact_id).await.map(|_| ())?;
@@ -79,7 +79,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// - [`MemoryError::Database`] on query failure.
+    /// - [`MemoryError::Database`](crate::MemoryError::Database) on query failure.
     pub async fn get_outcome_counts_batch(
         &self,
         fact_ids: &[i64],

--- a/memory-engine/lib/memory-engine/src/engine/restore.rs
+++ b/memory-engine/lib/memory-engine/src/engine/restore.rs
@@ -91,7 +91,7 @@ impl MemoryEngine {
         )
     }
 
-    /// Restore from a [`dump_sqlite()`](crate::inspect::dump::dump_sqlite) backup
+    /// Restore from a `dump_sqlite()` backup
     /// into a new file-backed engine.
     ///
     /// **Only accepts clean backups** produced by `dump_state(DumpFormat::Sqlite(..))`.

--- a/memory-engine/lib/memory-engine/src/error.rs
+++ b/memory-engine/lib/memory-engine/src/error.rs
@@ -12,9 +12,9 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ConflictError {
-    /// A [`MemoryQuery`](crate::types::MemoryQuery) combined options that are
+    /// A [`MemoryQuery`](crate::MemoryQuery) combined options that are
     /// mutually exclusive or incomplete (e.g. a half-open period, `valid_at`
-    /// together with a period, or a [`SearchMode`](crate::types::SearchMode)
+    /// together with a period, or a [`SearchMode`](crate::SearchMode)
     /// missing its required input). The string names the specific rule violated.
     #[error("{0}")]
     QueryValidation(String),
@@ -53,7 +53,7 @@ pub enum ConflictError {
     /// `VACUUM INTO` writes a file, and the engine refuses to unlink a directory
     /// to make room — surfacing the mistake as a clear conflict instead of an
     /// opaque "is a directory" I/O failure (see the trusted-path contract on
-    /// [`dump_sqlite`](crate::inspect::dump::dump_sqlite)).
+    /// `dump_sqlite`).
     #[error("dump target is an existing directory")]
     DumpTargetIsDirectory,
 

--- a/memory-engine/lib/memory-engine/src/search/hybrid.rs
+++ b/memory-engine/lib/memory-engine/src/search/hybrid.rs
@@ -20,7 +20,7 @@ pub enum SearchMode {
     /// `embedding`; ignores any `text`. Best for paraphrase and concept recall.
     Vector,
     /// Both lexical and semantic, fused with Reciprocal Rank Fusion (see
-    /// [`rrf_merge`]). Uses whichever of `text`/`embedding` are present. The
+    /// `rrf_merge`). Uses whichever of `text`/`embedding` are present. The
     /// default, balancing keyword precision with semantic recall.
     Hybrid,
 }

--- a/memory-engine/lib/memory-engine/src/search/strategy.rs
+++ b/memory-engine/lib/memory-engine/src/search/strategy.rs
@@ -7,7 +7,7 @@ use crate::types::FactType;
 /// Strategy for vector similarity search.
 ///
 /// Implementations provide a single `search` method with the same contract as
-/// [`crate::search::vector::vector_search`].  The engine holds a boxed strategy
+/// `crate::search::vector::vector_search`.  The engine holds a boxed strategy
 /// and dispatches through it, allowing runtime selection between algorithms
 /// (analogous to introsort dispatching between quicksort / heapsort / insertion
 /// sort based on partition size).

--- a/memory-engine/lib/memory-engine/src/search/vector.rs
+++ b/memory-engine/lib/memory-engine/src/search/vector.rs
@@ -57,7 +57,7 @@ static BRUTE_FORCE_WARN_ONCE: std::sync::Once = std::sync::Once::new();
 /// shorter slice, so any trailing components of the longer slice are ignored.
 /// This function performs no length check; the **caller is responsible for
 /// passing equal-length vectors**. In-engine callers already enforce dimension
-/// uniformity at the store/query layer (e.g. [`vector_search_filtered`] rejects
+/// uniformity at the store/query layer (e.g. `vector_search_filtered` rejects
 /// a wrongly-sized query, and stored embeddings are validated against
 /// `embed_dim`), so the truncation never fires on the real read path.
 #[must_use]

--- a/memory-engine/lib/memory-engine/src/storage/consolidation.rs
+++ b/memory-engine/lib/memory-engine/src/storage/consolidation.rs
@@ -57,7 +57,7 @@ pub trait ConsolidationStore: Send + Sync {
     // Stage A atomic port method (Fork B, §3 of the #631 plan)
     // -------------------------------------------------------------------------
 
-    /// Atomically apply a validated [`CycleReport`]'s DB-touching deltas in a
+    /// Atomically apply a validated [`CycleReport`](crate::CycleReport)'s DB-touching deltas in a
     /// single `rusqlite` transaction, returning the supersede-edge triples that
     /// the engine must mirror into its in-memory graph after commit.
     ///
@@ -145,7 +145,7 @@ pub trait ConsolidationStore: Send + Sync {
         config: crate::traits::ConsolidationConfig,
     ) -> Result<crate::consolidation::Snapshot>;
 
-    /// Phase 3 — apply a fully-computed [`ConsolidationPlan`](crate::consolidation::ConsolidationPlan)
+    /// Phase 3 — apply a fully-computed `ConsolidationPlan`
     /// in a single transaction, firing the post-commit HNSW `notify_expire` for the
     /// ids it actually expired (Stage B).
     ///

--- a/memory-engine/lib/memory-engine/src/storage/postgres/mod.rs
+++ b/memory-engine/lib/memory-engine/src/storage/postgres/mod.rs
@@ -4,14 +4,14 @@
 //! and its async-native opposite. `SQLite` delegates every method through
 //! `block_read`/`block_write` (`spawn_blocking` + a `!Send` `rusqlite` guard + a
 //! read-pool/write-mutex pool); Postgres is MVCC and `tokio-postgres` is natively
-//! async, so the seam here is a single [`PgBackend::with_client`] — *acquire a pooled
+//! async, so the seam here is a single `PgBackend::with_client` — *acquire a pooled
 //! client, run an async closure, map driver errors at the boundary* — with **no**
 //! `spawn_blocking` and **no** write serialization.
 //!
 //! ## Scope of #633 (honest boundary)
 //!
 //! This is the **skeleton**: the pool, a fresh migration chain producing the live v14
-//! logical schema (see [`migrations`]), and the [`SchemaManager`](crate::storage::SchemaManager)
+//! logical schema (see the `migrations` module), and the [`SchemaManager`](crate::storage::SchemaManager)
 //! lifecycle/identity/config surface. It is **NOT** a full
 //! [`StorageBackend`](crate::storage::StorageBackend): the umbrella's blanket impl
 //! requires all six bounded traits, and `PgBackend` implements only `SchemaManager`
@@ -23,12 +23,12 @@
 //! ## Seam invariants (mirroring `SQLite`'s, minus the blocking concerns)
 //!
 //! - **No driver type crosses the seam:** a `tokio_postgres::Error` is mapped to
-//!   [`MemoryError::Storage`] wrapping [`StorageError::Backend`] by [`pg_err`] at the
+//!   [`MemoryError::Storage`] wrapping [`StorageError::Backend`] by `pg_err` at the
 //!   boundary; semantic variants (`Migration`, `EmbeddingDimension`, `ReadOnly`,
 //!   `Internal`, …) have a precise home and are constructed directly.
 //! - **Read-only:** write methods check `read_only` first and return
 //!   [`MemoryError::ReadOnly`] (the typed, primary guard); the pool's
-//!   `default_transaction_read_only` is the DB-level backstop (see [`pool`]).
+//!   `default_transaction_read_only` is the DB-level backstop (see the `pool` module).
 //! - **Transactions:** the multi-statement migration chain runs in one transaction —
 //!   Postgres DDL is transactional (a genuine win over `SQLite`'s per-statement DDL).
 

--- a/memory-engine/lib/memory-engine/src/storage/schema.rs
+++ b/memory-engine/lib/memory-engine/src/storage/schema.rs
@@ -118,7 +118,7 @@ pub trait SchemaManager: Send + Sync {
 
     /// Compute aggregate engine statistics (fact/edge/summary/scope/event counts
     /// + storage metrics). Replaces `inspect::statistics::compute_statistics`; the
-    /// backend supplies its own db path for [`StorageStats::file_path`].
+    /// backend supplies its own db path for [`StorageStats::file_path`](crate::inspect::types::StorageStats::file_path).
     ///
     /// # Errors
     ///
@@ -126,12 +126,12 @@ pub trait SchemaManager: Send + Sync {
     /// backend failure.
     async fn statistics(&self) -> Result<crate::inspect::EngineStatistics>;
 
-    /// Export full engine state to a file in the requested [`DumpFormat`].
+    /// Export full engine state to a file in the requested [`DumpFormat`](crate::inspect::types::DumpFormat).
     ///
     /// Relocates `inspect::dump::{dump_json,_gzip,_zstd,dump_sqlite}` below the
     /// seam: the JSON variants stream via a read connection; the `Sqlite`
     /// (`VACUUM INTO`) variant routes through the write connection so a read-only
-    /// backend rejects it with [`MemoryError::ReadOnly`]. Feature-gated compression
+    /// backend rejects it with [`MemoryError::ReadOnly`](crate::MemoryError::ReadOnly). Feature-gated compression
     /// dispatch lives in the impl, keeping this trait surface `#[cfg]`-free.
     ///
     /// # Errors
@@ -140,7 +140,7 @@ pub trait SchemaManager: Send + Sync {
     /// failure, [`MemoryError::Conflict`](crate::error::MemoryError::Conflict) if a
     /// dump target resolves to the live database or a directory,
     /// [`MemoryError::NotImplemented`](crate::error::MemoryError::NotImplemented) for
-    /// a compression format whose feature is disabled, [`MemoryError::ReadOnly`] for
+    /// a compression format whose feature is disabled, [`MemoryError::ReadOnly`](crate::MemoryError::ReadOnly) for
     /// the `Sqlite` format on a read-only backend, or
     /// [`MemoryError::Storage`](crate::error::MemoryError::Storage) on a backend failure.
     async fn dump_state(&self, embed_dim: usize, format: crate::inspect::DumpFormat) -> Result<()>;
@@ -207,7 +207,7 @@ pub trait SchemaManager: Send + Sync {
     /// anti-join): `(fact_id, content)` pairs with `fact_id > after_id`,
     /// id-ordered, capped at `limit`. An empty window means the space is fully
     /// backfilled. Covers every fact, expired or not (the homogeneity invariant —
-    /// see [`store::fact_vectors`](crate::store::fact_vectors)).
+    /// see `store::fact_vectors`).
     ///
     /// # Errors
     ///

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
@@ -1,10 +1,10 @@
 //! The default, in-process `SQLite` implementation of the storage port (#630).
 //!
 //! `SqliteBackend` is the sole owner of every `SQLite`-private concern — the
-//! read-pool/write-mutex [`ConnectionPool`] and the event [`UpcasterRegistry`] —
+//! read-pool/write-mutex `ConnectionPool` and the event [`UpcasterRegistry`] —
 //! and the bounded-trait impls in this module's siblings are a thin, uniform
-//! delegation layer over two primitives: [`SqliteBackend::block_read`] and
-//! [`SqliteBackend::block_write`], which encapsulate *"acquire a connection and run
+//! delegation layer over two primitives: `SqliteBackend::block_read` and
+//! `SqliteBackend::block_write`, which encapsulate *"acquire a connection and run
 //! a sync `rusqlite` closure on a blocking thread"*.
 //!
 //! ## Why delegation, not absorption
@@ -17,11 +17,11 @@
 //!
 //! ## Seam invariants
 //!
-//! - **Conn selection (D-design):** read methods → [`ConnectionPool::read`]; write
-//!   methods → [`ConnectionPool::try_write`] (so a read-only pool rejects writes
+//! - **Conn selection (D-design):** read methods → `ConnectionPool::read`; write
+//!   methods → `ConnectionPool::try_write` (so a read-only pool rejects writes
 //!   with [`MemoryError::ReadOnly`] — Key Design Decision #6, preserved for free).
 //! - **No driver type crosses the seam (D4):** a `rusqlite` failure surfaces as
-//!   [`MemoryError::Database`] from the concrete store; [`map_seam_err`] maps it to
+//!   [`MemoryError::Database`] from the concrete store; `map_seam_err` maps it to
 //!   [`MemoryError::Storage`] wrapping [`StorageError::Backend`] at the boundary.
 //!   Semantic variants (`NotFound`, `Migration`, `EmbeddingDimension`, `Conflict`,
 //!   `ReadOnly`, `Internal`, …) already have a precise home and pass through.
@@ -67,7 +67,7 @@ mod session;
 ///
 /// When the `ann` feature is enabled and a [`SearchConfig`] with
 /// `ann_threshold < usize::MAX` is provided via [`SqliteBackend::with_search_config`],
-/// an [`HnswStrategy`] is built from the database and stored here. `vector_search`
+/// an `HnswStrategy` is built from the database and stored here. `vector_search`
 /// dispatches to HNSW when `active_count() >= ann_threshold`, mirroring the engine's
 /// `should_use_hnsw()` predicate exactly. Without a `search_config` (the default),
 /// `vector_search` is always brute-force, preserving the `#630` behavior.
@@ -118,7 +118,7 @@ pub enum HnswOpenSource {
 
 impl SqliteBackend {
     /// Wrap an already-opened pool + upcaster registry. The canonical constructor
-    /// `#631` will use where it builds the [`ConnectionPool`] today. `embed_dim` is
+    /// `#631` will use where it builds the `ConnectionPool` today. `embed_dim` is
     /// read from the pool, so a backend's dimension cannot diverge from its pool's.
     ///
     /// The backend produced by this constructor has no `SearchConfig`, so HNSW never
@@ -180,8 +180,8 @@ impl SqliteBackend {
     /// `ann_threshold < usize::MAX`, materializes the HNSW index from the
     /// requested [`HnswOpenSource`]:
     ///
-    /// - [`HnswOpenSource::Snapshot(Some(snap))`] → restore from the sidecar blob.
-    /// - [`HnswOpenSource::Snapshot(None)`] or [`HnswOpenSource::Rebuild`] → build
+    /// - [`HnswOpenSource::Snapshot`]`(Some(snap))` → restore from the sidecar blob.
+    /// - [`HnswOpenSource::Snapshot`]`(None)` or [`HnswOpenSource::Rebuild`] → build
     ///   from a full DB scan.
     ///
     /// Mirrors `engine/mod.rs::try_load_snapshot`'s match arms exactly so the

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
@@ -180,8 +180,8 @@ impl SqliteBackend {
     /// `ann_threshold < usize::MAX`, materializes the HNSW index from the
     /// requested [`HnswOpenSource`]:
     ///
-    /// - [`HnswOpenSource::Snapshot`]`(Some(snap))` → restore from the sidecar blob.
-    /// - [`HnswOpenSource::Snapshot`]`(None)` or [`HnswOpenSource::Rebuild`] → build
+    /// - [`HnswOpenSource::Snapshot`] with `Some(snap)` → restore from the sidecar blob.
+    /// - [`HnswOpenSource::Snapshot`] with `None`, or [`HnswOpenSource::Rebuild`] → build
     ///   from a full DB scan.
     ///
     /// Mirrors `engine/mod.rs::try_load_snapshot`'s match arms exactly so the

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/search_index.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/search_index.rs
@@ -122,7 +122,7 @@ impl SearchIndex for SqliteBackend {
     }
 
     /// Rebuild the in-memory HNSW index after a same-dim reconstruction promote
-    /// (#624). With `ann`, delegates to [`hnsw_rebuild_from_db`](SqliteBackend::hnsw_rebuild_from_db)
+    /// (#624). With `ann`, delegates to `hnsw_rebuild_from_db`
     /// (itself a no-op when no HNSW index is active). Without `ann`, the brute-force
     /// vector path reads `facts.embedding` directly, so there is nothing to rebuild.
     async fn rebuild_vector_index(&self) -> Result<()> {

--- a/memory-engine/lib/memory-engine/src/traits.rs
+++ b/memory-engine/lib/memory-engine/src/traits.rs
@@ -435,7 +435,7 @@ impl ConsolidationConfig {
     /// Returns `MemoryError::Conflict` if `dedup_threshold` or `cluster_threshold`
     /// is not a finite value in `[0.0, 1.0]` (each is a cosine-similarity gate), or
     /// if `min_cluster_size < 2` (a cluster requires at least two members to be
-    /// fused into a summary; see [`crate::consolidation`]).
+    /// fused into a summary).
     pub fn validate(&self) -> Result<()> {
         use crate::error::{ConflictError, MemoryError};
 

--- a/memory-engine/lib/memory-engine/src/types/events.rs
+++ b/memory-engine/lib/memory-engine/src/types/events.rs
@@ -45,10 +45,10 @@ impl FromStr for EventType {
     /// shared by every consumer surface (the MCP server's `ingest` / `replay`
     /// tool parameters). Mirroring [`FactType::from_str`](crate::types::FactType::from_str),
     /// it is intentionally lenient on casing so it accepts both wire conventions
-    /// present in the codebase: [`Display`] emits `snake_case` (`"interaction"`),
+    /// present in the codebase: [`std::fmt::Display`] emits `snake_case` (`"interaction"`),
     /// while serde-derive and the MCP JSON-schema enums use `PascalCase`
     /// (`"Interaction"`). Parsing reconciles both to one canonical enum;
-    /// [`EventType::to_string`] remains the canonical output.
+    /// [`ToString::to_string`] remains the canonical output.
     ///
     /// It accepts **all** variants, including [`EventType::OutcomeSignal`] — a
     /// complete parser that round-trips with `Display`. Surfaces that must reject
@@ -122,7 +122,7 @@ impl FromStr for Outcome {
     /// Mirroring [`FactType::from_str`](crate::types::FactType::from_str), it is
     /// lenient on casing so it accepts both the `PascalCase` wire form the MCP
     /// JSON schema advertises (`"Positive"`) and the `snake_case`/lowercase
-    /// [`Display`] form (`"positive"`); [`Outcome::to_string`] round-trips through
+    /// [`std::fmt::Display`] form (`"positive"`); [`ToString::to_string`] round-trips through
     /// it. Parsing reconciles every casing to one canonical enum.
     ///
     /// Note: this is orthogonal to the strict DB serialization — the serde

--- a/memory-engine/lib/memory-engine/src/types/facts.rs
+++ b/memory-engine/lib/memory-engine/src/types/facts.rs
@@ -96,7 +96,7 @@ impl fmt::Display for ConsolidationLevel {
 /// the per-field docs.
 ///
 /// Importance is likewise split across two fields, easily confused:
-/// [`importance`](Self::importance) is the *static, consumer-supplied prior* set at insertion,
+/// [`base_importance`](Self::base_importance) is the *static, consumer-supplied prior* set at insertion,
 /// while [`importance_score`](Self::importance_score) is the *computed, decaying score* the
 /// engine ranks and forgets by (the prior is one of its inputs). See those fields' docs.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/memory-engine/lib/memory-engine/src/types/facts.rs
+++ b/memory-engine/lib/memory-engine/src/types/facts.rs
@@ -52,7 +52,7 @@ impl FromStr for FactType {
     /// casing so it accepts both wire conventions present in the codebase:
     /// `Display` emits `snake_case` (`"episodic"`), while serde-derive and the MCP
     /// JSON-schema enums use `PascalCase` (`"Episodic"`). Parsing reconciles both
-    /// to one canonical enum; [`FactType::to_string`] remains the canonical output.
+    /// to one canonical enum; [`ToString::to_string`] remains the canonical output.
     ///
     /// Note: this is orthogonal to the serde `Deserialize` derive, which stays
     /// `PascalCase` to preserve `.pak` cold-storage archive back-compat.

--- a/memory-engine/lib/memory-engine/src/types/provenance.rs
+++ b/memory-engine/lib/memory-engine/src/types/provenance.rs
@@ -13,7 +13,7 @@ use crate::types::facts::FactId;
 /// The owning `lineage_id` (DB row PK) is **not** part of this envelope — it is a
 /// property of the row, not of the provenance. Read paths return it alongside the
 /// envelope in the companion [`LineageRecord`] / [`LineageSnapshotEntry`], and the
-/// write path returns it in [`PromotionResult`]. Previously this struct carried a
+/// write path returns it in [`PromotionResult`](crate::PromotionResult). Previously this struct carried a
 /// phantom `lineage_id: i64` with `#[serde(skip_serializing, default)]` that was
 /// always `0` on deserialization and reconstructed from the PK on read — a lying
 /// field with an invisible "0 means not-yet-persisted" invariant. It is removed.
@@ -45,7 +45,7 @@ pub struct NewLineageRecord {
 }
 
 /// One proposed merge: a set of source facts an
-/// [`LlmDreamCycle`](crate::engine::cycle) should collapse into a single
+/// [`LlmDreamCycle`](crate::LlmDreamCycle) should collapse into a single
 /// synthesized `summary`.
 ///
 /// The output of a [`DeltaProposer`](crate::traits::DeltaProposer), it is a raw


### PR DESCRIPTION
## What

Closes #739. The issue named two broken intra-doc links; running the strict gate (`-D rustdoc::broken_intra_doc_links`) exposed **~36 of the same class crate-wide**, so this clears them all and adds a CI gate so the class cannot regress.

## Changes

- **Fix every broken/private intra-doc link in the `memory-engine` core crate** (25 source files). Decision rule:
  - **Real link to the correct public symbol** where one exists — e.g. `crate::error::MemoryError::*` (stale after the #560 error-split), `SchemaManager::write_engine_snapshot` (the method actually lives there, not on `StorageBackend`), `base_importance` (field renamed from `importance`), `crate::MemoryQuery`/`SearchMode` (live in `search`, not `types`), `ToString::to_string` / `std::fmt::Display` (blanket-impl, not inherent).
  - **Plain code span** where the target is `pub(crate)`/private and thus unlinkable from public docs (e.g. `rrf_merge`, `ConnectionPool`, `dump_sqlite`, `map_seam_err`).
- The `--all-features` pass additionally surfaced **6 feature-gated links** (`archive`, `backend-postgres`) invisible under default features — fixed too.
- **New CI job `Docs (intra-doc links)`** denying both `broken_intra_doc_links` and `private_intra_doc_links`, default + all-features. `cargo test --doc` only catches failing *examples*, not broken *links*, so this is a distinct gate.

## Scope note

Gate is scoped to the `memory-engine` **core crate**. The `cli`/`mcp`/`embed` crates carry ~9 residual broken links of the same class (out of #739's scope) — tracked as a follow-up before the gate widens to `--workspace`.

## Verification

`RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" cargo doc --no-deps -p memory-engine` and `... --all-features` both green (rc=0, zero error/warning). Doc-comment + CI only; no code behavior change.
