### PR TITLE
fix(storage): archive() handles boundary edges (one archived endpoint) without FK violation

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -527,11 +527,11 @@ mod tests {
         //    hard-deletes them from the DB and prunes the nodes from the graph)
         //  - survivor: survivor -> survivor  (must be left untouched)
         //
-        // Boundary edges (exactly one archived endpoint) are deliberately *not*
-        // exercised here: they are an orthogonal, pre-existing DB-side concern
-        // (archive's `hard_delete_by_facts` only removes edges with *both*
-        // endpoints archived, so a surviving boundary edge trips the facts FK on
-        // hard-delete). That is unrelated to #332's in-memory two-phase update.
+        // Boundary edges (exactly one archived endpoint) are covered by the
+        // dedicated #847 regression below
+        // (`archive_removes_boundary_edge_without_fk_violation`); this test keeps
+        // its focus on #332's in-memory two-phase update with internal/survivor
+        // edges only.
         engine
             .storage()
             .insert_edge(&make_edge(archived_ids[0], archived_ids[1]))
@@ -599,6 +599,134 @@ mod tests {
             node_count, 2,
             "graph should hold exactly the two survivor nodes, found {node_count}"
         );
+    }
+
+    /// #847 regression (end-to-end): `archive()` must succeed when a *boundary*
+    /// edge — one with exactly ONE endpoint in the archive set — crosses the cut.
+    ///
+    /// Before the fix, the DB commit deleted only edges whose *both* endpoints
+    /// were archived, so a boundary edge (`archived → survivor`, or the reverse)
+    /// survived the edge-delete and then referenced an about-to-be-hard-deleted
+    /// archived fact → `FOREIGN KEY constraint failed`, and the whole `archive()`
+    /// returned `Err`. The fix hard-deletes every edge incident to an archived
+    /// fact inside the same transaction.
+    ///
+    /// This test also proves the in-memory graph stays consistent: the survivor
+    /// keeps its node but loses the dangling boundary edge, mirroring the DB.
+    #[tokio::test]
+    async fn archive_removes_boundary_edge_without_fk_violation() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = MemoryEngine::builder(DIM)
+            .path(dir.path().join("boundary.db"))
+            .build()
+            .unwrap();
+
+        // One survivor (active) — it must outlive the archive.
+        let survivor = engine
+            .storage()
+            .insert_fact(&make_active_fact("survivor"))
+            .await
+            .unwrap();
+
+        // Enough expired, non-pinned facts to clear `min_facts`.
+        let expired_at = Utc::now() - Duration::hours(1);
+        let mut archived_ids = Vec::new();
+        for i in 0..5 {
+            archived_ids.push(
+                engine
+                    .storage()
+                    .insert_fact(&make_expired_fact(&format!("doomed {i}"), expired_at))
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        // Boundary edge #1: archived → survivor.
+        engine
+            .storage()
+            .insert_edge(&make_edge(archived_ids[0], survivor))
+            .await
+            .unwrap();
+        // Boundary edge #2: survivor → archived (the other direction).
+        engine
+            .storage()
+            .insert_edge(&make_edge(survivor, archived_ids[1]))
+            .await
+            .unwrap();
+        // An internal archived↔archived edge for good measure.
+        engine
+            .storage()
+            .insert_edge(&make_edge(archived_ids[0], archived_ids[1]))
+            .await
+            .unwrap();
+
+        // Seed the in-memory graph from the DB exactly as `open` does.
+        {
+            let active_edges = engine.storage().list_active_edges().await.unwrap();
+            *engine.graph.write() = MemoryGraph::from_active_edges(&active_edges);
+        }
+        assert!(engine.graph_has_node(survivor));
+        // `graph_degree` counts incident edges in both directions, so it sees
+        // both boundary edges (survivor→archived and archived→survivor).
+        assert_eq!(
+            engine.graph_degree(survivor),
+            2,
+            "survivor starts linked to two archived facts via boundary edges"
+        );
+
+        let policy = ArchivePolicy {
+            expired_before: Utc::now() + Duration::hours(1),
+            min_facts: 1,
+        };
+
+        // The crux: this must NOT FK-violate. Pre-fix it returns an FK error.
+        let stats = engine
+            .archive(&policy)
+            .await
+            .expect("archive with a boundary edge must not trip the facts FK")
+            .expect("archive should run with candidates present");
+        assert_eq!(stats.facts_archived, archived_ids.len());
+
+        // The survivor remains in the live DB.
+        assert!(
+            engine.storage().get_fact(survivor).await.is_ok(),
+            "survivor fact must remain in the live DB"
+        );
+        // No archived fact remains (hard-deleted → `get_fact` errors NotFound).
+        for &id in &archived_ids {
+            assert!(
+                engine.storage().get_fact(id).await.is_err(),
+                "archived fact {id} must be hard-deleted from the live DB"
+            );
+        }
+        // No active edge survives — the survivor's only links were to archived
+        // facts, so the boundary edges are gone with them.
+        assert!(
+            engine
+                .storage()
+                .list_active_edges()
+                .await
+                .unwrap()
+                .is_empty(),
+            "all boundary edges to archived facts must be hard-deleted"
+        );
+
+        // In-memory graph: survivor node kept, but now isolated (no neighbors).
+        assert!(
+            engine.graph_has_node(survivor),
+            "survivor node must remain in the graph cache"
+        );
+        assert_eq!(
+            engine.graph_degree(survivor),
+            0,
+            "survivor must lose its dangling boundary edges in the graph cache too"
+        );
+        for &id in &archived_ids {
+            assert!(
+                !engine.graph_has_node(id),
+                "archived fact {id} must be pruned from the graph cache"
+            );
+        }
     }
 
     /// #292: `verify_archives` must reject a manifest row whose `pak_path`

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/cold_storage.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/cold_storage.rs
@@ -116,8 +116,13 @@ impl ColdStorage for SqliteBackend {
                 blake3_hash: &blake3_hash,
             })?;
 
