### PR TITLE
refactor(retrieval): reframe edge-level graph primitives as sim-graph foundation (#879)

### DIFF
--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -100,11 +100,24 @@ impl MemoryGraph {
     /// scans O(E) and removes at most one edge. Short-circuits after the
     /// first match.
     ///
-    /// Intended for the edge-expiry graph-sync path (keep the in-memory graph in
-    /// step after `EdgeStore::expire`), but that wiring is not yet landed, so the
-    /// only current caller is the unit test below — hence `#[cfg(test)]` to keep
-    /// the lint honest without an `#[allow(dead_code)]` mask. Drop the gate when a
-    /// production caller is added (tracked as a follow-up to #276).
+    /// In-memory twin of the single-edge store primitive
+    /// [`FactGraph::expire_edge`](crate::storage::FactGraph::expire_edge): when one
+    /// edge is soft-expired in the store *without* expiring either endpoint fact,
+    /// this drops the matching edge from the derived graph cache so reads (degree,
+    /// neighbors, components, `explain_fact` context) stay consistent. Its
+    /// fact-level sibling [`remove_edges_by_fact`](Self::remove_edges_by_fact) is
+    /// the path wired today; this edge-level one has **no production caller yet**,
+    /// because nothing in the engine expires a *single* edge in isolation — fact
+    /// supersession expires edges in bulk, by fact. The drift its absence could
+    /// imply is therefore latent, not active (#879).
+    ///
+    /// The designed consumer is the geometric associative-memory substrate (epic
+    /// #761, E0 #763): its kNN similarity-edge graph invalidates *individual*
+    /// similarity edges when the metric (whitening `W` or sim-graph `k`) is
+    /// retuned, keeping both endpoint facts. When that path lands, call this beside
+    /// `expire_edge` in the invalidation step and drop the `#[cfg(test)]` gate. The
+    /// gate keeps the dead-code lint honest meanwhile, without an
+    /// `#[allow(dead_code)]` mask.
     #[cfg(test)]
     pub fn remove_edge_by_id(&mut self, edge_id: i64) {
         if let Some(ei) = self
@@ -119,7 +132,12 @@ impl MemoryGraph {
     /// Remove a node and all its edges from the graph.
     ///
     /// No-op if the fact id is not in the graph.
-    /// Used by archival after hard-deleting facts from `SQLite`.
+    ///
+    /// Used by archival (`#[cfg(feature = "archive")]`) after the facts are
+    /// hard-deleted from `SQLite` into a cold-storage `.pak`. That archival prune
+    /// is its only production caller, so the method is gated to
+    /// `any(feature = "archive", test)`: without the `archive` feature it would be
+    /// dead code, and the repo forbids `#[allow(dead_code)]` masks (#879).
     ///
     /// petgraph's [`DiGraph::remove_node`] uses swap-remove: the former last
     /// node is relocated into the freed slot, which invalidates that node's
@@ -127,6 +145,7 @@ impl MemoryGraph {
     /// removal it rewrites `node_map` for the displaced node so every surviving
     /// node still resolves to its correct index. Callers may therefore remove
     /// nodes in a loop (e.g. archival) without corrupting the map.
+    #[cfg(any(feature = "archive", test))]
     pub fn remove_node(&mut self, fact_id: i64) {
         let Some(idx) = self.node_map.remove(&fact_id) else {
             return;


### PR DESCRIPTION
## What

Addresses #879 (`Refs`, intentionally **not** `Fixes` — see below). Archaeology on the report changes the conclusion: this is **not a live bug**, and the two methods are **foundation for a designed-but-unstarted feature**, not dead code.

## Finding (the premise correction)

#879 says expiring an edge in SQLite leaves the in-memory petgraph stale via `remove_edge_by_id`. But:

- The engine **never expires a single edge in isolation** in production. `FactGraph::expire_edge` (the single-edge store primitive, #629) has **no engine caller** — only conformance/unit tests. Edge expiry is exclusively **fact-level** (`expire_edges_by_fact` ↔ `remove_edges_by_fact`), which **is** fully wired (archive/conflict/cycle).
- So the in-memory graph never drifts via this path — the inconsistency is **latent, not active**.
- `remove_edge_by_id` has had **no production caller since its Phase-2 birth (#8)**; it only surfaced as dead when #878 narrowed `inspect` visibility.

Its designed consumer is the **geometric associative-memory substrate** (epic #761, E0 #763): the kNN similarity-edge graph invalidates *individual* similarity edges when the metric (whitening `W` / sim-graph `k`) is retuned, keeping both endpoint facts — exactly the single-edge-expiry semantic.

## Changes (graph dead-code hygiene, no behavior change)

- **`remove_edge_by_id`**: keep the honest `#[cfg(test)]` gate (no `#[allow(dead_code)]` mask); **rewrite the doc** to re-aim the breadcrumb from a stale `#276` ref to the sim-graph epic (#761/#763) and cross-link `FactGraph::expire_edge`, so the next implementer wires it correctly.
- **`remove_node`** (collateral from the #879 comment): already wired into the archival prune (#196), but warned dead in **default-features** builds because its only caller sits behind `#[cfg(feature = "archive")]`. Gate the method to `#[cfg(any(feature = "archive", test))]` to match its callers — honest gate, not an allow-mask.

## Why `Refs` not `Fixes`

#879 is repurposed (relabeled, retitled, re-parented under the geometric epic E1) as the tracker for *wiring* single-edge expiry when the sim-graph lands. This PR only does the dead-code hygiene + breadcrumb; it should not auto-close that tracker.

## Verification

Build matrix (default / `archive` / `ann` / all-features) clean — `remove_node` dead-code warning gone in default, no breakage under any feature. `clippy --all-features -- -D warnings` rc=0. 8 `remove_*` tests pass. New intra-doc links resolve.
