### PR TITLE
fix(storage): edge expiry syncs the in-memory graph (wire remove_edge_by_id)

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/graph.rs
+++ b/memory-engine/lib/memory-engine/src/engine/graph.rs
@@ -98,6 +98,49 @@ impl MemoryEngine {
         Ok(new_edges.len())
     }
 
+    // --- Public API: Edge expiry ---
+
+    /// Soft-expire a single edge by id, keeping the in-memory graph in sync.
+    ///
+    /// Sets the edge's `t_expired` in the backend, then — only after the commit
+    /// succeeds — drops it from the in-memory petgraph
+    /// ([`MemoryGraph::remove_edge_by_id`](crate::graph::MemoryGraph::remove_edge_by_id)).
+    /// This is the edge counterpart of the `add_edge` mirror in
+    /// [`link_session_facts`](Self::link_session_facts): without the graph step,
+    /// degree/neighbor/component queries would keep reporting the expired edge
+    /// until the next full rebuild (#879).
+    ///
+    /// **Graph/DB consistency:** the graph is mirrored only after the DB write
+    /// returns `Ok`. A panic in the small window between commit and mirror leaves
+    /// the graph transiently holding the stale edge for the rest of the session;
+    /// the next `open()` recovers it via `MemoryGraph::load_from_db`. (Same
+    /// post-commit-mirror contract as [`resolve_conflict`](Self::resolve_conflict).)
+    ///
+    /// # Errors
+    ///
+    /// - [`MemoryError::ReadOnly`](crate::error::MemoryError::ReadOnly) — the
+    ///   engine was opened read-only (the backend rejects the write; the graph is
+    ///   left untouched).
+    /// - [`MemoryError::NotFound`](crate::error::MemoryError::NotFound) — no
+    ///   *active* edge with `edge_id` exists (unknown id, or already expired); the
+    ///   write affected 0 rows, so the graph is not modified.
+    /// - [`MemoryError::Database`](crate::error::MemoryError::Database) on SQL
+    ///   failure.
+    pub async fn expire_edge(&self, edge_id: i64) -> Result<()> {
+        let now = Utc::now();
+        // DB write below the seam first. On NotFound/ReadOnly/Database the graph
+        // is deliberately left untouched (no edge transitioned to expired).
+        self.storage.expire_edge(edge_id, now).await?;
+
+        // Mirror the in-memory graph AFTER the commit (no guard held across
+        // `.await`). `remove_edge_by_id` is a no-op if the edge is absent from the
+        // graph (e.g. graph built without this edge), so it is safe even when the
+        // DB and graph briefly disagree.
+        self.graph.write().remove_edge_by_id(edge_id);
+
+        Ok(())
+    }
+
     // --- Public API: Graph queries (no lock exposure) ---
 
     /// Get the degree (in + out edges) for a fact in the graph.

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -3706,6 +3706,75 @@ async fn link_session_facts_ignores_expired() {
     assert_eq!(engine.graph_degree(f1), 2); // 1 out + 1 in
 }
 
