### PR TITLE
refactor(retrieval): replace stringly-typed Edge.relation_type with RelationType open enum (#114)

### DIFF
--- a/docs/usage/graph-relationships.md
+++ b/docs/usage/graph-relationships.md
@@ -45,7 +45,7 @@ pub struct Edge {
     pub id: i64,
     pub source_fact_id: i64,
     pub target_fact_id: i64,
-    pub relation_type: String,
+    pub relation_type: RelationType,
     pub weight: f64,
     pub t_created: DateTime<Utc>,
     pub t_expired: Option<DateTime<Utc>>,
@@ -59,7 +59,7 @@ For insertion:
 pub struct NewEdge {
     pub source_fact_id: i64,
     pub target_fact_id: i64,
-    pub relation_type: String,
+    pub relation_type: RelationType,
     pub weight: f64,
     pub t_created: DateTime<Utc>,
     pub t_expired: Option<DateTime<Utc>>,
@@ -67,7 +67,7 @@ pub struct NewEdge {
 }
 ```
 
-The `relation_type` is a free-form string. Built-in processes use `"supersedes"` (conflict resolution), `"duplicates"` (consolidation), and `"co_session"` (session co-occurrence), but the schema does not constrain it.
+The `relation_type` is a `RelationType` — an **open enum** with four canonical variants emitted by built-in processes: `CoSession` (session co-occurrence), `Supplements` and `Contradicts` (conflict resolution), and `Supersedes` (conflict resolution + consolidation). Any other label is carried as `RelationType::Custom(String)`, so the set is extensible and the schema (a `TEXT` column) does not constrain it. The type serializes as a **plain string** (e.g. `"co_session"`), so it is byte-compatible on the wire and on disk with the previous free-form `String` field.
 
 ## In-memory edge data
 
@@ -76,7 +76,7 @@ The petgraph edge weight stores a subset of the full edge:
 ```rust
 pub struct EdgeData {
     pub edge_id: i64,
-    pub relation_type: String,
+    pub relation_type: RelationType,
     pub weight: f64,
 }
 ```

--- a/memory-engine/lib/memory-engine/src/archive/types.rs
+++ b/memory-engine/lib/memory-engine/src/archive/types.rs
@@ -290,7 +290,7 @@ mod tests {
                 id in any::<i64>(),
                 source_fact_id in any::<i64>(),
                 target_fact_id in any::<i64>(),
-                relation_type in ".{0,16}",
+                relation_type_str in ".{0,16}",
                 // Discretized weight (n/1000) for the same exact-round-trip reason
                 // as the importance/embedding strategies above. Drawn from `i32` so
                 // `f64::from` is exact (no `cast_precision_loss`).
@@ -303,7 +303,7 @@ mod tests {
                     id,
                     source_fact_id,
                     target_fact_id,
-                    relation_type,
+                    relation_type: crate::types::RelationType::from(relation_type_str.as_str()),
                     weight,
                     t_created: ts_from_secs(t_created_s),
                     t_expired: t_expired_s.map(ts_from_secs),

--- a/memory-engine/lib/memory-engine/src/archive/types.rs
+++ b/memory-engine/lib/memory-engine/src/archive/types.rs
@@ -290,7 +290,17 @@ mod tests {
                 id in any::<i64>(),
                 source_fact_id in any::<i64>(),
                 target_fact_id in any::<i64>(),
-                relation_type_str in ".{0,16}",
+                // Mix the 4 canonical spellings (so the named variants traverse
+                // the .pak round-trip, not just the Custom arm) with the original
+                // bounded arbitrary-string strategy (weighted to keep Custom
+                // well-covered).
+                relation_type_str in prop_oneof![
+                    4 => proptest::string::string_regex(".{0,16}").expect("valid regex"),
+                    1 => Just("co_session".to_string()),
+                    1 => Just("supplements".to_string()),
+                    1 => Just("contradicts".to_string()),
+                    1 => Just("supersedes".to_string()),
+                ],
                 // Discretized weight (n/1000) for the same exact-round-trip reason
                 // as the importance/embedding strategies above. Drawn from `i32` so
                 // `f64::from` is exact (no `cast_precision_loss`).

--- a/memory-engine/lib/memory-engine/src/engine/conflict.rs
+++ b/memory-engine/lib/memory-engine/src/engine/conflict.rs
@@ -3,7 +3,7 @@ use chrono::Utc;
 use crate::error::Result;
 use crate::graph::EdgeData;
 use crate::traits::{ConflictArbiter, ConflictResolution, CrudDecision};
-use crate::types::NewFact;
+use crate::types::{NewFact, RelationType};
 
 use super::MemoryEngine;
 
@@ -147,7 +147,7 @@ impl MemoryEngine {
                             old_id,
                             EdgeData {
                                 edge_id,
-                                relation_type: relation.to_string(),
+                                relation_type: RelationType::from(relation),
                                 weight: Self::CONFLICT_EDGE_WEIGHT,
                             },
                         );
@@ -161,7 +161,7 @@ impl MemoryEngine {
                             old_id,
                             EdgeData {
                                 edge_id,
-                                relation_type: relation.to_string(),
+                                relation_type: RelationType::from(relation),
                                 weight: Self::CONFLICT_EDGE_WEIGHT,
                             },
                         );

--- a/memory-engine/lib/memory-engine/src/engine/cycle/apply.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cycle/apply.rs
@@ -14,11 +14,9 @@
 use crate::engine::MemoryEngine;
 use crate::error::Result;
 use crate::graph::EdgeData;
+use crate::types::RelationType;
 
 use super::report::{ApplyResult, CycleReport};
-
-/// `relation_type` of the in-memory graph edge mirrored for a `CycleDelta::Supersede`.
-const SUPERSEDES_RELATION: &str = "supersedes";
 
 impl MemoryEngine {
     /// Validate and apply a [`CycleReport`] atomically.
@@ -60,7 +58,7 @@ impl MemoryEngine {
                     old_id,
                     EdgeData {
                         edge_id,
-                        relation_type: SUPERSEDES_RELATION.to_owned(),
+                        relation_type: RelationType::Supersedes,
                         weight: 1.0,
                     },
                 );

--- a/memory-engine/lib/memory-engine/src/engine/graph.rs
+++ b/memory-engine/lib/memory-engine/src/engine/graph.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 
 use crate::error::{MemoryError, Result};
 use crate::graph::EdgeData;
+use crate::types::RelationType;
 
 use super::MemoryEngine;
 
@@ -62,7 +63,6 @@ impl MemoryEngine {
         }
 
         let now = Utc::now();
-        let relation = Self::CO_SESSION_RELATION.to_string();
 
         // Batch-dedup + edge inserts run in one transaction below the seam
         // (`insert_cosession_edges_atomic`). The engine resolves `scope_ids`
@@ -88,7 +88,7 @@ impl MemoryEngine {
                     tgt,
                     EdgeData {
                         edge_id,
-                        relation_type: relation.clone(),
+                        relation_type: RelationType::CoSession,
                         weight: Self::CO_SESSION_WEIGHT,
                     },
                 );

--- a/memory-engine/lib/memory-engine/src/engine/graph.rs
+++ b/memory-engine/lib/memory-engine/src/engine/graph.rs
@@ -9,8 +9,11 @@ use super::MemoryEngine;
 impl MemoryEngine {
     // --- Public API: Co-session edge creation ---
 
-    /// Relation type for edges linking facts that co-occur in the same session.
-    const CO_SESSION_RELATION: &str = "co_session";
+    /// Relation type (canonical wire string) for edges linking facts that
+    /// co-occur in the same session. Derived from [`RelationType::CoSession`] so
+    /// the string passed to the storage seam and the variant mirrored into the
+    /// in-memory graph share a single source of truth.
+    const CO_SESSION_RELATION: &str = RelationType::CoSession.as_str();
     /// Default weight for co-session edges — weaker than explicit semantic
     /// relationships by design intent. Note: the current forgetting system uses
     /// raw `graph.degree()` (unweighted), so the weight does not yet reduce

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -1070,7 +1070,7 @@ mod proptest_conflict {
     use super::MemoryEngine;
     use crate::graph::MemoryGraph;
     use crate::traits::{ConflictArbiter, CrudDecision};
-    use crate::types::{Fact, FactType, NewEdge, NewFact};
+    use crate::types::{Fact, FactType, NewEdge, NewFact, RelationType};
 
     const DIM: usize = 4;
 
@@ -1094,7 +1094,7 @@ mod proptest_conflict {
     }
 
     /// Canonical edge key for set-equality comparisons: `(source, target, relation)`.
-    type EdgeKey = (i64, i64, String);
+    type EdgeKey = (i64, i64, RelationType);
 
     /// Enumerate all edges currently held by the in-memory graph as a set of
     /// `(source, target, relation_type)` triples.
@@ -1183,7 +1183,7 @@ mod proptest_conflict {
                         .insert_edge(&NewEdge {
                             source_fact_id: old_id,
                             target_fact_id: side_id,
-                            relation_type: "related".to_string(),
+                            relation_type: "related".into(),
                             weight: 1.0,
                             t_created: now,
                             t_expired: None,

--- a/memory-engine/lib/memory-engine/src/engine/snapshot.rs
+++ b/memory-engine/lib/memory-engine/src/engine/snapshot.rs
@@ -22,7 +22,7 @@ use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{MemoryError, Result};
-use crate::types::ScopeNode;
+use crate::types::{RelationType, ScopeNode};
 
 /// Current snapshot format version. Bump on breaking changes to the snapshot
 /// layout or type definitions.
@@ -173,7 +173,7 @@ pub struct GraphEdgeSnapshot {
     pub edge_id: i64,
     pub source: i64,
     pub target: i64,
-    pub relation_type: String,
+    pub relation_type: RelationType,
     pub weight: f64,
 }
 
@@ -867,9 +867,10 @@ mod tests {
                 edge_id in any::<i64>(),
                 source in any::<i64>(),
                 target in any::<i64>(),
-                relation_type in ".*",
+                relation_type_str in ".*",
                 weight in proptest::num::f64::NORMAL | proptest::num::f64::ZERO,
             ) -> GraphEdgeSnapshot {
+                let relation_type = RelationType::from(relation_type_str.as_str());
                 GraphEdgeSnapshot { edge_id, source, target, relation_type, weight }
             }
         }

--- a/memory-engine/lib/memory-engine/src/engine/snapshot.rs
+++ b/memory-engine/lib/memory-engine/src/engine/snapshot.rs
@@ -867,7 +867,17 @@ mod tests {
                 edge_id in any::<i64>(),
                 source in any::<i64>(),
                 target in any::<i64>(),
-                relation_type_str in ".*",
+                // Mix the 4 canonical spellings (so the named variants traverse
+                // the snapshot round-trip, not just the Custom arm) with the
+                // original arbitrary-string strategy (weighted to keep Custom
+                // well-covered).
+                relation_type_str in prop_oneof![
+                    4 => proptest::string::string_regex(".*").expect("valid regex"),
+                    1 => Just("co_session".to_string()),
+                    1 => Just("supplements".to_string()),
+                    1 => Just("contradicts".to_string()),
+                    1 => Just("supersedes".to_string()),
+                ],
                 weight in proptest::num::f64::NORMAL | proptest::num::f64::ZERO,
             ) -> GraphEdgeSnapshot {
                 let relation_type = RelationType::from(relation_type_str.as_str());

--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -7,6 +7,7 @@ use rusqlite::Connection;
 
 use crate::error::Result;
 use crate::store::edges::EdgeStore;
+use crate::types::RelationType;
 
 /// Hard upper bound on the number of edges accepted from a single snapshot
 /// sidecar (50M).
@@ -46,8 +47,8 @@ fn check_edge_count_bound(count: usize) -> Result<()> {
 pub struct EdgeData {
     /// `SQLite` row id of the edge.
     pub edge_id: i64,
-    /// Relationship label (e.g. "contradicts", "supplements").
-    pub relation_type: String,
+    /// Relationship label (e.g. `"contradicts"`, `"supplements"`).
+    pub relation_type: RelationType,
     /// Numeric weight for the edge.
     pub weight: f64,
 }
@@ -291,7 +292,7 @@ impl MemoryGraph {
                 edge.source_fact_id,
                 edge.target_fact_id,
                 edge.id,
-                &edge.relation_type,
+                edge.relation_type.clone(),
                 edge.weight,
             );
         }
@@ -413,7 +414,7 @@ impl MemoryGraph {
                 edge.source,
                 edge.target,
                 edge.edge_id,
-                &edge.relation_type,
+                edge.relation_type.clone(),
                 edge.weight,
             );
         }
@@ -426,7 +427,7 @@ impl MemoryGraph {
         source: i64,
         target: i64,
         edge_id: i64,
-        relation_type: &str,
+        relation_type: RelationType,
         weight: f64,
     ) {
         self.add_edge(
@@ -434,7 +435,7 @@ impl MemoryGraph {
             target,
             EdgeData {
                 edge_id,
-                relation_type: relation_type.to_owned(),
+                relation_type,
                 weight,
             },
         );
@@ -453,12 +454,12 @@ mod tests {
     use chrono::Utc;
 
     use crate::store::schema::{init_schema, open_memory};
-    use crate::types::NewEdge;
+    use crate::types::{NewEdge, RelationType};
 
     fn make_edge_data(id: i64, rel: &str) -> EdgeData {
         EdgeData {
             edge_id: id,
-            relation_type: rel.to_string(),
+            relation_type: RelationType::from(rel),
             weight: 1.0,
         }
     }
@@ -996,7 +997,7 @@ mod tests {
         let e1 = NewEdge {
             source_fact_id: 1,
             target_fact_id: 2,
-            relation_type: "active".to_string(),
+            relation_type: "active".into(),
             weight: 1.0,
             scope_id: 1,
             t_created: now,
@@ -1005,7 +1006,7 @@ mod tests {
         let e2 = NewEdge {
             source_fact_id: 2,
             target_fact_id: 3,
-            relation_type: "expired".to_string(),
+            relation_type: "expired".into(),
             weight: 1.0,
             scope_id: 1,
             t_created: now,
@@ -1053,7 +1054,7 @@ mod tests {
             .insert(&NewEdge {
                 source_fact_id: 1,
                 target_fact_id: 2,
-                relation_type: "weighted".to_string(),
+                relation_type: "weighted".into(),
                 weight: 0.625,
                 scope_id: 1,
                 t_created: now,
@@ -1085,7 +1086,7 @@ mod tests {
             .insert(&NewEdge {
                 source_fact_id: 1,
                 target_fact_id: 2,
-                relation_type: "first".to_string(),
+                relation_type: "first".into(),
                 weight: 1.0,
                 scope_id: 1,
                 t_created: now,
@@ -1096,7 +1097,7 @@ mod tests {
             .insert(&NewEdge {
                 source_fact_id: 1,
                 target_fact_id: 2,
-                relation_type: "second".to_string(),
+                relation_type: "second".into(),
                 weight: 1.0,
                 scope_id: 1,
                 t_created: now,
@@ -1116,8 +1117,9 @@ mod tests {
         // Both relation types are present, edge_ids distinct.
         let snap = graph.to_snapshot();
         let mut rels: Vec<_> = snap.edges.iter().map(|e| e.relation_type.clone()).collect();
-        rels.sort();
-        assert_eq!(rels, vec!["first".to_string(), "second".to_string()]);
+        rels.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(rels[0], "first");
+        assert_eq!(rels[1], "second");
         let ids: HashSet<i64> = snap.edges.iter().map(|e| e.edge_id).collect();
         assert_eq!(ids.len(), 2);
     }
@@ -1167,7 +1169,7 @@ mod proptests {
                 t,
                 EdgeData {
                     edge_id,
-                    relation_type: "rel".to_string(),
+                    relation_type: "rel".into(),
                     weight: 1.0,
                 },
             );

--- a/memory-engine/lib/memory-engine/src/inspect/restore.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/restore.rs
@@ -400,7 +400,7 @@ fn restore_edges(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
             edge.id,
             edge.source_fact_id,
             edge.target_fact_id,
-            edge.relation_type,
+            edge.relation_type.as_str(),
             edge.weight,
             t_created,
             t_expired,

--- a/memory-engine/lib/memory-engine/src/inspect/statistics.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/statistics.rs
@@ -459,7 +459,7 @@ mod tests {
         let active_edge = |rel: &str| NewEdge {
             source_fact_id: f1,
             target_fact_id: f2,
-            relation_type: rel.to_owned(),
+            relation_type: rel.into(),
             weight: 1.0,
             t_created: chrono::Utc::now(),
             t_expired: None,

--- a/memory-engine/lib/memory-engine/src/lib.rs
+++ b/memory-engine/lib/memory-engine/src/lib.rs
@@ -171,8 +171,8 @@ pub use types::{
     LineageSnapshotEntry, MergeGroup, NewActivity, NewEdge, NewEvent, NewFact, NewFactBuilder,
     NewLineageRecord, NewSummary, Outcome, OutcomeClass, OutcomeCounts, ParseActivityStatusError,
     ProjectContext, PromoteOutcome, PromoteRequest, PromotionProvenance, PromotionResult,
-    RecordActivityRequest, RecordActivityResult, ScopeNode, ScopeQuery, SessionCheckpoint,
-    SessionFact, Summary,
+    RecordActivityRequest, RecordActivityResult, RelationType, ScopeNode, ScopeQuery,
+    SessionCheckpoint, SessionFact, Summary,
 };
 
 // Storage port — tight flat re-export of the umbrella + cross-cutting types only.

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
@@ -186,11 +186,12 @@ impl ConsolidationStore for SqliteBackend {
         use crate::store::facts::FactStore;
         use crate::store::lineage::LineageStore;
         use crate::store::schema::{get_config, set_config};
-        use crate::types::{EventType, NewEdge, NewEvent, NewLineageRecord, PromotionProvenance};
+        use crate::types::{
+            EventType, NewEdge, NewEvent, NewLineageRecord, PromotionProvenance, RelationType,
+        };
 
         // Config keys — local copies of the private consts in engine/cycle/apply.rs.
         const LAST_DREAM_CYCLE_AT: &str = "last_dream_cycle_at";
-        const SUPERSEDES_RELATION: &str = "supersedes";
         const DREAM_CYCLE_HISTORY: &str = "dream_cycle_history";
         const DREAM_CYCLE_HISTORY_MAX: usize = 8;
 
@@ -480,7 +481,7 @@ impl ConsolidationStore for SqliteBackend {
                             let edge_id = EdgeStore::new(&tx).insert(&NewEdge {
                                 source_fact_id: *new_id,
                                 target_fact_id: *old_id,
-                                relation_type: SUPERSEDES_RELATION.to_owned(),
+                                relation_type: RelationType::Supersedes,
                                 weight: 1.0,
                                 t_created: now,
                                 t_expired: None,
@@ -509,7 +510,7 @@ impl ConsolidationStore for SqliteBackend {
                                 let edge_id = EdgeStore::new(&tx).insert(&NewEdge {
                                     source_fact_id: synth_id,
                                     target_fact_id: *src,
-                                    relation_type: SUPERSEDES_RELATION.to_owned(),
+                                    relation_type: RelationType::Supersedes,
                                     weight: 1.0,
                                     t_created: now,
                                     t_expired: None,

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
@@ -25,8 +25,8 @@ use crate::store::edges::EdgeStore;
 use crate::store::facts::FactStore;
 use crate::store::scopes::ScopeStore;
 use crate::types::{
-    Edge, EmbeddingFingerprint, Fact, FactScoringRow, FactType, NewEdge, NewFact, ScopeNode,
-    SessionFact,
+    Edge, EmbeddingFingerprint, Fact, FactScoringRow, FactType, NewEdge, NewFact, RelationType,
+    ScopeNode, SessionFact,
 };
 
 /// `(fact_ids, scope_ids_to_cache, embeddings)` — the result of the batch-insert
@@ -835,7 +835,7 @@ impl FactGraph for SqliteBackend {
                             let edge_id = edge_store.insert(&NewEdge {
                                 source_fact_id: src,
                                 target_fact_id: tgt,
-                                relation_type: relation.clone(),
+                                relation_type: RelationType::from(relation.as_str()),
                                 weight,
                                 scope_id,
                                 t_created: now,
@@ -912,7 +912,7 @@ impl FactGraph for SqliteBackend {
                         let edge_id = EdgeStore::new(&tx).insert(&NewEdge {
                             source_fact_id: new_id,
                             target_fact_id: old_id,
-                            relation_type: relation.clone(),
+                            relation_type: RelationType::from(relation.as_str()),
                             weight,
                             scope_id,
                             t_created: now,
@@ -930,7 +930,7 @@ impl FactGraph for SqliteBackend {
                         let edge_id = EdgeStore::new(&tx).insert(&NewEdge {
                             source_fact_id: new_id,
                             target_fact_id: old_id,
-                            relation_type: relation.clone(),
+                            relation_type: RelationType::from(relation.as_str()),
                             weight,
                             scope_id,
                             t_created: now,

--- a/memory-engine/lib/memory-engine/src/store/edges.rs
+++ b/memory-engine/lib/memory-engine/src/store/edges.rs
@@ -3,7 +3,7 @@ use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
 use crate::store::{parse_optional_timestamp, parse_timestamp};
-use crate::types::{Edge, NewEdge};
+use crate::types::{Edge, NewEdge, RelationType};
 
 /// Store for graph edges with bi-temporal support.
 pub struct EdgeStore<'a> {
@@ -14,11 +14,12 @@ fn row_to_edge(row: &rusqlite::Row<'_>) -> rusqlite::Result<Edge> {
     let t_created_str: String = row.get("t_created")?;
     let t_expired_str: Option<String> = row.get("t_expired")?;
 
+    let relation_type_str: String = row.get("relation_type")?;
     Ok(Edge {
         id: row.get("id")?,
         source_fact_id: row.get("source_fact_id")?,
         target_fact_id: row.get("target_fact_id")?,
-        relation_type: row.get("relation_type")?,
+        relation_type: RelationType::from(relation_type_str),
         weight: row.get("weight")?,
         t_created: parse_timestamp(&t_created_str)?,
         t_expired: parse_optional_timestamp(t_expired_str.as_deref())?,
@@ -46,7 +47,7 @@ impl<'a> EdgeStore<'a> {
             params![
                 edge.source_fact_id,
                 edge.target_fact_id,
-                edge.relation_type,
+                edge.relation_type.as_str(),
                 edge.weight,
                 edge.t_created.to_rfc3339(),
                 edge.t_expired.map(|dt| dt.to_rfc3339()),
@@ -425,7 +426,7 @@ mod tests {
         NewEdge {
             source_fact_id: source,
             target_fact_id: target,
-            relation_type: rel.to_string(),
+            relation_type: rel.into(),
             weight: 1.0,
             t_created: Utc::now(),
             t_expired: None,

--- a/memory-engine/lib/memory-engine/src/types/facts.rs
+++ b/memory-engine/lib/memory-engine/src/types/facts.rs
@@ -5,6 +5,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use super::relation::RelationType;
+
 /// Semantic alias for fact identifiers. Lives in `facts` (a leaf module) so the
 /// provenance/cognitive submodules can both reference it without a module cycle.
 pub type FactId = i64;
@@ -239,7 +241,7 @@ pub struct Edge {
     pub id: i64,
     pub source_fact_id: i64,
     pub target_fact_id: i64,
-    pub relation_type: String,
+    pub relation_type: RelationType,
     pub weight: f64,
     pub t_created: DateTime<Utc>,
     pub t_expired: Option<DateTime<Utc>>,
@@ -565,7 +567,7 @@ impl NewFactBuilder {
 pub struct NewEdge {
     pub source_fact_id: i64,
     pub target_fact_id: i64,
-    pub relation_type: String,
+    pub relation_type: RelationType,
     pub weight: f64,
     pub t_created: DateTime<Utc>,
     pub t_expired: Option<DateTime<Utc>>,

--- a/memory-engine/lib/memory-engine/src/types/mod.rs
+++ b/memory-engine/lib/memory-engine/src/types/mod.rs
@@ -5,6 +5,7 @@ mod cognitive;
 mod events;
 mod facts;
 mod provenance;
+mod relation;
 mod scope;
 
 pub use activity::*;
@@ -12,4 +13,5 @@ pub use cognitive::*;
 pub use events::*;
 pub use facts::*;
 pub use provenance::*;
+pub use relation::*;
 pub use scope::*;

--- a/memory-engine/lib/memory-engine/src/types/relation.rs
+++ b/memory-engine/lib/memory-engine/src/types/relation.rs
@@ -109,10 +109,18 @@ impl From<&str> for RelationType {
 impl From<String> for RelationType {
     /// Infallible, canonicalizing construction from an owned `String`.
     ///
-    /// Delegates to [`From<&str>`] so the canonical-variant logic lives in
-    /// exactly one place.
+    /// Matches on the borrowed slice and reuses the owned `String` for the
+    /// [`Custom`](RelationType::Custom) arm, avoiding the redundant allocation a
+    /// delegation to `From<&str>` would incur. The canonical set is kept in sync
+    /// with `From<&str>` and [`as_str`](RelationType::as_str).
     fn from(s: String) -> Self {
-        Self::from(s.as_str())
+        match s.as_str() {
+            "co_session" => Self::CoSession,
+            "supplements" => Self::Supplements,
+            "contradicts" => Self::Contradicts,
+            "supersedes" => Self::Supersedes,
+            _ => Self::Custom(s),
+        }
     }
 }
 

--- a/memory-engine/lib/memory-engine/src/types/relation.rs
+++ b/memory-engine/lib/memory-engine/src/types/relation.rs
@@ -1,0 +1,378 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Typed edge-relation label for the knowledge graph.
+///
+/// An **open enum**: the four canonical well-known relation types are represented
+/// as variants for exhaustive pattern matching and zero-cost equality; any other
+/// label is carried transparently as [`RelationType::Custom`].
+///
+/// ## Construction (canonical, infallible)
+///
+/// Use [`From<&str>`] / [`From<String>`]: both are **canonicalizing**, meaning
+/// the four known spellings always produce their named variant — never
+/// `Custom("co_session")`. Unknown strings become `Custom`.
+///
+/// ```
+/// use memory_engine::RelationType;
+///
+/// assert_eq!(RelationType::from("co_session"), RelationType::CoSession);
+/// assert_eq!(RelationType::from("supplements"), RelationType::Supplements);
+/// assert_eq!(RelationType::from("contradicts"), RelationType::Contradicts);
+/// assert_eq!(RelationType::from("supersedes"),  RelationType::Supersedes);
+/// assert_eq!(RelationType::from("my_custom"),   RelationType::Custom("my_custom".into()));
+/// ```
+///
+/// ## Wire format (byte-identical to `String`)
+///
+/// Serializes as a **plain JSON string** via
+/// `#[serde(into = "String", from = "String")]`, preserving byte-for-byte
+/// compatibility with the old `relation_type: String` field in every
+/// JSON/MessagePack payload (`GraphEdgeSnapshot`, archive `.pak` files,
+/// `EngineSnapshot`).
+///
+/// ## Comparison
+///
+/// `PartialEq<&str>` and `PartialEq<str>` are implemented so call sites that
+/// compare `edge.relation_type == "supersedes"` continue to compile without
+/// churn.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(into = "String", from = "String")]
+pub enum RelationType {
+    /// Edges linking facts that co-occur in the same session.
+    /// On-wire string: `"co_session"`.
+    CoSession,
+    /// An edge indicating one fact supplements (adds to / coexists with) another.
+    /// On-wire string: `"supplements"`.
+    Supplements,
+    /// An edge indicating one fact contradicts another.
+    /// On-wire string: `"contradicts"`.
+    Contradicts,
+    /// An edge indicating one fact supersedes (replaces) another.
+    /// On-wire string: `"supersedes"`.
+    Supersedes,
+    /// Any other relation label not covered by the four canonical variants.
+    Custom(String),
+}
+
+impl RelationType {
+    /// Return the canonical on-wire string for this relation type.
+    ///
+    /// This is the single source of truth for the enum → string mapping. `Display`
+    /// delegates here so `format!("{}", rt)` and `rt.to_string()` both emit the
+    /// wire-format string.
+    #[must_use]
+    pub const fn as_str(&self) -> &str {
+        match self {
+            Self::CoSession => "co_session",
+            Self::Supplements => "supplements",
+            Self::Contradicts => "contradicts",
+            Self::Supersedes => "supersedes",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for RelationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for RelationType {
+    /// Infallible, canonicalizing construction from a string slice.
+    ///
+    /// The four canonical spellings map to their named variants; everything else
+    /// becomes [`RelationType::Custom`]. Case-sensitive: the canonical spellings are
+    /// lowercase snake\_case as stored on-disk.
+    fn from(s: &str) -> Self {
+        match s {
+            "co_session" => Self::CoSession,
+            "supplements" => Self::Supplements,
+            "contradicts" => Self::Contradicts,
+            "supersedes" => Self::Supersedes,
+            other => Self::Custom(other.to_owned()),
+        }
+    }
+}
+
+impl From<String> for RelationType {
+    /// Infallible, canonicalizing construction from an owned `String`.
+    ///
+    /// Delegates to [`From<&str>`] so the canonical-variant logic lives in
+    /// exactly one place.
+    fn from(s: String) -> Self {
+        Self::from(s.as_str())
+    }
+}
+
+impl From<RelationType> for String {
+    /// Convert to the canonical on-wire string.
+    ///
+    /// Required by `#[serde(into = "String")]`. Delegates to [`RelationType::as_str`].
+    fn from(rt: RelationType) -> Self {
+        rt.as_str().to_owned()
+    }
+}
+
+impl FromStr for RelationType {
+    type Err = std::convert::Infallible;
+
+    /// Infallible parse — delegates to [`From<&str>`].
+    ///
+    /// Satisfies generic bounds that require `str::parse::<RelationType>()`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s))
+    }
+}
+
+// --- PartialEq<&str> / PartialEq<str> for minimal churn at comparison sites ---
+
+impl PartialEq<&str> for RelationType {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<str> for RelationType {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<RelationType> for &str {
+    fn eq(&self, other: &RelationType) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<RelationType> for str {
+    fn eq(&self, other: &RelationType) -> bool {
+        self == other.as_str()
+    }
+}
+
+// --- String PartialEq convenience ---
+
+impl PartialEq<String> for RelationType {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<RelationType> for String {
+    fn eq(&self, other: &RelationType) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Canonical round-trip invariant ---
+
+    #[test]
+    fn canonical_variants_round_trip_through_from_str() {
+        for (input, expected) in [
+            ("co_session", RelationType::CoSession),
+            ("supplements", RelationType::Supplements),
+            ("contradicts", RelationType::Contradicts),
+            ("supersedes", RelationType::Supersedes),
+        ] {
+            let got = RelationType::from(input);
+            assert_eq!(
+                got, expected,
+                "canonical string '{input}' must produce its named variant"
+            );
+            // Reverse: the variant's as_str() must reproduce the canonical string.
+            assert_eq!(
+                got.as_str(),
+                input,
+                "as_str() of {expected:?} must equal '{input}'"
+            );
+            // Display matches as_str().
+            assert_eq!(
+                got.to_string(),
+                input,
+                "Display of {expected:?} must equal '{input}'"
+            );
+        }
+    }
+
+    #[test]
+    fn from_string_owned_matches_from_str() {
+        for s in [
+            "co_session",
+            "supplements",
+            "contradicts",
+            "supersedes",
+            "custom_rel",
+        ] {
+            assert_eq!(
+                RelationType::from(s.to_owned()),
+                RelationType::from(s),
+                "From<String> must agree with From<&str> for '{s}'"
+            );
+        }
+    }
+
+    // --- Custom round-trip ---
+
+    #[test]
+    fn custom_round_trips() {
+        let input = "my_arbitrary_relation";
+        let rt = RelationType::from(input);
+        assert!(
+            matches!(&rt, RelationType::Custom(s) if s == input),
+            "unknown string must produce Custom variant"
+        );
+        assert_eq!(
+            rt.as_str(),
+            input,
+            "Custom::as_str must return the inner string"
+        );
+        assert_eq!(rt.to_string(), input);
+        // Round-trip: from(rt.to_string()) must reproduce the original value.
+        assert_eq!(RelationType::from(rt.to_string()), rt);
+    }
+
+    #[test]
+    fn empty_string_becomes_custom() {
+        let rt = RelationType::from("");
+        assert!(
+            matches!(&rt, RelationType::Custom(s) if s.is_empty()),
+            "empty string must become Custom(\"\"), not a canonical variant"
+        );
+        assert_eq!(rt.as_str(), "");
+    }
+
+    // --- Canonicalization: known strings NEVER produce Custom ---
+
+    #[test]
+    fn known_strings_never_produce_custom() {
+        for s in ["co_session", "supplements", "contradicts", "supersedes"] {
+            let rt = RelationType::from(s);
+            assert!(
+                !matches!(rt, RelationType::Custom(_)),
+                "canonical string '{s}' must not produce Custom — it must canonicalize to its variant"
+            );
+        }
+    }
+
+    #[test]
+    fn case_mismatch_becomes_custom() {
+        // Construction is case-sensitive: non-canonical casing → Custom.
+        for s in ["Co_Session", "SUPPLEMENTS", "Contradicts", "Supersedes"] {
+            let rt = RelationType::from(s);
+            assert!(
+                matches!(rt, RelationType::Custom(_)),
+                "non-canonical casing '{s}' must produce Custom, not a named variant"
+            );
+        }
+    }
+
+    // --- PartialEq<&str> ---
+
+    #[test]
+    fn partial_eq_str_matches_as_str() {
+        assert_eq!(RelationType::CoSession, "co_session");
+        assert_eq!(RelationType::Supplements, "supplements");
+        assert_eq!(RelationType::Contradicts, "contradicts");
+        assert_eq!(RelationType::Supersedes, "supersedes");
+        assert_eq!(RelationType::Custom("foo".into()), "foo");
+
+        assert_ne!(RelationType::CoSession, "supplements");
+        assert_ne!(RelationType::Custom("bar".into()), "baz");
+    }
+
+    #[test]
+    fn partial_eq_reflexive_for_str_lhs() {
+        // PartialEq<RelationType> for &str
+        assert!("co_session" == RelationType::CoSession);
+        assert!("supersedes" == RelationType::Supersedes);
+        assert!("other" != RelationType::CoSession);
+    }
+
+    // --- Serde: plain-string wire format ---
+
+    #[test]
+    fn serde_serializes_to_plain_string() {
+        // The serde representation must be a plain JSON string, NOT a tagged enum.
+        assert_eq!(
+            serde_json::to_string(&RelationType::CoSession).unwrap(),
+            "\"co_session\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RelationType::Supplements).unwrap(),
+            "\"supplements\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RelationType::Contradicts).unwrap(),
+            "\"contradicts\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RelationType::Supersedes).unwrap(),
+            "\"supersedes\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RelationType::Custom("my_rel".into())).unwrap(),
+            "\"my_rel\""
+        );
+    }
+
+    #[test]
+    fn serde_deserializes_from_plain_string() {
+        assert_eq!(
+            serde_json::from_str::<RelationType>("\"co_session\"").unwrap(),
+            RelationType::CoSession
+        );
+        assert_eq!(
+            serde_json::from_str::<RelationType>("\"supplements\"").unwrap(),
+            RelationType::Supplements
+        );
+        assert_eq!(
+            serde_json::from_str::<RelationType>("\"custom_rel\"").unwrap(),
+            RelationType::Custom("custom_rel".into())
+        );
+    }
+
+    #[test]
+    fn serde_roundtrip_canonical_and_custom() {
+        for rt in [
+            RelationType::CoSession,
+            RelationType::Supplements,
+            RelationType::Contradicts,
+            RelationType::Supersedes,
+            RelationType::Custom("arbitrary".into()),
+            RelationType::Custom(String::new()),
+        ] {
+            let json = serde_json::to_string(&rt).unwrap();
+            let back: RelationType = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, rt, "serde round-trip must be identity for {rt:?}");
+        }
+    }
+
+    // --- FromStr (Infallible) ---
+
+    #[test]
+    fn from_str_infallible_delegates_to_from() {
+        let rt: RelationType = "co_session".parse().unwrap();
+        assert_eq!(rt, RelationType::CoSession);
+
+        let rt: RelationType = "unknown_rel".parse().unwrap();
+        assert_eq!(rt, RelationType::Custom("unknown_rel".into()));
+    }
+
+    // --- From<RelationType> for String ---
+
+    #[test]
+    fn into_string_returns_wire_form() {
+        let s: String = RelationType::CoSession.into();
+        assert_eq!(s, "co_session");
+        let s: String = RelationType::Custom("x".into()).into();
+        assert_eq!(s, "x");
+    }
+}

--- a/memory-engine/lib/memory-engine/src/types/relation.rs
+++ b/memory-engine/lib/memory-engine/src/types/relation.rs
@@ -27,18 +27,26 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Wire format (byte-identical to `String`)
 ///
-/// Serializes as a **plain JSON string** via
+/// Serializes as a **plain string** via
 /// `#[serde(into = "String", from = "String")]`, preserving byte-for-byte
-/// compatibility with the old `relation_type: String` field in every
-/// JSON/MessagePack payload (`GraphEdgeSnapshot`, archive `.pak` files,
-/// `EngineSnapshot`).
+/// compatibility with the old `relation_type: String` field across every
+/// payload — a JSON string in JSON payloads (`EngineSnapshot` dumps and archive
+/// `.pak` files, which are zstd-compressed JSON) and a `MessagePack` string in
+/// the `MessagePack` snapshot sidecar (`GraphEdgeSnapshot`).
 ///
-/// ## Comparison
+/// ## Equality
 ///
-/// `PartialEq<&str>` and `PartialEq<str>` are implemented so call sites that
+/// Equality is **semantic**, not structural: two values are equal iff their
+/// canonical [`as_str`](RelationType::as_str) spelling matches. `PartialEq`,
+/// `Eq` and `Hash` are hand-written (not derived) so the redundant
+/// representation `Custom("co_session")` compares and hashes equal to
+/// `CoSession`. Without this, structural equality would break the
+/// `deserialize(serialize(x)) == x` round-trip law (deserialize folds
+/// `Custom("co_session")` back to `CoSession`) and defeat `HashSet` dedup.
+/// `PartialEq<&str>` / `PartialEq<str>` are also provided so call sites that
 /// compare `edge.relation_type == "supersedes"` continue to compile without
 /// churn.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(into = "String", from = "String")]
 pub enum RelationType {
     /// Edges linking facts that co-occur in the same session.
@@ -125,6 +133,30 @@ impl FromStr for RelationType {
     /// Satisfies generic bounds that require `str::parse::<RelationType>()`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self::from(s))
+    }
+}
+
+// --- Semantic equality (hand-written, not derived) ---
+//
+// Two relation types are equal iff their canonical on-wire string (`as_str`)
+// matches. The canonicalizing `From` admits a redundant representation —
+// `Custom("co_session")` means the same as `CoSession` — and structural
+// equality would treat those as distinct, breaking the
+// `deserialize(serialize(x)) == x` round-trip (deserialize folds the redundant
+// form back to the variant) and `HashSet` dedup. `Hash` delegates to the same
+// `as_str` key so the `Eq`/`Hash` contract (`a == b ⇒ hash(a) == hash(b)`) holds.
+
+impl PartialEq for RelationType {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for RelationType {}
+
+impl std::hash::Hash for RelationType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
     }
 }
 
@@ -294,6 +326,57 @@ mod tests {
         assert!("co_session" == RelationType::CoSession);
         assert!("supersedes" == RelationType::Supersedes);
         assert!("other" != RelationType::CoSession);
+    }
+
+    // --- Semantic self-equality: redundant Custom(canonical) == named variant ---
+
+    #[test]
+    fn custom_canonical_equals_named_variant_and_dedups() {
+        let pairs = [
+            (
+                RelationType::Custom("co_session".into()),
+                RelationType::CoSession,
+            ),
+            (
+                RelationType::Custom("supplements".into()),
+                RelationType::Supplements,
+            ),
+            (
+                RelationType::Custom("contradicts".into()),
+                RelationType::Contradicts,
+            ),
+            (
+                RelationType::Custom("supersedes".into()),
+                RelationType::Supersedes,
+            ),
+        ];
+        for (custom, named) in pairs {
+            assert_eq!(
+                custom, named,
+                "Custom(canonical) must equal the named variant"
+            );
+            // Eq/Hash contract: equal values must hash equally.
+            let mut h1 = std::collections::hash_map::DefaultHasher::new();
+            let mut h2 = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(&custom, &mut h1);
+            std::hash::Hash::hash(&named, &mut h2);
+            assert_eq!(
+                std::hash::Hasher::finish(&h1),
+                std::hash::Hasher::finish(&h2),
+                "equal RelationType values must hash equally"
+            );
+            // HashSet collapses the redundant representation into one.
+            let set: std::collections::HashSet<RelationType> =
+                [custom.clone(), named.clone()].into_iter().collect();
+            assert_eq!(set.len(), 1, "redundant representations must dedup to one");
+        }
+        // The serialize -> deserialize round-trip is identity under == even for
+        // the redundant representation (deserialize canonicalizes it).
+        let custom = RelationType::Custom("supersedes".into());
+        let json = serde_json::to_string(&custom).unwrap();
+        let back: RelationType = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, custom);
+        assert_eq!(back, RelationType::Supersedes);
     }
 
     // --- Serde: plain-string wire format ---


### PR DESCRIPTION
## Summary

Closes #114 (super-qa: `Edge.relation_type` is stringly-typed). Replaces the bare `relation_type: String` with a typed **open enum** `RelationType`:

```rust
pub enum RelationType { CoSession, Supplements, Contradicts, Supersedes, Custom(String) }
```

The four canonical relations used across the codebase (`co_session`, `supplements`, `contradicts`, `supersedes`) become first-class variants; any other label is carried in `Custom(String)`, so the set stays extensible.

### Design

- **Canonicalizing, infallible construction** — `From<&str>`/`From<String>` map the four known spellings to their variants (never `Custom("co_session")`) and everything else to `Custom`. `FromStr` is provided with `Err = Infallible` for generic bounds.
- **Byte-identical wire format** — `#[serde(into = "String", from = "String")]` serializes as a *plain string*, so JSON (dumps, archive `.pak`), MessagePack (snapshot sidecar), and the SQLite/Postgres `TEXT` columns are all unchanged on disk. Verified empirically (a throwaway round-trip test during review) across every path including `Custom`, empty, and the canonical strings.
- **Semantic equality** — `PartialEq`/`Eq`/`Hash` are hand-written to delegate to `as_str()` (not derived), so the redundant `Custom("co_session")` compares and hashes equal to `CoSession`. This keeps `deserialize(serialize(x)) == x` total and `HashSet` dedup correct (the proportionate form of `http::Method`'s unconstructable-illegal-state pattern).
- **`PartialEq<&str>`** keeps test assertions (`edge.relation_type == "supersedes"`) churn-free.

### Boundary policy

Domain + in-memory + wire structs carry `RelationType` (`Edge`, `NewEdge`, `GraphEdgeSnapshot`, `EdgeData`). The **storage trait + SQL stay `&str`/TEXT** — the persisted form — converting only at the seam (`row_to_edge` reads via `From`, inserts bind `.as_str()`). Both backends' SQL is untouched.

## Review

Two independent adversarial reviews (agy/Gemini 3.1 Pro + a 4-lens refute-by-default workflow: wire-fidelity / semantic-equality / completeness / test-adequacy). Outcome:
- **Confirmed & fixed:** the structural-vs-semantic equality gap (above); a stale `docs/usage/graph-relationships.md` (struct snippets + a non-existent `"duplicates"` relation); proptest generators that never hit the canonical variants (now mixed in via `prop_oneof!`); a two-source-of-truth for the co-session label (now derived from `RelationType::CoSession.as_str()`).
- **Verified clean / refuted:** no wire or on-disk byte divergence on any path; equality/dedup outcomes unchanged for all canonically-constructed values; no missed production consumer.

## Verification

All CI gates green: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo build --workspace` (default + `--all-features`), `cargo test --workspace --all-features`, and `cargo doc --no-deps -p memory-engine` (default + `--all-features`) with the broken/private intra-doc-link denies.