### PR TITLE
fix(build): re-attach orphaned eval test harness (56 tests dark since #814)

### DIFF
--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -75,6 +75,15 @@ harness = false
 
 # --- integration tests (top-level ../../../tests/) — attached explicitly since this
 #     crate dir has no tests/ subdir for Cargo to auto-discover ---
+# The two-tier eval harness (#16): a multi-file binary rooted at tests/eval/main.rs.
+# Cargo auto-discovered it when the repo root was a package; after the bin/lib
+# restructure the core crate's dir has no tests/ subdir, so it must be attached
+# explicitly like every other top-level integration test below -- otherwise the
+# whole conformance + quality suite silently stops building under `cargo test`.
+[[test]]
+name = "eval"
+path = "../../../tests/eval/main.rs"
+
 [[test]]
 name = "activity_stream_test"
 path = "../../../tests/activity_stream_test.rs"


### PR DESCRIPTION
## What

Add an explicit `[[test]] name = "eval"` target to `memory-engine/lib/memory-engine/Cargo.toml`, pointing at the repo-root `../../../tests/eval/main.rs` harness. This re-attaches the two-tier eval harness (#16) so `cargo test --workspace` compiles and runs its **56 conformance + quality tests** again.

## Why it went dark

Cargo auto-discovers integration tests only under a *package's own* `tests/` dir. The #814 bin/lib restructure moved the core crate to `memory-engine/lib/memory-engine/`, whose dir has **no `tests/` subdir** — but the eval harness lives at the repo root `tests/eval/`. With `autotests = false` and no explicit `[[test]]` target, Cargo **silently** stopped building and running the whole harness: no error, no warning. Every PR that added or modified `tests/eval/` since #814 had **false-green CI**.

## Blast radius

The harness has been dark since #814. This re-enables the full conformance + quality suite, **including PR #902's previously dormant** `quality::forgetting::well_connected_fact_survives_prune` integration test (#312), which could not run while the harness was orphaned.

## Verification

`cargo test --workspace --all-features` now runs the eval binary:

```
Running ../../../tests/eval/main.rs (target/debug/deps/eval-...)
running 59 tests
...
test quality::forgetting::well_connected_fact_survives_prune ... ok
test result: ok. 56 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
```

(The 59 = 56 conformance/quality + 3 `skeletons.rs` `#[ignore]` placeholders.)

All gates green:
- `cargo test --workspace --all-features` — pass (eval: 56 passed, 0 failed, 3 ignored; whole workspace 0 failures)
- `cargo fmt --all --check` — clean
- `cargo build --workspace` / `cargo build --workspace --all-features` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean

Discovered during the #255 area:forgetting sweep (PR #902). Split out per the no-silent-descope contract.

Closes #903
Part of #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)