+// --- Edge expiry / graph-sync regression (#879) ---
+
+#[tokio::test]
+async fn expire_edge_syncs_in_memory_graph() {
+    // #879 regression: expiring a single edge must update BOTH the DB
+    // (t_expired set) AND the in-memory petgraph, so degree/neighbor/stat
+    // queries against the graph stop reporting the now-logically-gone edge
+    // without waiting for a full rebuild. Mirrors `add_edge`'s under-lock
+    // graph sync in `link_session_facts`.
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let (_, f1) = add_session_fact(&engine, "fact a", "s1").await;
+    let (_, f2) = add_session_fact(&engine, "fact b", "s1").await;
+
+    // Two co_session edges (f1→f2 and f2→f1); both mirrored into the graph.
+    let created = engine.link_session_facts("s1", None).await.unwrap();
+    assert_eq!(created, 2);
+    assert_eq!(engine.graph_stats().1, 2, "both edges present pre-expiry");
+    assert_eq!(engine.graph_degree(f1), 2);
+    assert_eq!(engine.graph_neighbors(f1), vec![f2]);
+
+    // Pick the f1→f2 edge to expire.
+    let target_edge = {
+        let edges = engine.storage().list_active_edges().await.unwrap();
+        edges
+            .into_iter()
+            .find(|e| e.source_fact_id == f1 && e.target_fact_id == f2)
+            .expect("f1->f2 co_session edge exists")
+    };
+
+    engine.expire_edge(target_edge.id).await.unwrap();
+
+    // DB side: the edge is soft-deleted.
+    let db_edge = engine.storage().get_edge(target_edge.id).await.unwrap();
+    assert!(
+        db_edge.t_expired.is_some(),
+        "edge must be expired in the DB"
+    );
+
+    // Graph side (the part #879 was missing): the in-memory petgraph no
+    // longer reports the expired edge. Only the f2→f1 edge survives.
+    assert_eq!(
+        engine.graph_stats().1,
+        1,
+        "expired edge must be dropped from the in-memory graph, not just the DB"
+    );
+    assert!(
+        engine.graph_neighbors(f1).is_empty(),
+        "f1 has no outgoing neighbor after its only out-edge expired"
+    );
+    assert_eq!(engine.graph_neighbors(f2), vec![f1], "f2->f1 untouched");
+    assert_eq!(engine.graph_degree(f1), 1); // only the incoming f2->f1 remains
+}
+
+#[tokio::test]
+async fn expire_edge_nonexistent_is_not_found() {
+    // Mirrors `EdgeStore::expire`'s rows-affected contract surfaced through
+    // the engine facade: an unknown id is NotFound, and the graph is left
+    // untouched.
+    let engine = MemoryEngine::builder(DIM).build().unwrap();
+    let err = engine
+        .expire_edge(9999)
+        .await
+        .expect_err("expiring a nonexistent edge must return NotFound");
+    assert!(
+        matches!(err, MemoryError::NotFound(_)),
+        "expected MemoryError::NotFound, got {err:?}"
+    );
+}
+
 // --- Scope-aware session linking tests ---
 
 /// Helper: add a fact in a specific scope, linked to a session.

