### PR TITLE
docs(qa): harden instruction files + add qa-sweep skill and false-green guard

### DIFF
--- a/.claude/skills/qa-sweep/SKILL.md
+++ b/.claude/skills/qa-sweep/SKILL.md
@@ -24,10 +24,12 @@ a local pass that diverges (weaker features, narrower scope, piped output) is a 
 ```bash
 cargo fmt --all --check                                                # Format
 cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy (deny warnings)
-cargo build --workspace --all-features                                 # Build (CI also builds default features)
+cargo build --workspace                                                # Build (default features)
+cargo build --workspace --all-features                                 # Build (all features)
 cargo test  --workspace --all-features                                 # Test
-RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
-  cargo doc --no-deps -p memory-engine --all-features                  # Docs (core crate only; #915 widens to --workspace)
+export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
+cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only; #915 widens to --workspace)
+cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain
 ```
 
@@ -45,10 +47,12 @@ name its class, apply the countermeasure.
 
 The gate reported pass while tests were dark or never ran.
 
-- **Piping a cargo gate through `head`/`tail`/`grep`** truncates output (hides RED) _and_ discards
+- **Piping a cargo gate through `head`/`tail`** truncates output (hides RED) _and_ discards
   cargo's exit code (PIPESTATUS reflects the pager, not cargo). `head -N` masked 8 RED insta
   snapshots (#254); a `tail` + `$PIPESTATUS` capture came back empty (#259). → **Run unpiped, or
-  redirect to a file and read the file.** The `cargo-gate-guard.sh` hook blocks this mechanically.
+  redirect to a file and read the file.** The `cargo-gate-guard.sh` hook blocks the `head`/`tail`
+  forms mechanically. `grep` is allowed (it doesn't truncate) but _also_ masks the exit code —
+  check `${PIPESTATUS[0]}` or redirect if you filter a gate through it.
 - **`clippy --all-features` compiles tests but does not run them** — a clippy-green diff can have RED
   tests (#255).
 - **`cargo build` green ≠ tests green** for file moves / `include_str!` / `[[test]]` registration —

--- a/.claude/skills/qa-sweep/SKILL.md
+++ b/.claude/skills/qa-sweep/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: qa-sweep
+description: "Use when running a super-qa sweep, clearing a [super-qa] Auto-fix rollup issue, addressing a batch of QA/audit findings, or doing any multi-PR quality pass in memory-engine. Holds the memory-engine-specific verification gate, the 7-class failure taxonomy distilled from the #248 super-qa epic (forgetting/retrieval/mcp/temporal/storage/core/cli/consolidation sweeps), the triage→waves→orchestrate→close-out playbook, and the build-hygiene + PR-orchestration gotchas. Triggers on /super-qa in this repo, 'clear the super-qa rollup', 'address these findings', 'qa sweep', 'sweep the audit issues'."
+---
+
+# qa-sweep — memory-engine QA sweep playbook
+
+Canonical, hard-won reference for running a quality sweep in this repo. Distilled from the
+**#248 super-qa epic** (the area sweeps #251/#253/#254/#255/#256/#257/#258/#259 and the
+#739/#879 doc/sim-graph tail). The committed `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` carry the
+gate + the short trap list for _every_ session; **this skill carries the full playbook** so those
+files stay lean. Read it before starting a sweep.
+
+Pairs with the global `super-qa`, `finish-pr`, and `address-issue` skills (those live in
+`dutiona/my-dotfiles`; file issues there for cross-repo improvements, don't fork them here).
+
+---
+
+## 0. The authoritative gate (the CI contract)
+
+CI (`.github/workflows/ci.yml`) is the single source of truth. Run the **exact** commands below;
+a local pass that diverges (weaker features, narrower scope, piped output) is a **false pass**.
+
+```bash
+cargo fmt --all --check                                                # Format
+cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy (deny warnings)
+cargo build --workspace --all-features                                 # Build (CI also builds default features)
+cargo test  --workspace --all-features                                 # Test
+RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
+  cargo doc --no-deps -p memory-engine --all-features                  # Docs (core crate only; #915 widens to --workspace)
+cargo deny check                                                       # Supply-chain
+```
+
+MSRV is **1.88** (let-chains). The MSRV CI job builds `--workspace --tests --examples` on exactly
+1.88, default _and_ all-features — a dev-dep needing newer Rust fails it.
+
+---
+
+## 1. The failure taxonomy (what bit us, ranked)
+
+Every sweep finding and every rework cycle reduced to one of these seven classes. Read a finding,
+name its class, apply the countermeasure.
+
+### Class 1 — Verification false-green (most frequent; the reason this skill exists)
+
+The gate reported pass while tests were dark or never ran.
+
+- **Piping a cargo gate through `head`/`tail`/`grep`** truncates output (hides RED) _and_ discards
+  cargo's exit code (PIPESTATUS reflects the pager, not cargo). `head -N` masked 8 RED insta
+  snapshots (#254); a `tail` + `$PIPESTATUS` capture came back empty (#259). → **Run unpiped, or
+  redirect to a file and read the file.** The `cargo-gate-guard.sh` hook blocks this mechanically.
+- **`clippy --all-features` compiles tests but does not run them** — a clippy-green diff can have RED
+  tests (#255).
+- **`cargo build` green ≠ tests green** for file moves / `include_str!` / `[[test]]` registration —
+  only `cargo test` catches a dropped target. **56 eval tests were dark since #814** (a `[[test]]`
+  target wasn't registered; CI was false-green for weeks) → fixed by #903/#916.
+- **Proptests pass "lucky" at low case counts** — a decay-underflow flake was green at 256 cases,
+  RED at 200k (#255). Raise `PROPTEST_CASES` before trusting a property.
+
+### Class 2 — Gate incompleteness (local gate ≠ CI gate)
+
+- **Doc-links need BOTH gates**: `rustdoc -D broken_intra_doc_links` _and_ `clippy --all-features`
+  (the nursery `doc_link_with_quotes` lint). `cargo test --doc` checks failing examples, **not
+  broken links** (#739/#259).
+- **`clippy --fix` runs default features** and silently breaks `--all-features` (it `const fn`-ed a
+  fn that's non-const under `ann`) and misses cfg-gated nests (`ann`/`archive`). Always re-run the
+  exact CI clippy after any `--fix` (#667, build-hygiene).
+- **An MSRV bump is a lint iceberg**, not one lint — declaring 1.88 unlocked `collapsible_if`→let-chain
+  suggestions codebase-wide (#667).
+
+### Class 3 — Genuine coverage gaps (real bugs that PASSED `cargo test`)
+
+Tests existed and were green; the bug lived in an unexercised path. Only **adversarial review** with
+a mutation/edge lens found these:
+
+- edge swap-remove sibling corruption needing descending-sort+dedup (#257, #833 — a BLOCKER);
+- `IndexInconsistent` post-commit contract (#257, #837);
+- a TOCTOU in the atomic Add arm (#259, #335);
+- the #312 cascade canary that was a _coverage gap_, not a bug (#255).
+  → On any behavior-changing finding, add the failing test FIRST (TDD), and run ≥2 adversarial lenses.
+
+### Class 4 — Snapshot staleness (the issue describes code that no longer exists)
+
+- The #628/#631 reorg made **every** file:line in #259's snapshot stale
+  (`conflict/temporal.rs` → `engine/conflict.rs`). Triage against **current main**, not the issue.
+- A long-parked issue may already be fixed elsewhere — **recurred 3×** (#251). `gh issue view N` +
+  `grep` before resuming.
+- A "magic constant" may be a **named sentinel** (`Fact::UNSCORED_IMPORTANCE` = 0.5 — PRESERVE, don't
+  "fix" it, #259); "dead code" may be **epic-foundation** (`remove_edge_by_id`/`expire_edge` are E0
+  sim-graph scaffolding, #879). Pickaxe (`git log -S`) + check the roadmap (Projects #6) before
+  changing or deleting.
+
+### Class 5 — PR orchestration hazards (concurrency + merge mechanics)
+
+See §3. The big ones: `closingIssuesReferences` auto-close trap, `mergeable=CLEAN` ≠ semantically
+safe, subagent cwd-leak, `git add -A` sweeping build artifacts, hot-file serialization, god-split-last.
+
+### Class 6 — Review / evidence discipline
+
+- The gemini-code-assist bot (and now the Codex connector bot) re-post already-fixed FPs on each
+  push — **verify against current bytes** before acting, and the bots are type-blind.
+- **Always post refuting/fixing evidence on issue closure** (SHA / file:line / canonical #) and
+  re-verify before `gh issue close`.
+- Under budget, prefer **2–3 in-house adversarial subagents with diverse lenses** over `/super-review`
+  (saves external-model quota).
+
+### Class 7 — Instruction/doc drift (the guidance itself lies)
+
+- A migration that **relocates data** breaks raw-SQL consumers elsewhere — grep the WHOLE workspace
+  for consumers of the old location (#622).
+- ADR parity ME↔KB is **semantic, not byte** (#853).
+- These very instruction files drifted (1.85 vs 1.88, 3 vs 4 crates, a deleted `async` feature). When
+  you touch the code that an `.md`/skill describes, update the doc in the same PR.
+
+---
+
+## 2. Sweep execution playbook
+
+**1. Triage BEFORE implementing, against current `main`.** Fan out a read-only agent per finding →
+classify {still-open / already-fixed / moot-FP / changed}. Collapse duplicates that share a location.
+On past rollups this killed ~30–40% of findings before any code was written.
+
+**2. Bucket by KIND, risk-tiered into waves.**
+
+- _Wave 1_ behavior-preserving/additive (docs, tests, refactor, perf): parallel, light review.
+- _Wave 2_ behavior-changing (correctness, security, schema, soundness): **TDD-first** (failing test →
+  fix → green), ≥2–3 adversarial lenses each, a **persisted-format-compat** lens on any
+  schema/serialization change.
+- **Serialize hot files**: one PR per wave may touch a given hot file (e.g. `memory_graph.rs`,
+  `hybrid.rs`, `ann.rs`) — otherwise rebases thrash. One PR/wave/hot-file.
+- **God-split goes LAST.** A module split's real conflict isn't git — it's the test-mod `use super::{}`
+  list and **duplicate test-fn names → E0428 compile error** that no textual merge detects.
+
+**3. Orchestrate with worktrees; agents return PATCHES, you gate.** Use `isolation: 'worktree'` or
+inline worktree edits. Agents' self-gates are advisory — **you** apply each patch to a controlled
+`.claude/worktrees/` branch, run the authoritative gate (§0) yourself, commit, PR. Watch for:
+subagents inheriting the **main** cwd (their relative-path edits land in `main`, not the worktree —
+use absolute worktree paths); schema/`insta` agents leaking into the main checkout (`git -C <main>
+status --porcelain` after). Throttle bursts to ~9 concurrent agents (18 got rate-limited).
+
+**4. Re-gate every branch against THEN-CURRENT main right before merge.** `mergeable=CLEAN` ≠
+compiles: a sibling can drift an indirect dependency in a file your patch never touched (main moved
+~7× during one sweep). `git diff --name-only <base> origin/main` for overlap; `git rebase
+origin/main` + re-run the full gate on the combined state. Commit `fmt` BEFORE gating.
+
+**5. Close-out with evidence.** Non-final PRs use `Refs #N` / `Part of #N` (never `Closes/Fixes #N`
+— that auto-closes the umbrella and orphans remaining waves). The final PR uses exactly one
+`Closes #N`. Close the rollup with a disposition table mapping every finding →
+{merged PR / already-fixed / FP / carved-out issue}. File epic-scale/needs-design findings as their
+own labeled issues (per the PM contract in CLAUDE.md), don't fold them in.
+
+---
+
+## 3. PR-orchestration gotchas (Class 5, expanded)
+
+- **`closingIssuesReferences` auto-close trap.** GitHub parses `close|fix|resolve(+s/+d) #N` from PR
+  title, body, **and commit messages**. Verify before merge:
+  `gh api graphql -f query='…pullRequest(number:N){ closingIssuesReferences{ nodes{ number } } }'`
+  — want `[]` (non-closing) or `[N]` (the intended final close).
+- **Subagent cwd-leak.** Fan-out agents inherit the main session cwd, not a worktree. Do worktree
+  edits inline with absolute paths; read-only reviewers must use `gh pr diff <N>` + absolute paths.
+- **`git add -A` after a build-running subagent** swept a 4.1 MB ELF onto main (#726). Stage explicit
+  paths, or `git status --porcelain` and eyeball every untracked entry first.
+- **Coordinate with concurrent sessions.** The user runs parallel sessions that merge siblings and
+  edit shared files (incl. MEMORY.md) mid-sweep. Re-check each PR `state` before merging; respect
+  fenced-off PRs.
+- **`gh pr edit` label changes** sometimes fail via GraphQL → use the REST path.
+- **`isolation:'worktree'` leaks branch-locking worktrees** — clean them up (`git worktree remove`)
+  or the branch can't be deleted post-merge.
+
+---
+
+## 4. Build-hygiene gotchas (Class 2, expanded)
+
+- **`significant_drop_tightening` is ~always a FALSE POSITIVE** on the store wrappers (they borrow
+  `&conn` transitively; clippy misses it). Use a scoped `#[allow(…, reason = "…")]`.
+- **The clippy gate is `-D warnings` workspace-wide now** (pedantic/nursery cleared to 0 + ~19
+  justified `#[allow]`s). Keep changed code 0-warning or add a justified `#[allow]`.
+- **`Cargo.lock` is gitignored** — a `cargo update -p X` commits nothing; CI resolves fresh. A
+  RustSec advisory is closed by raising the MSRV floor (which excludes the vulnerable version via the
+  MSRV-aware resolver), _not_ by a committed pin. Say that in the PR.
+- **Mechanical fix patterns**: `as`→`try_from` (truncation/sign); count→`f64` keeps `as f64` + scoped
+  `cast_precision_loss` allow (NOT saturating `try_from().unwrap_or(MAX)` — not lossless); >3-bool
+  struct → one bool becomes a meaningful enum; `too_many_lines` → extract a cohesive helper.
+
+---
+
+## 5. The mechanical guard
+
+`utils/scripts/hooks/cargo-gate-guard.sh` is a PreToolUse/Bash hook that **blocks** piping a
+`cargo (test|clippy|build|doc)` through `head`/`tail` (Class 1, trap 1). Its logic is committed and
+reviewable; its activation lives in the gitignored `.claude/settings.json` (local-only — the
+committed `.md` files remain the guardrail that reaches every clone). Wiring is documented in the
+script header and `CLAUDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ cargo doc --no-deps -p memory-engine --all-features                    # Docs, a
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
-Run all of them after every change. Do not skip any, and do not substitute a weaker variant.
+Run all of them after every change. Do not skip any, and do not substitute a weaker variant. CI also runs an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it if you touch let-chains or edition-sensitive code.
 
 **Critical:** The workspace contains **4 crates** — `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can break the CLI, MCP, and embed crates silently if only the root crate is checked. Always use `--workspace`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## What This Is
 
-Embedded Rust library (edition 2024, Rust 1.85+) providing durable long-term memory for AI agents. Single facade type `MemoryEngine` with 5 primitives: Ingest, Query, Consolidate, Forget, Resolve. Zero LLM/network dependencies — consumers implement traits (`EmbeddingProvider`, `SummaryGenerator`, `ConflictArbiter`, `PersistenceClassifier`, `Reranker`).
+Embedded Rust library (edition 2024, **Rust 1.88+** — the workspace uses let-chains) providing durable long-term memory for AI agents. Single facade type `MemoryEngine` (async-native; DB methods are `async fn` over an `Arc<dyn StorageBackend>` — `tokio` is non-optional) with 5 primitives: Ingest, Query, Consolidate, Forget, Resolve. Zero LLM/network dependencies — consumers implement traits (`EmbeddingProvider`, `SummaryGenerator`, `ConflictArbiter`, `PersistenceClassifier`, `Reranker`).
 
 Part of a four-layer cognitive architecture. Companion repos: `knowledge-base` (Python MCP server, Knowledge layer), `autonomous-agent-project` (research, no code).
 
@@ -18,41 +18,62 @@ No external services needed — SQLite is bundled via `rusqlite`.
 
 ## Verify
 
+These are the **exact** commands CI runs (`.github/workflows/ci.yml`). A local pass that diverges from them — weaker features, narrower scope, or piped output — is a **false pass**:
+
 ```bash
-cargo build --workspace               # ALL 3 crates must compile
-cargo test --workspace                # ALL 3 crates' tests must pass
-cargo clippy --workspace --all-targets # ALL 3 crates must lint-clean (pedantic + nursery)
-cargo fmt --check                     # must pass — no reformats
+cargo fmt --all --check                                                # Format
+cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy (deny warnings)
+cargo build --workspace --all-features                                 # Build
+cargo test  --workspace --all-features                                 # Test — --all-features is mandatory, or ann/archive/eval tests never run
+RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
+  cargo doc --no-deps -p memory-engine --all-features                  # Docs — broken/private intra-doc links (core crate only)
+cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
-Run all four commands after every change. Do not skip any.
+Run all of them after every change. Do not skip any, and do not substitute a weaker variant.
 
-**Critical:** The workspace contains 3 crates: `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`. Changes to `error.rs`, `types.rs`, `traits.rs`, or any public API in the core crate can break the CLI and MCP crates silently if only the root crate is checked. Always use `--workspace`.
+**Critical:** The workspace contains **4 crates** — `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can break the CLI, MCP, and embed crates silently if only the root crate is checked. Always use `--workspace`.
+
+**Verification traps** (each cost a real rework cycle):
+
+1. **Never pipe a cargo gate through `head`/`tail`/`grep`** — truncation hides RED results and the pipe drops cargo's exit code → false green. Run unpiped or redirect to a file.
+2. **`clippy --all-features` compiles tests but does not run them** — only `cargo test --all-features` runs them.
+3. **`cargo build` green ≠ tests green** for file moves / `include_str!` / `[[test]]` registration — only `cargo test` catches a dark test target.
+4. **Triage findings against current `main`, not the issue snapshot** — file:lines drift across reorgs; a "magic constant" or "dead" item may be an intentional sentinel or epic-foundation (`git log -S` + check the roadmap before changing it).
 
 ## Project Layout
 
+The workspace is a virtual root (no root package); crates live under `memory-engine/`. Paths are **`memory-engine/lib/memory-engine/src/…`**, not `src/…` (the #814 bin/lib reorg).
+
 ```
-src/
-  lib.rs              # Crate root, re-exports
-  engine.rs           # MemoryEngine facade, EngineConfig
-  types.rs            # Core data types (Event, Fact, Edge, Summary, enums)
-  traits.rs           # Consumer-implemented traits
-  error.rs            # MemoryError enum (thiserror)
-  store/              # SQLite persistence (schema, events, facts, edges, summaries, scopes)
-  search/             # Hybrid retrieval (FTS5, vector, HNSW, RRF merge)
-  graph/              # In-memory petgraph knowledge graph
-  consolidation/      # 3-pass pipeline (dedup, cluster, global)
-  forgetting/         # Ebbinghaus decay + importance scoring
-  conflict/           # Bi-temporal conflict resolution
-  pool/               # ConnectionPool (N readers + 1 writer)
-  scope/              # Hierarchical scope tree
-  resume/             # 4-tier cognitive boot (pinned → importance → due → recent)
-  bootstrap/          # Claude Code JSONL session import
-  inspect/            # Debugging APIs (explain, replay, dump, restore, statistics)
-tests/                # Integration tests
-benches/              # Criterion benchmarks
-examples/             # 3 runnable examples
-docs/                 # Sphinx narrative documentation
+memory-engine/
+  lib/memory-engine/src/   # core crate (the library)
+    lib.rs                 # crate root, re-exports; backend compile_error! guard
+    engine/                # MemoryEngine facade, EngineConfig, conflict resolution (was engine.rs + conflict/)
+    types/                 # core data types (Event, Fact, Edge, Summary, enums) — split into submodules
+    traits.rs              # consumer-implemented traits (zero LLM/network deps in core)
+    error.rs               # MemoryError enum (thiserror)
+    store/                 # original SQLite stores (events, facts, edges, summaries, scopes)
+    storage/               # #628 pluggable StorageBackend: sqlite/ (live) + postgres/ (skeleton)
+    search/                # hybrid retrieval (FTS5 + vector + HNSW, RRF merge)
+    graph/                 # in-memory petgraph knowledge graph
+    consolidation/         # 3-pass pipeline (dedup, cluster, global)
+    forgetting/            # Ebbinghaus decay + multi-signal importance
+    pool/                  # ConnectionPool (N readers + 1 writer)
+    scope/                 # hierarchical scope tree
+    resume/                # 4-tier cognitive boot (pinned → importance → due → recent)
+    bootstrap/             # Claude Code JSONL session import
+    inspect/               # debugging APIs (explain, replay, dump, restore, statistics)
+    limits.rs              # resource/size guards
+  lib/embed/               # memory-engine-embed (HTTP embedding provider + HttpDeltaProposer)
+  bin/cli/                 # memory-engine-cli (inspector binary)
+  bin/mcp/                 # memory-engine-mcp (MCP server)
+tests/                     # workspace integration tests
+benches/                   # Criterion benchmarks
+examples/                  # runnable examples
+fuzz/                      # cargo-fuzz targets (detached workspace, nightly-only)
+utils/                     # scripts (github-pm tooling, hooks)
+docs/                      # Sphinx narrative documentation
 ```
 
 ## Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,12 @@ These are the **exact** commands CI runs (`.github/workflows/ci.yml`). A local p
 ```bash
 cargo fmt --all --check                                                # Format
 cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy (deny warnings)
-cargo build --workspace --all-features                                 # Build
+cargo build --workspace                                                # Build (default features)
+cargo build --workspace --all-features                                 # Build (all features)
 cargo test  --workspace --all-features                                 # Test — --all-features is mandatory, or ann/archive/eval tests never run
-RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
-  cargo doc --no-deps -p memory-engine --all-features                  # Docs — broken/private intra-doc links (core crate only)
+export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
+cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only)
+cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
@@ -36,7 +38,7 @@ Run all of them after every change. Do not skip any, and do not substitute a wea
 
 **Verification traps** (each cost a real rework cycle):
 
-1. **Never pipe a cargo gate through `head`/`tail`/`grep`** — truncation hides RED results and the pipe drops cargo's exit code → false green. Run unpiped or redirect to a file.
+1. **Never pipe a cargo gate through `head`/`tail`** — truncation hides RED results and the pipe drops cargo's exit code → false green. Run unpiped or redirect to a file. (`grep` doesn't truncate but also masks the exit code — check `${PIPESTATUS[0]}` if you must filter.)
 2. **`clippy --all-features` compiles tests but does not run them** — only `cargo test --all-features` runs them.
 3. **`cargo build` green ≠ tests green** for file moves / `include_str!` / `[[test]]` registration — only `cargo test` catches a dark test target.
 4. **Triage findings against current `main`, not the issue snapshot** — file:lines drift across reorgs; a "magic constant" or "dead" item may be an intentional sentinel or epic-foundation (`git log -S` + check the roadmap before changing it).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,12 @@ Feature flags: `backend-sqlite` (default; the in-process SQLite backend — a #6
 ```bash
 cargo fmt --all --check                                                # Format
 cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy (deny warnings)
-cargo build --workspace --all-features                                 # Build (also runs default-feature build in CI)
+cargo build --workspace                                                # Build (default features)
+cargo build --workspace --all-features                                 # Build (all features)
 cargo test  --workspace --all-features                                 # Test — NB: --all-features, or ann/archive/eval tests never run
-RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
-  cargo doc --no-deps -p memory-engine --all-features                  # Docs — broken/private intra-doc links (core crate only; #915 widens to --workspace)
+export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
+cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only; #915 widens to --workspace)
+cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
@@ -48,7 +50,7 @@ The workspace contains **4 crates** (`memory-engine` core, `memory-engine-cli`, 
 
 **Verification traps** — each one cost a real super-qa rework cycle; the `qa-sweep` skill holds the full taxonomy:
 
-1. **Never pipe a cargo gate through `head`/`tail`/`grep`.** Truncation hides RED results _and_ the pipe discards cargo's exit code (PIPESTATUS) → false green. Run unpiped, or redirect to a file and read it. (Enforced by the `cargo-gate-guard.sh` hook below.)
+1. **Never pipe a cargo gate through `head`/`tail`.** Truncation hides RED results _and_ the pipe discards cargo's exit code (PIPESTATUS) → false green. Run unpiped, or redirect to a file and read it. (The `cargo-gate-guard.sh` hook below mechanically blocks the `head`/`tail` forms.) `grep` is softer — it doesn't truncate, but it _also_ masks the exit code, so if you must filter, check `${PIPESTATUS[0]}` or redirect first.
 2. **`clippy --all-features` _compiles_ tests; it does not _run_ them** — only `cargo test --all-features` does. A clippy-green diff can still have RED tests.
 3. **`cargo build` green ≠ tests green** for file moves / `include_str!` / `[[test]]` registration — only `cargo test` catches a dropped or dark test target (56 eval tests were dark for weeks this way).
 4. **Proptests pass "lucky" at low case counts** — raise `PROPTEST_CASES` before trusting a property holds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ cargo doc --no-deps -p memory-engine --all-features                    # Docs, a
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
+CI also runs an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it if you touch let-chains or edition-sensitive code.
+
 The workspace contains **4 crates** (`memory-engine` core, `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`); the CLI/MCP/embed crates consume the core's public API, so `--workspace` is mandatory — a change to error variants, type definitions, or trait signatures can break them silently if only the root crate is checked.
 
 **Verification traps** — each one cost a real super-qa rework cycle; the `qa-sweep` skill holds the full taxonomy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,16 +32,30 @@ uv run sphinx-build -b html docs docs/_build  # narrative docs (Python 3.12+)
 
 Feature flags: `backend-sqlite` (default; the in-process SQLite backend — a #633 marker today, since `rusqlite` is still unconditional), `backend-postgres` (the #633 `PgBackend`: `deadpool-postgres` pool + fresh v14 migration chain + `SchemaManager`), `ann` (HNSW vector search), `archive` (cold storage .pak files), `compress-gzip`, `compress-zstd`, `test-util` (cross-crate test-only port hooks). At least one backend feature must be enabled (a `compile_error!` in `lib.rs` enforces it). `tokio` is a **non-optional** dependency — the engine is async-native, so there is no `async` feature to toggle (#702). The `backend-postgres` live tests are `#[ignore]`-by-default (they need a Docker/Postgres testcontainer): `cargo test -p memory-engine --features backend-postgres -- --ignored`.
 
-**Workspace verification gate** — run before every commit, especially when modifying `error.rs`, `types.rs`, `traits.rs`, `lib.rs`, or any public API:
+**Verification gate — this is the CI contract** (`.github/workflows/ci.yml`); run it before every commit, especially when touching `error.rs`, `types/`, `traits.rs`, `lib.rs`, or any public API. These are the _exact_ commands CI runs — a local pass that diverges from them (weaker features, narrower scope, piped output) is a **false pass**:
 
 ```bash
-cargo build --workspace               # ALL crates compile
-cargo test --workspace                # ALL crates' tests pass
-cargo clippy --workspace --all-targets # ALL crates lint-clean
-cargo deny check                      # supply-chain gate (advisories/licenses/bans/sources)
+cargo fmt --all --check                                                # Format
+cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy (deny warnings)
+cargo build --workspace --all-features                                 # Build (also runs default-feature build in CI)
+cargo test  --workspace --all-features                                 # Test — NB: --all-features, or ann/archive/eval tests never run
+RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
+  cargo doc --no-deps -p memory-engine --all-features                  # Docs — broken/private intra-doc links (core crate only; #915 widens to --workspace)
+cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
-The workspace contains 4 crates: `memory-engine` (core), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. The CLI, MCP, and embed crates consume the core's public API — changes to error variants, type definitions, or trait signatures can break them silently if only the root crate is checked.
+The workspace contains **4 crates** (`memory-engine` core, `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`); the CLI/MCP/embed crates consume the core's public API, so `--workspace` is mandatory — a change to error variants, type definitions, or trait signatures can break them silently if only the root crate is checked.
+
+**Verification traps** — each one cost a real super-qa rework cycle; the `qa-sweep` skill holds the full taxonomy:
+
+1. **Never pipe a cargo gate through `head`/`tail`/`grep`.** Truncation hides RED results _and_ the pipe discards cargo's exit code (PIPESTATUS) → false green. Run unpiped, or redirect to a file and read it. (Enforced by the `cargo-gate-guard.sh` hook below.)
+2. **`clippy --all-features` _compiles_ tests; it does not _run_ them** — only `cargo test --all-features` does. A clippy-green diff can still have RED tests.
+3. **`cargo build` green ≠ tests green** for file moves / `include_str!` / `[[test]]` registration — only `cargo test` catches a dropped or dark test target (56 eval tests were dark for weeks this way).
+4. **Proptests pass "lucky" at low case counts** — raise `PROPTEST_CASES` before trusting a property holds.
+5. **Triage findings against _current_ main, not the issue snapshot** — file:lines drift across reorgs; a parked issue may already be fixed elsewhere (re-`grep`/`gh issue view` first).
+6. **A "magic constant" or "dead" item may be intentional** (a named sentinel, epic-foundation scaffolding) — pickaxe (`git log -S`) + check the roadmap before "fixing" or deleting it.
+
+A repo-local **PreToolUse hook** (`utils/scripts/hooks/cargo-gate-guard.sh`) mechanically blocks trap #1; wire it via `.claude/settings.json` (gitignored, so local-only — see the script header for the one-line wiring). The committed `.md` files remain the guardrail that reaches every agent on a fresh clone.
 
 **Supply-chain gate** — `deny.toml` at the repo root configures [`cargo-deny`](https://embarkstudios.github.io/cargo-deny/) and runs as the `cargo-deny` CI job. It fails on RustSec security advisories (against the full all-features graph) and on disallowed licenses or non-crates.io sources; duplicate transitive versions are surfaced as non-blocking warnings. Install locally with `cargo install cargo-deny --locked`. Note: the MSRV is **Rust 1.88**, required by the workspace's own use of **let-chains** (a 1.88 language feature). It was originally raised from 1.85 to take `time` 0.3.47 (RUSTSEC-2026-0009); that dependency has since been dropped (rusqlite narrowed to `bundled`), but the let-chain usage keeps the floor at 1.88.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -25,16 +25,18 @@ cargo doc --no-deps --open            # API reference
 ```bash
 cargo fmt --all --check                                                # Format
 cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy (deny warnings)
-cargo build --workspace --all-features                                 # Build
+cargo build --workspace                                                # Build (default features)
+cargo build --workspace --all-features                                 # Build (all features)
 cargo test  --workspace --all-features                                 # Test — --all-features is mandatory, or ann/archive/eval tests never run
-RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
-  cargo doc --no-deps -p memory-engine --all-features                  # Docs — broken/private intra-doc links (core crate only)
+export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
+cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only)
+cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
 The workspace contains **4 crates**: `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can silently break the CLI, MCP, and embed crates if only the root crate is checked. Always use `--workspace`.
 
-**Verification traps** — never pipe a cargo gate through `head`/`tail`/`grep` (truncation + dropped exit code → false green); `clippy --all-features` compiles tests but does not run them; `cargo build` green ≠ tests green for file moves / dark `[[test]]` targets; triage findings against current `main`, not the issue snapshot (a "magic constant" may be an intentional sentinel — `git log -S` first).
+**Verification traps** — never pipe a cargo gate through `head`/`tail` (truncation + dropped exit code → false green; `grep` doesn't truncate but also masks the exit code); `clippy --all-features` compiles tests but does not run them; `cargo build` green ≠ tests green for file moves / dark `[[test]]` targets; triage findings against current `main`, not the issue snapshot (a "magic constant" may be an intentional sentinel — `git log -S` first).
 
 Feature flags: `backend-sqlite` (default, in-process SQLite), `backend-postgres` (`PgBackend` skeleton, gated tests), `ann` (HNSW vector search), `archive` (cold storage .pak files), `compress-gzip`, `compress-zstd`, `test-util` (cross-crate test-only hooks). At least one backend feature must be enabled. There is **no** `async` feature — `tokio` is non-optional (#702).
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@
 
 ## What This Is
 
-Embedded Rust library (edition 2024, Rust 1.85+) providing durable long-term memory for AI agents. Single facade type `MemoryEngine` with 5 primitives: Ingest, Query, Consolidate, Forget, Resolve. Zero LLM/network dependencies — consumers inject intelligence via traits (`EmbeddingProvider`, `SummaryGenerator`, `ConflictArbiter`, `PersistenceClassifier`, `Reranker`).
+Embedded Rust library (edition 2024, **Rust 1.88+** — the workspace uses let-chains) providing durable long-term memory for AI agents. Single facade type `MemoryEngine` (async-native; DB methods are `async fn` over an `Arc<dyn StorageBackend>`, so `tokio` is non-optional) with 5 primitives: Ingest, Query, Consolidate, Forget, Resolve. Zero LLM/network dependencies — consumers inject intelligence via traits (`EmbeddingProvider`, `SummaryGenerator`, `ConflictArbiter`, `PersistenceClassifier`, `Reranker`).
 
 Part of a four-layer cognitive architecture (Knowledge → Memory → Wisdom → Intelligence). This crate is the Memory layer. Companion repos: `knowledge-base` (`~/dev/knowledge-base`, Python MCP server, Knowledge layer), `autonomous-agent-project` (`~/dev/autonomous-agent-project`, research, no code).
 
@@ -13,46 +13,52 @@ Part of a four-layer cognitive architecture (Knowledge → Memory → Wisdom →
 ```bash
 cargo build                           # debug build (root crate only)
 cargo test                            # all tests (root crate only)
-cargo test --all-features             # with async + HNSW + compression
+cargo test --all-features             # with HNSW + archive + compression + test-util
 cargo clippy --all-targets            # lint (pedantic + nursery enabled)
 cargo fmt --check                     # format check
 cargo bench                           # Criterion benchmarks
 cargo doc --no-deps --open            # API reference
 ```
 
-**Workspace verification gate** — run before every commit:
+**Verification gate — the CI contract** (`.github/workflows/ci.yml`); run before every commit. These are the _exact_ commands CI runs. A local pass that diverges — weaker features, narrower scope, or **piped output** — is a **false pass**:
 
 ```bash
-cargo build --workspace               # ALL 3 crates must compile
-cargo test --workspace                # ALL 3 crates' tests must pass
-cargo clippy --workspace --all-targets # ALL 3 crates must lint-clean
+cargo fmt --all --check                                                # Format
+cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy (deny warnings)
+cargo build --workspace --all-features                                 # Build
+cargo test  --workspace --all-features                                 # Test — --all-features is mandatory, or ann/archive/eval tests never run
+RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
+  cargo doc --no-deps -p memory-engine --all-features                  # Docs — broken/private intra-doc links (core crate only)
+cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
-The workspace contains 3 crates: `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`. Changes to `error.rs`, `types.rs`, `traits.rs`, or any public API in the core crate can silently break the CLI and MCP crates if only the root crate is checked. Always use `--workspace`.
+The workspace contains **4 crates**: `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can silently break the CLI, MCP, and embed crates if only the root crate is checked. Always use `--workspace`.
 
-Feature flags: `async` (tokio wrapper), `ann` (HNSW vector search), `archive` (cold storage .pak files), `compress-gzip`, `compress-zstd`.
+**Verification traps** — never pipe a cargo gate through `head`/`tail`/`grep` (truncation + dropped exit code → false green); `clippy --all-features` compiles tests but does not run them; `cargo build` green ≠ tests green for file moves / dark `[[test]]` targets; triage findings against current `main`, not the issue snapshot (a "magic constant" may be an intentional sentinel — `git log -S` first).
+
+Feature flags: `backend-sqlite` (default, in-process SQLite), `backend-postgres` (`PgBackend` skeleton, gated tests), `ann` (HNSW vector search), `archive` (cold storage .pak files), `compress-gzip`, `compress-zstd`, `test-util` (cross-crate test-only hooks). At least one backend feature must be enabled. There is **no** `async` feature — `tokio` is non-optional (#702).
 
 ## Project Structure
 
-Source lives in `src/`. Each module owns its domain:
+Virtual workspace (no root package); crates live under `memory-engine/`. The core library is at **`memory-engine/lib/memory-engine/src/…`**, not `src/…` (the #814 bin/lib reorg). Each module owns its domain:
 
-- `engine.rs` — `MemoryEngine` facade, `EngineConfig`. All public methods take `&self`; thread-safe via `ConnectionPool` + `RwLock`.
-- `types.rs` — Core data types: `Event`, `Fact`, `Edge`, `Summary`, `ScopeNode`, enums, option structs.
+- `engine/` — `MemoryEngine` facade, `EngineConfig`, and bi-temporal conflict resolution (was `engine.rs` + `conflict/`). Async-native; DB methods `.await` an `Arc<dyn StorageBackend>`.
+- `types/` — Core data types: `Event`, `Fact`, `Edge`, `Summary`, `ScopeNode`, enums, option structs (split into submodules).
 - `traits.rs` — Consumer-implemented traits. Engine has zero network/LLM deps.
 - `error.rs` — `MemoryError` enum with `thiserror`. `Result<T>` alias.
-- `store/` — SQLite persistence: schema + migrations, `EventStore`, `FactStore`, `EdgeStore`, `SummaryStore`, `ScopeStore`.
+- `store/` — Original SQLite stores: schema + migrations, `EventStore`, `FactStore`, `EdgeStore`, `SummaryStore`, `ScopeStore`.
+- `storage/` — #628 pluggable `StorageBackend` trait family: `sqlite/` (live) + `postgres/` (skeleton, `backend-postgres`).
 - `search/` — Hybrid retrieval: FTS5 (BM25) + vector (cosine/HNSW) + RRF merge (k=60). `MemoryQuery` fluent builder.
 - `graph/` — `MemoryGraph` (petgraph `DiGraph`), loaded from SQLite on startup.
 - `consolidation/` — 3-pass pipeline: local dedup → cluster fusion → global integration.
 - `forgetting/` — Ebbinghaus decay + multi-signal importance scoring.
-- `conflict/` — Bi-temporal conflict resolution via `ConflictArbiter` trait.
-- `pool/` — `ConnectionPool`: N readers + 1 writer, `parking_lot::Mutex`.
+- `pool/` — `ConnectionPool`: N readers + 1 writer.
 - `scope/` — `ScopeTree` hierarchical cache. Paths like `"user:michael/project:demo"`.
 - `resume/` — 4-tier cognitive boot: pinned → high_importance → due → recent.
 - `bootstrap/` — Parse Claude Code JSONL session logs into historical facts.
 - `inspect/` — Debugging APIs: `explain_fact`, `fact_history`, `replay_events`, `dump_state`, `statistics`.
 
-Tests in `tests/` (6 integration tests), benchmarks in `benches/`, examples in `examples/` (3).
+Sibling crates: `lib/embed/` (`memory-engine-embed` — HTTP embedding + `HttpDeltaProposer`), `bin/cli/`, `bin/mcp/`. Workspace integration tests in `tests/`, benchmarks in `benches/`, examples in `examples/`, fuzz targets in `fuzz/` (detached, nightly).
 
 ## Conventions
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -34,6 +34,8 @@ cargo doc --no-deps -p memory-engine --all-features                    # Docs, a
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
+CI also runs an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it if you touch let-chains or edition-sensitive code.
+
 The workspace contains **4 crates**: `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can silently break the CLI, MCP, and embed crates if only the root crate is checked. Always use `--workspace`.
 
 **Verification traps** — never pipe a cargo gate through `head`/`tail` (truncation + dropped exit code → false green; `grep` doesn't truncate but also masks the exit code); `clippy --all-features` compiles tests but does not run them; `cargo build` green ≠ tests green for file moves / dark `[[test]]` targets; triage findings against current `main`, not the issue snapshot (a "magic constant" may be an intentional sentinel — `git log -S` first).

--- a/utils/scripts/hooks/cargo-gate-guard.sh
+++ b/utils/scripts/hooks/cargo-gate-guard.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# cargo-gate-guard.sh — PreToolUse/Bash guard against false-green cargo gates.
+#
+# Blocks piping a `cargo {test,clippy,build,doc,nextest}` invocation through
+# head/tail. That truncation hides RED results AND the pipe discards cargo's
+# exit code (PIPESTATUS reflects the pager, not cargo) → a FALSE-GREEN gate.
+# This is the #1 recurring super-qa failure class in this repo (see the
+# `qa-sweep` skill, Class 1, trap 1: `head -N` once masked 8 RED insta
+# snapshots; a `tail` + PIPESTATUS capture came back empty).
+#
+# ── WIRING (local only) ──────────────────────────────────────────────────────
+# `.claude/settings.json` is gitignored here, so this hook protects only the
+# local checkout — the committed CLAUDE.md / AGENTS.md / GEMINI.md remain the
+# guardrail that reaches every clone. To activate, add to `.claude/settings.json`
+# (it coexists additively with the global rtk hook):
+#
+#   {
+#     "hooks": {
+#       "PreToolUse": [
+#         { "matcher": "Bash",
+#           "hooks": [
+#             { "type": "command",
+#               "command": "$CLAUDE_PROJECT_DIR/utils/scripts/hooks/cargo-gate-guard.sh" }
+#           ] }
+#       ]
+#     }
+#   }
+#
+# ── PROTOCOL ─────────────────────────────────────────────────────────────────
+# Reads the PreToolUse JSON on stdin; on a match it prints the reason to stderr
+# and exits 2 (the portable "block this tool call" signal). Otherwise exits 0
+# (allow). It never mutates the command.
+
+set -uo pipefail
+
+input="$(cat)"
+
+# Pull the command field. Prefer jq; fall back to a best-effort sed parse so the
+# guard still works on a box without jq.
+if command -v jq >/dev/null 2>&1; then
+	cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+else
+	cmd="$(printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p')"
+fi
+
+[ -z "${cmd:-}" ] && exit 0
+
+# Match a cargo gate subcommand (optionally `cargo +toolchain …`) AND a pipe into
+# head/tail. grep is intentionally NOT blocked — it filters without the same
+# truncation hazard and is used legitimately.
+if printf '%s' "$cmd" | grep -Eq 'cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|clippy|build|doc|nextest)\b' &&
+	printf '%s' "$cmd" | grep -Eq '\|[[:space:]]*(head|tail)\b'; then
+	cat >&2 <<'EOF'
+cargo-gate-guard: refusing to pipe a cargo gate through head/tail.
+
+Truncation hides RED results, and the pipe discards cargo's exit code
+(PIPESTATUS reflects head/tail, not cargo) → a FALSE-GREEN gate.
+
+Run it unpiped, or redirect to a file and read the file:
+  cargo test --workspace --all-features > /tmp/cargo-gate.log 2>&1; tail -40 /tmp/cargo-gate.log
+EOF
+	exit 2
+fi
+
+exit 0

--- a/utils/scripts/hooks/cargo-gate-guard.sh
+++ b/utils/scripts/hooks/cargo-gate-guard.sh
@@ -45,12 +45,35 @@ fi
 
 [ -z "${cmd:-}" ] && exit 0
 
-# Match a cargo gate subcommand (optionally `cargo +toolchain …`) AND a pipe into
-# head/tail. grep is intentionally NOT blocked — it filters without the same
-# truncation hazard and is used legitimately.
-if printf '%s' "$cmd" | grep -Eq 'cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|clippy|build|doc|nextest)\b' &&
-	printf '%s' "$cmd" | grep -Eq '\|[[:space:]]*(head|tail)\b'; then
-	cat >&2 <<'EOF'
+# Best-effort heuristic (NOT a full bash parser). Rather than matching the cargo
+# subcommand and the `| head/tail` independently anywhere in the string — which
+# false-positives on `cargo build && ls | head` and `echo "cargo test | head"`,
+# and is bypassed by `|&` / a newline / a path-prefixed `head` — we split the
+# command into pipeline SEGMENTS on the logical separators `;`, `&&`, `||`, then
+# block only a segment that is BOTH a cargo gate invocation AND pipes into
+# head/tail. This scopes the pipe to its own pipeline and anchors `cargo` to the
+# segment start (after optional `VAR=val` env prefixes), so a quoted literal or a
+# sibling command no longer trips it. grep is intentionally NOT blocked (it does
+# not truncate). Residual, accepted misses: a subshell-wrapped `( cargo test |
+# head )` and an indirected pager like `| stdbuf -oL head`.
+
+# Normalize newlines/tabs to spaces (a newline-separated pipe would dodge a
+# line-oriented grep), then turn logical separators into segment boundaries.
+norm="${cmd//$'\n'/ }"
+norm="${norm//$'\t'/ }"
+norm="${norm//';'/$'\n'}"
+norm="${norm//'&&'/$'\n'}"
+norm="${norm//'||'/$'\n'}"
+
+GATE_RE='^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|clippy|build|doc|nextest)\b'
+# A pipe (`|` or `|&`) into head/tail, allowing a leading path (`/usr/bin/head`).
+PIPE_RE='\|&?[[:space:]]*([^[:space:]|]*/)?(head|tail)\b'
+
+while IFS= read -r seg; do
+	[ -z "$seg" ] && continue
+	printf '%s' "$seg" | grep -Eq "$GATE_RE" || continue
+	if printf '%s' "$seg" | grep -Eq "$PIPE_RE"; then
+		cat >&2 <<'EOF'
 cargo-gate-guard: refusing to pipe a cargo gate through head/tail.
 
 Truncation hides RED results, and the pipe discards cargo's exit code
@@ -59,7 +82,8 @@ Truncation hides RED results, and the pipe discards cargo's exit code
 Run it unpiped, or redirect to a file and read the file:
   cargo test --workspace --all-features > /tmp/cargo-gate.log 2>&1; tail -40 /tmp/cargo-gate.log
 EOF
-	exit 2
-fi
+		exit 2
+	fi
+done <<<"$norm"
 
 exit 0

--- a/utils/scripts/hooks/cargo-gate-guard.sh
+++ b/utils/scripts/hooks/cargo-gate-guard.sh
@@ -55,23 +55,49 @@ fi
 # command into pipeline SEGMENTS on the logical separators `;`, `&&`, `||`, then
 # block only a segment that is BOTH a cargo gate invocation AND pipes into
 # head/tail. This scopes the pipe to its own pipeline and anchors `cargo` to the
-# segment start (after optional `VAR=val` env prefixes), so a quoted literal or a
-# sibling command no longer trips it. grep is intentionally NOT blocked (it does
-# not truncate). Residual, accepted misses: a subshell-wrapped `( cargo test |
-# head )` and an indirected pager like `| stdbuf -oL head`.
+# segment start (after optional `VAR=val` assignments or a bare wrapper like
+# `env`/`command`/`nice`/`time`/`nohup`), so a quoted literal or a sibling command
+# no longer trips it. grep is intentionally NOT blocked (it does not truncate).
+# Residual, accepted misses (it is a heuristic, not a bash parser): a subshell
+# `( cargo test | head )`, an arg-taking wrapper (`timeout 60 cargo … | head`,
+# `stdbuf -oL head`), and full indirection (`sh -c '…' | head`, shell aliases).
+
+# Replace quoted spans with spaces so a separator or pipe INSIDE a quoted argument
+# (e.g. `cargo test --features "a;b" | head`) cannot confuse the split below. Pure
+# bash, no deps; errs toward masking (a false negative is at worst the no-guard
+# baseline). Escaped quotes inside quotes are not tracked — acceptable for a guard.
+mask_quotes() {
+	local s="$1" out="" q="" c i
+	for ((i = 0; i < ${#s}; i++)); do
+		c="${s:i:1}"
+		if [ -z "$q" ]; then
+			case "$c" in '"' | "'") q="$c" out+=" " ;; *) out+="$c" ;; esac
+		elif [ "$c" = "$q" ]; then
+			q="" out+=" "
+		else
+			out+=" "
+		fi
+	done
+	printf '%s' "$out"
+}
 
 # Normalize newlines/tabs to spaces (a newline-separated pipe would dodge a
-# line-oriented grep), then turn logical separators into segment boundaries.
+# line-oriented grep), mask quoted spans, then split on the logical separators.
 norm="${cmd//$'\n'/ }"
 norm="${norm//$'\t'/ }"
+norm="$(mask_quotes "$norm")"
 norm="${norm//';'/$'\n'}"
 norm="${norm//'&&'/$'\n'}"
 norm="${norm//'||'/$'\n'}"
 
-# `([^[:alnum:]_]|$)` is the POSIX-ERE word boundary (`\b` is a GNU/BSD extension,
-# not portable POSIX ERE) — it keeps `build`/`tail` from matching `buildx`/`tailor`.
-GATE_RE='^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|clippy|build|doc|nextest)([^[:alnum:]_]|$)'
+# A cargo gate at the segment start: optional `VAR=val` assignments and/or a bare
+# wrapper (env/command/nice/time/nohup), then `cargo [+toolchain] <gate>`. The gate
+# is closed by whitespace, a pipe, or end — `([[:space:]|]|$)`, NOT a general
+# non-alnum boundary, so a hyphenated subcommand like `build-docs`/`doc-open` is
+# NOT mistaken for the `build`/`doc` gate (`\b` is also a non-POSIX GNU extension).
+GATE_RE='^[[:space:]]*((env|command|nice|time|nohup|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*)[[:space:]]+)*cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|clippy|build|doc|nextest)([[:space:]|]|$)'
 # A pipe (`|` or `|&`) into head/tail, allowing a leading path (`/usr/bin/head`).
+# Over-matching here is safe (it only ever blocks more), so the looser boundary stays.
 PIPE_RE='\|&?[[:space:]]*([^[:space:]|]*/)?(head|tail)([^[:alnum:]_]|$)'
 
 while IFS= read -r seg; do

--- a/utils/scripts/hooks/cargo-gate-guard.sh
+++ b/utils/scripts/hooks/cargo-gate-guard.sh
@@ -40,7 +40,10 @@ input="$(cat)"
 if command -v jq >/dev/null 2>&1; then
 	cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
 else
-	cmd="$(printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p')"
+	# `[^"]*` (not greedy `.*`) stops at the first closing quote of the value, so a
+	# later JSON key cannot bleed into the captured command. A command containing an
+	# escaped quote (`\"`) is the jq path's job; this fallback is best-effort.
+	cmd="$(printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
 fi
 
 [ -z "${cmd:-}" ] && exit 0
@@ -65,9 +68,11 @@ norm="${norm//';'/$'\n'}"
 norm="${norm//'&&'/$'\n'}"
 norm="${norm//'||'/$'\n'}"
 
-GATE_RE='^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|clippy|build|doc|nextest)\b'
+# `([^[:alnum:]_]|$)` is the POSIX-ERE word boundary (`\b` is a GNU/BSD extension,
+# not portable POSIX ERE) — it keeps `build`/`tail` from matching `buildx`/`tailor`.
+GATE_RE='^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|clippy|build|doc|nextest)([^[:alnum:]_]|$)'
 # A pipe (`|` or `|&`) into head/tail, allowing a leading path (`/usr/bin/head`).
-PIPE_RE='\|&?[[:space:]]*([^[:space:]|]*/)?(head|tail)\b'
+PIPE_RE='\|&?[[:space:]]*([^[:space:]|]*/)?(head|tail)([^[:alnum:]_]|$)'
 
 while IFS= read -r seg; do
 	[ -z "$seg" ] && continue


### PR DESCRIPTION
## What & why

A retrospective on the **#248 super-qa epic** (area sweeps #251/#253/#254/#255/#256/#257/#258/#259 + the #739/#879 tail) distilled the recurring rework into **seven failure classes**. This PR turns those lessons into durable guardrails.

The headline finding (the user's "test coverage was lacking" instinct): the **instruction files codified a gate weaker than CI** — `cargo test --workspace` *without* `--all-features`, and no rustdoc intra-doc-link gate. That is precisely the gate that lets `ann`/`archive`/`eval` tests stay dark (56 eval tests were dark for weeks, #903) and doc-links rot (#739).

## Changes

- **`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`** — replace the weak gate with the **CI-exact contract** from `ci.yml`; add a compact **verification-traps** block; fix accumulated drift (Class 7): `Rust 1.85`→`1.88`, `3 crates`→`4`, remove the deleted `async` feature, correct the pre-#814 `src/` layout to the live virtual-workspace tree.
- **`.claude/skills/qa-sweep/SKILL.md`** (new, repo-local) — the full 7-class taxonomy + triage→waves→orchestrate→close-out playbook + build-hygiene & PR-orchestration gotchas, on-demand, so the always-loaded `.md` files stay lean.
- **`utils/scripts/hooks/cargo-gate-guard.sh`** (new) — a PreToolUse/Bash guard blocking `cargo {test,clippy,build,doc} | {head,tail}` (Class 1, trap 1). Logic committed + reviewable; activation lives in the gitignored `.claude/settings.json` (local-only) — the committed `.md` files remain the guardrail that reaches every clone. Verified against 5 block/allow cases.

## Scope / verification

Docs + config only — **zero `.rs` changed**, so the cargo gate is N/A. Markdown fences balanced; new paths confirmed trackable; hook guard unit-tested (exit 2 on dangerous pipes, 0 otherwise).

Cross-repo skill upgrades (`super-qa`/`finish-pr`/`address-issue`) are filed upstream in `dutiona/my-dotfiles`, not forked here.