-            // Delete edges first (FK safety), then facts.
-            EdgeStore::new(&tx).hard_delete_by_facts(&fact_ids)?;
+            // Delete edges first (FK safety), then facts. Delete EVERY edge
+            // incident to an archived fact — internal (both endpoints archived)
+            // AND boundary (exactly one endpoint archived) — because the archived
+            // fact leaves the live DB (#847). A boundary edge left behind would
+            // reference an about-to-be-hard-deleted fact and trip the
+            // `edges.*_fact_id REFERENCES facts(id)` FK, aborting the whole tx.
+            EdgeStore::new(&tx).hard_delete_incident_to_facts(&fact_ids)?;
             FactStore::new(&tx, dim).hard_delete_ids(&fact_ids)?;
 
             tx.commit().map_err(|e| {
@@ -138,9 +143,10 @@ mod tests {
     use super::super::SqliteBackend;
     use crate::pool::ConnectionPool;
     use crate::storage::cold_storage::ColdStorage;
+    use crate::store::edges::EdgeStore;
     use crate::store::facts::FactStore;
     use crate::store::upcaster::UpcasterRegistry;
-    use crate::types::{FactType, NewFact};
+    use crate::types::{FactType, NewEdge, NewFact};
 
     const DIM: usize = 4;
 
@@ -150,6 +156,18 @@ mod tests {
 
     fn backend() -> SqliteBackend {
         backend_from(Arc::new(ConnectionPool::open_memory(DIM).unwrap()))
+    }
+
+    fn new_edge(source: i64, target: i64) -> NewEdge {
+        NewEdge {
+            source_fact_id: source,
+            target_fact_id: target,
+            relation_type: "related".into(),
+            weight: 1.0,
+            t_created: Utc::now(),
+            t_expired: None,
+            scope_id: 1,
+        }
     }
 
     fn new_fact(content: &str) -> NewFact {
@@ -292,7 +310,7 @@ mod tests {
         // Drop the `facts` table to force `hard_delete_ids` to fail mid-tx.
         // The transaction sequence inside `commit_archive_atomic` is:
         //   1. ArchiveManifestStore::insert  ← succeeds
-        //   2. EdgeStore::hard_delete_by_facts ← succeeds (no edges)
+        //   2. EdgeStore::hard_delete_incident_to_facts ← succeeds (no edges)
         //   3. FactStore::hard_delete_ids    ← FAILS (table gone)
         // The whole tx must roll back.
         {
@@ -339,5 +357,108 @@ mod tests {
             "the surviving entry must be the pre-seeded one, not the rolled-back one"
         );
         assert_eq!(manifest_after[0].pak_path, "archives/before.pak");
+    }
+
+    /// #847 regression: a *boundary* edge — one with exactly ONE endpoint in the
+    /// archive set (archived → survivor, or survivor → archived) — must not trip
+    /// the `edges.source_fact_id/target_fact_id REFERENCES facts(id)` FK when the
+    /// archived fact is hard-deleted inside `commit_archive_atomic`.
+    ///
+    /// Before the fix, `commit_archive_atomic` deleted only edges whose *both*
+    /// endpoints were archived (`hard_delete_by_facts`), so a boundary edge
+    /// survived the edge-delete and then referenced an about-to-be-hard-deleted
+    /// archived fact → `FOREIGN KEY constraint failed`, aborting the whole tx.
+    ///
+    /// The archived fact moves to cold storage and the boundary edge is *not*
+    /// part of the `.pak` (only internal edges are), so the live link is dangling:
+    /// the correct, FK-safe behavior is to hard-delete the boundary edge in the
+    /// same transaction. (A mere soft-expire would leave the edge row — and its
+    /// FK column — in place, so it would still violate the FK on the fact delete.)
+    ///
+    /// This test is non-vacuous: with the old both-endpoints-only delete it fails
+    /// with an FK-violation `Err`; with the fix it succeeds and the boundary edge
+    /// is gone.
+    #[tokio::test]
+    #[allow(clippy::significant_drop_tightening)]
+    async fn commit_archive_atomic_removes_boundary_edge_without_fk_violation() {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+
+        // f1, f2 are archive candidates; survivor stays in the live DB.
+        let (archived_a, archived_b, survivor, edge_ids) = {
+            let conn = pool.write();
+            let fact_store = FactStore::new(&conn, DIM);
+            let archived_a = fact_store.insert(&new_fact("archived a")).unwrap();
+            let archived_b = fact_store.insert(&new_fact("archived b")).unwrap();
+            // The survivor must NOT be pre-expired — it is a live fact left behind.
+            let survivor = fact_store
+                .insert(&NewFact {
+                    t_expired: None,
+                    ..new_fact("survivor")
+                })
+                .unwrap();
+
+            let edge_store = EdgeStore::new(&conn);
+            let internal = edge_store
+                .insert(&new_edge(archived_a, archived_b))
+                .unwrap();
+            // Boundary edge #1: archived → survivor.
+            let out = edge_store.insert(&new_edge(archived_a, survivor)).unwrap();
+            // Boundary edge #2: survivor → archived (other direction).
+            let inn = edge_store.insert(&new_edge(survivor, archived_b)).unwrap();
+            (archived_a, archived_b, survivor, [internal, out, inn])
+        };
+
+        let be = backend_from(Arc::clone(&pool));
+        let fact_ids = vec![archived_a, archived_b];
+        let now = Utc::now();
+
+        // The crux: this must NOT FK-violate. Pre-fix it returns an FK error.
+        be.commit_archive_atomic(
+            "boundary.pak",
+            2,
+            1,
+            archived_a,
+            archived_b,
+            now,
+            now,
+            4096,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            &fact_ids,
+        )
+        .await
+        .expect("archive with a boundary edge must succeed, not trip the facts FK");
+
+        // The archived facts are gone; the survivor remains.
+        {
+            let conn = pool.write();
+            let fact_store = FactStore::new(&conn, DIM);
+            assert!(
+                fact_store.get(archived_a).is_err(),
+                "archived fact a must be hard-deleted"
+            );
+            assert!(
+                fact_store.get(archived_b).is_err(),
+                "archived fact b must be hard-deleted"
+            );
+            assert!(
+                fact_store.get(survivor).is_ok(),
+                "survivor fact must remain in the live DB"
+            );
+
+            // ALL edges incident to an archived fact (internal + both boundary
+            // edges) are gone; no dangling edge references a departed fact.
+            let edge_store = EdgeStore::new(&conn);
+            for id in edge_ids {
+                assert!(
+                    edge_store.get(id).is_err(),
+                    "edge {id} incident to an archived fact must be hard-deleted"
+                );
+            }
+            assert!(
+                edge_store.list_all().unwrap().is_empty(),
+                "no edge may survive: the survivor's only links were to archived facts"
+            );
+        }
+        let _ = survivor;
     }
 }

--- a/memory-engine/lib/memory-engine/src/store/edges.rs
+++ b/memory-engine/lib/memory-engine/src/store/edges.rs
@@ -342,6 +342,44 @@ impl<'a> EdgeStore<'a> {
         let deleted = self.conn.execute(&sql, params.as_slice())?;
         Ok(deleted)
     }
+
+    /// Hard-delete every edge incident to any fact in the given set — i.e. with
+    /// EITHER endpoint (source or target) in `fact_ids`.
+    ///
+    /// Unlike [`Self::hard_delete_by_facts`] (both endpoints internal), this also
+    /// removes *boundary* edges that straddle the set: `archived → survivor` and
+    /// `survivor → archived`. Used by the archive commit (#847): when an archived
+    /// fact is hard-deleted from the live DB, any live edge still referencing it
+    /// would trip the `edges.source_fact_id/target_fact_id REFERENCES facts(id)`
+    /// FK. The archived fact moves to cold storage and the boundary edge is not
+    /// part of the `.pak` (only internal edges are), so the link is genuinely
+    /// dangling and must go with the fact. A soft-expire would leave the row — and
+    /// its FK column — in place, so it would *not* satisfy the FK on fact delete;
+    /// only a hard-delete is referentially safe here.
+    ///
+    /// Returns the number of rows deleted. A no-op for an empty `fact_ids` slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
+    pub fn hard_delete_incident_to_facts(&self, fact_ids: &[i64]) -> Result<usize> {
+        if fact_ids.is_empty() {
+            return Ok(0);
+        }
+        let placeholders: String = fact_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "DELETE FROM edges WHERE source_fact_id IN ({placeholders}) OR target_fact_id IN ({placeholders})"
+        );
+        let mut params: Vec<&dyn rusqlite::types::ToSql> = Vec::with_capacity(fact_ids.len() * 2);
+        for id in fact_ids {
+            params.push(id as &dyn rusqlite::types::ToSql);
+        }
+        for id in fact_ids {
+            params.push(id as &dyn rusqlite::types::ToSql);
+        }
+        let deleted = self.conn.execute(&sql, params.as_slice())?;
+        Ok(deleted)
+    }
 }
 
 #[cfg(test)]
@@ -651,5 +689,68 @@ mod tests {
         let remaining = store.list_all().unwrap();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].relation_type, "external");
+    }
+
+    // --- hard_delete_incident_to_facts tests (#847) ---
+
+    #[test]
+    fn hard_delete_incident_to_facts_removes_internal_and_boundary_edges() {
+        // facts: 1, 2, 3
+        // edges:
+        //   f1→f2 internal (both in set [1,2])
+        //   f1→f3 boundary (source in set, target survives)
+        //   f3→f2 boundary (target in set, source survives)
+        //   (no edge entirely outside the set to leave behind)
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+
+        store.insert(&make_edge(1, 2, "internal")).unwrap();
+        store.insert(&make_edge(1, 3, "boundary_out")).unwrap();
+        store.insert(&make_edge(3, 2, "boundary_in")).unwrap();
+
+        let deleted = store.hard_delete_incident_to_facts(&[1, 2]).unwrap();
+        assert_eq!(
+            deleted, 3,
+            "every edge with at least one endpoint in the set must be deleted"
+        );
+        assert!(
+            store.list_all().unwrap().is_empty(),
+            "no edge incident to an archived fact may survive"
+        );
+    }
+
+    #[test]
+    fn hard_delete_incident_to_facts_leaves_unrelated_edges() {
+        // An edge entirely outside the set (f3↔f3 is invalid; use a self-link-free
+        // pair via a 4th fact). Insert one extra fact so we have a fully-external
+        // edge to assert is preserved.
+        let conn = setup();
+        conn.execute(
+            "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, importance, access_count, last_accessed, metadata)
+             VALUES ('fact4', 'h4', X'00000000', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}')",
+            [],
+        ).unwrap();
+        let store = EdgeStore::new(&conn);
+
+        store.insert(&make_edge(1, 2, "incident")).unwrap(); // f1 in set
+        store.insert(&make_edge(3, 4, "external")).unwrap(); // neither in set
+
+        let deleted = store.hard_delete_incident_to_facts(&[1]).unwrap();
+        assert_eq!(deleted, 1, "only the edge touching f1 is deleted");
+
+        let remaining = store.list_all().unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].relation_type, "external");
+    }
+
+    #[test]
+    fn hard_delete_incident_to_facts_empty_slice_is_noop() {
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+        store.insert(&make_edge(1, 2, "a")).unwrap();
+
+        let deleted = store.hard_delete_incident_to_facts(&[]).unwrap();
+        assert_eq!(deleted, 0);
+        assert_eq!(store.list_all().unwrap().len(), 1);
     }
 }

