### PR TITLE
docs(storage): #500 cleanup — docs, redundant-clone + flaky-order fixes, coverage

### DIFF
--- a/memory-engine/lib/memory-engine/src/archive/search.rs
+++ b/memory-engine/lib/memory-engine/src/archive/search.rs
@@ -125,6 +125,8 @@ const fn entry_is_prunable(_entry: &ArchiveManifestEntry, _query: &MemoryQuery) 
 /// # Errors
 ///
 /// Returns `MemoryError::Archive` on I/O or decompression failure.
+/// Returns `MemoryError::Serialization` if a `.pak` file's JSON is corrupt or
+/// truncated (surfaced by `read_pak` during decompression and deserialization).
 pub fn search_archives(
     archive_dir: &Path,
     manifest_entries: &[ArchiveManifestEntry],

--- a/memory-engine/lib/memory-engine/src/archive/types.rs
+++ b/memory-engine/lib/memory-engine/src/archive/types.rs
@@ -56,14 +56,20 @@ impl Default for ArchivePolicy {
     /// Returns a policy with a 30-day look-back cutoff relative to the current
     /// wall-clock time and a 100-fact minimum batch size.
     ///
-    /// The `expired_before` cutoff is intentionally now-relative: a retention
-    /// policy's default horizon is "facts that expired at least 30 days ago",
-    /// which is meaningless without anchoring to *now*. Storing a fixed timestamp
-    /// would silently archive nothing (or everything) depending on when the binary
-    /// was built.
+    /// The `expired_before` cutoff is captured from the wall clock **when
+    /// `default()` is called** — a retention policy's horizon is "facts that
+    /// expired at least 30 days ago", which is meaningless without anchoring to
+    /// *now*. Computing it here (rather than as a fixed compile-time timestamp)
+    /// avoids silently archiving nothing — or everything — depending on when the
+    /// binary was built.
+    ///
+    /// Note: the cutoff is frozen at construction, so a once-built `default()`
+    /// does **not** slide its horizon forward over time. In a long-running
+    /// process, construct a fresh `ArchivePolicy` (or set `expired_before`
+    /// explicitly) per archival run.
     fn default() -> Self {
         Self {
-            expired_before: Utc::now() - chrono::Duration::days(30),
+            expired_before: Utc::now() - chrono::TimeDelta::days(30),
             min_facts: 100,
         }
     }

--- a/memory-engine/lib/memory-engine/src/archive/types.rs
+++ b/memory-engine/lib/memory-engine/src/archive/types.rs
@@ -24,22 +24,43 @@ pub const CURRENT_PAK_VERSION: u32 = 2;
 /// (design: "archival is compaction preserving the event log").
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArchivePak {
+    /// On-disk format version; checked on read against [`CURRENT_PAK_VERSION`].
     pub pak_version: u32,
+    /// Schema version of the engine that wrote this pak; used for forward-compatibility
+    /// checks on read.
     pub engine_schema_version: u32,
+    /// Embedding dimension of the facts stored in this pak. Must match the engine's
+    /// configured `embed_dim` before any vectors are compared.
     pub embed_dim: usize,
+    /// System timestamp when this pak was written (wall-clock, UTC).
     pub created_at: DateTime<Utc>,
+    /// Archived facts; ordering is by `id` ascending (insertion order).
     pub facts: Vec<Fact>,
+    /// Archived edges whose both endpoints are in `facts` (internal edges only).
     pub edges: Vec<Edge>,
 }
 
 /// Policy controlling which facts are eligible for archival.
 #[derive(Debug, Clone)]
 pub struct ArchivePolicy {
+    /// Only facts whose system-time expiry (`t_expired`) is strictly before this
+    /// instant are candidates for archival.
     pub expired_before: DateTime<Utc>,
+    /// Minimum number of candidate facts required to trigger an archival pass.
+    /// If fewer candidates exist, `archive()` returns `None` without writing a
+    /// `.pak` file.
     pub min_facts: usize,
 }
 
 impl Default for ArchivePolicy {
+    /// Returns a policy with a 30-day look-back cutoff relative to the current
+    /// wall-clock time and a 100-fact minimum batch size.
+    ///
+    /// The `expired_before` cutoff is intentionally now-relative: a retention
+    /// policy's default horizon is "facts that expired at least 30 days ago",
+    /// which is meaningless without anchoring to *now*. Storing a fixed timestamp
+    /// would silently archive nothing (or everything) depending on when the binary
+    /// was built.
     fn default() -> Self {
         Self {
             expired_before: Utc::now() - chrono::Duration::days(30),
@@ -61,16 +82,28 @@ pub struct ArchiveStats {
 /// A row from the `archive_manifest` table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArchiveManifestEntry {
+    /// Auto-assigned primary key from `archive_manifest.id`.
     pub id: i64,
+    /// Relative path to the `.pak` file from the archive directory; never contains
+    /// `..` or an absolute anchor (enforced by the path-traversal guard on read).
     pub pak_path: String,
+    /// System timestamp when the archival commit completed (wall-clock, UTC).
     pub created_at: DateTime<Utc>,
+    /// Number of facts stored in the pak.
     pub fact_count: i64,
+    /// Number of edges stored in the pak.
     pub edge_count: i64,
+    /// Smallest fact id in the pak (used for manifest-level skip optimization).
     pub fact_id_min: i64,
+    /// Largest fact id in the pak (used for manifest-level skip optimization).
     pub fact_id_max: i64,
+    /// Earliest `t_created` timestamp among facts in the pak (system time).
     pub t_created_min: DateTime<Utc>,
+    /// Latest `t_created` timestamp among facts in the pak (system time).
     pub t_created_max: DateTime<Utc>,
+    /// Compressed file size in bytes.
     pub size_bytes: i64,
+    /// Blake3 hex digest of the compressed pak file for integrity verification.
     pub blake3_hash: String,
 }
 

--- a/memory-engine/lib/memory-engine/src/inspect/statistics.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/statistics.rs
@@ -563,4 +563,83 @@ mod tests {
             "exactly the two active, past-t_valid, non-invalidated facts are due"
         );
     }
+
+    // --- nested scopes + edges coverage (#500) ----------------------------
+    //
+    // ScopeStats.max_depth was always observed as 0 (root-only) in every
+    // existing test, so the MAX(depth) aggregation had no positive coverage.
+    // EdgeStats is separately covered by
+    // `edges_total_active_expired_are_distinct_and_correctly_partitioned`, but
+    // that test does not reach the ScopeStats path with non-zero max_depth.
+    // This test exercises both in one fixture: two user scopes at depth 1 and
+    // depth 2 (≥2 levels), plus two edges whose counts are asserted non-zero.
+    //
+    // A mutation that hard-codes max_depth=0 or zeros edge totals fails here.
+    // A mutation that reads MAX(id) instead of MAX(depth) for scopes also fails
+    // because the depth-2 scope has id=3 while its depth is 2 — only if both
+    // happen to be equal would the mutation survive, which does not hold in the
+    // general case (root has id=1/depth=0, depth-1 scope has id=2/depth=1, etc.).
+
+    #[test]
+    fn nested_scopes_and_edges_are_counted_correctly() {
+        let conn = open_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        // id=1 (depth=0) is the root scope inserted by init_schema.
+        // Insert a depth-1 scope under root ...
+        conn.execute(
+            "INSERT INTO scopes (id, parent_id, label, depth) VALUES (2, 1, 'child', 1)",
+            [],
+        )
+        .unwrap();
+        // ... and a depth-2 scope under the depth-1 scope.
+        conn.execute(
+            "INSERT INTO scopes (id, parent_id, label, depth) VALUES (3, 2, 'grandchild', 2)",
+            [],
+        )
+        .unwrap();
+
+        // Two facts to satisfy the edges FK constraints.
+        let f1 = insert_raw_fact(&conn, "scope fact 1", None, None, None);
+        let f2 = insert_raw_fact(&conn, "scope fact 2", None, None, None);
+
+        // Two active edges.
+        let store = EdgeStore::new(&conn);
+        store
+            .insert(&NewEdge {
+                source_fact_id: f1,
+                target_fact_id: f2,
+                relation_type: "relates_to".into(),
+                weight: 1.0,
+                t_created: chrono::Utc::now(),
+                t_expired: None,
+                scope_id: 1,
+            })
+            .unwrap();
+        store
+            .insert(&NewEdge {
+                source_fact_id: f2,
+                target_fact_id: f1,
+                relation_type: "related_from".into(),
+                weight: 1.0,
+                t_created: chrono::Utc::now(),
+                t_expired: None,
+                scope_id: 2,
+            })
+            .unwrap();
+
+        let stats = super::compute_statistics(&conn, None).unwrap();
+
+        // Three scopes total: root (depth=0) + depth-1 + depth-2.
+        assert_eq!(stats.scopes.total, 3, "root + two nested scopes");
+        // max_depth must reflect the deepest inserted scope, not hard-code 0.
+        assert_eq!(
+            stats.scopes.max_depth, 2,
+            "deepest scope is at depth 2 (grandchild)"
+        );
+        // Both edges are active (t_expired IS NULL).
+        assert_eq!(stats.edges.total, 2, "two edges total");
+        assert_eq!(stats.edges.active, 2, "both edges are active");
+        assert_eq!(stats.edges.expired, 0, "no expired edges");
+    }
 }

--- a/memory-engine/lib/memory-engine/src/inspect/types.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/types.rs
@@ -71,6 +71,11 @@ pub struct FactProvenance {
     /// The fact's base importance prior (mirrors [`crate::types::Fact::base_importance`]).
     /// Serde key is `base_importance` (#274 export/MCP break).
     pub base_importance: f64,
+    /// The effective decayed importance as of the last forgetting pass
+    /// (mirrors [`crate::types::Fact::importance_score`]). This is the live,
+    /// computed value — it starts equal to `base_importance` and drifts downward
+    /// over time as the Ebbinghaus decay is applied, or upward when the fact is
+    /// accessed and reinforced.
     pub importance_score: f64,
     pub is_pinned: bool,
     pub access_count: i64,

--- a/memory-engine/lib/memory-engine/src/store/activities.rs
+++ b/memory-engine/lib/memory-engine/src/store/activities.rs
@@ -23,6 +23,11 @@ impl<'a> ActivityStore<'a> {
     /// `dedup_window_secs` of the most recent matching activity.
     ///
     /// Returns `(id, was_deduplicated)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure (e.g. FK violation if
+    /// `activity.scope_id` references a non-existent scope).
     pub fn insert_or_dedup(
         &self,
         activity: &NewActivity,
@@ -101,6 +106,11 @@ impl<'a> ActivityStore<'a> {
     ///
     /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
     /// impl can call it in non-test builds (#630).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if no activity with `id` exists.
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn get(&self, id: i64) -> Result<Activity> {
         self.conn
             .query_row(
@@ -123,6 +133,10 @@ impl<'a> ActivityStore<'a> {
     ///
     /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
     /// impl can call it in non-test builds (#630).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn list_by_session(&self, session_id: &str, limit: Option<usize>) -> Result<Vec<Activity>> {
         let base = "SELECT id, session_id, tool_name, args_hash, args, result_summary,
                         outcome_class, status, occurrence_count, first_seen, last_seen,
@@ -143,6 +157,10 @@ impl<'a> ActivityStore<'a> {
     /// List recent activities for a set of scope IDs, most recent first.
     ///
     /// Uses `idx_activities_scope_recent` for efficient lookup.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn list_recent_by_scope(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Activity>> {
         if scope_ids.is_empty() {
             return Ok(Vec::new());
@@ -170,6 +188,11 @@ impl<'a> ActivityStore<'a> {
     }
 
     /// Update the status of an activity and optionally link to a promoted fact.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if no activity with `id` exists.
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn update_status(
         &self,
         id: i64,
@@ -193,6 +216,10 @@ impl<'a> ActivityStore<'a> {
     ///
     /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
     /// impl can call it in non-test builds (#630).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn count_by_session(&self, session_id: &str) -> Result<i64> {
         self.conn
             .query_row(

--- a/memory-engine/lib/memory-engine/src/store/checkpoints.rs
+++ b/memory-engine/lib/memory-engine/src/store/checkpoints.rs
@@ -106,7 +106,7 @@ impl<'a> CheckpointStore<'a> {
             .prepare(
                 "SELECT session_id, scope_path, summary, last_activity_id, checkpoint_at, metadata
                  FROM session_checkpoints
-                 ORDER BY checkpoint_at DESC
+                 ORDER BY checkpoint_at DESC, session_id DESC
                  LIMIT ?1",
             )
             .map_err(MemoryError::Database)?;

--- a/memory-engine/lib/memory-engine/src/store/checkpoints.rs
+++ b/memory-engine/lib/memory-engine/src/store/checkpoints.rs
@@ -18,6 +18,10 @@ impl<'a> CheckpointStore<'a> {
     }
 
     /// Upsert a session checkpoint (last-write-wins per `session_id`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn upsert(&self, checkpoint: &SessionCheckpoint) -> Result<()> {
         self.conn
             .execute(
@@ -47,6 +51,12 @@ impl<'a> CheckpointStore<'a> {
     ///
     /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
     /// impl can call it in non-test builds (#630).
+    ///
+    /// Returns `Ok(None)` if no checkpoint exists for this session.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn get(&self, session_id: &str) -> Result<Option<SessionCheckpoint>> {
         self.conn
             .query_row(
@@ -61,6 +71,12 @@ impl<'a> CheckpointStore<'a> {
     }
 
     /// Get the most recent checkpoint for a scope path.
+    ///
+    /// Returns `Ok(None)` if no checkpoint exists for this scope path.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn get_by_scope(&self, scope_path: &str) -> Result<Option<SessionCheckpoint>> {
         self.conn
             .query_row(
@@ -80,6 +96,10 @@ impl<'a> CheckpointStore<'a> {
     ///
     /// Made unconditional (removed `#[cfg(test)]`) so the [`SessionStore`] trait
     /// impl can call it in non-test builds (#630).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn list_recent(&self, limit: usize) -> Result<Vec<SessionCheckpoint>> {
         let mut stmt = self
             .conn

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -608,6 +608,11 @@ impl<'a> FactStore<'a> {
     /// List active facts in a set of scopes with importance >= threshold,
     /// excluding specific fact IDs, ordered by importance DESC.
     ///
+    /// # Panics
+    ///
+    /// Panics if `scope_ids` or `exclude_ids` cannot be serialized to JSON —
+    /// infallible in practice for `&[i64]` / `&HashSet<i64>`.
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on query failure.
@@ -648,6 +653,15 @@ impl<'a> FactStore<'a> {
     /// pushed down to SQL (`LIMIT ?`) so the DB never transmits or deserializes the
     /// embedding BLOBs of facts beyond the cap (#395) — matching the pattern of
     /// `list_by_importance_score`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `scope_ids` cannot be serialized to JSON — infallible in practice
+    /// for `&[i64]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
     pub fn list_pinned(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Fact>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         let base =
@@ -682,6 +696,15 @@ impl<'a> FactStore<'a> {
     /// returns ALL due facts). Pushing both down (#396) keeps the resume Tier-3
     /// path from materializing — and decoding the embedding BLOB of — every due
     /// fact only to filter+cap it in Rust, matching `list_by_importance_score`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `exclude` cannot be serialized to JSON — infallible in practice
+    /// for `&[i64]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
     pub fn list_due(
         &self,
         now: DateTime<Utc>,
@@ -1080,6 +1103,15 @@ impl<'a> FactStore<'a> {
 
     /// List active facts ordered by materialized `importance_score`, excluding IDs in `exclude`.
     /// Pass empty `scope_ids` to query across all scopes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `exclude` or `scope_ids` cannot be serialized to JSON —
+    /// infallible in practice for `&HashSet<i64>` / `&[i64]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on query failure.
     pub fn list_by_importance_score(
         &self,
         scope_ids: &[i64],
@@ -1178,6 +1210,11 @@ impl<'a> FactStore<'a> {
     /// List active facts in a set of scopes, excluding specific fact IDs,
     /// ordered by `t_created` DESC (most recent first).
     ///
+    /// # Panics
+    ///
+    /// Panics if `scope_ids` or `exclude_ids` cannot be serialized to JSON —
+    /// infallible in practice for `&[i64]` / `&HashSet<i64>`.
+    ///
     /// # Errors
     ///
     /// Returns `MemoryError::Database` on query failure.
@@ -1230,6 +1267,11 @@ impl<'a> FactStore<'a> {
     /// into the SQL JSON path, **never bound**, so it must never carry client input.
     /// A runtime guard rejects a non-identifier key in **all** build profiles
     /// (not just `debug`), since the key is interpolated into SQL.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `scope_ids` cannot be serialized to JSON — infallible in practice
+    /// for `&[i64]`.
     ///
     /// # Errors
     ///

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -4093,4 +4093,37 @@ mod tests {
             "the callback's own error must propagate verbatim, got {err:?}"
         );
     }
+
+    /// All `FactType` variants survive an insert → `get()` roundtrip through the
+    /// real `SQLite` store (#500).
+    ///
+    /// This exercises both the write path (`fact_type_to_str` → stored string) and
+    /// the read path (`str_to_fact_type` → parsed enum) for every variant in one
+    /// test. A mutation that returns the wrong stored string for any variant, or
+    /// that maps the wrong stored string to the wrong variant on read-back, fails
+    /// here. The three variants are exhaustive (no `#[non_exhaustive]`), so adding
+    /// a new variant without updating the serialisation paths will be caught by a
+    /// compile-time match exhaustiveness error before this test runs.
+    #[test]
+    fn all_fact_types_survive_store_roundtrip() {
+        let conn = setup();
+        let store = FactStore::new(&conn, DIM);
+        let variants = [FactType::Episodic, FactType::Semantic, FactType::Procedural];
+        for expected in variants {
+            let fact = crate::test_utils::new_fact_with_type(
+                "roundtrip content",
+                vec![0.1; DIM],
+                expected,
+            );
+            let id = store.insert(&fact).unwrap();
+            let retrieved = store
+                .get(id)
+                .unwrap_or_else(|e| panic!("get failed for variant {expected:?}: {e}"));
+            assert_eq!(
+                retrieved.fact_type, expected,
+                "fact_type roundtrip failed: inserted {expected:?}, read back {:?}",
+                retrieved.fact_type
+            );
+        }
+    }
 }

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -704,7 +704,9 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// - Returns `MemoryError::Serialization` if `scope_ids` cannot be serialized
+    ///   to JSON (infallible in practice for `&[i64]`).
+    /// - Returns `MemoryError::Database` on query failure.
     pub fn list_due(
         &self,
         now: DateTime<Utc>,

--- a/memory-engine/lib/memory-engine/src/store/scopes.rs
+++ b/memory-engine/lib/memory-engine/src/store/scopes.rs
@@ -15,6 +15,11 @@ impl<'a> ScopeStore<'a> {
     }
 
     /// Get a scope by id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::NotFound` if no scope with `id` exists.
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn get(&self, id: i64) -> Result<ScopeNode> {
         self.conn
             .query_row(
@@ -38,6 +43,12 @@ impl<'a> ScopeStore<'a> {
     }
 
     /// Find a scope by `parent_id` + label.
+    ///
+    /// Returns `Ok(None)` if no match is found.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn find_by_label(&self, parent_id: i64, label: &str) -> Result<Option<ScopeNode>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, parent_id, label, depth FROM scopes WHERE parent_id = ?1 AND label = ?2",
@@ -67,6 +78,11 @@ impl<'a> ScopeStore<'a> {
     /// label here can break round-tripping through
     /// [`crate::scope::ScopeTree::resolve_path`]. Prefer [`Self::ensure_path`]
     /// for a validated, idempotent alternative.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure (e.g. FK violation if
+    /// `parent_id` does not exist, or a UNIQUE constraint on `(parent_id, label)`).
     pub fn insert(&self, parent_id: i64, label: &str, depth: i64) -> Result<ScopeNode> {
         self.conn.execute(
             "INSERT INTO scopes (parent_id, label, depth) VALUES (?1, ?2, ?3)",
@@ -106,6 +122,13 @@ impl<'a> ScopeStore<'a> {
     ///
     /// All top-level segments are children of root (id=1). Uses
     /// `INSERT OR IGNORE` + `SELECT` for race-safe creation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Conflict` if `path` is empty or any segment is
+    /// invalid (empty, contains `/`, has leading/trailing whitespace, or exceeds
+    /// [`crate::scope::MAX_SEGMENT_LEN`] bytes).
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn ensure_path(&self, path: &str) -> Result<i64> {
         if path.is_empty() {
             return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
@@ -140,6 +163,10 @@ impl<'a> ScopeStore<'a> {
     }
 
     /// List all scopes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Database` on SQL failure.
     pub fn list_all(&self) -> Result<Vec<ScopeNode>> {
         let mut stmt = self
             .conn

--- a/memory-engine/lib/memory-engine/src/store/upcaster.rs
+++ b/memory-engine/lib/memory-engine/src/store/upcaster.rs
@@ -15,16 +15,21 @@ pub type UpcasterFn = fn(serde_json::Value) -> Result<serde_json::Value>;
 /// semantics are preserved. Only `get_upcasted`/`list_upcasted` apply the chain.
 #[derive(Clone)]
 pub struct UpcasterRegistry {
-    /// `(event_type, from_revision)` → upcaster function
-    upcasters: HashMap<(String, u16), UpcasterFn>,
+    /// `event_type` → (`from_revision` → upcaster function).
+    ///
+    /// Two-level map so the hot upcasting loop can look up the event type's chain
+    /// once (by `&str` borrow, no allocation) and then index into it by revision
+    /// without cloning the event-type string on every step.
+    upcasters: HashMap<String, HashMap<u16, UpcasterFn>>,
     /// `event_type` → latest known revision
     latest: HashMap<String, u16>,
 }
 
 impl std::fmt::Debug for UpcasterRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let count: usize = self.upcasters.values().map(HashMap::len).sum();
         f.debug_struct("UpcasterRegistry")
-            .field("registered_upcasters", &self.upcasters.len())
+            .field("registered_upcasters", &count)
             .field("latest_revisions", &self.latest)
             .finish()
     }
@@ -49,10 +54,12 @@ impl UpcasterRegistry {
     /// Number of registered upcaster functions. Used by the construction
     /// equivalence harness to prove the builder preserves the registry verbatim
     /// (deterministic, unlike the `Debug` impl's `HashMap` ordering).
+    ///
+    /// Counts individual (`event_type`, `from_revision`) pairs across all chains.
     #[must_use]
     #[allow(dead_code)] // observed only by the equivalence test harness
     pub(crate) fn registered_count(&self) -> usize {
-        self.upcasters.len()
+        self.upcasters.values().map(HashMap::len).sum()
     }
 
     /// Register an upcaster that transforms `event_type` payloads from
@@ -63,7 +70,9 @@ impl UpcasterRegistry {
     pub fn register(&mut self, event_type: &str, from_revision: u16, func: UpcasterFn) {
         let target = from_revision.saturating_add(1);
         self.upcasters
-            .insert((event_type.to_string(), from_revision), func);
+            .entry(event_type.to_string())
+            .or_default()
+            .insert(from_revision, func);
         let current = self.latest.entry(event_type.to_string()).or_insert(1);
         if target > *current {
             *current = target;
@@ -102,11 +111,11 @@ impl UpcasterRegistry {
 
         let mut value = payload;
         let mut rev = current_revision;
-        let type_key = event_type.to_string();
+        // Look up the inner chain once by &str — no String allocation in the loop.
+        let chain = self.upcasters.get(event_type);
 
         while rev < latest {
-            let key = (type_key.clone(), rev);
-            let func = self.upcasters.get(&key).ok_or_else(|| {
+            let func = chain.and_then(|inner| inner.get(&rev)).ok_or_else(|| {
                 MigrationError::MissingUpcaster(format!(
                     "missing upcaster for event type '{event_type}' from revision {rev} to {}",
                     rev + 1


### PR DESCRIPTION
Addresses the valuable, reasonable-effort subset of grouped issue #500 (low/info storage findings), triaged against current `main`. Three atomic commits:

1. **docs** — additive `# Errors`/`# Panics` doc sections on `store::{scopes,activities,checkpoints,facts}` methods that lacked them; `# Errors` for `search_archives` (adds `MemoryError::Serialization`); public field docs on archive `types.rs`; `FactProvenance::importance_score` doc; a note on `ArchivePolicy::default()` clarifying its now-relative cutoff is **by design** (a retention policy's default is inherently relative to now — not an oversight, not "fixed").
2. **perf/correctness** — eliminate the per-step `String` clone in the upcaster hot loop (nested `HashMap<String, HashMap<u16, _>>` so the event-type chain is looked up once by `&str`; `(type,rev)→fn` mapping, `registered_count`, and `Debug` semantics all preserved); deterministic `list_recent` ordering (`ORDER BY checkpoint_at DESC, session_id DESC` — fixes a `Utc::now()`-tie flake). `build_pak` left by-reference (the caller reuses the slices, so by-value would only relocate the clone — documented).
3. **tests** — non-zero `EdgeStats`/`ScopeStats` coverage (nested scopes; `max_depth` was always 0 before); `FactType` round-trip through the store for every variant.

**Disposition of the rest of #500:** 6 sub-findings already-fixed by earlier waves (closed with evidence on #500); the large test-infra items (public-API doc-tests, fuzz harness, archive feature-combo CI, integration-test embedder dedup) are tracked in **#923**; info-severity design observations (`UpcasterFn` fn-ptr, `commit_archive` 7-arg, VACUUM-INTO `format!` path — an inherent SQLite limitation, already mitigated) dispositioned won't-fix/accept on #500.

Refs #500.

## Verification
All CI gates pass locally: fmt, `clippy --workspace --all-targets --all-features -D warnings`, build all-features, `test --workspace --all-features` (1967 pass), cargo doc all-features.