### PR TITLE
test(core): shared test_utils + FK-pragma fix; dedup test helpers (#485, #120)

### DIFF
--- a/memory-engine/lib/memory-engine/src/consolidation/cluster.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/cluster.rs
@@ -244,21 +244,6 @@ mod tests {
         }
     }
 
-    /// Mock embedder returning a fixed-dimension constant vector.
-    struct MockEmbedder {
-        embed_dim: usize,
-    }
-
-    impl EmbeddingProvider for MockEmbedder {
-        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![0.5; self.embed_dim])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", self.embed_dim)
-        }
-    }
-
     fn insert_fact(conn: &Connection, dim: usize, content: &str, embedding: Vec<f32>) -> i64 {
         let store = FactStore::new(conn, dim);
         store
@@ -299,7 +284,7 @@ mod tests {
         insert_fact(&conn, dim, "c2c", vec![0.03, 0.97, 0.0, 0.0]);
 
         let mock_gen = MockGenerator;
-        let mock_embed = MockEmbedder { embed_dim: dim };
+        let mock_embed = crate::test_utils::MockEmbedder::new(dim);
         let clusters = cluster(&conn, &mock_gen, &mock_embed, dim, 3, 0.85).unwrap();
         assert_eq!(clusters, 2);
 
@@ -320,7 +305,7 @@ mod tests {
         insert_fact(&conn, dim, "b", vec![0.99, 0.01, 0.0, 0.0]);
 
         let mock_gen = MockGenerator;
-        let mock_embed = MockEmbedder { embed_dim: dim };
+        let mock_embed = crate::test_utils::MockEmbedder::new(dim);
         let clusters = cluster(&conn, &mock_gen, &mock_embed, dim, 3, 0.85).unwrap();
         assert_eq!(clusters, 0);
     }
@@ -336,7 +321,7 @@ mod tests {
         insert_fact(&conn, dim, "gamma", vec![0.98, 0.02, 0.0, 0.0]);
 
         let mock_gen = MockGenerator;
-        let mock_embed = MockEmbedder { embed_dim: dim };
+        let mock_embed = crate::test_utils::MockEmbedder::new(dim);
         cluster(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
 
         let summaries = SummaryStore::new(&conn, dim)
@@ -358,7 +343,7 @@ mod tests {
         insert_fact(&conn, dim, "z", vec![0.98, 0.02, 0.0, 0.0]);
 
         let mock_gen = MockGenerator;
-        let mock_embed = MockEmbedder { embed_dim: dim };
+        let mock_embed = crate::test_utils::MockEmbedder::new(dim);
 
         // Run twice — should have exactly the same result
         cluster(&conn, &mock_gen, &mock_embed, dim, 2, 0.85).unwrap();
@@ -389,7 +374,7 @@ mod tests {
         let made = cluster(
             &loose,
             &MockGenerator,
-            &MockEmbedder { embed_dim: dim },
+            &crate::test_utils::MockEmbedder::new(dim),
             dim,
             2,
             0.85,
@@ -405,7 +390,7 @@ mod tests {
         let made = cluster(
             &strict,
             &MockGenerator,
-            &MockEmbedder { embed_dim: dim },
+            &crate::test_utils::MockEmbedder::new(dim),
             dim,
             2,
             0.95,
@@ -551,7 +536,7 @@ mod tests {
         cluster(
             conn,
             &MockGenerator,
-            &MockEmbedder { embed_dim: dim },
+            &crate::test_utils::MockEmbedder::new(dim),
             dim,
             2,
             0.85,

--- a/memory-engine/lib/memory-engine/src/consolidation/global.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/global.rs
@@ -135,21 +135,6 @@ mod tests {
         }
     }
 
-    /// Mock embedder returning a fixed-dimension constant vector.
-    struct MockEmbedder {
-        embed_dim: usize,
-    }
-
-    impl EmbeddingProvider for MockEmbedder {
-        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![0.5; self.embed_dim])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", self.embed_dim)
-        }
-    }
-
     #[test]
     fn global_integration_summarizes_clusters() {
         let conn = open_memory().unwrap();
@@ -172,7 +157,7 @@ mod tests {
         }
 
         let mock_gen = MockGenerator;
-        let mock_embed = MockEmbedder { embed_dim: dim };
+        let mock_embed = crate::test_utils::MockEmbedder::new(dim);
         let count =
             global_integration(&conn, &mock_gen, &mock_embed, dim, chrono::Utc::now()).unwrap();
         assert_eq!(count, 1);
@@ -194,7 +179,7 @@ mod tests {
         let dim = 4;
 
         let mock_gen = MockGenerator;
-        let mock_embed = MockEmbedder { embed_dim: dim };
+        let mock_embed = crate::test_utils::MockEmbedder::new(dim);
         let count =
             global_integration(&conn, &mock_gen, &mock_embed, dim, chrono::Utc::now()).unwrap();
         assert_eq!(count, 0);
@@ -219,7 +204,7 @@ mod tests {
             .unwrap();
 
         let mock_gen = MockGenerator;
-        let mock_embed = MockEmbedder { embed_dim: dim };
+        let mock_embed = crate::test_utils::MockEmbedder::new(dim);
 
         // Run twice
         global_integration(&conn, &mock_gen, &mock_embed, dim, chrono::Utc::now()).unwrap();

--- a/memory-engine/lib/memory-engine/src/consolidation/mod.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/mod.rs
@@ -462,19 +462,6 @@ mod tests {
         }
     }
 
-    /// Mock embedder returning a fixed-dimension constant vector.
-    struct MockEmbedder;
-
-    impl EmbeddingProvider for MockEmbedder {
-        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![0.5; DIM])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", DIM)
-        }
-    }
-
     /// Insert an active fact, returning its id.
     fn insert_fact(conn: &Connection, content: &str, embedding: Vec<f32>, importance: f64) -> i64 {
         let store = FactStore::new(conn, DIM);
@@ -515,7 +502,7 @@ mod tests {
         let (stats, expired) = consolidate(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -554,7 +541,14 @@ mod tests {
             min_cluster_size: 0,
             ..Default::default()
         };
-        let err = consolidate(&conn, &MockGenerator, &MockEmbedder, DIM, &bad).unwrap_err();
+        let err = consolidate(
+            &conn,
+            &MockGenerator,
+            &crate::test_utils::MockEmbedder::new(DIM),
+            DIM,
+            &bad,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("min_cluster_size"),
             "error should name the offending parameter, got: {err}"
@@ -586,7 +580,7 @@ mod tests {
         let (stats, expired) = consolidate(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -628,7 +622,7 @@ mod tests {
         let (stats, _) = consolidate(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -667,7 +661,7 @@ mod tests {
         let (stats, _) = consolidate(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -679,7 +673,7 @@ mod tests {
 
         assert_eq!(
             crate::store::embedding_meta::load(&conn).unwrap(),
-            Some(MockEmbedder.fingerprint()),
+            Some(crate::test_utils::MockEmbedder::new(DIM).fingerprint()),
             "a summary-writing consolidation records the embedder's fingerprint"
         );
     }
@@ -697,7 +691,7 @@ mod tests {
         consolidate(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -732,7 +726,7 @@ mod tests {
         let (stats, expired) = consolidate(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -757,7 +751,7 @@ mod tests {
         let err = consolidate(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -789,7 +783,7 @@ mod tests {
         let err = consolidate(
             &conn,
             &FailingGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -836,7 +830,7 @@ mod tests {
         let (stats, expired) = consolidate(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
         )
@@ -873,7 +867,7 @@ mod tests {
         let (stats, expired) = consolidate_with_caps(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
             1,
@@ -935,7 +929,7 @@ mod tests {
         let (stats, expired) = consolidate_with_caps(
             &conn,
             &MockGenerator,
-            &MockEmbedder,
+            &crate::test_utils::MockEmbedder::new(DIM),
             DIM,
             &ConsolidationConfig::default(),
             1,
@@ -975,7 +969,14 @@ mod tests {
 
         let config = ConsolidationConfig::default();
         let snapshot = load_snapshot(&conn, DIM, &config).unwrap();
-        let plan = compute_plan(&snapshot, &MockGenerator, &MockEmbedder, DIM, &config).unwrap();
+        let plan = compute_plan(
+            &snapshot,
+            &MockGenerator,
+            &crate::test_utils::MockEmbedder::new(DIM),
+            DIM,
+            &config,
+        )
+        .unwrap();
         assert_eq!(
             plan.dedup.expirations.len(),
             1,
@@ -1015,7 +1016,14 @@ mod tests {
 
         let config = ConsolidationConfig::default();
         let snapshot = load_snapshot(&conn, DIM, &config).unwrap();
-        let plan = compute_plan(&snapshot, &MockGenerator, &MockEmbedder, DIM, &config).unwrap();
+        let plan = compute_plan(
+            &snapshot,
+            &MockGenerator,
+            &crate::test_utils::MockEmbedder::new(DIM),
+            DIM,
+            &config,
+        )
+        .unwrap();
         assert_eq!(plan.dedup.expirations.len(), 1);
         let survivor = plan.dedup.expirations[0].survivor;
         let loser = plan.dedup.expirations[0].loser;
@@ -1073,7 +1081,14 @@ mod tests {
 
         let config = ConsolidationConfig::default();
         let snapshot = load_snapshot(&conn, DIM, &config).unwrap();
-        let plan = compute_plan(&snapshot, &MockGenerator, &MockEmbedder, DIM, &config).unwrap();
+        let plan = compute_plan(
+            &snapshot,
+            &MockGenerator,
+            &crate::test_utils::MockEmbedder::new(DIM),
+            DIM,
+            &config,
+        )
+        .unwrap();
         let survivor = plan.dedup.expirations[0].survivor;
 
         // Concurrently expire the survivor → the plan's summary view is now stale.

--- a/memory-engine/lib/memory-engine/src/engine/cognitive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cognitive.rs
@@ -467,19 +467,7 @@ mod tests {
 
     /// Helper: add source facts so that lineage validation passes.
     async fn add_source_facts(engine: &MemoryEngine, ids: &[i64]) -> Vec<i64> {
-        use crate::traits::EmbeddingProvider;
         use crate::types::AddFactRequest;
-
-        struct FixedEmbed;
-        impl EmbeddingProvider for FixedEmbed {
-            fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-                Ok(vec![0.1, 0.2, 0.3, 0.4])
-            }
-
-            fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-                crate::types::EmbeddingFingerprint::new("mock", "test", 4)
-            }
-        }
 
         let mut actual_ids = Vec::new();
         for _ in ids {
@@ -494,7 +482,8 @@ mod tests {
                 engine
                     .add_fact(
                         &req,
-                        std::sync::Arc::new(FixedEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                        std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                            as std::sync::Arc<dyn crate::traits::EmbeddingProvider>,
                         None,
                     )
                     .await

--- a/memory-engine/lib/memory-engine/src/engine/cycle/apply.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cycle/apply.rs
@@ -81,23 +81,13 @@ mod tests {
 
     const DIM: usize = 4;
 
-    struct FixedEmbed;
-    impl EmbeddingProvider for FixedEmbed {
-        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![0.1, 0.2, 0.3, 0.4])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
-        }
-    }
-
     async fn engine() -> MemoryEngine {
         let engine = MemoryEngine::builder(DIM).build().unwrap();
         // Stamp the embedding identity so apply tests can apply pre-computed-vector
         // deltas (AddFact/Synthesize) — #613 requires a recorded identity for those.
         // This mirrors production, where facts (and thus the identity) exist before a
-        // cycle runs. Same fingerprint FixedEmbed records, so a later `add()` is a no-op.
+        // cycle runs. Same fingerprint MockEmbedder::fixed4() records, so a later
+        // `add()` is a no-op.
         engine
             .storage()
             .store_embedding_fingerprint(&crate::types::EmbeddingFingerprint::new(
@@ -119,7 +109,8 @@ mod tests {
         engine
             .add_fact(
                 &req,
-                std::sync::Arc::new(FixedEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await

--- a/memory-engine/lib/memory-engine/src/engine/cycle/default_impl.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cycle/default_impl.rs
@@ -275,20 +275,9 @@ mod tests {
     use super::*;
     use crate::engine::MemoryEngine;
     use crate::traits::EmbeddingProvider;
-    use crate::types::{AddFactOptions, AddFactRequest, EmbeddingFingerprint, FactType, Outcome};
+    use crate::types::{AddFactOptions, AddFactRequest, FactType, Outcome};
 
     const DIM: usize = 4;
-
-    struct FixedEmbed;
-    impl EmbeddingProvider for FixedEmbed {
-        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![1.0, 0.0, 0.0, 0.0])
-        }
-
-        fn fingerprint(&self) -> EmbeddingFingerprint {
-            EmbeddingFingerprint::new("mock", "test", 4)
-        }
-    }
 
     async fn add(engine: &MemoryEngine, content: &str, ft: FactType, importance: f64) -> i64 {
         let req = AddFactRequest {
@@ -304,7 +293,8 @@ mod tests {
         engine
             .add_fact(
                 &req,
-                std::sync::Arc::new(FixedEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await

--- a/memory-engine/lib/memory-engine/src/engine/cycle/llm_impl.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cycle/llm_impl.rs
@@ -206,17 +206,6 @@ mod tests {
 
     const DIM: usize = 4;
 
-    /// Returns a fixed-dimension embedding; `dim` lets a test force a mismatch.
-    struct FixedEmbed(usize);
-    impl EmbeddingProvider for FixedEmbed {
-        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![0.1; self.0])
-        }
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", self.0)
-        }
-    }
-
     /// A proposer that returns a canned set of merge groups, ignoring its inputs.
     struct FakeProposer {
         merges: Vec<MergeGroup>,
@@ -248,7 +237,8 @@ mod tests {
         engine
             .add_fact(
                 &req,
-                std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -291,7 +281,8 @@ mod tests {
         };
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>,
         );
 
         let report = engine.run_dream_cycle(&llm).await.unwrap();
@@ -320,7 +311,8 @@ mod tests {
         };
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>,
         );
 
         let report = engine.run_dream_cycle(&llm).await.unwrap();
@@ -369,7 +361,8 @@ mod tests {
         };
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>,
         );
 
         let report = engine.run_dream_cycle(&llm).await.unwrap();
@@ -389,7 +382,8 @@ mod tests {
         };
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>,
         );
 
         let report = engine.run_dream_cycle(&llm).await.unwrap();
@@ -409,7 +403,8 @@ mod tests {
         let proposer = FakeProposer { merges: vec![] };
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>,
         );
 
         let report = engine.run_dream_cycle(&llm).await.unwrap();
@@ -429,10 +424,10 @@ mod tests {
         let proposer = FakeProposer {
             merges: vec![merge(vec![s1, s2], "merged")],
         };
-        let bad_embedder = FixedEmbed(DIM + 4); // wrong dimension
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(bad_embedder) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM + 4, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>, // wrong dimension
         );
 
         let report = engine.run_dream_cycle(&llm).await.unwrap(); // run itself can't know engine dim
@@ -451,7 +446,8 @@ mod tests {
         };
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>,
         );
 
         let first = engine.run_dream_cycle(&llm).await.unwrap();
@@ -480,7 +476,8 @@ mod tests {
         };
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>,
         );
 
         let report = engine.run_dream_cycle(&llm).await.unwrap();
@@ -514,7 +511,8 @@ mod tests {
         };
         let llm = LlmDreamCycle::new(
             std::sync::Arc::new(proposer) as std::sync::Arc<dyn DeltaProposer>,
-            std::sync::Arc::new(FixedEmbed(DIM)) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::constant(DIM, 0.1))
+                as std::sync::Arc<dyn EmbeddingProvider>,
         );
 
         let report = engine.run_dream_cycle(&llm).await.unwrap();

--- a/memory-engine/lib/memory-engine/src/engine/dormant.rs
+++ b/memory-engine/lib/memory-engine/src/engine/dormant.rs
@@ -77,6 +77,8 @@ mod tests {
     use crate::traits::EmbeddingProvider;
     use crate::types::{AddFactRequest, FactType};
 
+    // kept: purpose-built - caller supplies the exact embedding vector so tests can
+    // control per-fact importance-weighted distances precisely. Not a generic double.
     struct FixedEmbedder(Vec<f32>);
     impl EmbeddingProvider for FixedEmbedder {
         fn embed(&self, _text: &str) -> Result<Vec<f32>> {

--- a/memory-engine/lib/memory-engine/src/engine/ingest.rs
+++ b/memory-engine/lib/memory-engine/src/engine/ingest.rs
@@ -505,17 +505,6 @@ mod tests {
 
     const DIM: usize = 4;
 
-    struct FakeEmbed;
-    impl EmbeddingProvider for FakeEmbed {
-        fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![0.1, 0.2, 0.3, 0.4])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
-        }
-    }
-
     /// An oversized event payload is rejected by `ingest` before it touches the
     /// write path.
     #[tokio::test]
@@ -562,7 +551,8 @@ mod tests {
         let err = engine
             .add_fact(
                 &req,
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -590,7 +580,8 @@ mod tests {
             engine
                 .add_fact(
                     &ok_req,
-                    std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                    std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                        as std::sync::Arc<dyn EmbeddingProvider>,
                     None
                 )
                 .await
@@ -613,7 +604,8 @@ mod tests {
         let err = engine
             .add_fact(
                 &req,
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -650,7 +642,8 @@ mod tests {
         let results = engine
             .add_facts_batch_partial(
                 &entries,
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -688,7 +681,8 @@ mod tests {
         let results = engine
             .add_facts_batch_partial(
                 &entries,
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await

--- a/memory-engine/lib/memory-engine/src/engine/lineage.rs
+++ b/memory-engine/lib/memory-engine/src/engine/lineage.rs
@@ -98,21 +98,10 @@ mod tests {
         }
     }
 
-    /// Minimal embedder for testing — returns a fixed-dimension vector.
-    struct FixedEmbedder;
-    impl crate::traits::EmbeddingProvider for FixedEmbedder {
-        fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
-            Ok(vec![0.1, 0.2, 0.3, 0.4])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
-        }
-    }
-
     async fn engine_with_facts() -> MemoryEngine {
         let engine = MemoryEngine::builder(4).build().unwrap();
-        let embedder: std::sync::Arc<dyn EmbeddingProvider> = std::sync::Arc::new(FixedEmbedder);
+        let embedder: std::sync::Arc<dyn EmbeddingProvider> =
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4());
 
         // Insert wisdom fact (id=1)
         engine

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -900,6 +900,8 @@ mod proptest_temporal {
     use super::{fact_overlaps_period, passes_temporal_cutoff};
     use crate::types::{Fact, FactType};
 
+    // kept: returns `Fact` (not `NewFact`), takes t_valid/t_invalid — bi-temporal
+    // test fixture; semantics differ entirely from test_utils::new_fact*.
     /// Build a `Fact` carrying only the valid-time fields the helpers read;
     /// every other field is an inert placeholder.
     fn make_fact(t_valid: Option<DateTime<Utc>>, t_invalid: Option<DateTime<Utc>>) -> Fact {
@@ -1070,7 +1072,7 @@ mod proptest_conflict {
     use super::MemoryEngine;
     use crate::graph::MemoryGraph;
     use crate::traits::{ConflictArbiter, CrudDecision};
-    use crate::types::{Fact, FactType, NewEdge, NewFact, RelationType};
+    use crate::types::{Fact, NewEdge, NewFact, RelationType};
 
     const DIM: usize = 4;
 
@@ -1088,9 +1090,8 @@ mod proptest_conflict {
 
     /// Build a `NewFact` with a distinct content string and a fixed embedding.
     fn make_fact(content: &str) -> NewFact {
-        NewFact::builder(content, vec![0.5_f32; DIM], FactType::Semantic)
-            .content_hash(blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string())
-            .build()
+        // kept: single-arg wrapper (embedding fixed to vec![0.5; DIM] using local DIM const)
+        crate::test_utils::new_fact_hashed(content, vec![0.5_f32; DIM])
     }
 
     /// Canonical edge key for set-equality comparisons: `(source, target, relation)`.

--- a/memory-engine/lib/memory-engine/src/engine/reconstruct.rs
+++ b/memory-engine/lib/memory-engine/src/engine/reconstruct.rs
@@ -288,7 +288,10 @@ mod tests {
     const DIM: usize = 4;
     const SPACE: &str = "shadow";
 
-    /// A constant-vector embedder — the backfill *mechanism* (windowing,
+    // kept: distinct fingerprint model "recon-test" (vs "mock") - reconstruct tests
+    // deliberately use a different model name to probe the fingerprint-swap path.
+    // vec![0.5; dim] output matches MockEmbedder::new(dim) but the fingerprint diverges.
+    /// A constant-vector embedder -- the backfill *mechanism* (windowing,
     /// resumability, idempotency) is what these tests exercise; vector content is
     /// irrelevant here (T4 uses a distinguishable embedder for the promote swap).
     struct ConstEmbedder {
@@ -432,8 +435,10 @@ mod tests {
 
     // --- reconstruct() end-to-end (#623 T4) ---
 
+    // kept: purpose-built - parameterized model slug + value so reconstruction tests
+    // can assert that old vs new identities and vectors are observably different.
     /// A distinguishable embedder: every text maps to the constant `[value; dim]`,
-    /// and a unique `model` slug — so old vs new vectors AND identities are
+    /// and a unique `model` slug -- so old vs new vectors AND identities are
     /// observably different across a reconstruction.
     struct TagEmbedder {
         model: &'static str,
@@ -656,6 +661,8 @@ mod tests {
         // actually returns wider vectors must be rejected before its blobs reach
         // `fact_vectors` — otherwise the promote copy-swaps corruption straight into
         // `facts.embedding` (the same-dim guard only checks the declared dim).
+        // kept: purpose-built - tests that declared dim != actual output dim is
+        // rejected. MockEmbedder always returns consistent dim; this intentionally lies.
         struct LyingEmbedder {
             declared: usize,
             actual: usize,

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -15,20 +15,6 @@ use crate::types::{
 
 const DIM: usize = 4;
 
-struct MockEmbedder {
-    dim: usize,
-}
-
-impl EmbeddingProvider for MockEmbedder {
-    fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-        Ok(vec![0.5; self.dim])
-    }
-
-    fn fingerprint(&self) -> EmbeddingFingerprint {
-        EmbeddingFingerprint::new("mock", "test", self.dim)
-    }
-}
-
 /// Keyword-driven embedder that maps a small fixed vocabulary to orthogonal
 /// basis vectors in a 4-dimensional space (issue #453).
 ///
@@ -198,7 +184,7 @@ async fn ingest_returns_event_id() {
 async fn add_fact_returns_fact_id() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let id = engine
         .add_fact(
             &AddFactRequest {
@@ -220,7 +206,7 @@ async fn add_fact_returns_fact_id() {
 async fn query_returns_results_after_adding_facts() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -363,7 +349,7 @@ async fn embed_dim_validation_rejects_mismatch() {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(MockEmbedder { dim: 768 })
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::new(768))
                     as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
@@ -408,7 +394,7 @@ async fn first_add_fact_records_embedding_meta() {
         "no identity before any write"
     );
 
-    let expected = MockEmbedder { dim: DIM }.fingerprint();
+    let expected = crate::test_utils::MockEmbedder::new(DIM).fingerprint();
     let req = |c: &str| AddFactRequest {
         content: c.into(),
         fact_type: FactType::Semantic,
@@ -419,7 +405,8 @@ async fn first_add_fact_records_embedding_meta() {
     engine
         .add_fact(
             &req("a"),
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             None,
         )
         .await
@@ -470,13 +457,13 @@ async fn verify_embedding_identity_enforces_match() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     // Fresh store has no identity yet -> any same-dim provider is compatible.
     engine
-        .verify_embedding_identity(&MockEmbedder { dim: DIM })
+        .verify_embedding_identity(&crate::test_utils::MockEmbedder::new(DIM))
         .await
         .expect("fresh store compatible with any same-dim provider");
     // ...but a wrong-dim provider still fails fast on a fresh store (would otherwise
     // fail on every later write/query).
     let dim_err = engine
-        .verify_embedding_identity(&MockEmbedder { dim: DIM + 1 })
+        .verify_embedding_identity(&crate::test_utils::MockEmbedder::new(DIM + 1))
         .await
         .expect_err("wrong-dim provider must fail the eager check on a fresh store");
     assert!(
@@ -495,7 +482,8 @@ async fn verify_embedding_identity_enforces_match() {
     engine
         .add_fact(
             &req,
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             None,
         )
         .await
@@ -503,7 +491,7 @@ async fn verify_embedding_identity_enforces_match() {
 
     // Matching provider -> Ok; differing provider -> EmbeddingModelMismatch.
     engine
-        .verify_embedding_identity(&MockEmbedder { dim: DIM })
+        .verify_embedding_identity(&crate::test_utils::MockEmbedder::new(DIM))
         .await
         .expect("matching provider passes the eager check");
     let err = engine
@@ -583,7 +571,8 @@ async fn noop_bootstrap_does_not_stamp_identity() {
     let report = engine
         .bootstrap_session(
             std::io::Cursor::new(""),
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             std::sync::Arc::new(crate::KeywordExtractor)
                 as std::sync::Arc<dyn crate::bootstrap::SessionExtractor>,
             &crate::BootstrapConfig::default(),
@@ -624,7 +613,8 @@ async fn noop_bootstrap_then_real_write_records_real_embedder() {
     engine
         .bootstrap_session(
             std::io::Cursor::new(""),
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             std::sync::Arc::new(crate::KeywordExtractor)
                 as std::sync::Arc<dyn crate::bootstrap::SessionExtractor>,
             &crate::BootstrapConfig::default(),
@@ -675,7 +665,8 @@ async fn bootstrap_creating_facts_stamps_identity() {
     let report = engine
         .bootstrap_session(
             std::io::Cursor::new(fixture),
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             std::sync::Arc::new(crate::KeywordExtractor)
                 as std::sync::Arc<dyn crate::bootstrap::SessionExtractor>,
             &crate::BootstrapConfig::default(),
@@ -686,7 +677,7 @@ async fn bootstrap_creating_facts_stamps_identity() {
     assert!(report.facts_created > 0, "fixture should create facts");
     assert_eq!(
         engine.storage().load_embedding_fingerprint().await.unwrap(),
-        Some(MockEmbedder { dim: DIM }.fingerprint()),
+        Some(crate::test_utils::MockEmbedder::new(DIM).fingerprint()),
         "a fact-creating bootstrap records the embedder's fingerprint"
     );
 }
@@ -701,7 +692,8 @@ async fn noop_bootstrap_directory_does_not_stamp_identity() {
     let report = engine
         .bootstrap_directory(
             dir.path(),
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             std::sync::Arc::new(crate::KeywordExtractor)
                 as std::sync::Arc<dyn crate::bootstrap::SessionExtractor>,
             &crate::BootstrapConfig::default(),
@@ -735,7 +727,8 @@ async fn bootstrap_directory_creating_facts_stamps_identity() {
     let report = engine
         .bootstrap_directory(
             dir.path(),
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             std::sync::Arc::new(crate::KeywordExtractor)
                 as std::sync::Arc<dyn crate::bootstrap::SessionExtractor>,
             &crate::BootstrapConfig::default(),
@@ -746,7 +739,7 @@ async fn bootstrap_directory_creating_facts_stamps_identity() {
     assert!(report.facts_created > 0, "fixture should create facts");
     assert_eq!(
         engine.storage().load_embedding_fingerprint().await.unwrap(),
-        Some(MockEmbedder { dim: DIM }.fingerprint()),
+        Some(crate::test_utils::MockEmbedder::new(DIM).fingerprint()),
         "a fact-creating directory bootstrap records the embedder's fingerprint"
     );
 }
@@ -764,7 +757,8 @@ async fn memory_directory_stamps_identity_even_when_empty() {
     engine
         .bootstrap_memory_directory(
             dir.path(),
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             &crate::BootstrapConfig::default(),
             None,
         )
@@ -772,7 +766,7 @@ async fn memory_directory_stamps_identity_even_when_empty() {
         .unwrap();
     assert_eq!(
         engine.storage().load_embedding_fingerprint().await.unwrap(),
-        Some(MockEmbedder { dim: DIM }.fingerprint()),
+        Some(crate::test_utils::MockEmbedder::new(DIM).fingerprint()),
         "memory-directory import is meta-first: it stamps even with no files"
     );
 }
@@ -841,7 +835,8 @@ async fn consolidate_deduplicates_similar_facts() {
     let stats = engine
         .consolidate(
             std::sync::Arc::new(MockGen) as std::sync::Arc<dyn SummaryGenerator>,
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             &config,
         )
         .await
@@ -874,7 +869,8 @@ async fn consolidate_is_idempotent() {
     let _stats1 = engine
         .consolidate(
             std::sync::Arc::new(MockGen) as std::sync::Arc<dyn SummaryGenerator>,
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             &config,
         )
         .await
@@ -882,7 +878,8 @@ async fn consolidate_is_idempotent() {
     let stats2 = engine
         .consolidate(
             std::sync::Arc::new(MockGen) as std::sync::Arc<dyn SummaryGenerator>,
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             &config,
         )
         .await
@@ -955,7 +952,8 @@ async fn consolidate_runs_consumer_callbacks_without_holding_write_lock() {
     let stats = engine
         .consolidate(
             std::sync::Arc::new(generator) as std::sync::Arc<dyn SummaryGenerator>,
-            std::sync::Arc::new(MockEmbedder { dim: DIM }) as std::sync::Arc<dyn EmbeddingProvider>,
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
+                as std::sync::Arc<dyn EmbeddingProvider>,
             &config,
         )
         .await
@@ -1451,7 +1449,7 @@ async fn list_summaries_empty() {
 async fn add_fact_with_custom_importance() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let opts = AddFactOptions {
         base_importance: Some(0.9),
         ..Default::default()
@@ -1478,7 +1476,7 @@ async fn add_fact_with_custom_importance() {
 async fn add_fact_with_temporal_bounds() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let now = Utc::now();
     let opts = AddFactOptions {
         t_valid: Some(now - chrono::Duration::hours(1)),
@@ -1508,7 +1506,7 @@ async fn add_fact_with_temporal_bounds() {
 async fn add_fact_with_scope_path() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let id = engine
         .add_fact(
             &AddFactRequest {
@@ -1531,7 +1529,7 @@ async fn add_fact_with_scope_path() {
 async fn add_fact_none_opts_uses_defaults() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let id = engine
         .add_fact(
             &AddFactRequest {
@@ -1566,7 +1564,7 @@ async fn engine_concurrent_reads() {
 
     let engine = std::sync::Arc::new(MemoryEngine::builder(DIM).path(db_path).build().unwrap());
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -1635,7 +1633,7 @@ async fn engine_write_then_read_across_threads() {
     let e_w = engine.clone();
     let writer = tokio::spawn(async move {
         let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-            std::sync::Arc::new(MockEmbedder { dim: DIM });
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
         e_w.add_fact(
             &AddFactRequest {
                 content: "Concurrent write test".into(),
@@ -1694,7 +1692,7 @@ async fn resume_empty_engine() {
 async fn resume_with_facts() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     // Add a pinned fact (appears in tier 1)
     let opts_pinned = AddFactOptions {
@@ -1789,7 +1787,7 @@ fn resume_config_default_now_is_none() {
 async fn resume_stamps_surfaced_at_on_pinned_due_fact() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let now = Utc::now();
     let past = now - chrono::Duration::hours(1);
 
@@ -1837,7 +1835,7 @@ async fn resume_stamps_surfaced_at_on_pinned_due_fact() {
 async fn resume_stamps_surfaced_at_on_high_importance_due_fact() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let now = Utc::now();
     let past = now - chrono::Duration::hours(1);
 
@@ -1885,7 +1883,7 @@ async fn resume_stamps_surfaced_at_on_high_importance_due_fact() {
 async fn resume_does_not_stamp_invalidated_pinned_due_fact() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let now = Utc::now();
     let past = now - chrono::Duration::hours(2);
     let past_invalid = now - chrono::Duration::hours(1);
@@ -1946,7 +1944,7 @@ async fn resume_does_not_stamp_invalidated_pinned_due_fact() {
 async fn resume_surfaced_at_is_idempotent() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let now = Utc::now();
     let past = now - chrono::Duration::hours(1);
     let later = now + chrono::Duration::hours(2);
@@ -2008,7 +2006,7 @@ async fn resume_surfaced_at_is_idempotent() {
 async fn list_due_surfaced_at_is_idempotent() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let now = Utc::now();
     let past = now - chrono::Duration::hours(1);
     let later = now + chrono::Duration::hours(2);
@@ -2073,7 +2071,7 @@ async fn list_due_surfaced_at_is_idempotent() {
 async fn resume_with_existing_scope_path_excludes_sibling_scope() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     // Two sibling scopes under a common parent: project/alpha and project/beta.
     let alpha_id = engine.ensure_scope_path("project/alpha").await.unwrap();
@@ -2174,7 +2172,7 @@ async fn query_nonexistent_scope_returns_empty() {
 
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     // Add a fact at root scope so there's something to find if search were unscoped
     engine
@@ -2210,7 +2208,7 @@ async fn query_nonexistent_scope_returns_empty() {
 async fn list_due_returns_scheduled_facts() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let past = Utc::now() - chrono::Duration::hours(1);
     let future = Utc::now() + chrono::Duration::hours(1);
 
@@ -2297,7 +2295,7 @@ async fn list_due_returns_scheduled_facts() {
 async fn pin_unpin_fact() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let id = engine
         .add_fact(
             &AddFactRequest {
@@ -2324,7 +2322,7 @@ async fn pin_unpin_fact() {
 async fn add_fact_with_explicit_pin() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let opts = AddFactOptions {
         pinned: Some(true),
         ..Default::default()
@@ -2357,7 +2355,7 @@ async fn add_fact_with_classifier() {
 
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let classifier: std::sync::Arc<dyn PersistenceClassifier> = std::sync::Arc::new(PinSemantic);
 
     let id = engine
@@ -2404,7 +2402,7 @@ async fn explicit_pin_overrides_classifier() {
 
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let classifier = AlwaysPin;
 
     // Explicitly set pinned=false — should override the classifier
@@ -2435,7 +2433,7 @@ async fn explicit_pin_overrides_classifier() {
 async fn execute_query_empty_returns_active_facts() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -2482,7 +2480,7 @@ async fn execute_query_empty_returns_active_facts() {
 async fn execute_query_text_search() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -2526,7 +2524,7 @@ async fn execute_query_text_search() {
 async fn execute_query_scope_only() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     // Add fact to "project:demo" scope (auto-created by add_fact)
     engine
@@ -2581,7 +2579,7 @@ async fn execute_query_scope_only() {
 async fn execute_query_subtree_multi_segment_scope() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     engine
         .add_fact(
@@ -2632,7 +2630,7 @@ async fn execute_query_subtree_multi_segment_scope() {
 async fn execute_query_fact_type_filter() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -2680,7 +2678,7 @@ async fn execute_query_fact_type_filter() {
 async fn execute_query_importance_threshold() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let opts_low = AddFactOptions {
         base_importance: Some(0.1),
@@ -2732,7 +2730,7 @@ async fn execute_query_importance_threshold() {
 async fn execute_query_pinned_only() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let id = engine
         .add_fact(
@@ -2779,7 +2777,7 @@ async fn execute_query_pinned_only() {
 async fn execute_query_future_dated_excluded() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     // Regular fact
     engine
@@ -2870,7 +2868,7 @@ async fn execute_query_search_mode_conflict() {
 async fn execute_query_search_mode_inference() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -2900,7 +2898,7 @@ async fn execute_query_search_mode_inference() {
 async fn execute_query_period_filter() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let now = Utc::now();
 
     // Fact valid in the past
@@ -2959,7 +2957,7 @@ async fn execute_query_period_filter() {
 async fn execute_query_composed_filters() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let opts_high = AddFactOptions {
         base_importance: Some(0.9),
@@ -3039,7 +3037,7 @@ async fn execute_query_empty_results() {
 async fn execute_query_default_limit() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     // Add 60 facts (over the default limit of 50)
     for i in 0..60 {
@@ -3123,7 +3121,7 @@ impl Reranker for SpyReranker {
 async fn reranker_none_results_unchanged() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -3168,7 +3166,7 @@ async fn reranker_reverses_order() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -3253,7 +3251,7 @@ async fn reranker_skipped_for_vector_only_no_text() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -3300,7 +3298,7 @@ async fn reranker_applies_to_fts_only_mode() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -3347,7 +3345,7 @@ async fn reranker_applies_to_vector_mode_with_text() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -3400,7 +3398,7 @@ async fn rerank_depth_overfetches_then_truncates() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     // Insert 10 facts
     for i in 0..10 {
@@ -3462,7 +3460,7 @@ async fn reranker_error_propagates() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -3518,7 +3516,7 @@ async fn debug_output_includes_reranker() {
 async fn rerank_depth_none_falls_back_to_limit() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     for i in 0..10 {
         engine
@@ -3554,7 +3552,7 @@ async fn rerank_depth_none_falls_back_to_limit() {
 /// Helper: ingest an event with a `session_id` and add a fact linked to it.
 async fn add_session_fact(engine: &MemoryEngine, content: &str, session_id: &str) -> (i64, i64) {
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let event = NewEvent {
         timestamp: Utc::now(),
         event_type: EventType::Interaction,
@@ -3783,7 +3781,7 @@ async fn add_scoped_session_fact(
     scope_path: &str,
 ) -> (i64, i64) {
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let event = NewEvent {
         timestamp: Utc::now(),
         event_type: EventType::Interaction,
@@ -3919,7 +3917,7 @@ async fn reranker_rejects_out_of_bounds_index() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -3961,7 +3959,7 @@ async fn reranker_rejects_duplicates() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -4018,7 +4016,7 @@ async fn reranker_allows_valid_subset() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -4082,7 +4080,7 @@ async fn reranker_allows_filtering_subset() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -4145,7 +4143,7 @@ async fn reranker_rejects_non_finite_score() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -4211,7 +4209,7 @@ async fn reranker_rejects_output_too_long() {
         .build()
         .unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     engine
         .add_fact(
             &AddFactRequest {
@@ -4285,7 +4283,7 @@ async fn embed_batch_default_impl_loops_embed() {
 
 #[tokio::test]
 async fn embed_batch_empty_returns_empty() {
-    let embedder = MockEmbedder { dim: DIM };
+    let embedder = crate::test_utils::MockEmbedder::new(DIM);
     let result = embedder.embed_batch(&[]).unwrap();
     assert!(result.is_empty());
 }
@@ -4294,7 +4292,7 @@ async fn embed_batch_empty_returns_empty() {
 async fn add_facts_batch_inserts_all_facts() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let entries: Vec<AddFactRequest> = (0..5)
         .map(|i| AddFactRequest {
@@ -4328,7 +4326,7 @@ async fn add_facts_batch_inserts_all_facts() {
 async fn add_facts_batch_empty_returns_empty() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let ids = engine
         .add_facts_batch(&[], embedder.clone(), None)
@@ -4341,7 +4339,7 @@ async fn add_facts_batch_empty_returns_empty() {
 async fn add_facts_batch_with_scopes() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let entries = vec![
         AddFactRequest {
@@ -4392,7 +4390,7 @@ async fn add_facts_batch_with_classifier() {
 
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
     let classifier = AlwaysPin;
 
     let entries = vec![AddFactRequest {
@@ -4441,7 +4439,7 @@ async fn add_facts_batch_classifier_interleaved_slots_align() {
 
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     // The classifier-decided slots (None) are deliberately NON-palindromic in
     // their verdicts (slots 0/2/4 → pin/skip/skip), so a mis-ordered stitch
@@ -4636,7 +4634,7 @@ async fn add_facts_batch_rollback_on_insert_failure() {
         scope: Some("rollback/scope-a".into()),
         opts: None,
     }];
-    let good_embedder = MockEmbedder { dim: DIM };
+    let good_embedder = crate::test_utils::MockEmbedder::new(DIM);
     let ids = engine
         .add_facts_batch(
             &good_entries,
@@ -4656,7 +4654,7 @@ async fn add_facts_batch_rollback_on_insert_failure() {
 async fn add_facts_batch_temporal_consistency() {
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let entries: Vec<AddFactRequest> = (0..3)
         .map(|i| AddFactRequest {
@@ -5084,7 +5082,7 @@ async fn builder_embed_dim_mismatch_is_rejected() {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(MockEmbedder { dim: DIM })
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM))
                     as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
@@ -5115,7 +5113,7 @@ async fn add_fact_invalid_scope_path_returns_scope_label_conflict() {
     // typed `Conflict(ScopeLabel)` — not a generic Database/Internal error.
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let err = engine
         .add_fact(
@@ -5183,7 +5181,7 @@ async fn add_fact_rejects_out_of_range_importance() {
     // still succeeds.
     let engine = MemoryEngine::builder(DIM).build().unwrap();
     let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-        std::sync::Arc::new(MockEmbedder { dim: DIM });
+        std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
 
     let request = |importance: f64| AddFactRequest {
         content: format!("importance = {importance}"),
@@ -5326,7 +5324,7 @@ mod snapshot_integration {
     }
 
     async fn add_test_fact(engine: &MemoryEngine, content: &str) -> i64 {
-        let embedder = MockEmbedder { dim: DIM };
+        let embedder = crate::test_utils::MockEmbedder::new(DIM);
         engine
             .add_fact(
                 &AddFactRequest {
@@ -5516,7 +5514,7 @@ mod snapshot_integration {
         // dimension-independent accessors keep working.
         let engine = MemoryEngine::builder(DIM).build().unwrap();
         let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-            std::sync::Arc::new(MockEmbedder { dim: DIM });
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
         let req = |content: &str| AddFactRequest {
             content: content.into(),
             fact_type: FactType::Semantic,
@@ -5587,13 +5585,13 @@ mod snapshot_integration {
                 MemoryEngine::open_from_config(&EngineConfig::new(db_path.clone(), DIM), None)
                     .unwrap();
             let old: std::sync::Arc<dyn EmbeddingProvider> =
-                std::sync::Arc::new(MockEmbedder { dim: DIM });
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
             for c in ["alpha", "beta", "gamma"] {
                 ids.push(engine.add_fact(&req(c), old.clone(), None).await.unwrap());
             }
 
             let new_provider: std::sync::Arc<dyn EmbeddingProvider> =
-                std::sync::Arc::new(MockEmbedder { dim: D2 });
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::new(D2));
             let new_fp = EmbeddingFingerprint::new("mock", "test", D2);
             let outcome = engine.reconstruct(&new_fp, &new_provider).await.unwrap();
             assert_eq!(outcome.promoted, 3);
@@ -5660,7 +5658,7 @@ mod snapshot_integration {
     async fn fence_covers_representative_gated_surface() {
         let engine = MemoryEngine::builder(DIM).build().unwrap();
         let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-            std::sync::Arc::new(MockEmbedder { dim: DIM });
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
         let req = |content: &str| AddFactRequest {
             content: content.into(),
             fact_type: FactType::Semantic,
@@ -5729,7 +5727,7 @@ mod expired_probe_e2e {
     /// FTS5, so the expired probe's `MATCH` query can find it) and return its id.
     async fn add_indexed_fact(engine: &MemoryEngine, content: &str) -> i64 {
         let embedder: std::sync::Arc<dyn EmbeddingProvider> =
-            std::sync::Arc::new(MockEmbedder { dim: DIM });
+            std::sync::Arc::new(crate::test_utils::MockEmbedder::new(DIM));
         engine
             .add_fact(
                 &AddFactRequest {

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -132,9 +132,7 @@ impl ConflictArbiter for CapturingArbiter {
 }
 
 fn make_new_fact(content: &str, embedding: Vec<f32>) -> NewFact {
-    NewFact::builder(content, embedding, FactType::Semantic)
-        .content_hash(blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string())
-        .build()
+    crate::test_utils::new_fact_hashed(content, embedding)
 }
 
 /// Test helper: insert a raw fact via the storage backend (bypasses engine's `add_fact`).

--- a/memory-engine/lib/memory-engine/src/inspect/dump.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/dump.rs
@@ -562,17 +562,6 @@ mod tests {
 
     const DIM: usize = 4;
 
-    struct FakeEmbed;
-    impl EmbeddingProvider for FakeEmbed {
-        fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
-            Ok(vec![0.1, 0.2, 0.3, 0.4])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
-        }
-    }
-
     #[tokio::test]
     async fn json_dump_roundtrip() {
         let engine = MemoryEngine::builder(DIM).build().unwrap();
@@ -585,7 +574,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -721,7 +711,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -759,7 +750,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -791,7 +783,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -838,7 +831,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await

--- a/memory-engine/lib/memory-engine/src/inspect/explain.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/explain.rs
@@ -508,17 +508,6 @@ mod tests {
         );
     }
 
-    struct FakeEmbed;
-    impl EmbeddingProvider for FakeEmbed {
-        fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
-            Ok(vec![0.1, 0.2, 0.3, 0.4])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
-        }
-    }
-
     #[tokio::test]
     async fn explain_active_fact() {
         let engine = MemoryEngine::builder(DIM).build().unwrap();
@@ -531,7 +520,7 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                Arc::new(FakeEmbed),
+                Arc::new(crate::test_utils::MockEmbedder::fixed4()),
                 None,
             )
             .await
@@ -558,7 +547,8 @@ mod tests {
                     scope: None,
                     opts: Some(opts),
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -584,7 +574,8 @@ mod tests {
                     scope: None,
                     opts: Some(opts),
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -617,7 +608,8 @@ mod tests {
                     scope: None,
                     opts: Some(opts),
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -652,7 +644,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -693,7 +686,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -722,7 +716,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -745,7 +740,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await

--- a/memory-engine/lib/memory-engine/src/inspect/replay.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/replay.rs
@@ -26,6 +26,9 @@ mod tests {
 
     const DIM: usize = 4;
 
+    // kept: distinct from test_utils::new_event — hardcodes session_id=Some("s1")
+    // (tests at lines 127/159/191/269/342 filter by "s1") and uses a
+    // source-embedding payload {"src": source} rather than the generic {"key":"value"}.
     fn make_event(source: &str) -> NewEvent {
         NewEvent {
             timestamp: Utc::now(),

--- a/memory-engine/lib/memory-engine/src/inspect/restore.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/restore.rs
@@ -629,17 +629,6 @@ mod tests {
 
     const DIM: usize = 4;
 
-    struct FakeEmbed;
-    impl EmbeddingProvider for FakeEmbed {
-        fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
-            Ok(vec![0.1, 0.2, 0.3, 0.4])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
-        }
-    }
-
     // --- Compression detection tests ---
 
     #[test]
@@ -794,7 +783,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -808,7 +798,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -906,7 +897,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -949,7 +941,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -963,7 +956,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -1647,7 +1641,8 @@ mod tests {
                         scope: None,
                         opts: None,
                     },
-                    std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                    std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                        as std::sync::Arc<dyn EmbeddingProvider>,
                     None,
                 )
                 .await

--- a/memory-engine/lib/memory-engine/src/inspect/statistics.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/statistics.rs
@@ -125,17 +125,6 @@ mod tests {
 
     const DIM: usize = 4;
 
-    struct FakeEmbed;
-    impl EmbeddingProvider for FakeEmbed {
-        fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
-            Ok(vec![0.1, 0.2, 0.3, 0.4])
-        }
-
-        fn fingerprint(&self) -> crate::types::EmbeddingFingerprint {
-            crate::types::EmbeddingFingerprint::new("mock", "test", 4)
-        }
-    }
-
     #[tokio::test]
     async fn empty_engine_statistics() {
         let engine = MemoryEngine::builder(DIM).build().unwrap();
@@ -170,7 +159,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -184,7 +174,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -203,7 +194,8 @@ mod tests {
                     scope: None,
                     opts: Some(pin_opts),
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -241,7 +233,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -255,7 +248,8 @@ mod tests {
                     scope: None,
                     opts: None,
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await
@@ -273,7 +267,8 @@ mod tests {
                     scope: None,
                     opts: Some(pin_opts),
                 },
-                std::sync::Arc::new(FakeEmbed) as std::sync::Arc<dyn EmbeddingProvider>,
+                std::sync::Arc::new(crate::test_utils::MockEmbedder::fixed4())
+                    as std::sync::Arc<dyn EmbeddingProvider>,
                 None,
             )
             .await

--- a/memory-engine/lib/memory-engine/src/lib.rs
+++ b/memory-engine/lib/memory-engine/src/lib.rs
@@ -128,6 +128,10 @@ pub(crate) mod resume;
 pub(crate) mod scope;
 pub(crate) mod store;
 
+// === Shared test utilities (#485 / #120) ===
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 // === Re-exports: flat access to the most-used consumer types ===
 #[cfg(feature = "archive")]
 pub use archive::{ArchiveManifestEntry, ArchivePolicy, ArchiveStats, ArchiveVerifyResult};

--- a/memory-engine/lib/memory-engine/src/search/fts.rs
+++ b/memory-engine/lib/memory-engine/src/search/fts.rs
@@ -253,23 +253,8 @@ mod tests {
     }
 
     fn make_fact(content: &str) -> NewFact {
-        NewFact {
-            content: content.into(),
-            content_hash: String::new(),
-            embedding: vec![0.1; DIM],
-            fact_type: FactType::Episodic,
-            t_created: Utc::now(),
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
-            scope_id: 1,
-            base_importance: 0.5,
-            access_count: 0,
-            last_accessed: Utc::now(),
-            metadata: serde_json::json!({}),
-            is_pinned: false,
-        }
+        // kept: single-arg (embedding fixed to vec![0.1; DIM] using local DIM const)
+        crate::test_utils::new_fact(content, vec![0.1; DIM])
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/search/hybrid.rs
+++ b/memory-engine/lib/memory-engine/src/search/hybrid.rs
@@ -586,27 +586,11 @@ mod tests {
     }
 
     fn make_fact_with(content: &str, embedding: Vec<f32>, fact_type: FactType) -> NewFact {
-        NewFact {
-            content: content.into(),
-            content_hash: String::new(),
-            embedding,
-            fact_type,
-            t_created: Utc::now(),
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
-            scope_id: 1,
-            base_importance: 0.5,
-            access_count: 0,
-            last_accessed: Utc::now(),
-            metadata: serde_json::json!({}),
-            is_pinned: false,
-        }
+        crate::test_utils::new_fact_with_type(content, embedding, fact_type)
     }
 
     fn make_fact(content: &str, embedding: Vec<f32>) -> NewFact {
-        make_fact_with(content, embedding, FactType::Episodic)
+        crate::test_utils::new_fact(content, embedding)
     }
 
     /// Like [`make_fact`], but lets a fixture carry explicit valid-time bounds.
@@ -617,6 +601,7 @@ mod tests {
     /// fact). This override is the seam the bi-temporal tests need to drive a fact
     /// that is future-dated (`t_valid > cutoff`) or already invalidated
     /// (`t_invalid <= cutoff`).
+    // kept: distinct — sets t_valid/t_invalid for bi-temporal filter tests.
     fn make_fact_temporal(
         content: &str,
         embedding: Vec<f32>,

--- a/memory-engine/lib/memory-engine/src/search/strategy.rs
+++ b/memory-engine/lib/memory-engine/src/search/strategy.rs
@@ -160,7 +160,6 @@ mod tests {
     use crate::store::facts::FactStore;
     use crate::store::schema::{init_schema, open_memory};
     use crate::types::NewFact;
-    use chrono::Utc;
 
     const DIM: usize = 4;
 
@@ -171,23 +170,7 @@ mod tests {
     }
 
     fn make_fact(content: &str, embedding: Vec<f32>) -> NewFact {
-        NewFact {
-            content: content.into(),
-            content_hash: String::new(),
-            embedding,
-            fact_type: FactType::Episodic,
-            t_created: Utc::now(),
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
-            scope_id: 1,
-            base_importance: 0.5,
-            access_count: 0,
-            last_accessed: Utc::now(),
-            metadata: serde_json::json!({}),
-            is_pinned: false,
-        }
+        crate::test_utils::new_fact(content, embedding)
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/search/vector.rs
+++ b/memory-engine/lib/memory-engine/src/search/vector.rs
@@ -187,7 +187,6 @@ mod tests {
     use crate::store::facts::FactStore;
     use crate::store::schema::{init_schema, open_memory};
     use crate::types::{FactType, NewFact};
-    use chrono::Utc;
 
     const DIM: usize = 4;
 
@@ -198,23 +197,7 @@ mod tests {
     }
 
     fn make_fact_with_embedding(content: &str, embedding: Vec<f32>) -> NewFact {
-        NewFact {
-            content: content.into(),
-            content_hash: String::new(),
-            embedding,
-            fact_type: FactType::Episodic,
-            t_created: Utc::now(),
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
-            scope_id: 1,
-            base_importance: 0.5,
-            access_count: 0,
-            last_accessed: Utc::now(),
-            metadata: serde_json::json!({}),
-            is_pinned: false,
-        }
+        crate::test_utils::new_fact(content, embedding)
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/event_log.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/event_log.rs
@@ -145,8 +145,6 @@ impl EventLog for SqliteBackend {
 mod tests {
     use std::sync::Arc;
 
-    use chrono::Utc;
-
     use super::super::SqliteBackend;
     use crate::error::MemoryError;
     use crate::pool::ConnectionPool;
@@ -160,17 +158,7 @@ mod tests {
     }
 
     fn make_event(source: &str, session_id: Option<&str>) -> NewEvent {
-        NewEvent {
-            timestamp: Utc::now(),
-            event_type: EventType::Interaction,
-            payload: serde_json::json!({ "k": "v" }),
-            source: source.into(),
-            session_id: session_id.map(Into::into),
-            scope_id: 1,
-            origin_node_id: "local".into(),
-            sequence_id: 0,
-            created_at: None,
-        }
+        crate::test_utils::new_event(source, session_id)
     }
 
     #[tokio::test]

--- a/memory-engine/lib/memory-engine/src/store/activities.rs
+++ b/memory-engine/lib/memory-engine/src/store/activities.rs
@@ -248,13 +248,10 @@ fn row_to_activity(row: &rusqlite::Row<'_>) -> rusqlite::Result<Activity> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::store::schema::init_schema;
     use chrono::Utc;
 
     fn setup() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        init_schema(&conn).unwrap();
-        conn
+        crate::test_utils::setup_memory_db()
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/store/activities.rs
+++ b/memory-engine/lib/memory-engine/src/store/activities.rs
@@ -298,10 +298,16 @@ mod tests {
             timestamp: Utc::now(),
             scope_id: 999_999, // no such scope → FK violation when enforcement is ON
         };
+        let err = store
+            .insert_or_dedup(&activity, 300)
+            .expect_err("dangling scope_id FK must be rejected when foreign_keys=ON (#485)");
+        // Assert the rejection is the FK constraint *specifically* — not an
+        // incidental NOT NULL / UNIQUE / CHECK / JSON error. A bare `is_err()`
+        // would pass for the wrong reason if a future schema change made the
+        // insert fail some other way, silently masking a lost FK pragma.
         assert!(
-            store.insert_or_dedup(&activity, 300).is_err(),
-            "activity insert with a dangling scope_id FK must be rejected when \
-             foreign_keys=ON (#485); Ok means the test harness lost the pragma"
+            err.to_string().to_lowercase().contains("foreign key"),
+            "expected a FOREIGN KEY violation (proof the pragma is ON); got: {err}"
         );
     }
 

--- a/memory-engine/lib/memory-engine/src/store/activities.rs
+++ b/memory-engine/lib/memory-engine/src/store/activities.rs
@@ -278,6 +278,33 @@ mod tests {
         assert_eq!(fetched.status, ActivityStatus::Recorded);
     }
 
+    /// #485 regression guard: [`crate::test_utils::setup_memory_db`] MUST enable
+    /// `PRAGMA foreign_keys`. With enforcement OFF (the original bug — raw
+    /// `Connection::open_in_memory`), an activity whose `scope_id` references a
+    /// non-existent scope inserts silently; with it ON, the FK constraint
+    /// (`activities.scope_id REFERENCES scopes(id)`) rejects it. This is the
+    /// mutation-proof check — it fails loudly if the harness ever loses the pragma.
+    #[test]
+    fn insert_with_dangling_scope_fk_is_rejected() {
+        let conn = setup();
+        let store = ActivityStore::new(&conn);
+        let activity = NewActivity {
+            session_id: "sess-fk".into(),
+            tool_name: "Read".into(),
+            args_hash: "ffffffffffffffffffffffffffffffff".into(),
+            args: serde_json::json!({}),
+            result_summary: None,
+            outcome_class: OutcomeClass::Success,
+            timestamp: Utc::now(),
+            scope_id: 999_999, // no such scope → FK violation when enforcement is ON
+        };
+        assert!(
+            store.insert_or_dedup(&activity, 300).is_err(),
+            "activity insert with a dangling scope_id FK must be rejected when \
+             foreign_keys=ON (#485); Ok means the test harness lost the pragma"
+        );
+    }
+
     /// Persist every [`OutcomeClass`] variant through the real `SQLite` `TEXT`
     /// column and read it back, proving the `to_string()` -> column ->
     /// `from_str()` round-trip in [`row_to_activity`] (the entire #347

--- a/memory-engine/lib/memory-engine/src/store/checkpoints.rs
+++ b/memory-engine/lib/memory-engine/src/store/checkpoints.rs
@@ -125,13 +125,10 @@ fn row_to_checkpoint(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionCheckpo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::store::schema::init_schema;
     use chrono::Utc;
 
     fn setup() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        init_schema(&conn).unwrap();
-        conn
+        crate::test_utils::setup_memory_db()
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/store/events.rs
+++ b/memory-engine/lib/memory-engine/src/store/events.rs
@@ -357,17 +357,7 @@ mod tests {
     }
 
     fn make_event(source: &str, session_id: Option<&str>) -> NewEvent {
-        NewEvent {
-            timestamp: Utc::now(),
-            event_type: EventType::Interaction,
-            payload: serde_json::json!({"key": "value"}),
-            source: source.into(),
-            session_id: session_id.map(Into::into),
-            scope_id: 1,
-            origin_node_id: "local".into(),
-            sequence_id: 0,
-            created_at: None,
-        }
+        crate::test_utils::new_event(source, session_id)
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -1531,23 +1531,7 @@ mod tests {
     }
 
     fn make_fact(content: &str, embedding: Vec<f32>) -> NewFact {
-        NewFact {
-            content: content.into(),
-            content_hash: String::new(), // store computes this
-            embedding,
-            fact_type: FactType::Episodic,
-            t_created: Utc::now(),
-            t_expired: None,
-            t_valid: None,
-            t_invalid: None,
-            source_event_id: None,
-            base_importance: 0.5,
-            access_count: 0,
-            last_accessed: Utc::now(),
-            metadata: serde_json::json!({}),
-            scope_id: 1,
-            is_pinned: false,
-        }
+        crate::test_utils::new_fact(content, embedding)
     }
 
     /// #366 end-to-end (read path): corrupt the stored `fact_type` of a real row,

--- a/memory-engine/lib/memory-engine/src/test_utils.rs
+++ b/memory-engine/lib/memory-engine/src/test_utils.rs
@@ -105,23 +105,7 @@ impl EmbeddingProvider for MockEmbedder {
 /// This is the dominant shape used by store-level and search tests where the
 /// content hash is not meaningful (the store computes or ignores it).
 pub fn new_fact(content: &str, embedding: Vec<f32>) -> NewFact {
-    NewFact {
-        content: content.into(),
-        content_hash: String::new(),
-        embedding,
-        fact_type: FactType::Episodic,
-        t_created: Utc::now(),
-        t_expired: None,
-        t_valid: None,
-        t_invalid: None,
-        source_event_id: None,
-        scope_id: 1,
-        base_importance: 0.5,
-        access_count: 0,
-        last_accessed: Utc::now(),
-        metadata: serde_json::json!({}),
-        is_pinned: false,
-    }
+    new_fact_with_type(content, embedding, FactType::Episodic)
 }
 
 /// Build a [`NewFact`] with `FactType::Semantic` and a blake3 content hash.

--- a/memory-engine/lib/memory-engine/src/test_utils.rs
+++ b/memory-engine/lib/memory-engine/src/test_utils.rs
@@ -1,0 +1,185 @@
+/// Shared test utilities for `memory-engine` unit tests.
+///
+/// This module is only compiled in `#[cfg(test)]` mode. It provides common
+/// test doubles and factory helpers that would otherwise be duplicated across
+/// every `mod tests { … }` block.
+///
+/// # FK-pragma guarantee
+///
+/// [`setup_memory_db`] opens the connection through [`crate::store::schema::open_memory`],
+/// which applies all pragmas including `PRAGMA foreign_keys = ON`. Raw
+/// `Connection::open_in_memory()` skips this pragma and silently masks FK
+/// violations; every store-level test setup must use this helper instead (#485).
+use chrono::Utc;
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::store::schema::{init_schema, open_memory};
+use crate::traits::EmbeddingProvider;
+use crate::types::{EmbeddingFingerprint, EventType, FactType, NewEvent, NewFact};
+
+// --- DB helpers ---
+
+/// Open an in-memory SQLite connection with all pragmas (including
+/// `foreign_keys = ON`) and the latest schema applied.
+///
+/// Use this in every store-level `fn setup() -> Connection` instead of
+/// `Connection::open_in_memory()`, which skips the FK pragma (#485).
+pub(crate) fn setup_memory_db() -> Connection {
+    let conn = open_memory().expect("open in-memory db");
+    init_schema(&conn).expect("init schema");
+    conn
+}
+
+// --- EmbeddingProvider test doubles ---
+
+/// Generic test double for [`EmbeddingProvider`] that produces a deterministic,
+/// constant output vector of a given dimension.
+///
+/// Use [`MockEmbedder::new`] for the dominant pattern (`vec![0.5; dim]`) or
+/// [`MockEmbedder::constant`] to choose a specific fill value. For tests that
+/// need a fixed 4-element gradient vector `[0.1, 0.2, 0.3, 0.4]`, use
+/// [`MockEmbedder::fixed4`].
+///
+/// **Not a replacement for purpose-built doubles.** If a test needs
+/// dimension-mismatching, call-counting, error injection, or text-dependent
+/// output, keep the local struct — those properties encode intent.
+pub(crate) struct MockEmbedder {
+    dim: usize,
+    value: f32,
+    /// When `Some`, overrides `value` and returns this exact vector.
+    fixed: Option<Vec<f32>>,
+}
+
+impl MockEmbedder {
+    /// Constant-vector embedder that returns `vec![0.5; dim]`.
+    ///
+    /// This is the most common pattern across store and consolidation tests.
+    pub(crate) fn new(dim: usize) -> Self {
+        Self {
+            dim,
+            value: 0.5,
+            fixed: None,
+        }
+    }
+
+    /// Constant-vector embedder that returns `vec![value; dim]`.
+    pub(crate) fn constant(dim: usize, value: f32) -> Self {
+        Self {
+            dim,
+            value,
+            fixed: None,
+        }
+    }
+
+    /// Fixed 4-element gradient vector `[0.1, 0.2, 0.3, 0.4]` with dim=4.
+    ///
+    /// Covers the family of `FakeEmbed` / `FixedEmbedder` / `FixedEmbed`
+    /// structs that all produce this exact vector (inspect, ingest, lineage,
+    /// apply, cognitive tests).
+    pub(crate) fn fixed4() -> Self {
+        Self {
+            dim: 4,
+            value: 0.0,
+            fixed: Some(vec![0.1, 0.2, 0.3, 0.4]),
+        }
+    }
+}
+
+impl EmbeddingProvider for MockEmbedder {
+    fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+        if let Some(ref v) = self.fixed {
+            Ok(v.clone())
+        } else {
+            Ok(vec![self.value; self.dim])
+        }
+    }
+
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("mock", "test", self.dim)
+    }
+}
+
+// --- NewFact helpers ---
+
+/// Build a [`NewFact`] with `FactType::Episodic` and an empty `content_hash`.
+///
+/// This is the dominant shape used by store-level and search tests where the
+/// content hash is not meaningful (the store computes or ignores it).
+pub(crate) fn new_fact(content: &str, embedding: Vec<f32>) -> NewFact {
+    NewFact {
+        content: content.into(),
+        content_hash: String::new(),
+        embedding,
+        fact_type: FactType::Episodic,
+        t_created: Utc::now(),
+        t_expired: None,
+        t_valid: None,
+        t_invalid: None,
+        source_event_id: None,
+        scope_id: 1,
+        base_importance: 0.5,
+        access_count: 0,
+        last_accessed: Utc::now(),
+        metadata: serde_json::json!({}),
+        is_pinned: false,
+    }
+}
+
+/// Build a [`NewFact`] with `FactType::Semantic` and a blake3 content hash.
+///
+/// Used by engine-level tests that go through dedup/conflict paths where the
+/// hash is significant (e.g. `engine/tests.rs`, `engine/mod.rs` resolve tests).
+pub(crate) fn new_fact_hashed(content: &str, embedding: Vec<f32>) -> NewFact {
+    NewFact::builder(content, embedding, FactType::Semantic)
+        .content_hash(blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string())
+        .build()
+}
+
+/// Build a [`NewFact`] with an explicit [`FactType`] and an empty `content_hash`.
+///
+/// Use this when the test needs to vary the fact type (e.g. `hybrid.rs`
+/// multi-type filter tests).
+pub(crate) fn new_fact_with_type(
+    content: &str,
+    embedding: Vec<f32>,
+    fact_type: FactType,
+) -> NewFact {
+    NewFact {
+        content: content.into(),
+        content_hash: String::new(),
+        embedding,
+        fact_type,
+        t_created: Utc::now(),
+        t_expired: None,
+        t_valid: None,
+        t_invalid: None,
+        source_event_id: None,
+        scope_id: 1,
+        base_importance: 0.5,
+        access_count: 0,
+        last_accessed: Utc::now(),
+        metadata: serde_json::json!({}),
+        is_pinned: false,
+    }
+}
+
+// --- NewEvent helpers ---
+
+/// Build a [`NewEvent`] with `EventType::Interaction`.
+///
+/// Covers `store/events.rs` and `storage/sqlite/event_log.rs` which both had
+/// identical two-argument `make_event(source, session_id)` helpers.
+pub(crate) fn new_event(source: &str, session_id: Option<&str>) -> NewEvent {
+    NewEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::Interaction,
+        payload: serde_json::json!({"key": "value"}),
+        source: source.into(),
+        session_id: session_id.map(Into::into),
+        scope_id: 1,
+        origin_node_id: "local".into(),
+        sequence_id: 0,
+        created_at: None,
+    }
+}

--- a/memory-engine/lib/memory-engine/src/test_utils.rs
+++ b/memory-engine/lib/memory-engine/src/test_utils.rs
@@ -20,12 +20,12 @@ use crate::types::{EmbeddingFingerprint, EventType, FactType, NewEvent, NewFact}
 
 // --- DB helpers ---
 
-/// Open an in-memory SQLite connection with all pragmas (including
+/// Open an in-memory `SQLite` connection with all pragmas (including
 /// `foreign_keys = ON`) and the latest schema applied.
 ///
 /// Use this in every store-level `fn setup() -> Connection` instead of
 /// `Connection::open_in_memory()`, which skips the FK pragma (#485).
-pub(crate) fn setup_memory_db() -> Connection {
+pub fn setup_memory_db() -> Connection {
     let conn = open_memory().expect("open in-memory db");
     init_schema(&conn).expect("init schema");
     conn
@@ -44,7 +44,7 @@ pub(crate) fn setup_memory_db() -> Connection {
 /// **Not a replacement for purpose-built doubles.** If a test needs
 /// dimension-mismatching, call-counting, error injection, or text-dependent
 /// output, keep the local struct — those properties encode intent.
-pub(crate) struct MockEmbedder {
+pub struct MockEmbedder {
     dim: usize,
     value: f32,
     /// When `Some`, overrides `value` and returns this exact vector.
@@ -55,7 +55,7 @@ impl MockEmbedder {
     /// Constant-vector embedder that returns `vec![0.5; dim]`.
     ///
     /// This is the most common pattern across store and consolidation tests.
-    pub(crate) fn new(dim: usize) -> Self {
+    pub fn new(dim: usize) -> Self {
         Self {
             dim,
             value: 0.5,
@@ -64,7 +64,7 @@ impl MockEmbedder {
     }
 
     /// Constant-vector embedder that returns `vec![value; dim]`.
-    pub(crate) fn constant(dim: usize, value: f32) -> Self {
+    pub fn constant(dim: usize, value: f32) -> Self {
         Self {
             dim,
             value,
@@ -77,7 +77,7 @@ impl MockEmbedder {
     /// Covers the family of `FakeEmbed` / `FixedEmbedder` / `FixedEmbed`
     /// structs that all produce this exact vector (inspect, ingest, lineage,
     /// apply, cognitive tests).
-    pub(crate) fn fixed4() -> Self {
+    pub fn fixed4() -> Self {
         Self {
             dim: 4,
             value: 0.0,
@@ -88,11 +88,9 @@ impl MockEmbedder {
 
 impl EmbeddingProvider for MockEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>> {
-        if let Some(ref v) = self.fixed {
-            Ok(v.clone())
-        } else {
-            Ok(vec![self.value; self.dim])
-        }
+        self.fixed
+            .as_ref()
+            .map_or_else(|| Ok(vec![self.value; self.dim]), |v| Ok(v.clone()))
     }
 
     fn fingerprint(&self) -> EmbeddingFingerprint {
@@ -106,7 +104,7 @@ impl EmbeddingProvider for MockEmbedder {
 ///
 /// This is the dominant shape used by store-level and search tests where the
 /// content hash is not meaningful (the store computes or ignores it).
-pub(crate) fn new_fact(content: &str, embedding: Vec<f32>) -> NewFact {
+pub fn new_fact(content: &str, embedding: Vec<f32>) -> NewFact {
     NewFact {
         content: content.into(),
         content_hash: String::new(),
@@ -130,7 +128,7 @@ pub(crate) fn new_fact(content: &str, embedding: Vec<f32>) -> NewFact {
 ///
 /// Used by engine-level tests that go through dedup/conflict paths where the
 /// hash is significant (e.g. `engine/tests.rs`, `engine/mod.rs` resolve tests).
-pub(crate) fn new_fact_hashed(content: &str, embedding: Vec<f32>) -> NewFact {
+pub fn new_fact_hashed(content: &str, embedding: Vec<f32>) -> NewFact {
     NewFact::builder(content, embedding, FactType::Semantic)
         .content_hash(blake3::hash(content.as_bytes()).to_hex().as_str()[..32].to_string())
         .build()
@@ -140,11 +138,7 @@ pub(crate) fn new_fact_hashed(content: &str, embedding: Vec<f32>) -> NewFact {
 ///
 /// Use this when the test needs to vary the fact type (e.g. `hybrid.rs`
 /// multi-type filter tests).
-pub(crate) fn new_fact_with_type(
-    content: &str,
-    embedding: Vec<f32>,
-    fact_type: FactType,
-) -> NewFact {
+pub fn new_fact_with_type(content: &str, embedding: Vec<f32>, fact_type: FactType) -> NewFact {
     NewFact {
         content: content.into(),
         content_hash: String::new(),
@@ -170,7 +164,7 @@ pub(crate) fn new_fact_with_type(
 ///
 /// Covers `store/events.rs` and `storage/sqlite/event_log.rs` which both had
 /// identical two-argument `make_event(source, session_id)` helpers.
-pub(crate) fn new_event(source: &str, session_id: Option<&str>) -> NewEvent {
+pub fn new_event(source: &str, session_id: Option<&str>) -> NewEvent {
     NewEvent {
         timestamp: Utc::now(),
         event_type: EventType::Interaction,


### PR DESCRIPTION
## Summary

Closes #485. Closes #120. (Coupled — #485's correct fix *is* #120's `setup_memory_db()` helper).

- **#485 (bug):** two unit-test setups (`store/checkpoints.rs`, `store/activities.rs`) opened a raw `Connection::open_in_memory()`, which skips `PRAGMA foreign_keys = ON` — so FK constraints were silently unenforced in those tests. Both now route through the shared `test_utils::setup_memory_db()` (= `open_memory()` + `init_schema`), which sets the pragma.
- **#120 (refactor):** ~10 `make_fact*`, 3 `make_event`, and a family of generic `EmbeddingProvider` test doubles were duplicated across 15+ modules. Introduce `#[cfg(test)] pub(crate) mod test_utils` with shared helpers and consolidate the genuine duplicates.

## `test_utils` API
- `setup_memory_db() -> Connection` — in-memory DB with all pragmas (incl. FK) + latest schema.
- `new_fact` / `new_fact_hashed` / `new_fact_with_type` — preserve each call site's convention (Episodic+empty-hash vs Semantic+blake3-hash vs explicit type).
- `make_event(source, session_id)`.
- `MockEmbedder` with `::new(dim)` (`vec![0.5; dim]`), `::constant(dim, value)`, `::fixed4()` (`[0.1,0.2,0.3,0.4]`) — reproduces each migrated generic double's **exact** output.

## What was consolidated vs. kept
Generic deterministic doubles (`FixedEmbed`, `FixedEmbedder`, `ConstEmbedder`, `FakeEmbed`, the four `MockEmbedder` copies incl. the `consolidation/{mod,global,cluster}.rs` ones) → the shared `MockEmbedder`. **Purpose-built doubles are kept** (they encode test intent, not duplication): `Failing`, `BadBatchEmbedder`/`BadDimBatchEmbedder`, `LyingEmbedder`, call-counting embedders, `Asymmetric`/`Symmetric`, `TagEmbedder`, and the bi-temporal/`Fact`-returning `make_fact` variants.

## Non-regression + mutation-proof
- Test count unchanged (1964 pass) — this removes helper *definitions*, not tests.
- Every generic-double migration preserves the **exact** output vector, so a green suite is a sufficient safety net (identical output ⇒ identical behavior).
- Added a **mutation-proof FK test** (`insert_with_dangling_scope_fk_is_rejected`): a dangling-`scope_id` insert must be rejected — fails with FK off, passes with FK on. Non-vacuity pinned by the sibling `insert_new_activity` (valid scope succeeds), so the scope is the sole discriminator.

## Verification
All CI gates pass locally (fmt, `clippy --workspace --all-targets --all-features -D warnings`, build default+all-features, `test --workspace --all-features`, cargo doc default+all-features).