--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -101,24 +101,20 @@ impl MemoryGraph {
     /// first match.
     ///
     /// In-memory twin of the single-edge store primitive
-    /// [`FactGraph::expire_edge`](crate::storage::FactGraph::expire_edge): when one
-    /// edge is soft-expired in the store *without* expiring either endpoint fact,
-    /// this drops the matching edge from the derived graph cache so reads (degree,
-    /// neighbors, components, `explain_fact` context) stay consistent. Its
-    /// fact-level sibling [`remove_edges_by_fact`](Self::remove_edges_by_fact) is
-    /// the path wired today; this edge-level one has **no production caller yet**,
-    /// because nothing in the engine expires a *single* edge in isolation — fact
-    /// supersession expires edges in bulk, by fact. The drift its absence could
-    /// imply is therefore latent, not active (#879).
+    /// [`EdgeStore::expire`](crate::store::edges::EdgeStore::expire), reached via
+    /// [`MemoryEngine::expire_edge`]: when one edge is soft-expired in the store
+    /// *without* expiring either endpoint fact, this drops the matching edge from
+    /// the derived graph cache so reads (degree, neighbors, components,
+    /// `explain_fact` context) stay consistent — the edge counterpart of
+    /// [`Self::remove_node`]. Its fact-level sibling
+    /// [`remove_edges_by_fact`](Self::remove_edges_by_fact) handles the bulk
+    /// fact-supersession path; this single-edge one is now wired through
+    /// `MemoryEngine::expire_edge` (#879).
     ///
-    /// The designed consumer is the geometric associative-memory substrate (epic
-    /// #761, E0 #763): its kNN similarity-edge graph invalidates *individual*
-    /// similarity edges when the metric (whitening `W` or sim-graph `k`) is
-    /// retuned, keeping both endpoint facts. When that path lands, call this beside
-    /// `expire_edge` in the invalidation step and drop the `#[cfg(test)]` gate. The
-    /// gate keeps the dead-code lint honest meanwhile, without an
-    /// `#[allow(dead_code)]` mask.
-    #[cfg(test)]
+    /// A second designed consumer is the geometric associative-memory substrate
+    /// (epic #761, E0 #763): its kNN similarity-edge graph invalidates *individual*
+    /// similarity edges when the metric (whitening `W` or sim-graph `k`) is retuned,
+    /// keeping both endpoint facts — call this beside `expire_edge` there too.
     pub fn remove_edge_by_id(&mut self, edge_id: i64) {
         if let Some(ei) = self
             .graph


### PR DESCRIPTION
## Root cause

Expiring a single edge wrote `t_expired` to SQLite but never touched the in-memory petgraph. `MemoryGraph::remove_edge_by_id` existed and was documented as *"used after expiring an edge … to keep the graph in sync"*, yet it had **no production caller** — only a unit test — so PR #878 gated it `#[cfg(test)]` as an honest dead-code stop-gap. There was in fact no engine-level single-edge expiry path at all (the storage trait's `expire_edge` was reached only by a conformance test).

Consequence: any consumer-driven single-edge expiry would leave the in-memory graph holding the stale edge until the next full rebuild, so graph reads — degree / neighbor / connected-component, and `explain_fact`'s graph context — could report an edge that is logically gone. Compare `remove_node` (archival), whose removal path *is* wired.

## Fix

Add `MemoryEngine::expire_edge(edge_id)` (in `engine/graph.rs`), mirroring the add-side sync in `link_session_facts` / `resolve_conflict`:

1. Backend write first: `self.storage.expire_edge(edge_id, now).await?` (honors the `t_expired IS NULL` rows-affected contract → `NotFound` on unknown/already-expired; `ReadOnly`/`Database` propagate).
2. **Only after** the commit returns `Ok`, drop the edge from the in-memory graph under the write lock: `self.graph.write().remove_edge_by_id(edge_id)`.

On any error the graph is left untouched (no edge transitioned to expired). `MemoryGraph::remove_edge_by_id` is now a plain `pub` production API again with its production doc restored (the `#[cfg(test)]` gate removed). Post-commit-mirror window matches `resolve_conflict`'s documented contract (a panic between commit and mirror self-heals on next `open()` via `load_from_db`).

## Test plan

Regression-first (TDD):

- `expire_edge_syncs_in_memory_graph` — link two facts into two `co_session` edges, expire the `f1→f2` edge, then assert **both** the DB (`get_edge().t_expired.is_some()`) and the in-memory graph (`graph_stats().1 == 1`, `graph_neighbors(f1).is_empty()`, `graph_neighbors(f2) == [f1]`, `graph_degree(f1) == 1`) drop exactly that edge while the reverse edge survives. **Confirmed to fail without the fix** (method `expire_edge` not found).
- `expire_edge_nonexistent_is_not_found` — unknown id → `MemoryError::NotFound`, graph untouched.

Full CI matrix, all green locally:

| Gate | Result |
| --- | --- |
| `cargo fmt --all --check` | clean |
| `cargo build --workspace` | pass (2 pre-existing, non-blocking warnings — see below) |
| `cargo build --workspace --all-features` | pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo test --workspace --all-features` | 1876 passed, 76 ignored |

## Collateral (filed separately, not folded in)

`cargo build --workspace` (default features) emits a **pre-existing** `dead_code` warning for `MemoryGraph::remove_node` (its only caller is `archive`-gated). Independently flagged by @dutiona in the #879 comment thread. It fails no CI gate (default build is non-`-D`; `--all-features` clippy enables `archive`). Filed as **#911** (under epic #818) rather than folded into this edge-only fix.

Fixes #879