--- a/memory-engine/lib/memory-engine/src/store/edges.rs
+++ b/memory-engine/lib/memory-engine/src/store/edges.rs
@@ -319,7 +319,18 @@ impl<'a> EdgeStore<'a> {
     /// moved to a `.pak` file. Edges where only one endpoint is archived are
     /// left intact (they may reference facts still in the live DB).
     ///
+    /// The id set is bound as a single serialized JSON array param and parsed
+    /// via `json_each(?1)`, so the bound-variable count is O(1) regardless of
+    /// `fact_ids.len()` — `SQLite`'s max-parameter limit is never hit even for
+    /// large archive sets (mirrors [`Self::list_internal_by_facts`] and the
+    /// `json_each` idiom used throughout [`crate::store::facts`]).
+    ///
     /// Returns the number of rows deleted.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `fact_ids` cannot be serialized to JSON — infallible in
+    /// practice for `&[i64]`.
     ///
     /// # Errors
     ///
@@ -328,18 +339,13 @@ impl<'a> EdgeStore<'a> {
         if fact_ids.is_empty() {
             return Ok(0);
         }
-        let placeholders: String = fact_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-        let sql = format!(
-            "DELETE FROM edges WHERE source_fact_id IN ({placeholders}) AND target_fact_id IN ({placeholders})"
-        );
-        let mut params: Vec<&dyn rusqlite::types::ToSql> = Vec::with_capacity(fact_ids.len() * 2);
-        for id in fact_ids {
-            params.push(id as &dyn rusqlite::types::ToSql);
-        }
-        for id in fact_ids {
-            params.push(id as &dyn rusqlite::types::ToSql);
-        }
-        let deleted = self.conn.execute(&sql, params.as_slice())?;
+        let ids_json = serde_json::to_string(fact_ids).expect("serialize fact_ids");
+        let deleted = self.conn.execute(
+            "DELETE FROM edges
+             WHERE source_fact_id IN (SELECT value FROM json_each(?1))
+               AND target_fact_id IN (SELECT value FROM json_each(?1))",
+            params![ids_json],
+        )?;
         Ok(deleted)
     }
 
@@ -359,6 +365,17 @@ impl<'a> EdgeStore<'a> {
     ///
     /// Returns the number of rows deleted. A no-op for an empty `fact_ids` slice.
     ///
+    /// The id set is bound as a single serialized JSON array param and parsed
+    /// via `json_each(?1)`, so the bound-variable count is O(1) regardless of
+    /// `fact_ids.len()` — `SQLite`'s max-parameter limit is never hit even for
+    /// large archive sets (mirrors [`Self::list_internal_by_facts`] and the
+    /// `json_each` idiom used throughout [`crate::store::facts`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `fact_ids` cannot be serialized to JSON — infallible in
+    /// practice for `&[i64]`.
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on SQL failure.
@@ -366,18 +383,13 @@ impl<'a> EdgeStore<'a> {
         if fact_ids.is_empty() {
             return Ok(0);
         }
-        let placeholders: String = fact_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-        let sql = format!(
-            "DELETE FROM edges WHERE source_fact_id IN ({placeholders}) OR target_fact_id IN ({placeholders})"
-        );
-        let mut params: Vec<&dyn rusqlite::types::ToSql> = Vec::with_capacity(fact_ids.len() * 2);
-        for id in fact_ids {
-            params.push(id as &dyn rusqlite::types::ToSql);
-        }
-        for id in fact_ids {
-            params.push(id as &dyn rusqlite::types::ToSql);
-        }
-        let deleted = self.conn.execute(&sql, params.as_slice())?;
+        let ids_json = serde_json::to_string(fact_ids).expect("serialize fact_ids");
+        let deleted = self.conn.execute(
+            "DELETE FROM edges
+             WHERE source_fact_id IN (SELECT value FROM json_each(?1))
+                OR target_fact_id IN (SELECT value FROM json_each(?1))",
+            params![ids_json],
+        )?;
         Ok(deleted)
     }
 }
@@ -752,5 +764,85 @@ mod tests {
         let deleted = store.hard_delete_incident_to_facts(&[]).unwrap();
         assert_eq!(deleted, 0);
         assert_eq!(store.list_all().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn hard_delete_incident_to_facts_handles_large_id_set_without_param_limit() {
+        // Regression for the gemini param-limit finding (#847 thread on edges.rs).
+        //
+        // The prior positional binding emitted one `?` per id, per IN clause —
+        // 2N bound variables for the OR-two-clause shape. SQLite caps bound
+        // variables at the compiled `SQLITE_MAX_VARIABLE_NUMBER` (32766 in the
+        // bundled build, empirically verified); an id set at or above that cap
+        // would have failed at prepare time with "too many SQL variables".
+        //
+        // We use an id set LARGER than the cap (`LARGE_N` > 32766) so the old
+        // binding would have overflowed even on a SINGLE IN clause — and doubly
+        // so at 2N — whereas the `json_each(?1)` rewrite binds exactly ONE param
+        // regardless of N, so the call must succeed.
+        //
+        // Non-vacuous: we insert real facts + edges so the delete actually
+        // removes rows (the asserted `deleted` count is positive), and pad the
+        // id slice past the cap to force the param-limit condition the old
+        // binding hit.
+        const LARGE_N: i64 = 35_000; // > 32766 → trips even a single old IN clause
+        let conn = setup();
+        let store = EdgeStore::new(&conn);
+
+        // Insert enough real facts (beyond the 3 seeded by `setup`) to attach
+        // edges to, then build incident edges whose source is in the archive set.
+        let real_facts: i64 = 50;
+        for i in 0..real_facts {
+            conn.execute(
+                "INSERT INTO facts (content, content_hash, embedding, fact_type, t_created, importance, access_count, last_accessed, metadata)
+                 VALUES (?1, ?2, X'00000000', 'episodic', datetime('now'), 0.5, 0, datetime('now'), '{}')",
+                params![format!("bulk{i}"), format!("bh{i}")],
+            )
+            .unwrap();
+        }
+        // Live id range starts after the 3 seed facts (ids 1..=3).
+        let first_bulk: i64 = 4;
+        let last_bulk: i64 = 3 + real_facts;
+
+        // Chain edges from `first_bulk` to each later bulk fact — every one is
+        // incident to `first_bulk`, which we include in the (large) id set.
+        let mut expected_deleted = 0usize;
+        for id in first_bulk..last_bulk {
+            store
+                .insert(&make_edge(first_bulk, id + 1, "incident"))
+                .unwrap();
+            expected_deleted += 1;
+        }
+        assert!(
+            expected_deleted > 0,
+            "test must delete real rows to be non-vacuous"
+        );
+        // An edge entirely outside the set must survive (proves we delete by the
+        // set, not everything).
+        store.insert(&make_edge(2, 3, "external")).unwrap();
+
+        // Build a LARGE id set: the one id that actually matches (`first_bulk`)
+        // plus padding ids that match nothing, to exceed the parameter cap.
+        let mut ids: Vec<i64> = vec![first_bulk];
+        // High, non-existent ids — far past any real row — purely to inflate N.
+        ids.extend(1_000_000..1_000_000 + (LARGE_N - 1));
+        assert!(
+            ids.len() > 32_766,
+            "id set must exceed SQLite's bound-variable cap to be a real regression"
+        );
+
+        // Under the old positional binding this would error with
+        // "too many SQL variables"; with json_each it succeeds.
+        let deleted = store
+            .hard_delete_incident_to_facts(&ids)
+            .expect("large id set must not trip the bound-variable limit");
+        assert_eq!(
+            deleted, expected_deleted,
+            "every edge incident to first_bulk must be deleted"
+        );
+
+        let remaining = store.list_all().unwrap();
+        assert_eq!(remaining.len(), 1, "only the fully-external edge survives");
+        assert_eq!(remaining[0].relation_type, "external");
     }
 }


### PR DESCRIPTION
## Root cause

`MemoryEngine::archive` failed with `FOREIGN KEY constraint failed` whenever an edge had **exactly one** endpoint in the archive candidate set — a *boundary* edge (`archived → survivor`, or `survivor → archived`).

`commit_archive_atomic` (`storage/sqlite/cold_storage.rs`) deleted edges via `EdgeStore::hard_delete_by_facts`, which by design removes only edges whose **both** endpoints are archived. A surviving boundary edge therefore still referenced an about-to-be-hard-deleted archived fact through `edges.source_fact_id/target_fact_id REFERENCES facts(id)` (the FK has **no** `ON DELETE CASCADE`). The subsequent `FactStore::hard_delete_ids` then tripped that FK and aborted the entire archive transaction.

## Fix

The archived fact leaves the live DB for cold storage, and the boundary edge is **not** part of the `.pak` (only internal — both-endpoints-archived — edges are archived). So the live link is genuinely dangling and must go with the fact.

- New `EdgeStore::hard_delete_incident_to_facts(fact_ids)` deletes every edge with **either** endpoint in the set (internal + boundary).
- `commit_archive_atomic` now calls it instead of `hard_delete_by_facts`, inside the same transaction → FK satisfied.
- A mere soft-expire (the issue's "Option A") would **not** work: it leaves the edge row, and its FK column, in place, so the fact hard-delete would still violate the FK. Only a hard-delete is referentially safe here ("the link is gone with the fact").
- The existing `hard_delete_by_facts` (both-endpoints contract) is left untouched.
- The in-memory graph already prunes by single fact (`remove_edges_by_fact`), so it stays consistent: the survivor keeps its node but loses the dangling boundary edge, mirroring the DB.

## Test plan

TDD — the regression tests fail without the fix (pre-fix: `Storage(Backend("FOREIGN KEY constraint failed"))`):

- `commit_archive_atomic_removes_boundary_edge_without_fk_violation` (store-level, direct atomic-commit path).
- `archive_removes_boundary_edge_without_fk_violation` (engine-level, full `archive()` path + in-memory graph consistency via `graph_degree`).
- `hard_delete_incident_to_facts_*` (3 unit tests for the new EdgeStore method: internal+boundary removal, unrelated-edge preservation, empty-slice no-op).

Full CI matrix, all green:

| Gate | Result |
| --- | --- |
| `cargo fmt --all` | clean |
| `cargo build --workspace` | OK (2 pre-existing warnings unrelated to this PR) |
| `cargo build --workspace --all-features` | OK |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | No issues found |
| `cargo test --workspace --all-features` | 1879 passed, 76 ignored, 0 failed |

Fixes #847