### PR TITLE
docs(storage): fix private-intra-doc link in expire_edge (unbreak Docs CI)

### DIFF
--- a/memory-engine/lib/memory-engine/src/engine/graph.rs
+++ b/memory-engine/lib/memory-engine/src/engine/graph.rs
@@ -103,8 +103,8 @@ impl MemoryEngine {
     /// Soft-expire a single edge by id, keeping the in-memory graph in sync.
     ///
     /// Sets the edge's `t_expired` in the backend, then — only after the commit
-    /// succeeds — drops it from the in-memory petgraph
-    /// ([`MemoryGraph::remove_edge_by_id`](crate::graph::MemoryGraph::remove_edge_by_id)).
+    /// succeeds — drops it from the in-memory petgraph (via the crate-internal
+    /// `MemoryGraph::remove_edge_by_id`).
     /// This is the edge counterpart of the `add_edge` mirror in
     /// [`link_session_facts`](Self::link_session_facts): without the graph step,
     /// degree/neighbor/component queries would keep reporting the expired edge


### PR DESCRIPTION
**Hotfix — main's `Docs (intra-doc links)` CI job is red since #913 merged.**

#913's new `MemoryEngine::expire_edge` doc linked to the crate-internal `MemoryGraph::remove_edge_by_id` via an intra-doc link; the Docs job runs `cargo doc --no-deps -p memory-engine` with `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links`, which denies a public item linking a private/crate-internal one. Reworded to a plain code span.

Root cause of the escape: the gate matrix used for the #258 sweep lacked `cargo doc` — the same lesson the #259 sweep recorded. Adding it to all subsequent waves.

**Test plan:** `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" cargo doc --no-deps -p memory-engine` (default + --all-features) — both Finished, 0 denied errors locally.