### PR TITLE
refactor(core): decouple rusqlite from me-types, delete MemoryError::Database

### DIFF
--- a/docs/advanced/conflict-resolution.md
+++ b/docs/advanced/conflict-resolution.md
@@ -115,6 +115,6 @@ The in-memory graph is updated after the transaction commits:
 
 - `MemoryError::NotFound` if `old_id` doesn't exist in the database.
 - Errors from the arbiter's `arbitrate()` call propagate directly.
-- `MemoryError::Database` on SQL failures.
+- `MemoryError::Storage(StorageError::Backend)` on backend/SQL failures (the driver error is mapped opaquely at the storage seam; #926).
 
 The arbiter can return errors to signal that it cannot make a decision (e.g., insufficient context). This aborts the resolution without any side effects.

--- a/docs/design/adr/0018-wave2-crate-decomposition-memoryctx.md
+++ b/docs/design/adr/0018-wave2-crate-decomposition-memoryctx.md
@@ -68,15 +68,25 @@ build on these boundaries have the durable _why_.
    `memory-engine-embed` publish. The publishable crates carry **versioned** path-deps on
    their internal deps (cargo-deny's wildcard rule does not exempt public crates).
 
-8. **Two deliberate, gated public-API breaks** (`cargo public-api` in the per-slice gate,
+8. **Three deliberate, gated public-API breaks** (`cargo public-api` in the per-slice gate,
    this ADR the record): (a) **`DreamCycle::run(&dyn CycleCtx)`** replacing
    `&CycleContext` — necessary so `me-traits` does not depend on `me-consolidate` (the DTO
    move alone leaves that cycle); `CycleCtx` is a `me-traits` capability trait enumerating
    the exact read-set the shipped `DefaultDreamCycle`/`LlmDreamCycle` use, and
    `me-consolidate`'s `CycleContext` _implements_ it. Landed in **S1** (keystone).
    (b) **`VectorSearchStrategy::search`** taking a storage port (`&dyn SearchIndex`)
-   instead of `&Connection` — deferred to **S4** (still `&Connection` after S1). `§M`'s
-   "public API unchanged" is amended to "unchanged **except** these two, gated".
+   instead of `&Connection` — deferred to **S4** (still `&Connection` after S1).
+   (c) **`MemoryError::Database` variant removed** (#926, at **S2**-start) — the SQLite
+   driver's `rusqlite::Error` no longer appears in the L0 public error enum; backend driver
+   errors now surface via `MemoryError::Storage(StorageError::Backend(String))`, mapped at
+   each backend call site through the new `StorageError::backend(impl Display)` helper. The
+   orphan rule previously pinned `impl From<rusqlite::Error> for MemoryError` — and thus
+   `rusqlite` + bundled SQLite — into L0 `me-types`; removing the variant lets `me-types`
+   drop `rusqlite` entirely (unblocking #633's `dep:rusqlite` gating). `#[non_exhaustive]`
+   on `MemoryError` softens the impact — only explicit `Database(_)` arms break, not
+   exhaustiveness. The `storage::sqlite::map_seam_err` boundary remap is deleted (subsumed:
+   the guarantee moves from a runtime match to compiler-enforced source-mapping). `§M`'s
+   "public API unchanged" is amended to "unchanged **except** these three, gated".
 
 ## Consequences
 
@@ -122,7 +132,7 @@ build on these boundaries have the durable _why_.
   return; the facade `count_events` early-out stays as a cheap embed-skip optimization.
   This is internal-port evolution (consumers call the `MemoryEngine` facade, not the port
   trait), guarded by `reexports_are_accessible` + cli/mcp/embed builds like the rest of the
-  carve — not a consumer-facing break, so point 8's "unchanged except two" still holds.
+  carve — not a consumer-facing break, so point 8's "unchanged except three" still holds.
 
 ## References
 

--- a/memory-engine/bin/mcp/src/error.rs
+++ b/memory-engine/bin/mcp/src/error.rs
@@ -27,8 +27,6 @@ pub fn to_mcp_error(err: MemoryError) -> ErrorData {
         // maps to invalid_params alongside `Conflict` — not the internal-error default.
         MemoryError::Cycle(e) => ErrorData::invalid_params(format!("cycle error: {e}"), None),
 
-        MemoryError::Database(e) => ErrorData::internal_error(format!("database error: {e}"), None),
-
         MemoryError::Serialization(e) => {
             ErrorData::internal_error(format!("serialization error: {e}"), None)
         }
@@ -152,13 +150,6 @@ mod tests {
         let mcp = to_mcp_error(err);
         assert_eq!(mcp.code, rmcp::model::ErrorCode::INVALID_PARAMS);
         assert!(mcp.message.contains("model mismatch"));
-    }
-
-    #[test]
-    fn database_maps_to_internal() {
-        let err = MemoryError::Database(rusqlite::Error::QueryReturnedNoRows);
-        let mcp = to_mcp_error(err);
-        assert_eq!(mcp.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
     }
 
     #[test]

--- a/memory-engine/bin/mcp/src/error.rs
+++ b/memory-engine/bin/mcp/src/error.rs
@@ -167,7 +167,10 @@ mod tests {
         let err = MemoryError::Storage(StorageError::Backend("boom".into()));
         let mcp = to_mcp_error(err);
         assert_eq!(mcp.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
-        assert!(mcp.message.contains("storage error"));
+        // #926: backend failures used to surface via the deleted `Database` arm as
+        // "database error: …"; they now flow through `Storage` as "storage error: …".
+        // Pin the exact prefix so that user-visible text change can never silently regress.
+        assert!(mcp.message.starts_with("storage error:"), "{}", mcp.message);
     }
 
     #[test]

--- a/memory-engine/lib/me-storage/src/schema.rs
+++ b/memory-engine/lib/me-storage/src/schema.rs
@@ -201,7 +201,7 @@ pub trait SchemaManager: Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns [`MemoryError::Database`](me_types::error::MemoryError::Database) on a
+    /// Returns [`MemoryError::Storage`](me_types::error::MemoryError::Storage) on a
     /// `name` collision or write failure, or
     /// [`MemoryError::Internal`](me_types::error::MemoryError::Internal) if the
     /// dimension overflows `i64`.

--- a/memory-engine/lib/me-types/Cargo.toml
+++ b/memory-engine/lib/me-types/Cargo.toml
@@ -15,13 +15,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
-# `MemoryError::Database(#[from] rusqlite::Error)` (error.rs) embeds the SQLite
-# driver's error type. The orphan rule forces the `From` impl to live wherever
-# `MemoryError` is defined, so L0 me-types must carry `rusqlite`. `bundled` keeps
-# the crate self-buildable (`cargo build -p me-types`) without a system libsqlite3.
-# Decoupling this (→ `Database(String)` + backend-side mapping) is tracked as a
-# follow-up — it is the real unblocker for #633's future `dep:rusqlite` gating.
-rusqlite = { version = "0.34", features = ["bundled"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/memory-engine/lib/me-types/src/error.rs
+++ b/memory-engine/lib/me-types/src/error.rs
@@ -374,9 +374,10 @@ pub enum CycleError {
 /// `String` **inside each backend** and never cross the trait seam — the engine
 /// depends on the storage port, not on any SQL driver. Causes that *do* have a
 /// precise `MemoryError` home (migration, pool, (de)serialization, not-found) are
-/// reported through those existing variants, not duplicated here (continues the
-/// #560 "one variant per recoverable cause" arc — the existing
-/// [`Database`](MemoryError::Database) variant stays for `SQLite`-internal use).
+/// reported through those existing variants, not duplicated here (completes the
+/// #560 "one variant per recoverable cause" arc — #926 removed the driver-typed
+/// `Database` variant, so backend driver errors now route here via
+/// [`StorageError::backend`]).
 ///
 /// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
 /// downstream `match` expressions must include a wildcard (`_`) arm.
@@ -403,6 +404,21 @@ pub enum StorageError {
     },
 }
 
+impl StorageError {
+    /// Map any backend driver error (`rusqlite::Error`, `tokio_postgres::Error`, …)
+    /// into the opaque [`Backend`](StorageError::Backend) variant, stringified at the
+    /// seam so **no driver type leaks past the storage port** (#926). Generic over
+    /// [`Display`](std::fmt::Display), so L0 `me-types` needs no driver dependency.
+    ///
+    /// Because [`MemoryError`] carries `#[from] StorageError`, a backend call site can
+    /// write `.map_err(StorageError::backend)?` and `?` performs the second hop
+    /// (`StorageError` → [`MemoryError::Storage`]) automatically.
+    #[must_use]
+    pub fn backend<E: std::fmt::Display>(err: E) -> Self {
+        Self::Backend(err.to_string())
+    }
+}
+
 /// Errors returned by the memory engine.
 ///
 /// Marked `#[non_exhaustive]`: new variants may be added in minor releases, so
@@ -413,10 +429,6 @@ pub enum MemoryError {
     /// A requested entity (fact, event, scope, snapshot, …) does not exist.
     #[error("not found: {0}")]
     NotFound(String),
-
-    /// An underlying `SQLite` operation failed (query, statement, or connection).
-    #[error("database error: {0}")]
-    Database(#[from] rusqlite::Error),
 
     /// JSON (de)serialization of a payload, snapshot, or config failed.
     #[error("serialization error: {0}")]
@@ -607,10 +619,18 @@ mod tests {
     }
 
     #[test]
-    fn from_rusqlite_error() {
-        let sqlite_err = rusqlite::Error::QueryReturnedNoRows;
-        let err: MemoryError = sqlite_err.into();
-        assert!(matches!(err, MemoryError::Database(_)));
+    fn backend_helper_maps_into_storage() {
+        // #926: `StorageError::backend` stringifies any `Display` error at the seam
+        // (no driver type in L0); `.into()`/`?` then lifts it to `MemoryError::Storage`
+        // via the `#[from] StorageError` impl. Replaces the old `#[from] rusqlite::Error`
+        // round-trip test, since `me-types` no longer depends on `rusqlite`.
+        let se = StorageError::backend("query returned no rows");
+        assert!(matches!(se, StorageError::Backend(_)));
+        let err: MemoryError = se.into();
+        assert!(matches!(
+            err,
+            MemoryError::Storage(StorageError::Backend(_))
+        ));
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/consolidation/cluster.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/cluster.rs
@@ -125,7 +125,7 @@ pub(super) fn compute_clusters(
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on SQL failure, or `MemoryError::Serialization` on
+/// Returns `MemoryError::Storage` on SQL failure, or `MemoryError::Serialization` on
 /// JSON serialization failure.
 pub(super) fn apply_clusters(
     conn: &Connection,

--- a/memory-engine/lib/memory-engine/src/consolidation/dedup.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/dedup.rs
@@ -193,7 +193,7 @@ pub(super) fn compute_dedup(
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on SQL failure, or `MemoryError::NotFound` from an
+/// Returns `MemoryError::Storage` on SQL failure, or `MemoryError::NotFound` from an
 /// importance update if a fact row is missing (facts are soft-deleted, so this does not
 /// fire for a merely-expired row).
 pub(super) fn apply_dedup(

--- a/memory-engine/lib/memory-engine/src/consolidation/global.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/global.rs
@@ -68,7 +68,7 @@ pub(super) fn compute_global(
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on SQL failure, or `MemoryError::Serialization` on
+/// Returns `MemoryError::Storage` on SQL failure, or `MemoryError::Serialization` on
 /// JSON serialization failure.
 pub(super) fn apply_global(
     conn: &Connection,

--- a/memory-engine/lib/memory-engine/src/consolidation/mod.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/mod.rs
@@ -21,6 +21,7 @@ mod cluster;
 mod dedup;
 mod global;
 
+use crate::error::StorageError;
 use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
@@ -86,7 +87,7 @@ pub use me_types::types::consolidation::{ConsolidationPlan, Snapshot};
 /// # Errors
 ///
 /// Returns `MemoryError::Conflict` if `config` fails validation, `MemoryError::Migration`
-/// if `last_consolidated_at` cannot be parsed, or `MemoryError::Database` on read failure.
+/// if `last_consolidated_at` cannot be parsed, or `MemoryError::Storage` on read failure.
 pub fn load_snapshot(
     conn: &Connection,
     embed_dim: usize,
@@ -276,14 +277,16 @@ fn compute_plan_capped(
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on SQL failure, or `MemoryError::Serialization` on a
+/// Returns `MemoryError::Storage` on SQL failure, or `MemoryError::Serialization` on a
 /// summary serialization failure.
 pub fn apply_plan(
     conn: &Connection,
     plan: &ConsolidationPlan,
     embed_dim: usize,
 ) -> Result<(ConsolidationStats, Vec<i64>)> {
-    let tx = conn.unchecked_transaction()?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(StorageError::backend)?;
 
     // Dedup writes: importance inheritances + expirations (concurrency-tolerant, #409).
     // Returns the ids actually expired plus whether a survivor disappeared in the gap.
@@ -320,7 +323,7 @@ pub fn apply_plan(
         set_config(&tx, "last_consolidated_at", &plan.now.to_rfc3339())?;
     }
 
-    tx.commit()?;
+    tx.commit().map_err(StorageError::backend)?;
 
     let stats = ConsolidationStats {
         duplicates_removed: applied.expired.len(),

--- a/memory-engine/lib/memory-engine/src/engine/activity.rs
+++ b/memory-engine/lib/memory-engine/src/engine/activity.rs
@@ -37,7 +37,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on write failure, or
+    /// Returns `MemoryError::Storage` on write failure, or
     /// `MemoryError::ReadOnly` if the engine is read-only.
     pub async fn record_activity(
         &self,
@@ -160,7 +160,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Returns `MemoryError::Database` on write failure.
+    /// Returns `MemoryError::Storage` on write failure.
     pub async fn checkpoint_session(
         &self,
         session_id: &str,

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -50,7 +50,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::Archive` on I/O failure.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     /// Returns `MemoryError::ReadOnly` if the engine is read-only.
     pub async fn archive(&self, policy: &ArchivePolicy) -> Result<Option<ArchiveStats>> {
         self.ensure_open()?;
@@ -143,7 +143,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub async fn list_archives(&self) -> Result<Vec<ArchiveManifestEntry>> {
         self.cold.list_archive_manifest().await
     }
@@ -154,7 +154,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     /// I/O errors for individual `.pak` files are reported per-entry, not propagated.
     pub async fn verify_archives(&self) -> Result<Vec<ArchiveVerifyResult>> {
         let entries = self.list_archives().await?;
@@ -327,7 +327,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on manifest read failure.
+    /// Returns `MemoryError::Storage` on manifest read failure.
     /// Returns `MemoryError::Archive` on `.pak` I/O or decompression failure.
     pub(crate) async fn search_archives_fallback(
         &self,

--- a/memory-engine/lib/memory-engine/src/engine/builder.rs
+++ b/memory-engine/lib/memory-engine/src/engine/builder.rs
@@ -168,7 +168,7 @@ impl MemoryEngineBuilder<InMemory> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` if the connection or schema setup fails.
+    /// Returns `MemoryError::Storage` if the connection or schema setup fails.
     pub fn build(self) -> Result<MemoryEngine> {
         let pool = ConnectionPool::open_memory(self.embed_dim)?;
         MemoryEngine::init_from_pool(

--- a/memory-engine/lib/memory-engine/src/engine/forgetting.rs
+++ b/memory-engine/lib/memory-engine/src/engine/forgetting.rs
@@ -16,7 +16,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Conflict` if the policy is invalid.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub async fn forget(&self, policy: &ForgetPolicy) -> Result<PruneStats> {
         self.ensure_open()?;
         // The prune walk reads the in-memory graph (degree per fact) *before* any
@@ -36,7 +36,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Returns `MemoryError::Database` if the update fails.
+    /// Returns `MemoryError::Storage` if the update fails.
     pub async fn pin_fact(&self, id: i64) -> Result<()> {
         self.storage.set_fact_pinned(id, true).await
     }
@@ -46,7 +46,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Returns `MemoryError::Database` if the update fails.
+    /// Returns `MemoryError::Storage` if the update fails.
     pub async fn unpin_fact(&self, id: i64) -> Result<()> {
         self.storage.set_fact_pinned(id, false).await
     }

--- a/memory-engine/lib/memory-engine/src/engine/graph.rs
+++ b/memory-engine/lib/memory-engine/src/engine/graph.rs
@@ -39,7 +39,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     /// Returns `MemoryError::NotFound` if `scope` is `Some` but the path
     /// does not exist.
     pub async fn link_session_facts(&self, session_id: &str, scope: Option<&str>) -> Result<usize> {
@@ -127,7 +127,7 @@ impl MemoryEngine {
     /// - [`MemoryError::NotFound`](crate::error::MemoryError::NotFound) — no
     ///   *active* edge with `edge_id` exists (unknown id, or already expired); the
     ///   write affected 0 rows, so the graph is not modified.
-    /// - [`MemoryError::Database`](crate::error::MemoryError::Database) on SQL
+    /// - [`MemoryError::Storage`](crate::error::MemoryError::Storage) on SQL
     ///   failure.
     pub async fn expire_edge(&self, edge_id: i64) -> Result<()> {
         let now = Utc::now();

--- a/memory-engine/lib/memory-engine/src/engine/ingest.rs
+++ b/memory-engine/lib/memory-engine/src/engine/ingest.rs
@@ -17,7 +17,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Returns `MemoryError::Database` on insert failure.
+    /// Returns `MemoryError::Storage` on insert failure.
     pub async fn ingest(&self, event: &NewEvent) -> Result<i64> {
         self.ensure_open()?;
         check_json_size(&event.payload, "event payload")?;

--- a/memory-engine/lib/memory-engine/src/engine/inspect.rs
+++ b/memory-engine/lib/memory-engine/src/engine/inspect.rs
@@ -12,7 +12,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub async fn statistics(&self) -> Result<crate::inspect::EngineStatistics> {
         self.ensure_open()?;
         self.storage.statistics().await
@@ -29,7 +29,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub async fn list_recent_insights(
         &self,
         scope_path: &str,
@@ -61,7 +61,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub async fn replay_events(
         &self,
         filter: &crate::inspect::ReplayFilter,
@@ -88,7 +88,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::NotFound` if the fact doesn't exist.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     ///
     /// # Lock strategy
     ///
@@ -157,7 +157,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::NotFound` if the fact doesn't exist.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub async fn fact_history(&self, id: i64) -> Result<crate::inspect::FactHistory> {
         self.ensure_open()?;
         // The bi-temporal timeline is pure over a single fact's timestamps: fetch via
@@ -182,7 +182,7 @@ impl MemoryEngine {
     ///
     /// Returns [`MemoryError::Io`](crate::MemoryError::Io) on filesystem failure.
     /// Returns [`MemoryError::Conflict`](crate::MemoryError::Conflict) if the target path resolves to the live database.
-    /// Returns [`MemoryError::Database`](crate::MemoryError::Database) on SQL failure.
+    /// Returns [`MemoryError::Storage`](crate::MemoryError::Storage) on SQL failure.
     /// Returns [`MemoryError::Serialization`](crate::MemoryError::Serialization) for the JSON formats if snapshot
     /// serialization fails.
     /// Returns [`MemoryError::NotImplemented`](crate::MemoryError::NotImplemented) if a compression format is used

--- a/memory-engine/lib/memory-engine/src/engine/lineage.rs
+++ b/memory-engine/lib/memory-engine/src/engine/lineage.rs
@@ -24,7 +24,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine is read-only.
     /// Returns `MemoryError::Lineage` if the wisdom fact is missing or expired,
     /// or a source fact ID does not exist.
-    /// Returns `MemoryError::Database` on insert failure.
+    /// Returns `MemoryError::Storage` on insert failure.
     ///
     /// `#[cfg(test)]`: production promotion writes lineage atomically inside
     /// [`promote_in_conn`](crate::engine::MemoryEngine::promote_in_conn) (one

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -633,7 +633,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub async fn get_config(&self, key: &str) -> Result<Option<String>> {
         self.storage.get_config(key).await
     }
@@ -643,7 +643,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Returns `MemoryError::Database` on write failure.
+    /// Returns `MemoryError::Storage` on write failure.
     pub async fn set_config(&self, key: &str, value: &str) -> Result<()> {
         self.storage.set_config(key, value).await
     }
@@ -717,7 +717,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
-    /// Returns `MemoryError::Database` on insert failure.
+    /// Returns `MemoryError::Storage` on insert failure.
     pub async fn ensure_scope_path(&self, path: &str) -> Result<i64> {
         let id = self.storage.ensure_scope_path(path).await?;
         self.cache_scope_chain(id).await?;
@@ -743,7 +743,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub async fn list_active_facts(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
         self.ensure_open()?;
         self.storage.list_active_facts(limit).await
@@ -753,7 +753,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub async fn list_summaries(
         &self,
         level: &ConsolidationLevel,

--- a/memory-engine/lib/memory-engine/src/engine/outcome.rs
+++ b/memory-engine/lib/memory-engine/src/engine/outcome.rs
@@ -22,7 +22,7 @@ impl MemoryEngine {
     ///
     /// - [`MemoryError::NotFound`](crate::MemoryError::NotFound) if `fact_id` does not exist.
     /// - [`MemoryError::ReadOnly`](crate::MemoryError::ReadOnly) if the engine is read-only.
-    /// - [`MemoryError::Database`](crate::MemoryError::Database) on insert failure.
+    /// - [`MemoryError::Storage`](crate::MemoryError::Storage) on insert failure.
     pub async fn record_outcome(&self, fact_id: i64, outcome: Outcome) -> Result<i64> {
         // Validate fact exists via the port — propagate DB errors as-is,
         // only remap NotFound for a clearer message.
@@ -57,7 +57,7 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// - [`MemoryError::NotFound`](crate::MemoryError::NotFound) if `fact_id` does not exist.
-    /// - [`MemoryError::Database`](crate::MemoryError::Database) on query failure.
+    /// - [`MemoryError::Storage`](crate::MemoryError::Storage) on query failure.
     pub async fn get_outcome_counts(&self, fact_id: i64) -> Result<OutcomeCounts> {
         // Validate fact exists (consistent with record_outcome) — propagate NotFound.
         self.storage.get_fact(fact_id).await.map(|_| ())?;
@@ -79,7 +79,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// - [`MemoryError::Database`](crate::MemoryError::Database) on query failure.
+    /// - [`MemoryError::Storage`](crate::MemoryError::Storage) on query failure.
     pub async fn get_outcome_counts_batch(
         &self,
         fact_ids: &[i64],

--- a/memory-engine/lib/memory-engine/src/engine/query.rs
+++ b/memory-engine/lib/memory-engine/src/engine/query.rs
@@ -54,7 +54,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     /// Returns `MemoryError::Reranker` if a configured [`Reranker`](crate::traits::Reranker)
     /// fails or returns an invalid permutation.
     ///
@@ -124,7 +124,7 @@ impl MemoryEngine {
     /// - `valid_at` and `period` are both set (mutually exclusive)
     /// - `search_mode` conflicts with available text/embedding inputs
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub async fn execute_query(&self, query: &MemoryQuery) -> Result<QueryResponse> {
         self.ensure_open()?;
         // --- Validation ---

--- a/memory-engine/lib/memory-engine/src/engine/scheduling.rs
+++ b/memory-engine/lib/memory-engine/src/engine/scheduling.rs
@@ -16,7 +16,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` if scope resolution, the query, or
+    /// Returns `MemoryError::Storage` if scope resolution, the query, or
     /// surfaced-at stamping fails.
     pub async fn list_due(&self, now: DateTime<Utc>, scope: Option<&str>) -> Result<Vec<Fact>> {
         let scope_ids = self.resolve_scope_ids(scope)?;
@@ -47,7 +47,7 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` if scope resolution or the query fails.
+    /// Returns `MemoryError::Storage` if scope resolution or the query fails.
     pub async fn next_due_time(&self, scope: Option<&str>) -> Result<Option<DateTime<Utc>>> {
         let scope_ids = self.resolve_scope_ids(scope)?;
         self.storage.next_due_time(Utc::now(), &scope_ids).await

--- a/memory-engine/lib/memory-engine/src/engine/snapshot.rs
+++ b/memory-engine/lib/memory-engine/src/engine/snapshot.rs
@@ -14,6 +14,7 @@
 //! The blake3 checksum covers the payload bytes only. Header is checked first
 //! (cheap) so `format_version/embed_dim` mismatches reject without hashing.
 
+use crate::error::StorageError;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -175,7 +176,7 @@ pub fn read_fingerprint(conn: &Connection) -> Result<DbFingerprint> {
             })
         },
     )
-    .map_err(MemoryError::from)
+    .map_err(|e| StorageError::backend(e).into())
 }
 
 // ---------------------------------------------------------------------------

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -5278,7 +5278,7 @@ async fn restore_sqlite_non_sqlite_file_returns_database_error() {
     // `restore_sqlite` accepts only a real SQLite backup. A regular file that is
     // NOT a SQLite database passes the `is_file()` precondition, gets copied to
     // the target, and then fails when the probe connection runs its first
-    // statement against the bogus header — surfacing `MemoryError::Database`.
+    // statement against the bogus header — surfacing `MemoryError::Storage`.
     // The orphaned copy must be cleaned up.
     let dir = tempfile::tempdir().unwrap();
     let bogus = dir.path().join("not_a_db.bin");
@@ -5290,7 +5290,10 @@ async fn restore_sqlite_non_sqlite_file_returns_database_error() {
 
     let err = MemoryEngine::restore_sqlite(&bogus, &config).unwrap_err();
     assert!(
-        matches!(err, MemoryError::Database(_)),
+        matches!(
+            err,
+            MemoryError::Storage(crate::error::StorageError::Backend(_))
+        ),
         "expected Database error when restoring from a non-SQLite file, got {err:?}"
     );
     // The copied orphan must be removed on the failure path.

--- a/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
+++ b/memory-engine/lib/memory-engine/src/graph/memory_graph.rs
@@ -270,7 +270,7 @@ impl MemoryGraph {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn load_from_db(conn: &Connection) -> Result<Self> {
         let store = EdgeStore::new(conn);
         let active_edges = store.list_active()?;

--- a/memory-engine/lib/memory-engine/src/inspect/dump.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/dump.rs
@@ -259,11 +259,11 @@ fn stream_snapshot<W: Write>(conn: &Connection, embed_dim: usize, writer: &mut W
 
     if let Err(serde_err) = serialize_all() {
         // Prefer the original typed store/DB error stashed by a `SeqStreamer`
-        // over the serde wrapper, so `Database`/`Io` survive the dump's error
+        // over the serde wrapper, so `Storage`/`Io` survive the dump's error
         // contract instead of collapsing to `MemoryError::Serialization`.
         return Err(store_err
             .into_inner()
-            .unwrap_or_else(|| MemoryError::Serialization(serde_err)));
+            .unwrap_or(MemoryError::Serialization(serde_err)));
     }
 
     writer.flush()?;
@@ -290,7 +290,7 @@ fn stream_snapshot<W: Write>(conn: &Connection, embed_dim: usize, writer: &mut W
 /// * A serde *element* error is stashed locally and re-raised verbatim as the
 ///   true cause (the placeholder [`MemoryError`] used to abort `iterate` never
 ///   escapes).
-/// * A genuine *store/DB* error ([`MemoryError::Database`], [`MemoryError::Io`],
+/// * A genuine *store/DB* error ([`MemoryError::Storage`], [`MemoryError::Io`],
 ///   …) is funneled through [`serde::ser::Error::custom`] so it can abort the
 ///   serializer — but the **original typed [`MemoryError`]** is *also* stashed
 ///   into the shared `store_err` cell so the caller ([`stream_snapshot`]) can
@@ -388,7 +388,7 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`] on SQL failure,
+/// Returns [`MemoryError::Storage`] on SQL failure,
 /// [`MemoryError::Io`] on filesystem failure, or
 /// [`MemoryError::Serialization`] on JSON serialization failure.
 pub fn dump_json(conn: &Connection, embed_dim: usize, path: &Path) -> Result<()> {
@@ -411,7 +411,7 @@ pub fn dump_json(conn: &Connection, embed_dim: usize, path: &Path) -> Result<()>
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`] on SQL failure,
+/// Returns [`MemoryError::Storage`] on SQL failure,
 /// [`MemoryError::Io`] on filesystem failure, or
 /// [`MemoryError::Serialization`] on JSON serialization failure.
 #[cfg(feature = "compress-gzip")]
@@ -437,7 +437,7 @@ pub fn dump_json_gzip(conn: &Connection, embed_dim: usize, path: &Path) -> Resul
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`] on SQL failure,
+/// Returns [`MemoryError::Storage`] on SQL failure,
 /// [`MemoryError::Io`] on filesystem or zstd I/O failure, or
 /// [`MemoryError::Serialization`] on JSON serialization failure.
 #[cfg(feature = "compress-zstd")]

--- a/memory-engine/lib/memory-engine/src/inspect/restore.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/restore.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use rusqlite::Connection;
 
-use crate::error::{ConflictError, MemoryError, MigrationError, Result};
+use crate::error::{ConflictError, MemoryError, MigrationError, Result, StorageError};
 use crate::store::events::event_type_to_str;
 use crate::store::lineage::LineageStore;
 use crate::store::schema::{CURRENT_SCHEMA_VERSION, STORAGE_EPOCH, set_config};
@@ -289,16 +289,28 @@ pub fn validate_snapshot(snapshot: &EngineSnapshot) -> Result<()> {
 ///
 /// The root scope (id=1) inserted by `init_schema` is expected and excluded.
 fn assert_empty_db(conn: &Connection) -> Result<()> {
-    let event_count: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))?;
-    let fact_count: i64 = conn.query_row("SELECT COUNT(*) FROM facts", [], |r| r.get(0))?;
-    let edge_count: i64 = conn.query_row("SELECT COUNT(*) FROM edges", [], |r| r.get(0))?;
-    let summary_count: i64 = conn.query_row("SELECT COUNT(*) FROM summaries", [], |r| r.get(0))?;
+    let event_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
+    let fact_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM facts", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
+    let edge_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM edges", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
+    let summary_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM summaries", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
     // scopes: root scope (id=1) is expected from init_schema
-    let scope_count: i64 =
-        conn.query_row("SELECT COUNT(*) FROM scopes WHERE id > 1", [], |r| r.get(0))?;
-    let lineage_count: i64 = conn.query_row("SELECT COUNT(*) FROM lineage", [], |r| r.get(0))?;
-    let fact_vector_count: i64 =
-        conn.query_row("SELECT COUNT(*) FROM fact_vectors", [], |r| r.get(0))?;
+    let scope_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM scopes WHERE id > 1", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
+    let lineage_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM lineage", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
+    let fact_vector_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM fact_vectors", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
 
     let total = event_count
         + fact_count
@@ -316,11 +328,13 @@ fn assert_empty_db(conn: &Connection) -> Result<()> {
 /// Insert all snapshot events, preserving explicit IDs. Helper for
 /// [`restore_snapshot_into`].
 fn restore_events(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
-    let mut stmt = conn.prepare(
-        "INSERT INTO events (id, timestamp, event_type, payload, source, session_id, \
+    let mut stmt = conn
+        .prepare(
+            "INSERT INTO events (id, timestamp, event_type, payload, source, session_id, \
          scope_id, origin_node_id, sequence_id, created_at, event_revision) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-    )?;
+        )
+        .map_err(StorageError::backend)?;
     for event in &snapshot.events {
         let ts = event.timestamp.to_rfc3339();
         let et = event_type_to_str(&event.event_type);
@@ -338,7 +352,8 @@ fn restore_events(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
             event.sequence_id,
             created,
             event.event_revision,
-        ])?;
+        ])
+        .map_err(StorageError::backend)?;
     }
     Ok(())
 }
@@ -346,12 +361,14 @@ fn restore_events(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
 /// Insert all snapshot facts, preserving explicit IDs. Helper for
 /// [`restore_snapshot_into`].
 fn restore_facts(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
-    let mut stmt = conn.prepare(
-        "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, \
+    let mut stmt = conn
+        .prepare(
+            "INSERT INTO facts (id, content, content_hash, embedding, fact_type, t_created, \
          t_expired, t_valid, t_invalid, source_event_id, importance, access_count, \
          last_accessed, metadata, scope_id, is_pinned, importance_score, surfaced_at) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
-    )?;
+        )
+        .map_err(StorageError::backend)?;
     for fact in &snapshot.facts {
         let embedding_blob = serialize_embedding(&fact.embedding);
         let ft = crate::store::facts::fact_type_to_str(&fact.fact_type);
@@ -380,7 +397,8 @@ fn restore_facts(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
             fact.is_pinned,
             fact.importance_score,
             fact.surfaced_at.map(|dt| dt.to_rfc3339()),
-        ])?;
+        ])
+        .map_err(StorageError::backend)?;
     }
     Ok(())
 }
@@ -388,11 +406,13 @@ fn restore_facts(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
 /// Insert all snapshot edges, preserving explicit IDs. Helper for
 /// [`restore_snapshot_into`].
 fn restore_edges(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
-    let mut stmt = conn.prepare(
-        "INSERT INTO edges (id, source_fact_id, target_fact_id, relation_type, weight, \
+    let mut stmt = conn
+        .prepare(
+            "INSERT INTO edges (id, source_fact_id, target_fact_id, relation_type, weight, \
          t_created, t_expired, scope_id) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-    )?;
+        )
+        .map_err(StorageError::backend)?;
     for edge in &snapshot.edges {
         let t_created = edge.t_created.to_rfc3339();
         let t_expired = edge.t_expired.map(|dt| dt.to_rfc3339());
@@ -405,7 +425,8 @@ fn restore_edges(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
             t_created,
             t_expired,
             edge.scope_id,
-        ])?;
+        ])
+        .map_err(StorageError::backend)?;
     }
     Ok(())
 }
@@ -419,7 +440,7 @@ fn restore_edges(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
 /// # Errors
 ///
 /// Returns [`MemoryError::Migration`] on a corrupt legacy `embedding_meta` value or an
-/// unrecognized space status, and [`MemoryError::Database`]/[`MemoryError::Internal`] on
+/// unrecognized space status, and [`MemoryError::Storage`]/[`MemoryError::Internal`] on
 /// insert failure (e.g. a second active space).
 fn restore_embedding_spaces(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
     if snapshot.embedding_spaces.is_empty() {
@@ -458,10 +479,12 @@ fn restore_fact_vectors(conn: &Connection, snapshot: &EngineSnapshot) -> Result<
         return Ok(());
     }
     let mut stmt = conn
-        .prepare("INSERT INTO fact_vectors (fact_id, space_id, embedding) VALUES (?1, ?2, ?3)")?;
+        .prepare("INSERT INTO fact_vectors (fact_id, space_id, embedding) VALUES (?1, ?2, ?3)")
+        .map_err(StorageError::backend)?;
     for fv in &snapshot.fact_vectors {
         let blob = serialize_embedding(&fv.embedding);
-        stmt.execute(rusqlite::params![fv.fact_id, fv.space_id, blob])?;
+        stmt.execute(rusqlite::params![fv.fact_id, fv.space_id, blob])
+            .map_err(StorageError::backend)?;
     }
     Ok(())
 }
@@ -473,7 +496,7 @@ fn restore_fact_vectors(conn: &Connection, snapshot: &EngineSnapshot) -> Result<
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`] on any SQL failure (transaction rolls back).
+/// Returns [`MemoryError::Storage`] on any SQL failure (transaction rolls back).
 /// Returns [`MemoryError::Conflict`] if the database is not empty.
 /// Propagates the validation errors from [`validate_snapshot`]:
 /// [`MemoryError::Migration`] if the snapshot's `schema_version` is newer than
@@ -481,30 +504,39 @@ fn restore_fact_vectors(conn: &Connection, snapshot: &EngineSnapshot) -> Result<
 /// [`MemoryError::Internal`] if `embed_dim` is zero or the root scope is missing.
 /// Returns [`MemoryError::Serialization`] if a summary's `source_fact_ids`
 /// cannot be serialized to JSON.
+#[allow(
+    clippy::too_many_lines,
+    reason = "#926 mapped each rusqlite seam call via `.map_err(StorageError::backend)`, whose line-wrapping pushed this already-long restore fn one line over 100 — mechanical verbosity, no added logic"
+)]
 pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
     validate_snapshot(snapshot)?;
     assert_empty_db(conn)?;
 
-    let tx = conn.unchecked_transaction()?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(StorageError::backend)?;
 
     // 1. Replace scopes with snapshot's scopes (preserving original IDs).
     //    When the snapshot has scopes, delete the auto-inserted root and reinsert all.
     //    When the snapshot has no scopes (empty snapshot), keep the root from init_schema.
     if !snapshot.scopes.is_empty() {
-        tx.execute("DELETE FROM scopes", [])?;
+        tx.execute("DELETE FROM scopes", [])
+            .map_err(StorageError::backend)?;
 
         // 2. Insert scopes (sorted by depth then id to satisfy parent FK).
         let mut scope_idx: Vec<usize> = (0..snapshot.scopes.len()).collect();
         scope_idx.sort_by_key(|&i| (snapshot.scopes[i].depth, snapshot.scopes[i].id));
-        let mut stmt =
-            tx.prepare("INSERT INTO scopes (id, parent_id, label, depth) VALUES (?1, ?2, ?3, ?4)")?;
+        let mut stmt = tx
+            .prepare("INSERT INTO scopes (id, parent_id, label, depth) VALUES (?1, ?2, ?3, ?4)")
+            .map_err(StorageError::backend)?;
         for scope in scope_idx.into_iter().map(|i| &snapshot.scopes[i]) {
             stmt.execute(rusqlite::params![
                 scope.id,
                 scope.parent_id,
                 scope.label,
                 scope.depth,
-            ])?;
+            ])
+            .map_err(StorageError::backend)?;
         }
     }
 
@@ -515,11 +547,13 @@ pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Re
 
     // 6. Insert summaries.
     {
-        let mut stmt = tx.prepare(
-            "INSERT INTO summaries (id, content, embedding, level, source_fact_ids, \
+        let mut stmt = tx
+            .prepare(
+                "INSERT INTO summaries (id, content, embedding, level, source_fact_ids, \
              created_at, scope_id) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-        )?;
+            )
+            .map_err(StorageError::backend)?;
         for summary in &snapshot.summaries {
             let embedding_blob = serialize_embedding(&summary.embedding);
             let level = crate::store::summaries::level_to_str(&summary.level);
@@ -533,7 +567,8 @@ pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Re
                 source_ids,
                 created,
                 summary.scope_id,
-            ])?;
+            ])
+            .map_err(StorageError::backend)?;
         }
     }
 
@@ -597,7 +632,7 @@ pub fn restore_snapshot_into(conn: &Connection, snapshot: &EngineSnapshot) -> Re
     )?;
 
     // 10. Commit.
-    tx.commit()?;
+    tx.commit().map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -609,11 +644,13 @@ fn reset_autoincrement(conn: &Connection, table: &str, max_id: i64) -> Result<()
     conn.execute(
         "DELETE FROM sqlite_sequence WHERE name = ?1",
         rusqlite::params![table],
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     conn.execute(
         "INSERT INTO sqlite_sequence (name, seq) VALUES (?1, ?2)",
         rusqlite::params![table, max_id],
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }
 

--- a/memory-engine/lib/memory-engine/src/inspect/statistics.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/statistics.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -14,7 +15,7 @@ use crate::store::summaries::str_to_level;
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`] on SQL failure.
+/// Returns [`MemoryError::Storage`] on SQL failure.
 pub fn compute_statistics(conn: &Connection, db_path: Option<&Path>) -> Result<EngineStatistics> {
     let now = Utc::now();
     let now_str = now.to_rfc3339();
@@ -31,18 +32,20 @@ pub fn compute_statistics(conn: &Connection, db_path: Option<&Path>) -> Result<E
          FROM facts",
         [&now_str],
         |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
-    )?;
+    ).map_err(StorageError::backend)?;
 
     // Edge counts — one conditional-aggregation scan instead of three (#394).
-    let (edge_total, edge_active, edge_expired): (i64, i64, i64) = conn.query_row(
-        "SELECT \
+    let (edge_total, edge_active, edge_expired): (i64, i64, i64) = conn
+        .query_row(
+            "SELECT \
             COUNT(*), \
             COALESCE(SUM(t_expired IS NULL), 0), \
             COALESCE(SUM(t_expired IS NOT NULL), 0) \
          FROM edges",
-        [],
-        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
-    )?;
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .map_err(StorageError::backend)?;
 
     // Summary counts by level — the GROUP BY already partitions the table, so its
     // counts sum to the total; deriving `summary_total` from them (rather than a
@@ -54,32 +57,45 @@ pub fn compute_statistics(conn: &Connection, db_path: Option<&Path>) -> Result<E
     let mut by_level = BTreeMap::new();
     let mut summary_total: i64 = 0;
     {
-        let mut stmt = conn.prepare("SELECT level, COUNT(*) FROM summaries GROUP BY level")?;
-        let rows = stmt.query_map([], |row| {
-            let level = str_to_level(&row.get::<_, String>(0)?)?;
-            let count: i64 = row.get(1)?;
-            Ok((level, count))
-        })?;
+        let mut stmt = conn
+            .prepare("SELECT level, COUNT(*) FROM summaries GROUP BY level")
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map([], |row| {
+                let level = str_to_level(&row.get::<_, String>(0)?)?;
+                let count: i64 = row.get(1)?;
+                Ok((level, count))
+            })
+            .map_err(StorageError::backend)?;
         for row in rows {
-            let (level, count) = row?;
+            let (level, count) = row.map_err(StorageError::backend)?;
             summary_total += count;
             by_level.insert(level, count);
         }
     }
 
     // Scope counts
-    let scope_total: i64 = conn.query_row("SELECT COUNT(*) FROM scopes", [], |r| r.get(0))?;
-    let scope_max_depth: i64 =
-        conn.query_row("SELECT COALESCE(MAX(depth), 0) FROM scopes", [], |r| {
+    let scope_total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM scopes", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
+    let scope_max_depth: i64 = conn
+        .query_row("SELECT COALESCE(MAX(depth), 0) FROM scopes", [], |r| {
             r.get(0)
-        })?;
+        })
+        .map_err(StorageError::backend)?;
 
     // Event count
-    let event_total: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))?;
+    let event_total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
 
     // Storage stats
-    let page_count: i64 = conn.query_row("PRAGMA page_count", [], |r| r.get(0))?;
-    let page_size: i64 = conn.query_row("PRAGMA page_size", [], |r| r.get(0))?;
+    let page_count: i64 = conn
+        .query_row("PRAGMA page_count", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
+    let page_size: i64 = conn
+        .query_row("PRAGMA page_size", [], |r| r.get(0))
+        .map_err(StorageError::backend)?;
     let main_db_bytes = page_count.checked_mul(page_size).ok_or_else(|| {
         crate::error::MemoryError::Internal(format!(
             "storage size overflow: page_count {page_count} * page_size {page_size}"
@@ -416,7 +432,10 @@ mod tests {
 
         let err = super::compute_statistics(&conn, None).unwrap_err();
         assert!(
-            matches!(err, crate::error::MemoryError::Database(_)),
+            matches!(
+                err,
+                crate::error::MemoryError::Storage(crate::error::StorageError::Backend(_))
+            ),
             "expected a Database error from the unknown level, got: {err:?}"
         );
         // Pin the *cause*, not just the variant: the #337 guard must surface the

--- a/memory-engine/lib/memory-engine/src/pool/connection_pool.rs
+++ b/memory-engine/lib/memory-engine/src/pool/connection_pool.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -310,7 +311,7 @@ impl ConnectionPool {
     /// (256): each read connection is a real OS file descriptor, so an excessive
     /// value is rejected (not clamped) before it can exhaust the FD table /
     /// over-allocate (#415, CWE-770/789).
-    /// Returns `MemoryError::Database` if any connection or schema setup fails.
+    /// Returns `MemoryError::Storage` if any connection or schema setup fails.
     /// Returns `MemoryError::Migration` if the schema version cannot be determined
     /// or the stored version is newer than the compiled-in maximum.
     /// Returns `MemoryError::UnsupportedEpoch` if the database was written by a
@@ -332,7 +333,7 @@ impl ConnectionPool {
         for _ in 0..read_pool_size {
             let conn = open_connection(&path_str)?;
             conn.execute_batch("PRAGMA query_only = ON")
-                .map_err(MemoryError::Database)?;
+                .map_err(StorageError::backend)?;
             read_conns.push(conn);
         }
 
@@ -354,7 +355,7 @@ impl ConnectionPool {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` if connection or schema setup fails.
+    /// Returns `MemoryError::Storage` if connection or schema setup fails.
     pub fn open_memory(embed_dim: usize) -> Result<Self> {
         let conn = open_memory_conn()?;
         init_schema(&conn)?;
@@ -389,7 +390,7 @@ impl ConnectionPool {
     /// connection; #340/#356), or if it exceeds `MAX_READ_POOL` (256): each read
     /// connection is a real OS file descriptor, so an oversized value is rejected
     /// rather than allowed to exhaust the FD table (#415, CWE-770/789).
-    /// Returns `MemoryError::Database` if any connection or pragma setup fails.
+    /// Returns `MemoryError::Storage` if any connection or pragma setup fails.
     /// Returns `MemoryError::Migration` if the file does not exist, the schema
     /// is uninitialized, or the schema needs migration.
     /// Returns `MemoryError::UnsupportedEpoch` if the DB epoch is from the future.

--- a/memory-engine/lib/memory-engine/src/search/ann.rs
+++ b/memory-engine/lib/memory-engine/src/search/ann.rs
@@ -4,6 +4,7 @@
 //! Uses the `hnsw` crate (rust-cv) which owns inserted vectors,
 //! avoiding lifetime issues with the HNSW graph.
 
+use crate::error::StorageError;
 use space::Metric;
 
 use crate::search::cosine_similarity;
@@ -187,23 +188,26 @@ impl HnswStrategy {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure, `MemoryError::Internal` if
+    /// Returns `MemoryError::Storage` on query failure, `MemoryError::Internal` if
     /// HNSW does not assign sequential IDs starting from 0, or
     /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
     fn build_inner(conn: &Connection, embed_dim: usize) -> Result<HnswInner> {
-        let mut stmt =
-            conn.prepare("SELECT id, embedding FROM facts WHERE t_expired IS NULL ORDER BY id")?;
+        let mut stmt = conn
+            .prepare("SELECT id, embedding FROM facts WHERE t_expired IS NULL ORDER BY id")
+            .map_err(StorageError::backend)?;
         // The mapped-rows iterator borrows `stmt`, which is owned here and outlives
         // the `build_hnsw_inner` call below — so the kernel can pull rows lazily.
         // Each item is fallible: a rusqlite row error or a wrong-width blob is
         // threaded through as `Err`, and `build_hnsw_inner` short-circuits on it.
-        let rows = stmt.query_map([], |row| {
-            let id: i64 = row.get(0)?;
-            let blob: Vec<u8> = row.get(1)?;
-            Ok((id, blob))
-        })?;
+        let rows = stmt
+            .query_map([], |row| {
+                let id: i64 = row.get(0)?;
+                let blob: Vec<u8> = row.get(1)?;
+                Ok((id, blob))
+            })
+            .map_err(StorageError::backend)?;
         let decoded = rows.map(|row| {
-            let (fact_id, blob) = row?;
+            let (fact_id, blob) = row.map_err(StorageError::backend)?;
             let embedding = deserialize_embedding(&blob, embed_dim)?;
             Ok((fact_id, embedding))
         });
@@ -215,7 +219,7 @@ impl HnswStrategy {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure, or
+    /// Returns `MemoryError::Storage` on query failure, or
     /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
     pub fn build_from_db(conn: &Connection, embed_dim: usize) -> Result<Self> {
         Ok(Self {
@@ -250,7 +254,7 @@ impl HnswStrategy {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure, or
+    /// Returns `MemoryError::Storage` on query failure, or
     /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
     #[allow(
         clippy::significant_drop_tightening,
@@ -299,7 +303,7 @@ impl HnswStrategy {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure, or
+    /// Returns `MemoryError::Storage` on query failure, or
     /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
     #[allow(
         clippy::unused_self,
@@ -312,17 +316,20 @@ impl HnswStrategy {
     ) -> Result<crate::types::snapshot::HnswSnapshot> {
         use crate::types::snapshot::{HnswEntry, HnswSnapshot};
 
-        let mut stmt =
-            conn.prepare("SELECT id, embedding FROM facts WHERE t_expired IS NULL ORDER BY id")?;
-        let rows = stmt.query_map([], |row| {
-            let id: i64 = row.get(0)?;
-            let blob: Vec<u8> = row.get(1)?;
-            Ok((id, blob))
-        })?;
+        let mut stmt = conn
+            .prepare("SELECT id, embedding FROM facts WHERE t_expired IS NULL ORDER BY id")
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map([], |row| {
+                let id: i64 = row.get(0)?;
+                let blob: Vec<u8> = row.get(1)?;
+                Ok((id, blob))
+            })
+            .map_err(StorageError::backend)?;
 
         let mut entries = Vec::new();
         for row in rows {
-            let (fact_id, blob) = row?;
+            let (fact_id, blob) = row.map_err(StorageError::backend)?;
             let embedding = deserialize_embedding(&blob, embed_dim)?;
             entries.push(HnswEntry { fact_id, embedding });
         }
@@ -591,7 +598,7 @@ impl VectorSearchStrategy for HnswStrategy {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure, `MemoryError::Serialization`
+/// Returns `MemoryError::Storage` on query failure, `MemoryError::Serialization`
 /// if the id/scope JSON cannot be built, or `MemoryError::EmbeddingDimension` if a
 /// stored embedding has the wrong width.
 fn fetch_candidate_embeddings(
@@ -612,25 +619,29 @@ fn fetch_candidate_embeddings(
         serde_json::to_string(candidate_ids).map_err(crate::error::MemoryError::Serialization)?;
     let scope_json = serialize_scope_ids(scope_ids)?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, embedding FROM facts
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, embedding FROM facts
          WHERE id IN (SELECT value FROM json_each(?1))
            AND t_expired IS NULL
            AND (?2 IS NULL OR fact_type = ?2)
            AND (?3 IS NULL OR scope_id IN (SELECT value FROM json_each(?3)))",
-    )?;
-    let rows = stmt.query_map(
-        rusqlite::params![ids_json, fact_type.map(fact_type_to_str), scope_json],
-        |row| {
-            let id: i64 = row.get(0)?;
-            let blob: Vec<u8> = row.get(1)?;
-            Ok((id, blob))
-        },
-    )?;
+        )
+        .map_err(StorageError::backend)?;
+    let rows = stmt
+        .query_map(
+            rusqlite::params![ids_json, fact_type.map(fact_type_to_str), scope_json],
+            |row| {
+                let id: i64 = row.get(0)?;
+                let blob: Vec<u8> = row.get(1)?;
+                Ok((id, blob))
+            },
+        )
+        .map_err(StorageError::backend)?;
 
     let mut out = HashMap::with_capacity(candidate_ids.len());
     for row in rows {
-        let (fact_id, blob) = row?;
+        let (fact_id, blob) = row.map_err(StorageError::backend)?;
         let embedding = deserialize_embedding(&blob, embed_dim)?;
         out.insert(fact_id, embedding);
     }

--- a/memory-engine/lib/memory-engine/src/search/fts.rs
+++ b/memory-engine/lib/memory-engine/src/search/fts.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use rusqlite::{Connection, ToSql, params_from_iter};
 
 use crate::error::Result;
@@ -31,7 +32,7 @@ pub struct FtsResult {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` for non-FTS5 database errors.
+/// Returns `MemoryError::Storage` for non-FTS5 database errors.
 pub fn fts_search(
     conn: &Connection,
     query: &str,
@@ -56,7 +57,7 @@ pub fn fts_search(
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` for non-FTS5 database errors.
+/// Returns `MemoryError::Storage` for non-FTS5 database errors.
 pub fn fts_search_filtered(
     conn: &Connection,
     query: &str,
@@ -72,7 +73,7 @@ pub fn fts_search_filtered(
          ORDER BY score LIMIT ?",
         filter.where_clause
     );
-    let mut stmt = conn.prepare(&sql)?;
+    let mut stmt = conn.prepare(&sql).map_err(StorageError::backend)?;
 
     let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
     // Param order mirrors the `?` order in the SQL above: MATCH query first, then
@@ -121,22 +122,24 @@ pub fn fts_search_filtered(
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` for non-FTS5 database errors.
+/// Returns `MemoryError::Storage` for non-FTS5 database errors.
 pub fn fts_count_expired(
     conn: &Connection,
     query: &str,
     fact_type: Option<&FactType>,
     scope_ids: Option<&[i64]>,
 ) -> Result<usize> {
-    let mut stmt = conn.prepare(
-        "SELECT COUNT(*) \
+    let mut stmt = conn
+        .prepare(
+            "SELECT COUNT(*) \
          FROM facts_fts \
          JOIN facts AS f ON f.id = facts_fts.rowid \
          WHERE facts_fts MATCH ?1 \
            AND f.t_expired IS NOT NULL \
            AND (?2 IS NULL OR f.fact_type = ?2) \
            AND (?3 IS NULL OR f.scope_id IN (SELECT value FROM json_each(?3)))",
-    )?;
+        )
+        .map_err(StorageError::backend)?;
 
     let fact_type_str: Option<&str> = fact_type.map(fact_type_to_str);
     let scope_ids_json = serialize_scope_ids(scope_ids)?;

--- a/memory-engine/lib/memory-engine/src/search/hybrid.rs
+++ b/memory-engine/lib/memory-engine/src/search/hybrid.rs
@@ -47,7 +47,7 @@ pub fn rrf_merge(fts: &[(i64, f64)], vec: &[(i64, f32)], k: u32) -> Vec<(i64, f6
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure.
+/// Returns `MemoryError::Storage` on query failure.
 /// Returns `MemoryError::EmbeddingDimension` if the query embedding or a stored
 /// embedding does not match the configured dimension during vector search.
 //
@@ -119,7 +119,7 @@ pub(crate) fn hybrid_search(
 ///
 /// # Errors
 ///
-/// Propagates `MemoryError::Database` on query failure and
+/// Propagates `MemoryError::Storage` on query failure and
 /// `MemoryError::EmbeddingDimension` on a wrong-length embedding (vector path).
 fn collect_candidates(
     conn: &Connection,

--- a/memory-engine/lib/memory-engine/src/search/strategy.rs
+++ b/memory-engine/lib/memory-engine/src/search/strategy.rs
@@ -23,7 +23,7 @@ pub trait VectorSearchStrategy: Send + Sync {
     /// # Errors
     ///
     /// Returns `MemoryError::EmbeddingDimension` if query dimension mismatches,
-    /// or `MemoryError::Database` on query failure.
+    /// or `MemoryError::Storage` on query failure.
     fn search(
         &self,
         conn: &Connection,

--- a/memory-engine/lib/memory-engine/src/search/vector.rs
+++ b/memory-engine/lib/memory-engine/src/search/vector.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use rusqlite::{Connection, params_from_iter};
 
 use crate::error::Result;
@@ -80,7 +81,7 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure, or
+/// Returns `MemoryError::Storage` on query failure, or
 /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
 //
 // The live SQLite path goes through `vector_search_filtered`; this unfiltered
@@ -112,7 +113,7 @@ pub(crate) fn vector_search(
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure, or
+/// Returns `MemoryError::Storage` on query failure, or
 /// `MemoryError::EmbeddingDimension` if a stored (or the query) embedding has the
 /// wrong size.
 pub fn vector_search_filtered(
@@ -133,17 +134,19 @@ pub fn vector_search_filtered(
         "SELECT id, embedding FROM facts WHERE {}",
         filter.where_clause
     );
-    let mut stmt = conn.prepare(&sql)?;
+    let mut stmt = conn.prepare(&sql).map_err(StorageError::backend)?;
 
-    let rows = stmt.query_map(params_from_iter(filter.bind_refs()), |row| {
-        let id: i64 = row.get(0)?;
-        let blob: Vec<u8> = row.get(1)?;
-        Ok((id, blob))
-    })?;
+    let rows = stmt
+        .query_map(params_from_iter(filter.bind_refs()), |row| {
+            let id: i64 = row.get(0)?;
+            let blob: Vec<u8> = row.get(1)?;
+            Ok((id, blob))
+        })
+        .map_err(StorageError::backend)?;
 
     let mut scored: Vec<VectorResult> = Vec::new();
     for row in rows {
-        let (id, blob) = row?;
+        let (id, blob) = row.map_err(StorageError::backend)?;
         let embedding = deserialize_embedding(&blob, embed_dim)?;
         let score = cosine_similarity(query_embedding, &embedding);
         scored.push(VectorResult { fact_id: id, score });

--- a/memory-engine/lib/memory-engine/src/storage/postgres/schema.rs
+++ b/memory-engine/lib/memory-engine/src/storage/postgres/schema.rs
@@ -9,7 +9,7 @@
 //!
 //! The embedding-fingerprint methods reimplement the `store::embedding_meta` /
 //! `store::embedding_spaces` logic in PG SQL (R11): those free functions take a
-//! `&rusqlite::Connection` and return `MemoryError::Database` (a `#[from]
+//! `&rusqlite::Connection` and return `MemoryError::Storage` (a `#[from]
 //! rusqlite::Error` variant Postgres cannot construct), so PG re-expresses the SQL and
 //! maps driver errors via [`pg_err`], while preserving the *exact* semantic variants
 //! (`EmbeddingDimension`, `EmbeddingModelMismatch`, `Internal`).

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/cold_storage.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/cold_storage.rs
@@ -337,11 +337,9 @@ mod tests {
         assert!(
             matches!(
                 err,
-                crate::error::MemoryError::Archive(_)
-                    | crate::error::MemoryError::Database(_)
-                    | crate::error::MemoryError::Storage(_)
+                crate::error::MemoryError::Archive(_) | crate::error::MemoryError::Storage(_)
             ),
-            "expected Archive, Database or Storage error, got {err:?}"
+            "expected Archive or Storage error, got {err:?}"
         );
 
         // Manifest must be byte-identical to before: only the one pre-seeded entry,

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/consolidation.rs
@@ -10,6 +10,7 @@
 //! Summary methods that (de)serialize embeddings capture `self.embed_dim` as a
 //! `let` binding outside the closure — the `'static` closures cannot borrow `self`.
 
+use crate::error::StorageError;
 use async_trait::async_trait;
 
 use super::{SqliteBackend, stream_consumer_dropped};
@@ -336,7 +337,7 @@ impl ConsolidationStore for SqliteBackend {
 
                 let tx = conn
                     .unchecked_transaction()
-                    .map_err(MemoryError::Database)?;
+                    .map_err(StorageError::backend)?;
 
                 // #613 guard: AddFact / Synthesize carry pre-computed embeddings with no
                 // live provider — reject against an un-stamped store. Called inside the
@@ -587,7 +588,7 @@ impl ConsolidationStore for SqliteBackend {
                     set_config(&tx, DREAM_CYCLE_HISTORY, &serde_json::to_string(&history)?)?;
                 }
 
-                tx.commit().map_err(MemoryError::Database)?;
+                tx.commit().map_err(StorageError::backend)?;
                 Ok((result, supersede_edges, expired_ids, to_index))
             })
             .await?;
@@ -676,7 +677,9 @@ impl ConsolidationStore for SqliteBackend {
 
         let (result, scope_ids_to_cache) = self
             .block_write(move |conn| {
-                let tx = conn.unchecked_transaction()?;
+                let tx = conn
+                    .unchecked_transaction()
+                    .map_err(StorageError::backend)?;
 
                 // #613/#615 promotion identity guard (pre-computed vector, no live
                 // embedder to stamp the store).
@@ -701,7 +704,7 @@ impl ConsolidationStore for SqliteBackend {
                     &provenance,
                 )?;
 
-                tx.commit().map_err(crate::error::MemoryError::Database)?;
+                tx.commit().map_err(StorageError::backend)?;
                 Ok((
                     crate::types::PromotionResult {
                         fact_id,
@@ -1106,7 +1109,7 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            matches!(err, MemoryError::Database(_) | MemoryError::Storage(_)),
+            matches!(err, MemoryError::Storage(_)),
             "expected Database or Storage error, got {err:?}"
         );
 

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/event_log.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/event_log.rs
@@ -3,6 +3,7 @@
 //! The [`UpcasterRegistry`](crate::store::upcaster::UpcasterRegistry) is a backend
 //! construction detail (cloned into each closure), never crossing a method boundary.
 
+use crate::error::StorageError;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -71,19 +72,23 @@ impl EventLog for SqliteBackend {
     // `engine/outcome.rs::get_outcome_counts`).
     async fn count_outcome_signals(&self, fact_id: i64) -> Result<crate::types::OutcomeCounts> {
         self.block_read(move |conn| {
-            let mut stmt = conn.prepare(
-                "SELECT json_extract(payload, '$.outcome') AS outcome, COUNT(*) AS cnt
+            let mut stmt = conn
+                .prepare(
+                    "SELECT json_extract(payload, '$.outcome') AS outcome, COUNT(*) AS cnt
                  FROM events
                  WHERE event_type = 'OutcomeSignal'
                    AND json_extract(payload, '$.fact_id') = ?1
                  GROUP BY outcome",
-            )?;
+                )
+                .map_err(StorageError::backend)?;
             let mut counts = crate::types::OutcomeCounts::default();
-            let rows = stmt.query_map(rusqlite::params![fact_id], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
-            })?;
+            let rows = stmt
+                .query_map(rusqlite::params![fact_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+                })
+                .map_err(StorageError::backend)?;
             for row in rows {
-                let (outcome_str, cnt) = row?;
+                let (outcome_str, cnt) = row.map_err(StorageError::backend)?;
                 match outcome_str.as_str() {
                     "Positive" => counts.positive = cnt,
                     "Negative" => counts.negative = cnt,
@@ -107,26 +112,30 @@ impl EventLog for SqliteBackend {
         }
         let ids_json = serde_json::to_string(fact_ids)?;
         self.block_read(move |conn| {
-            let mut stmt = conn.prepare(
-                "SELECT json_extract(payload, '$.fact_id') AS fid,
+            let mut stmt = conn
+                .prepare(
+                    "SELECT json_extract(payload, '$.fact_id') AS fid,
                         json_extract(payload, '$.outcome') AS outcome,
                         COUNT(*) AS cnt
                  FROM events
                  WHERE event_type = 'OutcomeSignal'
                    AND json_extract(payload, '$.fact_id') IN (SELECT value FROM json_each(?1))
                  GROUP BY fid, outcome",
-            )?;
+                )
+                .map_err(StorageError::backend)?;
             let mut by_fact: std::collections::HashMap<i64, crate::types::OutcomeCounts> =
                 std::collections::HashMap::new();
-            let rows = stmt.query_map(rusqlite::params![ids_json], |row| {
-                Ok((
-                    row.get::<_, i64>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, u32>(2)?,
-                ))
-            })?;
+            let rows = stmt
+                .query_map(rusqlite::params![ids_json], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, u32>(2)?,
+                    ))
+                })
+                .map_err(StorageError::backend)?;
             for row in rows {
-                let (fid, outcome_str, cnt) = row?;
+                let (fid, outcome_str, cnt) = row.map_err(StorageError::backend)?;
                 let entry = by_fact.entry(fid).or_default();
                 match outcome_str.as_str() {
                     "Positive" => entry.positive = cnt,

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/graph.rs
@@ -12,6 +12,7 @@
 //! `embed_dim` is captured as a `let` binding outside the closure so `FactStore`
 //! construction is not coupled to `self` inside the blocking thread.
 
+use crate::error::StorageError;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -70,7 +71,8 @@ impl SqliteBackend {
 
         // Verbatim body of ingest.rs:397-476: savepoint wrapping stamp +
         // scope-resolve + per-fact insert.
-        conn.execute_batch("SAVEPOINT batch_insert")?;
+        conn.execute_batch("SAVEPOINT batch_insert")
+            .map_err(StorageError::backend)?;
 
         let result: Result<BatchInsertResult> = (|| {
             // Record the embedding identity on first write (#613), inside the
@@ -127,7 +129,8 @@ impl SqliteBackend {
 
         match result {
             Ok(triple) => {
-                conn.execute_batch("RELEASE batch_insert")?;
+                conn.execute_batch("RELEASE batch_insert")
+                    .map_err(StorageError::backend)?;
                 Ok(triple)
             }
             Err(e) => {
@@ -719,11 +722,13 @@ impl FactGraph for SqliteBackend {
                 // Verbatim body of ingest.rs:228-231: one unchecked_transaction wrapping
                 // stamp_identity + FactStore::insert so a vector is never committed
                 // without an established, matching identity (the #614 silent-corruption guard).
-                let tx = conn.unchecked_transaction()?;
+                let tx = conn
+                    .unchecked_transaction()
+                    .map_err(StorageError::backend)?;
                 // stamp_identity equivalent: record-if-absent or compare-and-reject
                 crate::store::embedding_meta::record_if_absent(&tx, &fingerprint, expected_dim)?;
                 let id = FactStore::new(&tx, dim).insert(&fact)?;
-                tx.commit()?;
+                tx.commit().map_err(StorageError::backend)?;
                 Ok(id)
             })
             .await?;
@@ -820,7 +825,9 @@ impl FactGraph for SqliteBackend {
         self.block_write(move |conn| {
             // Verbatim body of engine/graph.rs:71-101: one unchecked_transaction
             // wrapping batch-dedup + edge inserts.
-            let tx = conn.unchecked_transaction()?;
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(StorageError::backend)?;
             let edge_store = EdgeStore::new(&tx);
 
             let existing = edge_store.list_active_pairs_by_facts(&fact_ids, &relation)?;
@@ -847,7 +854,7 @@ impl FactGraph for SqliteBackend {
                 }
             }
 
-            tx.commit()?;
+            tx.commit().map_err(StorageError::backend)?;
             Ok(new_edges)
         })
         .await
@@ -895,7 +902,9 @@ impl FactGraph for SqliteBackend {
                 match decision {
                     CrudDecision::Noop => Ok((None, None)),
                     CrudDecision::Add => {
-                        let tx = conn.unchecked_transaction()?;
+                        let tx = conn
+                            .unchecked_transaction()
+                            .map_err(StorageError::backend)?;
                         // #335 (TOCTOU): the arbiter decided on `old_id` as read
                         // BEFORE this transaction opened. Re-validate it is still
                         // active here; if it was expired concurrently in that window,
@@ -918,11 +927,13 @@ impl FactGraph for SqliteBackend {
                             t_created: now,
                             t_expired: None,
                         })?;
-                        tx.commit()?;
+                        tx.commit().map_err(StorageError::backend)?;
                         Ok((Some(new_id), Some(edge_id)))
                     }
                     CrudDecision::Update => {
-                        let tx = conn.unchecked_transaction()?;
+                        let tx = conn
+                            .unchecked_transaction()
+                            .map_err(StorageError::backend)?;
                         cascade_expire(&tx)?;
                         // Insert the replacement fact.
                         let new_id = FactStore::new(&tx, dim).insert(&new_fact)?;
@@ -936,13 +947,15 @@ impl FactGraph for SqliteBackend {
                             t_created: now,
                             t_expired: None,
                         })?;
-                        tx.commit()?;
+                        tx.commit().map_err(StorageError::backend)?;
                         Ok((Some(new_id), Some(edge_id)))
                     }
                     CrudDecision::Delete => {
-                        let tx = conn.unchecked_transaction()?;
+                        let tx = conn
+                            .unchecked_transaction()
+                            .map_err(StorageError::backend)?;
                         cascade_expire(&tx)?;
-                        tx.commit()?;
+                        tx.commit().map_err(StorageError::backend)?;
                         Ok((None, None))
                     }
                 }
@@ -998,7 +1011,9 @@ impl FactGraph for SqliteBackend {
         let to_expire = to_expire.to_vec();
         let (stats, expired) = self
             .block_write(move |conn| {
-                let tx = conn.unchecked_transaction()?;
+                let tx = conn
+                    .unchecked_transaction()
+                    .map_err(StorageError::backend)?;
                 let fact_store = FactStore::new(&tx, dim);
                 let edge_store = EdgeStore::new(&tx);
 
@@ -1010,7 +1025,7 @@ impl FactGraph for SqliteBackend {
                     fact_store.expire(fact_id, now)?;
                     edge_store.expire_by_fact(fact_id, now)?;
                 }
-                tx.commit()?;
+                tx.commit().map_err(StorageError::backend)?;
 
                 let stats = crate::forgetting::PruneStats {
                     facts_expired: to_expire.len(),
@@ -1048,7 +1063,7 @@ impl FactGraph for SqliteBackend {
         let skip_if_present = skip_if_present.cloned();
         let fingerprint = fingerprint.clone();
         self.block_write(move |conn| {
-            conn.execute_batch("SAVEPOINT ingest_bootstrap")?;
+            conn.execute_batch("SAVEPOINT ingest_bootstrap").map_err(StorageError::backend)?;
             let outcome = (|| -> Result<BootstrapIngestOutcome> {
                 // Authoritative idempotency guard, checked FIRST inside the savepoint
                 // (under the write lock): a matching event ⟹ the batch is a no-op. This
@@ -1098,7 +1113,7 @@ impl FactGraph for SqliteBackend {
             })();
             match outcome {
                 Ok(out) => {
-                    conn.execute_batch("RELEASE ingest_bootstrap")?;
+                    conn.execute_batch("RELEASE ingest_bootstrap").map_err(StorageError::backend)?;
                     Ok(out)
                 }
                 Err(e) => {
@@ -1885,7 +1900,7 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            matches!(err, MemoryError::Storage(_) | MemoryError::Database(_)),
+            matches!(err, MemoryError::Storage(_)),
             "expected a storage/database error from FK violation, got {err:?}"
         );
 

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/mod.rs
@@ -20,9 +20,9 @@
 //! - **Conn selection (D-design):** read methods → `ConnectionPool::read`; write
 //!   methods → `ConnectionPool::try_write` (so a read-only pool rejects writes
 //!   with [`MemoryError::ReadOnly`] — Key Design Decision #6, preserved for free).
-//! - **No driver type crosses the seam (D4):** a `rusqlite` failure surfaces as
-//!   [`MemoryError::Database`] from the concrete store; `map_seam_err` maps it to
-//!   [`MemoryError::Storage`] wrapping [`StorageError::Backend`] at the boundary.
+//! - **No driver type crosses the seam (D4):** a `rusqlite` failure is mapped at
+//!   its call site via [`StorageError::backend`] into [`MemoryError::Storage`]
+//!   wrapping [`StorageError::Backend`], so no driver type ever reaches the seam (#926).
 //!   Semantic variants (`NotFound`, `Migration`, `EmbeddingDimension`, `Conflict`,
 //!   `ReadOnly`, `Internal`, …) already have a precise home and pass through.
 //! - **Async (D1):** the backend is async-native — `spawn_blocking` needs a tokio
@@ -35,7 +35,12 @@
 
 use std::sync::Arc;
 
-use crate::error::{MemoryError, Result, StorageError};
+use crate::error::{MemoryError, Result};
+// `StorageError` lost its last non-test user when #926 removed `map_seam_err`;
+// it is still referenced by the `#[cfg(test)]` tests and this module's seam
+// doc-links, so import it for those configs only (avoids an unused-import warn).
+#[cfg(any(test, doc))]
+use crate::error::StorageError;
 use crate::pool::ConnectionPool;
 #[cfg(feature = "ann")]
 use crate::search::ann::HnswStrategy;
@@ -147,7 +152,7 @@ impl SqliteBackend {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on a pool or query failure, or
+    /// Returns `MemoryError::Storage` on a pool or query failure, or
     /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
     // Non-ann builds see only `self.search_config = Some(cfg); Ok(self)` which
     // clippy flags as `missing_const_for_fn`. It is not const: under `ann` the
@@ -189,7 +194,7 @@ impl SqliteBackend {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on a pool/query failure or
+    /// Returns `MemoryError::Storage` on a pool/query failure or
     /// `MemoryError::EmbeddingDimension` on a corrupt snapshot/stored embedding.
     #[cfg_attr(
         not(feature = "ann"),
@@ -284,7 +289,7 @@ impl SqliteBackend {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on pool or query failure, or
+    /// Returns `MemoryError::Storage` on pool or query failure, or
     /// `MemoryError::EmbeddingDimension` if a stored embedding has the wrong size.
     #[cfg(feature = "ann")]
     pub fn hnsw_snapshot(&self) -> Result<Option<crate::types::snapshot::HnswSnapshot>> {
@@ -401,37 +406,25 @@ fn map_join(e: tokio::task::JoinError) -> MemoryError {
     MemoryError::Pool(format!("task join error: {e}"))
 }
 
-/// D4: confine `rusqlite` below the seam. A raw driver failure
-/// ([`MemoryError::Database`]) becomes opaque [`StorageError::Backend`]; every
-/// semantic variant (which has a precise `MemoryError` home) passes through.
-fn map_seam_err<T>(r: Result<T>) -> Result<T> {
-    match r {
-        Err(MemoryError::Database(e)) => {
-            Err(MemoryError::Storage(StorageError::Backend(e.to_string())))
-        }
-        other => other,
-    }
-}
-
 impl SqliteBackend {
     /// Acquire a READ connection and run `f` on a blocking thread.
     ///
     /// The pool `Arc` is cloned in; the `!Send` read guard is acquired *inside* the
     /// closure (acquiring it on the executor would not compile and would serialize
-    /// the runtime). Driver errors are mapped at the boundary by [`map_seam_err`].
+    /// the runtime). Driver errors are mapped to [`StorageError::Backend`] at each
+    /// call site via [`StorageError::backend`] (#926), not at this boundary.
     async fn block_read<T, F>(&self, f: F) -> Result<T>
     where
         T: Send + 'static,
         F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static,
     {
         let pool = Arc::clone(&self.pool);
-        let out = tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             let conn = pool.read()?;
             f(&conn)
         })
         .await
-        .map_err(map_join)?;
-        map_seam_err(out)
+        .map_err(map_join)?
     }
 
     /// Acquire the WRITE connection (via [`ConnectionPool::try_write`], so a
@@ -443,13 +436,12 @@ impl SqliteBackend {
         F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static,
     {
         let pool = Arc::clone(&self.pool);
-        let out = tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             let conn = pool.try_write()?;
             f(&conn)
         })
         .await
-        .map_err(map_join)?;
-        map_seam_err(out)
+        .map_err(map_join)?
     }
 
     /// Stream rows produced by a blocking `&Connection` scan to a non-`'static`,
@@ -490,7 +482,7 @@ impl SqliteBackend {
         }
         drop(rx); // unblock / abort the scan's next blocking_send
 
-        let scan_res = map_seam_err(handle.await.map_err(map_join)?);
+        let scan_res = handle.await.map_err(map_join)?;
         // The callback error wins over the scan's induced send failure; otherwise
         // surface any mid-scan SQL error.
         cb_err.map_or(scan_res, Err)
@@ -518,20 +510,25 @@ mod tests {
     async fn block_read_runs_and_returns() {
         let be = memory_backend();
         let n: i64 = be
-            .block_read(|c| Ok(c.query_row("SELECT 1 + 1", [], |r| r.get(0))?))
+            .block_read(|c| {
+                Ok(c.query_row("SELECT 1 + 1", [], |r| r.get(0))
+                    .map_err(StorageError::backend)?)
+            })
             .await
             .unwrap();
         assert_eq!(n, 2);
     }
 
     #[tokio::test]
-    async fn block_read_maps_database_error_to_storage_backend() {
-        // D4 witness, at the precise boundary where the mapping lives: a Database
-        // error returned from the closure must surface as Storage(Backend).
+    async fn block_read_surfaces_closure_error() {
+        // block_read propagates a closure error unchanged (driver errors are mapped
+        // at the source since #926).
         let be = memory_backend();
         let err = be
             .block_read(|_| -> Result<()> {
-                Err(MemoryError::Database(rusqlite::Error::QueryReturnedNoRows))
+                Err(MemoryError::Storage(StorageError::Backend(
+                    "simulated backend failure".into(),
+                )))
             })
             .await
             .unwrap_err();
@@ -574,13 +571,19 @@ mod tests {
         let ro = ConnectionPool::open_read_only(&path, 4, 2).unwrap();
         let be = SqliteBackend::from_pool(Arc::new(ro), Arc::new(UpcasterRegistry::new()));
         let err = be
-            .block_write(|c| Ok(c.execute("CREATE TABLE t (x)", [])?))
+            .block_write(|c| {
+                Ok(c.execute("CREATE TABLE t (x)", [])
+                    .map_err(StorageError::backend)?)
+            })
             .await
             .unwrap_err();
         assert!(matches!(err, MemoryError::ReadOnly), "got {err:?}");
         // Reads still work on a read-only backend.
         let one: i64 = be
-            .block_read(|c| Ok(c.query_row("SELECT 1", [], |r| r.get(0))?))
+            .block_read(|c| {
+                Ok(c.query_row("SELECT 1", [], |r| r.get(0))
+                    .map_err(StorageError::backend)?)
+            })
             .await
             .unwrap();
         assert_eq!(one, 1);
@@ -647,7 +650,9 @@ mod tests {
                 |_conn, tx| {
                     tx.blocking_send(0_i64)
                         .map_err(|_| stream_consumer_dropped())?;
-                    Err(MemoryError::Database(rusqlite::Error::QueryReturnedNoRows))
+                    Err(MemoryError::Storage(StorageError::Backend(
+                        "simulated scan failure".into(),
+                    )))
                 },
                 &mut |_row: i64| Ok(()),
             )

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/schema.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/schema.rs
@@ -18,6 +18,8 @@
 //! `true_idf = true`, `server_side_vector = false` (brute-force in-process scan;
 //! HNSW moves into the backend in #631).
 
+#[cfg(feature = "test-util")]
+use crate::error::StorageError;
 use async_trait::async_trait;
 
 use super::SqliteBackend;
@@ -238,8 +240,11 @@ impl SchemaManager for SqliteBackend {
     #[cfg(feature = "test-util")]
     async fn raw_exec(&self, sql: &str) -> Result<()> {
         let sql = sql.to_owned();
-        self.block_write(move |c| c.execute_batch(&sql).map_err(Into::into))
-            .await
+        self.block_write(move |c| {
+            c.execute_batch(&sql)
+                .map_err(|e| StorageError::backend(e).into())
+        })
+        .await
     }
 
     // -------------------------------------------------------------------------

--- a/memory-engine/lib/memory-engine/src/storage/sqlite/search_index.rs
+++ b/memory-engine/lib/memory-engine/src/storage/sqlite/search_index.rs
@@ -92,7 +92,7 @@ impl SearchIndex for SqliteBackend {
             })
             .await
             .map_err(super::map_join)?;
-            return super::map_seam_err(out);
+            return out;
         }
 
         self.block_read(move |c| {

--- a/memory-engine/lib/memory-engine/src/store/activities.rs
+++ b/memory-engine/lib/memory-engine/src/store/activities.rs
@@ -1,5 +1,6 @@
 //! Store operations for activity records.
 
+use crate::error::StorageError;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::error::{MemoryError, Result};
@@ -26,7 +27,7 @@ impl<'a> ActivityStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure (e.g. FK violation if
+    /// Returns `MemoryError::Storage` on SQL failure (e.g. FK violation if
     /// `activity.scope_id` references a non-existent scope).
     pub fn insert_or_dedup(
         &self,
@@ -61,7 +62,7 @@ impl<'a> ActivityStore<'a> {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .optional()
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
 
         if let Some((existing_id, count)) = existing {
             self.conn
@@ -74,7 +75,7 @@ impl<'a> ActivityStore<'a> {
                      WHERE id = ?4",
                     params![count + 1, ts, activity.result_summary, existing_id],
                 )
-                .map_err(MemoryError::Database)?;
+                .map_err(StorageError::backend)?;
             return Ok((existing_id, true));
         }
 
@@ -96,7 +97,7 @@ impl<'a> ActivityStore<'a> {
                     activity.scope_id,
                 ],
             )
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
 
         let id = self.conn.last_insert_rowid();
         Ok((id, false))
@@ -110,7 +111,7 @@ impl<'a> ActivityStore<'a> {
     /// # Errors
     ///
     /// Returns `MemoryError::NotFound` if no activity with `id` exists.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn get(&self, id: i64) -> Result<Activity> {
         self.conn
             .query_row(
@@ -125,7 +126,7 @@ impl<'a> ActivityStore<'a> {
                 rusqlite::Error::QueryReturnedNoRows => {
                     MemoryError::NotFound(format!("activity {id}"))
                 }
-                other => MemoryError::Database(other),
+                other => StorageError::backend(other).into(),
             })
     }
 
@@ -136,7 +137,7 @@ impl<'a> ActivityStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_by_session(&self, session_id: &str, limit: Option<usize>) -> Result<Vec<Activity>> {
         let base = "SELECT id, session_id, tool_name, args_hash, args, result_summary,
                         outcome_class, status, occurrence_count, first_seen, last_seen,
@@ -146,12 +147,12 @@ impl<'a> ActivityStore<'a> {
                  ORDER BY last_seen DESC";
         let limit_i64: i64 = limit.map_or(-1, |n| i64::try_from(n).unwrap_or(i64::MAX));
         let sql = format!("{base} LIMIT ?2");
-        let mut stmt = self.conn.prepare(&sql).map_err(MemoryError::Database)?;
+        let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
         let rows = stmt
             .query_map(params![session_id, limit_i64], row_to_activity)
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<_, _>>()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// List recent activities for a set of scope IDs, most recent first.
@@ -160,14 +161,12 @@ impl<'a> ActivityStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_recent_by_scope(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Activity>> {
         if scope_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let ids_json = serde_json::to_string(scope_ids).map_err(|e| {
-            MemoryError::Database(rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
-        })?;
+        let ids_json = serde_json::to_string(scope_ids).map_err(MemoryError::Serialization)?;
         let mut stmt = self
             .conn
             .prepare(
@@ -179,12 +178,12 @@ impl<'a> ActivityStore<'a> {
                  ORDER BY last_seen DESC
                  LIMIT ?2",
             )
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
         let rows = stmt
             .query_map(params![ids_json, limit], row_to_activity)
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<_, _>>()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Update the status of an activity and optionally link to a promoted fact.
@@ -192,7 +191,7 @@ impl<'a> ActivityStore<'a> {
     /// # Errors
     ///
     /// Returns `MemoryError::NotFound` if no activity with `id` exists.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn update_status(
         &self,
         id: i64,
@@ -205,7 +204,7 @@ impl<'a> ActivityStore<'a> {
                 "UPDATE activities SET status = ?1, promoted_fact_id = ?2 WHERE id = ?3",
                 params![status.to_string(), promoted_fact_id, id],
             )
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
         if rows == 0 {
             return Err(MemoryError::NotFound(format!("activity {id}")));
         }
@@ -219,7 +218,7 @@ impl<'a> ActivityStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn count_by_session(&self, session_id: &str) -> Result<i64> {
         self.conn
             .query_row(
@@ -227,7 +226,7 @@ impl<'a> ActivityStore<'a> {
                 params![session_id],
                 |row| row.get(0),
             )
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 }
 

--- a/memory-engine/lib/memory-engine/src/store/activities.rs
+++ b/memory-engine/lib/memory-engine/src/store/activities.rs
@@ -161,7 +161,8 @@ impl<'a> ActivityStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Storage` on SQL failure.
+    /// Returns `MemoryError::Serialization` if the scope-id list cannot be JSON-encoded,
+    /// or `MemoryError::Storage` on backend/SQL failure.
     pub fn list_recent_by_scope(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Activity>> {
         if scope_ids.is_empty() {
             return Ok(Vec::new());

--- a/memory-engine/lib/memory-engine/src/store/archive_manifest.rs
+++ b/memory-engine/lib/memory-engine/src/store/archive_manifest.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
 use crate::archive::types::ArchiveManifestEntry;
-use crate::error::Result;
+use crate::error::{Result, StorageError};
 
 /// Store for archive manifest entries — tracks `.pak` files in the database.
 pub struct ArchiveManifestStore<'a> {
@@ -55,25 +55,27 @@ impl<'a> ArchiveManifestStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure (e.g. duplicate `pak_path`).
+    /// Returns `MemoryError::Storage` on SQL failure (e.g. duplicate `pak_path`).
     pub fn insert(&self, m: &NewArchiveManifest<'_>) -> Result<i64> {
-        self.conn.execute(
-            "INSERT INTO archive_manifest (pak_path, created_at, fact_count, edge_count,
+        self.conn
+            .execute(
+                "INSERT INTO archive_manifest (pak_path, created_at, fact_count, edge_count,
               fact_id_min, fact_id_max, t_created_min, t_created_max, size_bytes, blake3_hash)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-            rusqlite::params![
-                m.pak_path,
-                m.created_at.to_rfc3339(),
-                m.fact_count,
-                m.edge_count,
-                m.fact_id_min,
-                m.fact_id_max,
-                m.t_created_min.to_rfc3339(),
-                m.t_created_max.to_rfc3339(),
-                m.size_bytes,
-                m.blake3_hash,
-            ],
-        )?;
+                rusqlite::params![
+                    m.pak_path,
+                    m.created_at.to_rfc3339(),
+                    m.fact_count,
+                    m.edge_count,
+                    m.fact_id_min,
+                    m.fact_id_max,
+                    m.t_created_min.to_rfc3339(),
+                    m.t_created_max.to_rfc3339(),
+                    m.size_bytes,
+                    m.blake3_hash,
+                ],
+            )
+            .map_err(StorageError::backend)?;
         Ok(self.conn.last_insert_rowid())
     }
 
@@ -81,45 +83,50 @@ impl<'a> ArchiveManifestStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list(&self) -> Result<Vec<ArchiveManifestEntry>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, pak_path, created_at, fact_count, edge_count,
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, pak_path, created_at, fact_count, edge_count,
                     fact_id_min, fact_id_max, t_created_min, t_created_max,
                     size_bytes, blake3_hash
              FROM archive_manifest ORDER BY created_at",
-        )?;
-        let rows = stmt.query_map([], |row| {
-            let created_at_str: String = row.get(2)?;
-            let t_created_min_str: String = row.get(7)?;
-            let t_created_max_str: String = row.get(8)?;
+            )
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map([], |row| {
+                let created_at_str: String = row.get(2)?;
+                let t_created_min_str: String = row.get(7)?;
+                let t_created_max_str: String = row.get(8)?;
 
-            let parse_dt = |s: String, col_idx: usize| -> rusqlite::Result<DateTime<Utc>> {
-                s.parse().map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        col_idx,
-                        rusqlite::types::Type::Text,
-                        Box::new(e),
-                    )
+                let parse_dt = |s: String, col_idx: usize| -> rusqlite::Result<DateTime<Utc>> {
+                    s.parse().map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            col_idx,
+                            rusqlite::types::Type::Text,
+                            Box::new(e),
+                        )
+                    })
+                };
+
+                Ok(ArchiveManifestEntry {
+                    id: row.get(0)?,
+                    pak_path: row.get(1)?,
+                    created_at: parse_dt(created_at_str, 2)?,
+                    fact_count: row.get(3)?,
+                    edge_count: row.get(4)?,
+                    fact_id_min: row.get(5)?,
+                    fact_id_max: row.get(6)?,
+                    t_created_min: parse_dt(t_created_min_str, 7)?,
+                    t_created_max: parse_dt(t_created_max_str, 8)?,
+                    size_bytes: row.get(9)?,
+                    blake3_hash: row.get(10)?,
                 })
-            };
-
-            Ok(ArchiveManifestEntry {
-                id: row.get(0)?,
-                pak_path: row.get(1)?,
-                created_at: parse_dt(created_at_str, 2)?,
-                fact_count: row.get(3)?,
-                edge_count: row.get(4)?,
-                fact_id_min: row.get(5)?,
-                fact_id_max: row.get(6)?,
-                t_created_min: parse_dt(t_created_min_str, 7)?,
-                t_created_max: parse_dt(t_created_max_str, 8)?,
-                size_bytes: row.get(9)?,
-                blake3_hash: row.get(10)?,
             })
-        })?;
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Delete a manifest entry by id.
@@ -128,14 +135,17 @@ impl<'a> ArchiveManifestStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     // Forward-looking: archive management CLI will use this.
     #[allow(dead_code)]
     pub fn delete(&self, id: i64) -> Result<bool> {
-        let deleted = self.conn.execute(
-            "DELETE FROM archive_manifest WHERE id = ?1",
-            rusqlite::params![id],
-        )?;
+        let deleted = self
+            .conn
+            .execute(
+                "DELETE FROM archive_manifest WHERE id = ?1",
+                rusqlite::params![id],
+            )
+            .map_err(StorageError::backend)?;
         Ok(deleted > 0)
     }
 }

--- a/memory-engine/lib/memory-engine/src/store/checkpoints.rs
+++ b/memory-engine/lib/memory-engine/src/store/checkpoints.rs
@@ -1,8 +1,9 @@
 //! Store operations for session checkpoints.
 
+use crate::error::StorageError;
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::error::{MemoryError, Result};
+use crate::error::Result;
 use crate::types::SessionCheckpoint;
 
 use super::parse_timestamp;
@@ -21,7 +22,7 @@ impl<'a> CheckpointStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn upsert(&self, checkpoint: &SessionCheckpoint) -> Result<()> {
         self.conn
             .execute(
@@ -43,7 +44,7 @@ impl<'a> CheckpointStore<'a> {
                     checkpoint.metadata.to_string(),
                 ],
             )
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
         Ok(())
     }
 
@@ -56,7 +57,7 @@ impl<'a> CheckpointStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn get(&self, session_id: &str) -> Result<Option<SessionCheckpoint>> {
         self.conn
             .query_row(
@@ -67,7 +68,7 @@ impl<'a> CheckpointStore<'a> {
                 row_to_checkpoint,
             )
             .optional()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Get the most recent checkpoint for a scope path.
@@ -76,7 +77,7 @@ impl<'a> CheckpointStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn get_by_scope(&self, scope_path: &str) -> Result<Option<SessionCheckpoint>> {
         self.conn
             .query_row(
@@ -89,7 +90,7 @@ impl<'a> CheckpointStore<'a> {
                 row_to_checkpoint,
             )
             .optional()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// List recent checkpoints, most recent first.
@@ -99,7 +100,7 @@ impl<'a> CheckpointStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_recent(&self, limit: usize) -> Result<Vec<SessionCheckpoint>> {
         let mut stmt = self
             .conn
@@ -109,15 +110,15 @@ impl<'a> CheckpointStore<'a> {
                  ORDER BY checkpoint_at DESC, session_id DESC
                  LIMIT ?1",
             )
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
         let rows = stmt
             .query_map(
                 params![i64::try_from(limit).unwrap_or(i64::MAX)],
                 row_to_checkpoint,
             )
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<_, _>>()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 }
 

--- a/memory-engine/lib/memory-engine/src/store/edges.rs
+++ b/memory-engine/lib/memory-engine/src/store/edges.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
 
-use crate::error::{MemoryError, Result};
+use crate::error::{MemoryError, Result, StorageError};
 use crate::store::{parse_optional_timestamp, parse_timestamp};
 use crate::types::{Edge, NewEdge, RelationType};
 
@@ -39,7 +39,7 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure (e.g. FK violation).
+    /// Returns `MemoryError::Storage` on SQL failure (e.g. FK violation).
     pub fn insert(&self, edge: &NewEdge) -> Result<i64> {
         self.conn.execute(
             "INSERT INTO edges (source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id)
@@ -53,7 +53,7 @@ impl<'a> EdgeStore<'a> {
                 edge.t_expired.map(|dt| dt.to_rfc3339()),
                 edge.scope_id,
             ],
-        )?;
+        ).map_err(StorageError::backend)?;
         Ok(self.conn.last_insert_rowid())
     }
 
@@ -74,7 +74,7 @@ impl<'a> EdgeStore<'a> {
                 rusqlite::Error::QueryReturnedNoRows => {
                     MemoryError::NotFound(format!("edge {id}"))
                 }
-                other => MemoryError::Database(other),
+                other => StorageError::backend(other).into(),
             })
     }
 
@@ -88,12 +88,15 @@ impl<'a> EdgeStore<'a> {
     ///
     /// Returns `MemoryError::NotFound` if no active edge with `id` exists (the id
     /// is unknown, or the edge was already expired) — the UPDATE affected 0 rows.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn expire(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
-        let changed = self.conn.execute(
-            "UPDATE edges SET t_expired = ?1 WHERE id = ?2 AND t_expired IS NULL",
-            params![now.to_rfc3339(), id],
-        )?;
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE edges SET t_expired = ?1 WHERE id = ?2 AND t_expired IS NULL",
+                params![now.to_rfc3339(), id],
+            )
+            .map_err(StorageError::backend)?;
         if changed == 0 {
             return Err(MemoryError::NotFound(format!("edge {id}")));
         }
@@ -107,14 +110,17 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn expire_by_fact(&self, fact_id: i64, now: DateTime<Utc>) -> Result<usize> {
-        let count = self.conn.execute(
-            "UPDATE edges SET t_expired = ?1
+        let count = self
+            .conn
+            .execute(
+                "UPDATE edges SET t_expired = ?1
              WHERE (source_fact_id = ?2 OR target_fact_id = ?2)
                AND t_expired IS NULL",
-            params![now.to_rfc3339(), fact_id],
-        )?;
+                params![now.to_rfc3339(), fact_id],
+            )
+            .map_err(StorageError::backend)?;
         Ok(count)
     }
 
@@ -122,15 +128,17 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_all(&self) -> Result<Vec<Edge>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id
              FROM edges ORDER BY id ASC",
-        )?;
-        let rows = stmt.query_map([], row_to_edge)?;
+        ).map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map([], row_to_edge)
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Iterate all edges row-by-row, calling `f` for each.
@@ -141,7 +149,7 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure, or propagates any
+    /// Returns `MemoryError::Storage` on SQL failure, or propagates any
     /// error returned by `f`.
     pub fn for_each<F>(&self, mut f: F) -> Result<()>
     where
@@ -150,10 +158,10 @@ impl<'a> EdgeStore<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id
              FROM edges ORDER BY id ASC",
-        )?;
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
-            let edge = row_to_edge(row)?;
+        ).map_err(StorageError::backend)?;
+        let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+        while let Some(row) = rows.next().map_err(StorageError::backend)? {
+            let edge = row_to_edge(row).map_err(StorageError::backend)?;
             f(edge)?;
         }
         Ok(())
@@ -163,15 +171,17 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_active(&self) -> Result<Vec<Edge>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id
              FROM edges WHERE t_expired IS NULL",
-        )?;
+        ).map_err(StorageError::backend)?;
         let edges = stmt
-            .query_map([], row_to_edge)?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .query_map([], row_to_edge)
+            .map_err(StorageError::backend)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StorageError::backend)?;
         Ok(edges)
     }
 
@@ -179,15 +189,17 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_active_by_source(&self, source_fact_id: i64) -> Result<Vec<Edge>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id
              FROM edges WHERE source_fact_id = ?1 AND t_expired IS NULL",
-        )?;
+        ).map_err(StorageError::backend)?;
         let edges = stmt
-            .query_map(params![source_fact_id], row_to_edge)?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .query_map(params![source_fact_id], row_to_edge)
+            .map_err(StorageError::backend)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StorageError::backend)?;
         Ok(edges)
     }
 
@@ -197,7 +209,7 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn exists_active(
         &self,
         source_fact_id: i64,
@@ -215,7 +227,7 @@ impl<'a> EdgeStore<'a> {
                 params![source_fact_id, target_fact_id, relation_type],
                 |row| row.get(0),
             )
-            .map_err(MemoryError::Database)?;
+            .map_err(StorageError::backend)?;
         Ok(count > 0)
     }
 
@@ -231,7 +243,7 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_active_pairs_by_facts(
         &self,
         fact_ids: &[i64],
@@ -242,19 +254,24 @@ impl<'a> EdgeStore<'a> {
             return Ok(HashSet::new());
         }
         let ids_json = serde_json::to_string(fact_ids).expect("serialize fact_ids");
-        let mut stmt = self.conn.prepare(
-            "SELECT source_fact_id, target_fact_id FROM edges
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT source_fact_id, target_fact_id FROM edges
              WHERE source_fact_id IN (SELECT value FROM json_each(?1))
                AND target_fact_id IN (SELECT value FROM json_each(?1))
                AND relation_type = ?2
                AND t_expired IS NULL",
-        )?;
-        let rows = stmt.query_map(params![ids_json, relation_type], |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
-        })?;
+            )
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map(params![ids_json, relation_type], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+            })
+            .map_err(StorageError::backend)?;
         let mut set = HashSet::new();
         for row in rows {
-            set.insert(row?);
+            set.insert(row.map_err(StorageError::backend)?);
         }
         Ok(set)
     }
@@ -263,15 +280,17 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_active_by_target(&self, target_fact_id: i64) -> Result<Vec<Edge>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, source_fact_id, target_fact_id, relation_type, weight, t_created, t_expired, scope_id
              FROM edges WHERE target_fact_id = ?1 AND t_expired IS NULL",
-        )?;
+        ).map_err(StorageError::backend)?;
         let edges = stmt
-            .query_map(params![target_fact_id], row_to_edge)?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .query_map(params![target_fact_id], row_to_edge)
+            .map_err(StorageError::backend)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StorageError::backend)?;
         Ok(edges)
     }
 
@@ -290,7 +309,7 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure, or
+    /// Returns `MemoryError::Storage` on SQL failure, or
     /// `MemoryError::Serialization` if the `fact_ids` slice cannot be serialized
     /// to the JSON array bound into the query (infallible in practice for
     /// `&[i64]`).
@@ -308,10 +327,12 @@ impl<'a> EdgeStore<'a> {
              WHERE source_fact_id IN (SELECT value FROM ids)
                AND target_fact_id IN (SELECT value FROM ids)
              ORDER BY id ASC",
-        )?;
-        let rows = stmt.query_map(params![ids_json], row_to_edge)?;
+        ).map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map(params![ids_json], row_to_edge)
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Hard-delete edges where BOTH endpoints are in the given fact ID set.
@@ -335,18 +356,21 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn hard_delete_by_facts(&self, fact_ids: &[i64]) -> Result<usize> {
         if fact_ids.is_empty() {
             return Ok(0);
         }
         let ids_json = serde_json::to_string(fact_ids).expect("serialize fact_ids");
-        let deleted = self.conn.execute(
-            "DELETE FROM edges
+        let deleted = self
+            .conn
+            .execute(
+                "DELETE FROM edges
              WHERE source_fact_id IN (SELECT value FROM json_each(?1))
                AND target_fact_id IN (SELECT value FROM json_each(?1))",
-            params![ids_json],
-        )?;
+                params![ids_json],
+            )
+            .map_err(StorageError::backend)?;
         Ok(deleted)
     }
 
@@ -379,18 +403,21 @@ impl<'a> EdgeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn hard_delete_incident_to_facts(&self, fact_ids: &[i64]) -> Result<usize> {
         if fact_ids.is_empty() {
             return Ok(0);
         }
         let ids_json = serde_json::to_string(fact_ids).expect("serialize fact_ids");
-        let deleted = self.conn.execute(
-            "DELETE FROM edges
+        let deleted = self
+            .conn
+            .execute(
+                "DELETE FROM edges
              WHERE source_fact_id IN (SELECT value FROM json_each(?1))
                 OR target_fact_id IN (SELECT value FROM json_each(?1))",
-            params![ids_json],
-        )?;
+                params![ids_json],
+            )
+            .map_err(StorageError::backend)?;
         Ok(deleted)
     }
 }

--- a/memory-engine/lib/memory-engine/src/store/embedding_meta.rs
+++ b/memory-engine/lib/memory-engine/src/store/embedding_meta.rs
@@ -36,7 +36,7 @@ use crate::types::EmbeddingFingerprint;
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure, or `MemoryError::Internal` if a stored
+/// Returns `MemoryError::Storage` on query failure, or `MemoryError::Internal` if a stored
 /// dimension/status in the registry is corrupt (never a silent default, because the stored
 /// `dim` drives vector deserialization).
 pub fn load(conn: &Connection) -> Result<Option<EmbeddingFingerprint>> {
@@ -50,7 +50,7 @@ pub fn load(conn: &Connection) -> Result<Option<EmbeddingFingerprint>> {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on write failure or `MemoryError::Internal` if a
+/// Returns `MemoryError::Storage` on write failure or `MemoryError::Internal` if a
 /// dimension overflows `i64`.
 pub fn store(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
     super::embedding_spaces::upsert_active_fingerprint(conn, fp)

--- a/memory-engine/lib/memory-engine/src/store/embedding_spaces.rs
+++ b/memory-engine/lib/memory-engine/src/store/embedding_spaces.rs
@@ -27,6 +27,7 @@
 //! - Promoting [`SpaceStatus`] / [`EmbeddingSpace`] to public `types.rs` types — **#689**,
 //!   when a multi-space API is actually exposed to consumers.
 
+use crate::error::StorageError;
 use rusqlite::Connection;
 
 use crate::error::{MemoryError, MigrationError, Result};
@@ -156,18 +157,18 @@ const SELECT_COLS: &str =
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure, `MemoryError::Internal` if more than
+/// Returns `MemoryError::Storage` on query failure, `MemoryError::Internal` if more than
 /// one active row exists (impossible under the partial unique index — fail loud, never
 /// pick arbitrarily) or if a stored dimension/status is corrupt.
 pub fn find_active(conn: &Connection) -> Result<Option<EmbeddingSpace>> {
     let sql = format!("SELECT {SELECT_COLS} WHERE status = 'active'");
-    let mut stmt = conn.prepare(&sql)?;
-    let mut rows = stmt.query([])?;
-    let Some(first) = rows.next()? else {
+    let mut stmt = conn.prepare(&sql).map_err(StorageError::backend)?;
+    let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+    let Some(first) = rows.next().map_err(StorageError::backend)? else {
         return Ok(None);
     };
-    let space = row_to_space(first)??;
-    if rows.next()?.is_some() {
+    let space = row_to_space(first).map_err(StorageError::backend)??;
+    if rows.next().map_err(StorageError::backend)?.is_some() {
         return Err(MemoryError::Internal(
             "multiple active embedding spaces — single-active invariant corrupted".into(),
         ));
@@ -181,14 +182,14 @@ pub fn find_active(conn: &Connection) -> Result<Option<EmbeddingSpace>> {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure, or `MemoryError::Internal`/`Migration`
+/// Returns `MemoryError::Storage` on query failure, or `MemoryError::Internal`/`Migration`
 /// if a stored dimension/status is corrupt.
 pub fn find_by_name(conn: &Connection, name: &str) -> Result<Option<EmbeddingSpace>> {
     let sql = format!("SELECT {SELECT_COLS} WHERE name = ?1");
-    let mut stmt = conn.prepare(&sql)?;
-    let mut rows = stmt.query([name])?;
-    match rows.next()? {
-        Some(row) => Ok(Some(row_to_space(row)??)),
+    let mut stmt = conn.prepare(&sql).map_err(StorageError::backend)?;
+    let mut rows = stmt.query([name]).map_err(StorageError::backend)?;
+    match rows.next().map_err(StorageError::backend)? {
+        Some(row) => Ok(Some(row_to_space(row).map_err(StorageError::backend)??)),
         None => Ok(None),
     }
 }
@@ -197,15 +198,15 @@ pub fn find_by_name(conn: &Connection, name: &str) -> Result<Option<EmbeddingSpa
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure, or `MemoryError::Internal`/`Migration`
+/// Returns `MemoryError::Storage` on query failure, or `MemoryError::Internal`/`Migration`
 /// if a stored dimension/status is corrupt.
 pub fn list_spaces(conn: &Connection) -> Result<Vec<EmbeddingSpace>> {
     let sql = format!("SELECT {SELECT_COLS} ORDER BY created_at, name");
-    let mut stmt = conn.prepare(&sql)?;
+    let mut stmt = conn.prepare(&sql).map_err(StorageError::backend)?;
     let mut out = Vec::new();
-    let mut rows = stmt.query([])?;
-    while let Some(row) = rows.next()? {
-        out.push(row_to_space(row)??);
+    let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+    while let Some(row) = rows.next().map_err(StorageError::backend)? {
+        out.push(row_to_space(row).map_err(StorageError::backend)??);
     }
     Ok(out)
 }
@@ -222,7 +223,7 @@ pub fn list_spaces(conn: &Connection) -> Result<Vec<EmbeddingSpace>> {
 /// # Errors
 ///
 /// Returns `MemoryError::Internal` (via [`map_single_active_violation`]) if the insert
-/// would create a second active space, `MemoryError::Database` on any other write failure,
+/// would create a second active space, `MemoryError::Storage` on any other write failure,
 /// or `MemoryError::Internal` if a dimension overflows `i64`.
 pub fn insert_active(conn: &Connection, space: &EmbeddingSpace) -> Result<()> {
     let (dim, base) = dims_to_sql(&space.fingerprint)?;
@@ -253,7 +254,7 @@ pub fn insert_active(conn: &Connection, space: &EmbeddingSpace) -> Result<()> {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on a `name` PK collision or any other write failure, or
+/// Returns `MemoryError::Storage` on a `name` PK collision or any other write failure, or
 /// `MemoryError::Internal` if a dimension overflows `i64`.
 pub fn insert_populating(conn: &Connection, space: &EmbeddingSpace) -> Result<()> {
     let (dim, base) = dims_to_sql(&space.fingerprint)?;
@@ -285,7 +286,7 @@ pub fn insert_populating(conn: &Connection, space: &EmbeddingSpace) -> Result<()
 /// # Errors
 ///
 /// Returns `MemoryError::Internal` if the name is taken by an incompatible space,
-/// or `MemoryError::Database` on a write failure.
+/// or `MemoryError::Storage` on a write failure.
 pub fn begin_populating(conn: &Connection, space: &EmbeddingSpace) -> Result<()> {
     match find_by_name(conn, &space.name)? {
         None => insert_populating(conn, space),
@@ -308,12 +309,13 @@ pub fn begin_populating(conn: &Connection, space: &EmbeddingSpace) -> Result<()>
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on write failure.
+/// Returns `MemoryError::Storage` on write failure.
 pub fn deprecate(conn: &Connection, name: &str) -> Result<()> {
     conn.execute(
         "UPDATE embedding_spaces SET status = 'deprecated' WHERE name = ?1",
         rusqlite::params![name],
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -326,7 +328,7 @@ pub fn deprecate(conn: &Connection, name: &str) -> Result<()> {
 /// # Errors
 ///
 /// Returns `MemoryError::Internal` if activating `name` would create a second
-/// active space (the ordering was violated), or `MemoryError::Database` on any
+/// active space (the ordering was violated), or `MemoryError::Storage` on any
 /// other write failure.
 pub fn activate(conn: &Connection, name: &str) -> Result<()> {
     conn.execute(
@@ -353,18 +355,20 @@ pub fn activate(conn: &Connection, name: &str) -> Result<()> {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on write failure or `MemoryError::Internal` if a
+/// Returns `MemoryError::Storage` on write failure or `MemoryError::Internal` if a
 /// dimension overflows `i64`.
 pub fn upsert_active_fingerprint(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
     let (dim, base) = dims_to_sql(fp)?;
     // Re-stamp the current active row in place (at most one exists, by the partial
     // unique index), whatever its name.
-    let updated = conn.execute(
-        "UPDATE embedding_spaces
+    let updated = conn
+        .execute(
+            "UPDATE embedding_spaces
             SET model = ?1, provider = ?2, dim = ?3, matryoshka_base_dim = ?4, element_type = ?5
           WHERE status = 'active'",
-        rusqlite::params![fp.model, fp.provider, dim, base, fp.element_type],
-    )?;
+            rusqlite::params![fp.model, fp.provider, dim, base, fp.element_type],
+        )
+        .map_err(StorageError::backend)?;
     if updated == 0 {
         // No active space yet — seed the canonical `default` active row.
         conn.execute(
@@ -379,7 +383,8 @@ pub fn upsert_active_fingerprint(conn: &Connection, fp: &EmbeddingFingerprint) -
                 base,
                 fp.element_type,
             ],
-        )?;
+        )
+        .map_err(StorageError::backend)?;
     }
     Ok(())
 }
@@ -402,7 +407,7 @@ fn dims_to_sql(fp: &EmbeddingFingerprint) -> Result<(i64, Option<i64>)> {
 
 /// Remap a single-active partial-unique-index violation to a diagnosable engine error.
 /// Any other rusqlite error — including a `name` PRIMARY KEY collision — passes through
-/// unchanged (→ `MemoryError::Database`); only the `UNIQUE` extended code is the
+/// unchanged (→ `MemoryError::Storage`); only the `UNIQUE` extended code is the
 /// single-active index firing, so we gate on it rather than the generic constraint code.
 fn map_single_active_violation(e: rusqlite::Error) -> MemoryError {
     use rusqlite::ErrorCode;
@@ -419,7 +424,7 @@ fn map_single_active_violation(e: rusqlite::Error) -> MemoryError {
                 .into(),
         );
     }
-    MemoryError::Database(e)
+    StorageError::backend(e).into()
 }
 
 #[cfg(test)]
@@ -542,7 +547,10 @@ mod tests {
         )
         .expect_err("name PK collision must error");
         assert!(
-            matches!(err, MemoryError::Database(_)),
+            matches!(
+                err,
+                MemoryError::Storage(crate::error::StorageError::Backend(_))
+            ),
             "PK collision must pass through as Database, got {err:?}"
         );
     }

--- a/memory-engine/lib/memory-engine/src/store/embedding_spaces.rs
+++ b/memory-engine/lib/memory-engine/src/store/embedding_spaces.rs
@@ -14,7 +14,7 @@
 //! `UNIQUE(status) WHERE status = 'active'` (mirrors KB's `idx_embed_spaces_one_active`).
 //! It cannot be bypassed by any writer, now or in a future wave. A violation is remapped
 //! by [`map_single_active_violation`] to a diagnosable error rather than an opaque
-//! `Database` one.
+//! `Storage(StorageError::Backend)` one.
 //!
 //! ## Future seams (do NOT implement here — separate issues)
 //!
@@ -497,7 +497,7 @@ mod tests {
     #[test]
     fn single_active_index_rejects_second_active() {
         // The partial unique index makes a second active row unrepresentable; the error
-        // is remapped to a diagnosable Internal (not an opaque Database), and the first
+        // is remapped to a diagnosable Internal (not an opaque Storage(Backend)), and the first
         // row is untouched.
         let conn = fresh_conn();
         let a = EmbeddingFingerprint::new("model-a", "tei", 8);
@@ -527,7 +527,7 @@ mod tests {
     #[test]
     fn name_pk_collision_is_not_mislabeled_single_active() {
         // A PRIMARY KEY collision on `name` (not the status='active' partial index) must
-        // surface as a plain Database error, not the "single-active invariant violated"
+        // surface as a plain Storage(Backend) error, not the "single-active invariant violated"
         // message — only the UNIQUE extended code is the single-active index firing.
         let conn = fresh_conn();
         // A deprecated 'default' row: re-inserting 'default'/active PK-collides on name
@@ -551,7 +551,7 @@ mod tests {
                 err,
                 MemoryError::Storage(crate::error::StorageError::Backend(_))
             ),
-            "PK collision must pass through as Database, got {err:?}"
+            "PK collision must pass through as Storage(Backend), got {err:?}"
         );
     }
 

--- a/memory-engine/lib/memory-engine/src/store/events.rs
+++ b/memory-engine/lib/memory-engine/src/store/events.rs
@@ -39,16 +39,18 @@ pub const fn event_type_to_str(et: &EventType) -> &'static str {
 /// embeds the offending token verbatim for diagnostics.
 ///
 /// What a *read-path* caller sees, end-to-end: the read site ([`row_to_event`])
-/// boxes this `Internal` into `rusqlite::Error::FromSqlConversionFailure`, which
-/// re-maps to [`MemoryError::Storage`] via its `#[from]`. So the surfaced
-/// top-level variant is `Database` (a *data* error — the correct class for corrupt
-/// stored data, and crucially **not** `NotFound`, the conflation #366 reported),
-/// with this `Internal` preserved as the boxed source. The `Internal` value here
-/// is therefore the directly-observable error only for a *direct* caller; the read
-/// path re-classifies it to `Database`. Both surfaced behaviors are covered by
-/// tests (`corrupt_event_type_read_path_surfaces_database_not_notfound` for the
-/// end-to-end path, `str_to_event_type_rejects_unknown_as_internal` for the direct
-/// call).
+/// boxes this `Internal` into `rusqlite::Error::FromSqlConversionFailure`; at the
+/// call site `.map_err(StorageError::backend)` stringifies that rusqlite error
+/// (whose `Display` embeds the boxed `Internal`'s message) into a
+/// `StorageError::Backend`, which `?` then lifts to [`MemoryError::Storage`]
+/// (#926). So the surfaced top-level variant is `Storage(StorageError::Backend)` —
+/// a backend/data error, and crucially **not** `NotFound`, the conflation #366
+/// reported — with the `Internal`'s diagnostic message preserved as a substring of
+/// the `Backend` string. The structured `Internal` value here is therefore the
+/// directly-observable error only for a *direct* caller; the read path re-classifies
+/// it to `Storage(Backend)`. Both surfaced behaviors are covered by tests
+/// (`corrupt_event_type_read_path_surfaces_storage_not_notfound` for the end-to-end
+/// path, `str_to_event_type_rejects_unknown_as_internal` for the direct call).
 fn str_to_event_type(s: &str) -> Result<EventType> {
     match s {
         "Interaction" => Ok(EventType::Interaction),
@@ -415,18 +417,20 @@ mod tests {
     ///
     /// The isolated [`str_to_event_type_rejects_unknown_as_internal`] test below
     /// only exercises the private helper; the production caller (`row_to_event`)
-    /// boxes its error into `rusqlite::Error::FromSqlConversionFailure`, which
-    /// re-maps to [`MemoryError::Storage`] via its `#[from]`. So the helper's
-    /// `Internal` never reaches a read-path caller as the top-level variant.
+    /// boxes its error into `rusqlite::Error::FromSqlConversionFailure`, which the
+    /// call site maps via `.map_err(StorageError::backend)` and `?` lifts to
+    /// [`MemoryError::Storage`] (#926). So the helper's `Internal` never reaches a
+    /// read-path caller as the top-level variant.
     ///
     /// What #366 actually demanded — *do not surface [`MemoryError::NotFound`] for
-    /// a corrupt enum* — is met end-to-end: the surfaced variant is `Database` (a
-    /// data error, the correct class for corrupt stored data), distinct from
-    /// `NotFound`, with `Internal("corrupt stored event_type: …")` preserved as the
-    /// boxed source. Unlike `facts`, the `events.event_type` column has **no** CHECK
-    /// constraint, so this corruption is reachable through a plain UPDATE.
+    /// a corrupt enum* — is met end-to-end: the surfaced variant is
+    /// `Storage(StorageError::Backend)` (a backend/data error), distinct from
+    /// `NotFound`, with `Internal("corrupt stored event_type: …")`'s message
+    /// preserved inside the `Backend` string. Unlike `facts`, the
+    /// `events.event_type` column has **no** CHECK constraint, so this corruption is
+    /// reachable through a plain UPDATE.
     #[test]
-    fn corrupt_event_type_read_path_surfaces_database_not_notfound() {
+    fn corrupt_event_type_read_path_surfaces_storage_not_notfound() {
         let conn = setup();
         let registry = UpcasterRegistry::new();
         let store = EventStore::new(&conn, &registry);
@@ -438,14 +442,15 @@ mod tests {
         .unwrap();
 
         let err = store.get(id).unwrap_err();
-        // The user-visible top-level variant is Database (the helper's Internal is
-        // boxed by FromSqlConversionFailure and re-mapped via `#[from]`).
+        // The user-visible top-level variant is Storage(Backend): the helper's
+        // Internal is boxed by FromSqlConversionFailure, then the call site maps it
+        // via StorageError::backend and `?` lifts StorageError into Storage (#926).
         assert!(
             matches!(
                 err,
                 MemoryError::Storage(crate::error::StorageError::Backend(_))
             ),
-            "read-path corrupt event_type must surface Database, got {err:?}"
+            "read-path corrupt event_type must surface Storage(Backend), got {err:?}"
         );
         // #366's actual harm — surfacing NotFound for a corrupt enum — is gone.
         assert!(

--- a/memory-engine/lib/memory-engine/src/store/events.rs
+++ b/memory-engine/lib/memory-engine/src/store/events.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
 
@@ -39,7 +40,7 @@ pub const fn event_type_to_str(et: &EventType) -> &'static str {
 ///
 /// What a *read-path* caller sees, end-to-end: the read site ([`row_to_event`])
 /// boxes this `Internal` into `rusqlite::Error::FromSqlConversionFailure`, which
-/// re-maps to [`MemoryError::Database`] via its `#[from]`. So the surfaced
+/// re-maps to [`MemoryError::Storage`] via its `#[from]`. So the surfaced
 /// top-level variant is `Database` (a *data* error — the correct class for corrupt
 /// stored data, and crucially **not** `NotFound`, the conflation #366 reported),
 /// with this `Internal` preserved as the boxed source. The `Internal` value here
@@ -130,7 +131,7 @@ impl<'a> EventStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on insert failure.
+    /// Returns `MemoryError::Storage` on insert failure.
     pub fn insert(&self, event: &NewEvent) -> Result<i64> {
         let timestamp_str = event.timestamp.to_rfc3339();
         let event_type_str = event_type_to_str(&event.event_type);
@@ -138,23 +139,25 @@ impl<'a> EventStore<'a> {
 
         let created_at_str = event.created_at.map(|dt| dt.to_rfc3339());
 
-        self.conn.execute(
-            "INSERT INTO events (timestamp, event_type, payload, source, session_id, scope_id,
+        self.conn
+            .execute(
+                "INSERT INTO events (timestamp, event_type, payload, source, session_id, scope_id,
                 origin_node_id, sequence_id, created_at, event_revision)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-            params![
-                timestamp_str,
-                event_type_str,
-                payload_str,
-                event.source,
-                event.session_id,
-                event.scope_id,
-                event.origin_node_id,
-                event.sequence_id,
-                created_at_str,
-                i64::from(self.registry.latest_revision(event_type_str)),
-            ],
-        )?;
+                params![
+                    timestamp_str,
+                    event_type_str,
+                    payload_str,
+                    event.source,
+                    event.session_id,
+                    event.scope_id,
+                    event.origin_node_id,
+                    event.sequence_id,
+                    created_at_str,
+                    i64::from(self.registry.latest_revision(event_type_str)),
+                ],
+            )
+            .map_err(StorageError::backend)?;
         Ok(self.conn.last_insert_rowid())
     }
 
@@ -164,15 +167,20 @@ impl<'a> EventStore<'a> {
     ///
     /// Returns `MemoryError::NotFound` if the id doesn't exist.
     pub fn get(&self, id: i64) -> Result<Event> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
                     origin_node_id, sequence_id, created_at, event_revision
              FROM events WHERE id = ?1",
-        )?;
-        let mut rows = stmt.query_map(params![id], row_to_event)?;
+            )
+            .map_err(StorageError::backend)?;
+        let mut rows = stmt
+            .query_map(params![id], row_to_event)
+            .map_err(StorageError::backend)?;
         match rows.next() {
             Some(Ok(event)) => Ok(event),
-            Some(Err(e)) => Err(e.into()),
+            Some(Err(e)) => Err(StorageError::backend(e).into()),
             None => Err(MemoryError::NotFound(format!("event {id}"))),
         }
     }
@@ -181,18 +189,20 @@ impl<'a> EventStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list(&self, filter: &EventFilter) -> Result<Vec<Event>> {
         let (sql, values) = build_filter_query(
             "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
                     origin_node_id, sequence_id, created_at, event_revision FROM events",
             filter,
         );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(rusqlite::params_from_iter(values), row_to_event)?;
+        let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(values), row_to_event)
+            .map_err(StorageError::backend)?;
         let mut events = Vec::new();
         for row in rows {
-            events.push(row?);
+            events.push(row.map_err(StorageError::backend)?);
         }
         Ok(events)
     }
@@ -205,20 +215,23 @@ impl<'a> EventStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure, or propagates any
+    /// Returns `MemoryError::Storage` on SQL failure, or propagates any
     /// error returned by `f`.
     pub fn for_each<F>(&self, mut f: F) -> Result<()>
     where
         F: FnMut(Event) -> Result<()>,
     {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, timestamp, event_type, payload, source, session_id, scope_id,
                     origin_node_id, sequence_id, created_at, event_revision
              FROM events ORDER BY timestamp ASC",
-        )?;
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
-            let event = row_to_event(row)?;
+            )
+            .map_err(StorageError::backend)?;
+        let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+        while let Some(row) = rows.next().map_err(StorageError::backend)? {
+            let event = row_to_event(row).map_err(StorageError::backend)?;
             f(event)?;
         }
         Ok(())
@@ -228,11 +241,13 @@ impl<'a> EventStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn count(&self, filter: &EventFilter) -> Result<i64> {
         let (sql, values) = build_filter_query("SELECT COUNT(*) FROM events", filter);
-        let mut stmt = self.conn.prepare(&sql)?;
-        let count = stmt.query_row(rusqlite::params_from_iter(values), |row| row.get(0))?;
+        let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
+        let count = stmt
+            .query_row(rusqlite::params_from_iter(values), |row| row.get(0))
+            .map_err(StorageError::backend)?;
         Ok(count)
     }
 
@@ -257,7 +272,7 @@ impl<'a> EventStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     /// Returns `MemoryError::Migration` if upcasting fails.
     pub fn list_upcasted(&self, filter: &EventFilter) -> Result<Vec<Event>> {
         let events = self.list(filter)?;
@@ -401,7 +416,7 @@ mod tests {
     /// The isolated [`str_to_event_type_rejects_unknown_as_internal`] test below
     /// only exercises the private helper; the production caller (`row_to_event`)
     /// boxes its error into `rusqlite::Error::FromSqlConversionFailure`, which
-    /// re-maps to [`MemoryError::Database`] via its `#[from]`. So the helper's
+    /// re-maps to [`MemoryError::Storage`] via its `#[from]`. So the helper's
     /// `Internal` never reaches a read-path caller as the top-level variant.
     ///
     /// What #366 actually demanded — *do not surface [`MemoryError::NotFound`] for
@@ -426,7 +441,10 @@ mod tests {
         // The user-visible top-level variant is Database (the helper's Internal is
         // boxed by FromSqlConversionFailure and re-mapped via `#[from]`).
         assert!(
-            matches!(err, MemoryError::Database(_)),
+            matches!(
+                err,
+                MemoryError::Storage(crate::error::StorageError::Backend(_))
+            ),
             "read-path corrupt event_type must surface Database, got {err:?}"
         );
         // #366's actual harm — surfacing NotFound for a corrupt enum — is gone.

--- a/memory-engine/lib/memory-engine/src/store/fact_vectors.rs
+++ b/memory-engine/lib/memory-engine/src/store/fact_vectors.rs
@@ -23,6 +23,7 @@
 //! Re-embedding expired facts costs a few extra provider calls; a homogeneous
 //! active space is the correctness invariant that buys.
 
+use crate::error::StorageError;
 use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
@@ -48,7 +49,7 @@ use crate::types::PromoteOutcome;
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`](crate::error::MemoryError::Database) on query
+/// Returns [`MemoryError::Storage`](crate::error::MemoryError::Storage) on query
 /// failure, or [`MemoryError::Internal`](crate::error::MemoryError::Internal) if
 /// `limit` overflows `i64`.
 pub fn next_backfill_window(
@@ -59,18 +60,24 @@ pub fn next_backfill_window(
 ) -> Result<Vec<(i64, String)>> {
     let limit = i64::try_from(limit)
         .map_err(|_| MemoryError::Internal("backfill window limit exceeds i64".into()))?;
-    let mut stmt = conn.prepare(
-        "SELECT f.id, f.content
+    let mut stmt = conn
+        .prepare(
+            "SELECT f.id, f.content
            FROM facts f
            LEFT JOIN fact_vectors v ON v.fact_id = f.id AND v.space_id = ?1
           WHERE v.fact_id IS NULL AND f.id > ?2
           ORDER BY f.id
           LIMIT ?3",
-    )?;
-    let rows = stmt.query_map(params![space_id, after_id, limit], |row| {
-        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-    })?;
-    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+        )
+        .map_err(StorageError::backend)?;
+    let rows = stmt
+        .query_map(params![space_id, after_id, limit], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(StorageError::backend)?;
+    Ok(rows
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(StorageError::backend)?)
 }
 
 /// Idempotently write a batch of `(fact_id, embedding)` rows into `space_id`.
@@ -88,7 +95,7 @@ pub fn next_backfill_window(
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`](crate::error::MemoryError::Database) on a
+/// Returns [`MemoryError::Storage`](crate::error::MemoryError::Storage) on a
 /// write failure — including a foreign-key violation if `space_id` is not a
 /// registered space or a `fact_id` does not exist (FK enforcement is ON).
 pub fn write_backfill_batch(
@@ -96,20 +103,26 @@ pub fn write_backfill_batch(
     space_id: &str,
     rows: &[(i64, Vec<f32>)],
 ) -> Result<usize> {
-    let tx = conn.unchecked_transaction()?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(StorageError::backend)?;
     let mut inserted = 0usize;
     {
-        let mut stmt = tx.prepare(
-            "INSERT INTO fact_vectors (fact_id, space_id, embedding)
+        let mut stmt = tx
+            .prepare(
+                "INSERT INTO fact_vectors (fact_id, space_id, embedding)
              VALUES (?1, ?2, ?3)
              ON CONFLICT(fact_id, space_id) DO NOTHING",
-        )?;
+            )
+            .map_err(StorageError::backend)?;
         for (fact_id, embedding) in rows {
             let blob = serialize_embedding(embedding);
-            inserted += stmt.execute(params![fact_id, space_id, blob])?;
+            inserted += stmt
+                .execute(params![fact_id, space_id, blob])
+                .map_err(StorageError::backend)?;
         }
     }
-    tx.commit()?;
+    tx.commit().map_err(StorageError::backend)?;
     Ok(inserted)
 }
 
@@ -119,18 +132,20 @@ pub fn write_backfill_batch(
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`](crate::error::MemoryError::Database) on query
+/// Returns [`MemoryError::Storage`](crate::error::MemoryError::Storage) on query
 /// failure, or [`MemoryError::Internal`](crate::error::MemoryError::Internal) if
 /// the stored count is negative (impossible).
 pub fn count_unbackfilled(conn: &Connection, space_id: &str) -> Result<usize> {
-    let n: i64 = conn.query_row(
-        "SELECT COUNT(*)
+    let n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
            FROM facts f
            LEFT JOIN fact_vectors v ON v.fact_id = f.id AND v.space_id = ?1
           WHERE v.fact_id IS NULL",
-        params![space_id],
-        |row| row.get(0),
-    )?;
+            params![space_id],
+            |row| row.get(0),
+        )
+        .map_err(StorageError::backend)?;
     usize::try_from(n).map_err(|_| MemoryError::Internal("negative unbackfilled count".into()))
 }
 
@@ -169,9 +184,11 @@ pub fn count_unbackfilled(conn: &Connection, space_id: &str) -> Result<usize> {
 ///
 /// Returns [`MemoryError::Internal`] if there is no active space, the populating
 /// space is absent or not `populating`, or the completeness gate fails, or
-/// [`MemoryError::Database`] on a write failure (which rolls the transaction back).
+/// [`MemoryError::Storage`] on a write failure (which rolls the transaction back).
 pub fn promote_space(conn: &Connection, populating: &str) -> Result<PromoteOutcome> {
-    let tx = conn.unchecked_transaction()?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(StorageError::backend)?;
 
     // (0) Resolve both spaces. NO dim guard: a promote is dimension-agnostic at the
     // storage layer (the copy-swap below is a blob-level UPDATE), so #742 allows the
@@ -214,14 +231,17 @@ pub fn promote_space(conn: &Connection, populating: &str) -> Result<PromoteOutco
         "INSERT INTO fact_vectors (fact_id, space_id, embedding)
          SELECT id, ?1, embedding FROM facts",
         params![active.name],
-    )?;
+    )
+    .map_err(StorageError::backend)?;
 
     // (3) Copy-swap the populating vectors into the active serving store.
-    let promoted = tx.execute(
-        "UPDATE facts SET embedding =
+    let promoted = tx
+        .execute(
+            "UPDATE facts SET embedding =
             (SELECT embedding FROM fact_vectors WHERE fact_id = facts.id AND space_id = ?1)",
-        params![populating],
-    )?;
+            params![populating],
+        )
+        .map_err(StorageError::backend)?;
 
     // (4) Demote-then-activate (the partial-unique index never sees two actives).
     embedding_spaces::deprecate(&tx, &active.name)?;
@@ -231,9 +251,10 @@ pub fn promote_space(conn: &Connection, populating: &str) -> Result<PromoteOutco
     tx.execute(
         "DELETE FROM fact_vectors WHERE space_id = ?1",
         params![populating],
-    )?;
+    )
+    .map_err(StorageError::backend)?;
 
-    tx.commit()?;
+    tx.commit().map_err(StorageError::backend)?;
 
     Ok(PromoteOutcome {
         promoted,
@@ -259,7 +280,7 @@ pub fn promote_space(conn: &Connection, populating: &str) -> Result<PromoteOutco
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`](crate::error::MemoryError::Database) on query
+/// Returns [`MemoryError::Storage`](crate::error::MemoryError::Storage) on query
 /// failure, [`MemoryError::EmbeddingDimension`](crate::error::MemoryError::EmbeddingDimension)
 /// if a stored blob is not its space's dim, or any error the callback returns.
 pub fn for_each<F>(conn: &Connection, embed_dim: usize, mut cb: F) -> Result<()>
@@ -272,14 +293,14 @@ where
         .into_iter()
         .map(|s| (s.name, s.fingerprint.dim))
         .collect();
-    let mut stmt = conn.prepare(
-        "SELECT fact_id, space_id, embedding FROM fact_vectors ORDER BY space_id, fact_id",
-    )?;
-    let mut rows = stmt.query([])?;
-    while let Some(row) = rows.next()? {
-        let fact_id: i64 = row.get(0)?;
-        let space_id: String = row.get(1)?;
-        let blob: Vec<u8> = row.get(2)?;
+    let mut stmt = conn
+        .prepare("SELECT fact_id, space_id, embedding FROM fact_vectors ORDER BY space_id, fact_id")
+        .map_err(StorageError::backend)?;
+    let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+    while let Some(row) = rows.next().map_err(StorageError::backend)? {
+        let fact_id: i64 = row.get(0).map_err(StorageError::backend)?;
+        let space_id: String = row.get(1).map_err(StorageError::backend)?;
+        let blob: Vec<u8> = row.get(2).map_err(StorageError::backend)?;
         let dim = space_dims.get(&space_id).copied().unwrap_or(embed_dim);
         let embedding = crate::store::deserialize_embedding(&blob, dim)?;
         cb(fact_id, space_id, embedding)?;
@@ -294,16 +315,18 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`MemoryError::Database`](crate::error::MemoryError::Database) on query
+/// Returns [`MemoryError::Storage`](crate::error::MemoryError::Storage) on query
 /// failure, or [`MemoryError::Internal`](crate::error::MemoryError::Internal) if
 /// the stored count is negative (impossible).
 #[cfg(test)]
 pub fn count_vectors(conn: &Connection, space_id: &str) -> Result<usize> {
-    let n: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM fact_vectors WHERE space_id = ?1",
-        params![space_id],
-        |row| row.get(0),
-    )?;
+    let n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM fact_vectors WHERE space_id = ?1",
+            params![space_id],
+            |row| row.get(0),
+        )
+        .map_err(StorageError::backend)?;
     usize::try_from(n).map_err(|_| MemoryError::Internal("negative vector count".into()))
 }
 
@@ -509,7 +532,13 @@ mod tests {
         let conn = fresh_conn();
         let a = insert_fact(&conn, "alpha");
         let err = write_backfill_batch(&conn, "no-such-space", &vecs(&[a])).expect_err("FK");
-        assert!(matches!(err, MemoryError::Database(_)), "got {err:?}");
+        assert!(
+            matches!(
+                err,
+                MemoryError::Storage(crate::error::StorageError::Backend(_))
+            ),
+            "got {err:?}"
+        );
     }
 
     // --- promote (#623 T3) ---
@@ -657,7 +686,13 @@ mod tests {
         .expect("install trigger");
 
         let err = promote_space(&conn, SPACE).expect_err("mid-tx failure");
-        assert!(matches!(err, MemoryError::Database(_)), "got {err:?}");
+        assert!(
+            matches!(
+                err,
+                MemoryError::Storage(crate::error::StorageError::Backend(_))
+            ),
+            "got {err:?}"
+        );
 
         conn.execute_batch("DROP TRIGGER fail_swap;")
             .expect("drop trigger");

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::error::{MemoryError, Result};
+use crate::error::{MemoryError, Result, StorageError};
 use crate::store::{
     deserialize_embedding, parse_optional_timestamp, parse_timestamp, serialize_embedding,
 };
@@ -67,7 +67,7 @@ pub const fn fact_type_to_str(ft: &FactType) -> &'static str {
 /// What a *read-path* caller sees, end-to-end: the read sites ([`row_to_fact`],
 /// [`row_to_scoring_row`]) box this `Internal` into
 /// `rusqlite::Error::FromSqlConversionFailure`, which re-maps to
-/// [`MemoryError::Database`] via its `#[from]`. So the surfaced top-level variant
+/// [`MemoryError::Storage`] via its `#[from]`. So the surfaced top-level variant
 /// is `Database` (a *data* error — the correct class for corrupt stored data, and
 /// crucially **not** `NotFound`, which is exactly the conflation #366 reported),
 /// with this `Internal` preserved as the boxed source for diagnostics. The
@@ -114,13 +114,17 @@ fn content_hash(content: &str) -> String {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure.
+/// Returns `MemoryError::Storage` on query failure.
 pub fn existing_fact_ids(conn: &Connection) -> Result<std::collections::HashSet<i64>> {
-    let mut stmt = conn.prepare("SELECT id FROM facts")?;
-    let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+    let mut stmt = conn
+        .prepare("SELECT id FROM facts")
+        .map_err(StorageError::backend)?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, i64>(0))
+        .map_err(StorageError::backend)?;
     let mut ids = std::collections::HashSet::new();
     for row in rows {
-        ids.insert(row?);
+        ids.insert(row.map_err(StorageError::backend)?);
     }
     Ok(ids)
 }
@@ -140,7 +144,7 @@ impl<'a> FactStore<'a> {
     /// # Errors
     ///
     /// Returns `MemoryError::EmbeddingDimension` if embedding length != `embed_dim`.
-    /// Returns `MemoryError::Database` on insert failure.
+    /// Returns `MemoryError::Storage` on insert failure.
     pub fn insert(&self, fact: &NewFact) -> Result<i64> {
         if fact.embedding.len() != self.embed_dim {
             return Err(MemoryError::EmbeddingDimension {
@@ -159,31 +163,33 @@ impl<'a> FactStore<'a> {
         let last_accessed = fact.last_accessed.to_rfc3339();
         let metadata_str = serde_json::to_string(&fact.metadata)?;
 
-        self.conn.execute(
-            "INSERT INTO facts (content, content_hash, embedding, fact_type,
+        self.conn
+            .execute(
+                "INSERT INTO facts (content, content_hash, embedding, fact_type,
                 t_created, t_expired, t_valid, t_invalid,
                 source_event_id, importance, access_count, last_accessed, metadata, scope_id,
                 is_pinned, importance_score, surfaced_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, NULL)",
-            params![
-                fact.content,
-                hash,
-                blob,
-                fact_type_str,
-                t_created,
-                t_expired,
-                t_valid,
-                t_invalid,
-                fact.source_event_id,
-                fact.base_importance, // -> DB column `importance`
-                fact.access_count,
-                last_accessed,
-                metadata_str,
-                fact.scope_id,
-                i64::from(fact.is_pinned),
-                fact.base_importance, // seed importance_score from base importance
-            ],
-        )?;
+                params![
+                    fact.content,
+                    hash,
+                    blob,
+                    fact_type_str,
+                    t_created,
+                    t_expired,
+                    t_valid,
+                    t_invalid,
+                    fact.source_event_id,
+                    fact.base_importance, // -> DB column `importance`
+                    fact.access_count,
+                    last_accessed,
+                    metadata_str,
+                    fact.scope_id,
+                    i64::from(fact.is_pinned),
+                    fact.base_importance, // seed importance_score from base importance
+                ],
+            )
+            .map_err(StorageError::backend)?;
         Ok(self.conn.last_insert_rowid())
     }
 
@@ -220,7 +226,7 @@ impl<'a> FactStore<'a> {
     /// # Errors
     ///
     /// Returns `MemoryError::EmbeddingDimension` if embedding length != `embed_dim`.
-    /// Returns `MemoryError::Database` on query or insert failure.
+    /// Returns `MemoryError::Storage` on query or insert failure.
     pub fn insert_or_reinforce(&self, fact: &NewFact) -> Result<(i64, bool)> {
         if fact.embedding.len() != self.embed_dim {
             return Err(MemoryError::EmbeddingDimension {
@@ -240,7 +246,8 @@ impl<'a> FactStore<'a> {
                 params![hash, fact.content, fact.scope_id],
                 |row| row.get(0),
             )
-            .optional()?;
+            .optional()
+            .map_err(StorageError::backend)?;
 
         match existing {
             Some(id) => {
@@ -251,22 +258,24 @@ impl<'a> FactStore<'a> {
                 // store relies on for t_created/t_valid string comparison.)
                 let t_created = fact.t_created.to_rfc3339();
                 let last_accessed = fact.last_accessed.to_rfc3339();
-                self.conn.execute(
-                    "UPDATE facts
+                self.conn
+                    .execute(
+                        "UPDATE facts
                      SET access_count = access_count + 1,
                          t_created = min(t_created, ?1),
                          last_accessed = max(last_accessed, ?2),
                          is_pinned = max(is_pinned, ?3),
                          importance = max(importance, ?4)
                      WHERE id = ?5",
-                    params![
-                        t_created,
-                        last_accessed,
-                        i64::from(fact.is_pinned),
-                        fact.base_importance,
-                        id
-                    ],
-                )?;
+                        params![
+                            t_created,
+                            last_accessed,
+                            i64::from(fact.is_pinned),
+                            fact.base_importance,
+                            id
+                        ],
+                    )
+                    .map_err(StorageError::backend)?;
                 Ok((id, true))
             }
             None => Ok((self.insert(fact)?, false)),
@@ -281,12 +290,15 @@ impl<'a> FactStore<'a> {
     pub fn get(&self, id: i64) -> Result<Fact> {
         let mut stmt = self
             .conn
-            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts WHERE id = ?1"))?;
+            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts WHERE id = ?1"))
+            .map_err(StorageError::backend)?;
         let dim = self.embed_dim;
-        let mut rows = stmt.query_map(params![id], |row| row_to_fact(row, dim))?;
+        let mut rows = stmt
+            .query_map(params![id], |row| row_to_fact(row, dim))
+            .map_err(StorageError::backend)?;
         match rows.next() {
             Some(Ok(fact)) => Ok(fact),
-            Some(Err(e)) => Err(e.into()),
+            Some(Err(e)) => Err(StorageError::backend(e).into()),
             None => Err(MemoryError::NotFound(format!("fact {id}"))),
         }
     }
@@ -305,20 +317,25 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn get_many(&self, ids: &[i64]) -> Result<std::collections::HashMap<i64, Fact>> {
         if ids.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
         let ids_json = serde_json::to_string(ids)?;
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {FACT_COLUMNS} FROM facts WHERE id IN (SELECT value FROM json_each(?1))"
-        ))?;
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT {FACT_COLUMNS} FROM facts WHERE id IN (SELECT value FROM json_each(?1))"
+            ))
+            .map_err(StorageError::backend)?;
         let dim = self.embed_dim;
-        let rows = stmt.query_map(params![ids_json], |row| row_to_fact(row, dim))?;
+        let rows = stmt
+            .query_map(params![ids_json], |row| row_to_fact(row, dim))
+            .map_err(StorageError::backend)?;
         let mut out = std::collections::HashMap::with_capacity(ids.len());
         for row in rows {
-            let fact = row?;
+            let fact = row.map_err(StorageError::backend)?;
             out.insert(fact.id, fact);
         }
         Ok(out)
@@ -333,7 +350,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_active(&self, limit: Option<usize>) -> Result<Vec<Fact>> {
         let base = format!("SELECT {FACT_COLUMNS} FROM facts WHERE t_expired IS NULL");
         let limit_i64: i64 = limit.map_or(-1, |n| i64::try_from(n).unwrap_or(i64::MAX));
@@ -342,12 +359,14 @@ impl<'a> FactStore<'a> {
         // order-sensitive, so a stable insertion (rowid) order makes their output
         // reproducible rather than dependent on the storage engine's scan choice.
         let sql = format!("{base} ORDER BY id LIMIT ?1");
-        let mut stmt = self.conn.prepare(&sql)?;
+        let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
         let dim = self.embed_dim;
-        let rows = stmt.query_map(params![limit_i64], |row| row_to_fact(row, dim))?;
+        let rows = stmt
+            .query_map(params![limit_i64], |row| row_to_fact(row, dim))
+            .map_err(StorageError::backend)?;
         let mut facts = Vec::new();
         for row in rows {
-            facts.push(row?);
+            facts.push(row.map_err(StorageError::backend)?);
         }
         Ok(facts)
     }
@@ -362,13 +381,16 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn count_active(&self) -> Result<usize> {
-        let count: i64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM facts WHERE t_expired IS NULL",
-            [],
-            |row| row.get(0),
-        )?;
+        let count: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM facts WHERE t_expired IS NULL",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(StorageError::backend)?;
         Ok(usize::try_from(count).unwrap_or(0))
     }
 
@@ -381,13 +403,16 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn is_active(&self, id: i64) -> Result<bool> {
-        let active: bool = self.conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM facts WHERE id = ?1 AND t_expired IS NULL)",
-            params![id],
-            |row| row.get(0),
-        )?;
+        let active: bool = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM facts WHERE id = ?1 AND t_expired IS NULL)",
+                params![id],
+                |row| row.get(0),
+            )
+            .map_err(StorageError::backend)?;
         Ok(active)
     }
 
@@ -401,15 +426,20 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_active_scoring(&self) -> Result<Vec<FactScoringRow>> {
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {SCORING_COLUMNS} FROM facts WHERE t_expired IS NULL"
-        ))?;
-        let rows = stmt.query_map([], row_to_scoring_row)?;
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT {SCORING_COLUMNS} FROM facts WHERE t_expired IS NULL"
+            ))
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map([], row_to_scoring_row)
+            .map_err(StorageError::backend)?;
         let mut out = Vec::new();
         for row in rows {
-            out.push(row?);
+            out.push(row.map_err(StorageError::backend)?);
         }
         Ok(out)
     }
@@ -421,20 +451,25 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_active_at(&self, valid_at: DateTime<Utc>) -> Result<Vec<Fact>> {
         let valid_at_str = valid_at.to_rfc3339();
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {FACT_COLUMNS} FROM facts
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL
                AND (t_valid IS NULL OR t_valid <= ?1)
                AND (t_invalid IS NULL OR t_invalid > ?1)"
-        ))?;
+            ))
+            .map_err(StorageError::backend)?;
         let dim = self.embed_dim;
-        let rows = stmt.query_map(params![valid_at_str], |row| row_to_fact(row, dim))?;
+        let rows = stmt
+            .query_map(params![valid_at_str], |row| row_to_fact(row, dim))
+            .map_err(StorageError::backend)?;
         let mut facts = Vec::new();
         for row in rows {
-            facts.push(row?);
+            facts.push(row.map_err(StorageError::backend)?);
         }
         Ok(facts)
     }
@@ -455,7 +490,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_dormant(
         &self,
         importance_threshold: f64,
@@ -487,7 +522,7 @@ impl<'a> FactStore<'a> {
                AND (t_invalid IS NULL OR t_invalid > ?2){scope_clause}"
         );
 
-        let mut stmt = self.conn.prepare(&sql)?;
+        let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
         let dim = self.embed_dim;
 
         // Build params: [threshold, now, scope_json?]. `?3` is bound only when a
@@ -498,12 +533,14 @@ impl<'a> FactStore<'a> {
             all_params.push(Box::new(json));
         }
 
-        let rows = stmt.query_map(rusqlite::params_from_iter(all_params), |row| {
-            row_to_fact(row, dim)
-        })?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(all_params), |row| {
+                row_to_fact(row, dim)
+            })
+            .map_err(StorageError::backend)?;
         let mut facts = Vec::new();
         for row in rows {
-            facts.push(row?);
+            facts.push(row.map_err(StorageError::backend)?);
         }
         Ok(facts)
     }
@@ -515,10 +552,13 @@ impl<'a> FactStore<'a> {
     /// Returns `MemoryError::NotFound` if no rows affected.
     pub fn expire(&self, id: i64, now: DateTime<Utc>) -> Result<()> {
         let now_str = now.to_rfc3339();
-        let changed = self.conn.execute(
-            "UPDATE facts SET t_expired = ?1 WHERE id = ?2 AND t_expired IS NULL",
-            params![now_str, id],
-        )?;
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE facts SET t_expired = ?1 WHERE id = ?2 AND t_expired IS NULL",
+                params![now_str, id],
+            )
+            .map_err(StorageError::backend)?;
         if changed == 0 {
             return Err(MemoryError::NotFound(format!("fact {id}")));
         }
@@ -543,7 +583,7 @@ impl<'a> FactStore<'a> {
         let changed = self.conn.execute(
             "UPDATE facts SET t_expired = ?1, t_invalid = ?1 WHERE id = ?2 AND t_expired IS NULL",
             params![now_str, id],
-        )?;
+        ).map_err(StorageError::backend)?;
         if changed == 0 {
             return Err(MemoryError::NotFound(format!("fact {id}")));
         }
@@ -557,10 +597,13 @@ impl<'a> FactStore<'a> {
     ///
     /// Returns `MemoryError::NotFound` if no rows affected.
     pub fn update_base_importance(&self, id: i64, base_importance: f64) -> Result<()> {
-        let changed = self.conn.execute(
-            "UPDATE facts SET importance = ?1 WHERE id = ?2",
-            params![base_importance, id],
-        )?;
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE facts SET importance = ?1 WHERE id = ?2",
+                params![base_importance, id],
+            )
+            .map_err(StorageError::backend)?;
         if changed == 0 {
             return Err(MemoryError::NotFound(format!("fact {id}")));
         }
@@ -577,7 +620,7 @@ impl<'a> FactStore<'a> {
         let changed = self.conn.execute(
             "UPDATE facts SET access_count = access_count + 1, last_accessed = ?1 WHERE id = ?2",
             params![now_str, id],
-        )?;
+        ).map_err(StorageError::backend)?;
         if changed == 0 {
             return Err(MemoryError::NotFound(format!("fact {id}")));
         }
@@ -590,19 +633,24 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_by_scope_importance(&self, scope_id: i64, limit: usize) -> Result<Vec<Fact>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         let dim = self.embed_dim;
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {FACT_COLUMNS} FROM facts
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL AND scope_id = ?1
              ORDER BY importance DESC
              LIMIT ?2"
-        ))?;
-        let rows = stmt.query_map(params![scope_id, limit_i64], |row| row_to_fact(row, dim))?;
+            ))
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map(params![scope_id, limit_i64], |row| row_to_fact(row, dim))
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// List active facts in a set of scopes with importance >= threshold,
@@ -615,7 +663,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_by_scopes_importance(
         &self,
         scope_ids: &[i64],
@@ -628,21 +676,26 @@ impl<'a> FactStore<'a> {
         let exclude_json = serde_json::to_string(&exclude_ids.iter().copied().collect::<Vec<_>>())
             .expect("serialize exclude_ids");
         let dim = self.embed_dim;
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {FACT_COLUMNS} FROM facts
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
                AND importance >= ?2
                AND id NOT IN (SELECT value FROM json_each(?3))
              ORDER BY importance DESC
              LIMIT ?4"
-        ))?;
-        let rows = stmt.query_map(
-            params![scope_json, min_importance, exclude_json, limit_i64],
-            |row| row_to_fact(row, dim),
-        )?;
+            ))
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map(
+                params![scope_json, min_importance, exclude_json, limit_i64],
+                |row| row_to_fact(row, dim),
+            )
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// List active pinned (unforgettable) facts, optionally filtered by scope,
@@ -661,7 +714,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_pinned(&self, scope_ids: &[i64], limit: usize) -> Result<Vec<Fact>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         let base =
@@ -669,21 +722,25 @@ impl<'a> FactStore<'a> {
         let dim = self.embed_dim;
         if scope_ids.is_empty() {
             let sql = format!("{base} ORDER BY importance_score DESC LIMIT ?1");
-            let mut stmt = self.conn.prepare(&sql)?;
-            let rows = stmt.query_map(rusqlite::params![limit_i64], |row| row_to_fact(row, dim))?;
+            let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
+            let rows = stmt
+                .query_map(rusqlite::params![limit_i64], |row| row_to_fact(row, dim))
+                .map_err(StorageError::backend)?;
             rows.collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(Into::into)
+                .map_err(|e| StorageError::backend(e).into())
         } else {
             let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
             let sql = format!(
                 "{base} AND scope_id IN (SELECT value FROM json_each(?1)) ORDER BY importance_score DESC LIMIT ?2"
             );
-            let mut stmt = self.conn.prepare(&sql)?;
-            let rows = stmt.query_map(rusqlite::params![scope_json, limit_i64], |row| {
-                row_to_fact(row, dim)
-            })?;
+            let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
+            let rows = stmt
+                .query_map(rusqlite::params![scope_json, limit_i64], |row| {
+                    row_to_fact(row, dim)
+                })
+                .map_err(StorageError::backend)?;
             rows.collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(Into::into)
+                .map_err(|e| StorageError::backend(e).into())
         }
     }
 
@@ -706,7 +763,7 @@ impl<'a> FactStore<'a> {
     ///
     /// - Returns `MemoryError::Serialization` if `scope_ids` cannot be serialized
     ///   to JSON (infallible in practice for `&[i64]`).
-    /// - Returns `MemoryError::Database` on query failure.
+    /// - Returns `MemoryError::Storage` on query failure.
     pub fn list_due(
         &self,
         now: DateTime<Utc>,
@@ -759,13 +816,15 @@ impl<'a> FactStore<'a> {
 
         let sql =
             format!("{base}{scope_clause}{exclude_clause} ORDER BY t_valid ASC{limit_clause}");
-        let mut stmt = self.conn.prepare(&sql)?;
+        let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
         let dim = self.embed_dim;
-        let rows = stmt.query_map(rusqlite::params_from_iter(params), |row| {
-            row_to_fact(row, dim)
-        })?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(params), |row| {
+                row_to_fact(row, dim)
+            })
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Earliest future `t_valid` among active facts with `t_valid > now`.
@@ -789,11 +848,12 @@ impl<'a> FactStore<'a> {
             params.push(Box::new(serde_json::to_string(scope_ids)?));
             format!("{base} AND scope_id IN (SELECT value FROM json_each(?2))")
         };
-        let mut stmt = self.conn.prepare(&sql)?;
-        let result: Option<String> =
-            stmt.query_row(rusqlite::params_from_iter(params), |r| r.get(0))?;
+        let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
+        let result: Option<String> = stmt
+            .query_row(rusqlite::params_from_iter(params), |r| r.get(0))
+            .map_err(StorageError::backend)?;
         match result {
-            Some(s) => Ok(Some(parse_timestamp(&s)?)),
+            Some(s) => Ok(Some(parse_timestamp(&s).map_err(StorageError::backend)?)),
             None => Ok(None),
         }
     }
@@ -815,27 +875,32 @@ impl<'a> FactStore<'a> {
         self.conn.execute(
             "UPDATE facts SET surfaced_at = ?1 WHERE id IN (SELECT value FROM json_each(?2)) AND surfaced_at IS NULL",
             params![now_str, ids_json],
-        )?;
+        ).map_err(StorageError::backend)?;
         // Re-read persisted values for ALL requested IDs (handles concurrent races)
         let mut stmt = self.conn.prepare(
             "SELECT id, surfaced_at FROM facts WHERE id IN (SELECT value FROM json_each(?1)) AND surfaced_at IS NOT NULL",
-        )?;
-        let rows = stmt.query_map(params![ids_json], |row| {
-            let id: i64 = row.get(0)?;
-            let ts_str: String = row.get(1)?;
-            let ts = parse_timestamp(&ts_str)?;
-            Ok((id, ts))
-        })?;
+        ).map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map(params![ids_json], |row| {
+                let id: i64 = row.get(0)?;
+                let ts_str: String = row.get(1)?;
+                let ts = parse_timestamp(&ts_str)?;
+                Ok((id, ts))
+            })
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Set the pinned flag on a fact.
     pub fn set_pinned(&self, id: i64, pinned: bool) -> Result<()> {
-        let rows = self.conn.execute(
-            "UPDATE facts SET is_pinned = ?1 WHERE id = ?2",
-            rusqlite::params![i64::from(pinned), id],
-        )?;
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE facts SET is_pinned = ?1 WHERE id = ?2",
+                rusqlite::params![i64::from(pinned), id],
+            )
+            .map_err(StorageError::backend)?;
         if rows == 0 {
             return Err(crate::error::MemoryError::NotFound(format!("fact {id}")));
         }
@@ -846,15 +911,18 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_all(&self) -> Result<Vec<Fact>> {
         let mut stmt = self
             .conn
-            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts ORDER BY id ASC"))?;
+            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts ORDER BY id ASC"))
+            .map_err(StorageError::backend)?;
         let dim = self.embed_dim;
-        let rows = stmt.query_map([], |row| row_to_fact(row, dim))?;
+        let rows = stmt
+            .query_map([], |row| row_to_fact(row, dim))
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Iterate all facts row-by-row, calling `f` for each.
@@ -865,7 +933,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure, or propagates any
+    /// Returns `MemoryError::Storage` on SQL failure, or propagates any
     /// error returned by `f`.
     pub fn for_each<F>(&self, mut f: F) -> Result<()>
     where
@@ -873,11 +941,12 @@ impl<'a> FactStore<'a> {
     {
         let mut stmt = self
             .conn
-            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts ORDER BY id ASC"))?;
+            .prepare(&format!("SELECT {FACT_COLUMNS} FROM facts ORDER BY id ASC"))
+            .map_err(StorageError::backend)?;
         let dim = self.embed_dim;
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
-            let fact = row_to_fact(row, dim)?;
+        let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+        while let Some(row) = rows.next().map_err(StorageError::backend)? {
+            let fact = row_to_fact(row, dim).map_err(StorageError::backend)?;
             f(fact)?;
         }
         Ok(())
@@ -893,10 +962,13 @@ impl<'a> FactStore<'a> {
     /// nonexistent id would let a caller mistake a missing fact for a successful
     /// write (#328).
     pub fn update_importance_score(&self, id: i64, score: f64) -> Result<()> {
-        let changed = self.conn.execute(
-            "UPDATE facts SET importance_score = ?1 WHERE id = ?2",
-            rusqlite::params![score, id],
-        )?;
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE facts SET importance_score = ?1 WHERE id = ?2",
+                rusqlite::params![score, id],
+            )
+            .map_err(StorageError::backend)?;
         if changed == 0 {
             return Err(MemoryError::NotFound(format!("fact {id}")));
         }
@@ -941,7 +1013,7 @@ impl<'a> FactStore<'a> {
     /// Returns [`MemoryError::Conflict`](crate::error::MemoryError::Conflict) wrapping
     /// [`ConflictError::PolicyParameter`](crate::error::ConflictError::PolicyParameter)
     /// if any score is non-finite (the statement does not run). Returns
-    /// `MemoryError::Database` on SQL failure (or `MemoryError` from JSON
+    /// `MemoryError::Storage` on SQL failure (or `MemoryError` from JSON
     /// serialization, which cannot fail for the finite `id -> f64` map built here).
     pub fn update_importance_scores_bulk(&self, scores: &[(i64, f64)]) -> Result<()> {
         if scores.is_empty() {
@@ -965,13 +1037,15 @@ impl<'a> FactStore<'a> {
             map.insert(id.to_string(), serde_json::json!(score));
         }
         let payload = serde_json::to_string(&serde_json::Value::Object(map))?;
-        self.conn.execute(
-            "UPDATE facts \
+        self.conn
+            .execute(
+                "UPDATE facts \
              SET importance_score = s.value \
              FROM json_each(?1) AS s \
              WHERE facts.id = CAST(s.key AS INTEGER)",
-            params![payload],
-        )?;
+                params![payload],
+            )
+            .map_err(StorageError::backend)?;
         Ok(())
     }
 
@@ -998,7 +1072,8 @@ impl<'a> FactStore<'a> {
                 params![id],
                 |r| r.get(0),
             )
-            .optional()?;
+            .optional()
+            .map_err(StorageError::backend)?;
         let current = current.ok_or_else(|| MemoryError::NotFound(format!("fact {id}")))?;
 
         let mut value: serde_json::Value = serde_json::from_str(&current)?;
@@ -1012,10 +1087,13 @@ impl<'a> FactStore<'a> {
         }
 
         let new_str = serde_json::to_string(&value)?;
-        let changed = self.conn.execute(
-            "UPDATE facts SET metadata = ?1 WHERE id = ?2",
-            params![new_str, id],
-        )?;
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE facts SET metadata = ?1 WHERE id = ?2",
+                params![new_str, id],
+            )
+            .map_err(StorageError::backend)?;
         if changed == 0 {
             return Err(MemoryError::NotFound(format!("fact {id}")));
         }
@@ -1052,7 +1130,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub(crate) fn list_undreamt_in_period(
         &self,
         start: DateTime<Utc>,
@@ -1089,7 +1167,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn max_caller_written_fact_id(&self) -> Result<Option<i64>> {
         self.conn
             .query_row(
@@ -1100,7 +1178,7 @@ impl<'a> FactStore<'a> {
                 [],
                 |r| r.get::<_, Option<i64>>(0),
             )
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// List active facts ordered by materialized `importance_score`, excluding IDs in `exclude`.
@@ -1113,7 +1191,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_by_importance_score(
         &self,
         scope_ids: &[i64],
@@ -1134,26 +1212,30 @@ impl<'a> FactStore<'a> {
 
         if scope_ids.is_empty() {
             let sql = format!("{base} ORDER BY importance_score DESC LIMIT ?3");
-            let mut stmt = self.conn.prepare(&sql)?;
-            let rows = stmt.query_map(
-                rusqlite::params![min_score, exclude_json, limit_i64],
-                |row| row_to_fact(row, dim),
-            )?;
+            let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::params![min_score, exclude_json, limit_i64],
+                    |row| row_to_fact(row, dim),
+                )
+                .map_err(StorageError::backend)?;
             rows.collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(Into::into)
+                .map_err(|e| StorageError::backend(e).into())
         } else {
             let scope_json = serde_json::to_string(scope_ids).expect("serialize scope_ids");
             let sql = format!(
                 "{base} AND scope_id IN (SELECT value FROM json_each(?3))
                  ORDER BY importance_score DESC LIMIT ?4"
             );
-            let mut stmt = self.conn.prepare(&sql)?;
-            let rows = stmt.query_map(
-                rusqlite::params![min_score, exclude_json, scope_json, limit_i64],
-                |row| row_to_fact(row, dim),
-            )?;
+            let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::params![min_score, exclude_json, scope_json, limit_i64],
+                    |row| row_to_fact(row, dim),
+                )
+                .map_err(StorageError::backend)?;
             rows.collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(Into::into)
+                .map_err(|e| StorageError::backend(e).into())
         }
     }
 
@@ -1170,42 +1252,52 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_active_by_session(
         &self,
         session_id: &str,
         scope_ids: &[i64],
     ) -> Result<Vec<SessionFact>> {
         if scope_ids.is_empty() {
-            let mut stmt = self.conn.prepare(
-                "SELECT f.id
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT f.id
                  FROM facts f
                  INNER JOIN events e ON f.source_event_id = e.id
                  WHERE e.session_id = ?1
                    AND f.t_expired IS NULL
                  ORDER BY f.id",
-            )?;
-            let rows = stmt.query_map(params![session_id], |row| {
-                Ok(SessionFact { id: row.get(0)? })
-            })?;
+                )
+                .map_err(StorageError::backend)?;
+            let rows = stmt
+                .query_map(params![session_id], |row| {
+                    Ok(SessionFact { id: row.get(0)? })
+                })
+                .map_err(StorageError::backend)?;
             rows.collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(MemoryError::Database)
+                .map_err(|e| StorageError::backend(e).into())
         } else {
             let scope_json = serde_json::to_string(scope_ids)?;
-            let mut stmt = self.conn.prepare(
-                "SELECT f.id
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT f.id
                  FROM facts f
                  INNER JOIN events e ON f.source_event_id = e.id
                  WHERE e.session_id = ?1
                    AND f.t_expired IS NULL
                    AND f.scope_id IN (SELECT value FROM json_each(?2))
                  ORDER BY f.id",
-            )?;
-            let rows = stmt.query_map(params![session_id, scope_json], |row| {
-                Ok(SessionFact { id: row.get(0)? })
-            })?;
+                )
+                .map_err(StorageError::backend)?;
+            let rows = stmt
+                .query_map(params![session_id, scope_json], |row| {
+                    Ok(SessionFact { id: row.get(0)? })
+                })
+                .map_err(StorageError::backend)?;
             rows.collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(MemoryError::Database)
+                .map_err(|e| StorageError::backend(e).into())
         }
     }
 
@@ -1219,7 +1311,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_by_scopes_recent(
         &self,
         scope_ids: &[i64],
@@ -1231,19 +1323,24 @@ impl<'a> FactStore<'a> {
         let exclude_json = serde_json::to_string(&exclude_ids.iter().copied().collect::<Vec<_>>())
             .expect("serialize exclude_ids");
         let dim = self.embed_dim;
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {FACT_COLUMNS} FROM facts
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
                AND id NOT IN (SELECT value FROM json_each(?2))
              ORDER BY t_created DESC
              LIMIT ?3"
-        ))?;
-        let rows = stmt.query_map(params![scope_json, exclude_json, limit_i64], |row| {
-            row_to_fact(row, dim)
-        })?;
+            ))
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map(params![scope_json, exclude_json, limit_i64], |row| {
+                row_to_fact(row, dim)
+            })
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// List active facts in `scope_ids` whose `metadata` JSON carries the top-level
@@ -1279,7 +1376,7 @@ impl<'a> FactStore<'a> {
     ///
     /// Returns `MemoryError::Conflict(ConflictError::QueryValidation)` if
     /// `marker_key` is not a non-empty `[A-Za-z0-9_]+` identifier.
-    /// Returns `MemoryError::Database` on query failure.
+    /// Returns `MemoryError::Storage` on query failure.
     pub fn list_active_by_metadata_key_recent(
         &self,
         scope_ids: &[i64],
@@ -1308,17 +1405,22 @@ impl<'a> FactStore<'a> {
         // `json_extract` paths cannot be parameterized portably. `json_extract` (not
         // `json_type`) gives "present with a non-null value" semantics.
         let marker_predicate = format!("json_extract(metadata, '$.{marker_key}') IS NOT NULL");
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {FACT_COLUMNS} FROM facts
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT {FACT_COLUMNS} FROM facts
              WHERE t_expired IS NULL
                AND scope_id IN (SELECT value FROM json_each(?1))
                AND {marker_predicate}
              ORDER BY t_created DESC
              LIMIT ?2"
-        ))?;
-        let rows = stmt.query_map(params![scope_json, limit_i64], |row| row_to_fact(row, dim))?;
+            ))
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map(params![scope_json, limit_i64], |row| row_to_fact(row, dim))
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(MemoryError::Database)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// List active facts whose validity interval overlaps the given period `[start, end)`.
@@ -1400,7 +1502,7 @@ impl<'a> FactStore<'a> {
              ORDER BY importance_score DESC, id ASC"
         );
 
-        let mut stmt = self.conn.prepare(&sql)?;
+        let mut stmt = self.conn.prepare(&sql).map_err(StorageError::backend)?;
         let mut params: Vec<Box<dyn rusqlite::types::ToSql>> =
             vec![Box::new(end_str), Box::new(start_str)];
         if !scope_ids.is_empty() {
@@ -1410,11 +1512,13 @@ impl<'a> FactStore<'a> {
             params.push(Box::new(ft_str));
         }
 
-        let rows = stmt.query_map(rusqlite::params_from_iter(params), |row| {
-            row_to_fact(row, dim)
-        })?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(params), |row| {
+                row_to_fact(row, dim)
+            })
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
 
     /// Hard-delete facts by ID. Used after successful archival.
@@ -1427,7 +1531,7 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn hard_delete_ids(&self, ids: &[i64]) -> Result<usize> {
         if ids.is_empty() {
             return Ok(0);
@@ -1438,7 +1542,10 @@ impl<'a> FactStore<'a> {
             .iter()
             .map(|id| id as &dyn rusqlite::types::ToSql)
             .collect();
-        let deleted = self.conn.execute(&sql, params.as_slice())?;
+        let deleted = self
+            .conn
+            .execute(&sql, params.as_slice())
+            .map_err(StorageError::backend)?;
         Ok(deleted)
     }
 
@@ -1468,20 +1575,25 @@ impl<'a> FactStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_archive_candidates(&self, expired_before: DateTime<Utc>) -> Result<Vec<Fact>> {
         let cutoff = expired_before.to_rfc3339();
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {FACT_COLUMNS} FROM facts
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT {FACT_COLUMNS} FROM facts
              WHERE is_pinned = 0
                AND t_expired IS NOT NULL
                AND t_expired < ?1
              ORDER BY id ASC"
-        ))?;
+            ))
+            .map_err(StorageError::backend)?;
         let dim = self.embed_dim;
-        let rows = stmt.query_map(params![cutoff], |row| row_to_fact(row, dim))?;
+        let rows = stmt
+            .query_map(params![cutoff], |row| row_to_fact(row, dim))
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
 }
 
@@ -1587,7 +1699,7 @@ mod tests {
     /// exercises the private helper, but every production caller (`row_to_fact`,
     /// `row_to_scoring_row`) boxes the helper's error into
     /// `rusqlite::Error::FromSqlConversionFailure`, which re-maps to
-    /// [`MemoryError::Database`] via its `#[from]`. So the helper's `Internal`
+    /// [`MemoryError::Storage`] via its `#[from]`. So the helper's `Internal`
     /// never reaches a read-path caller as the top-level variant.
     ///
     /// What #366 actually demanded — *do not surface [`MemoryError::NotFound`] for
@@ -1623,7 +1735,10 @@ mod tests {
         // The user-visible top-level variant is Database (the helper's Internal is
         // boxed by FromSqlConversionFailure and re-mapped via `#[from]`).
         assert!(
-            matches!(err, MemoryError::Database(_)),
+            matches!(
+                err,
+                MemoryError::Storage(crate::error::StorageError::Backend(_))
+            ),
             "read-path corrupt fact_type must surface Database, got {err:?}"
         );
         // #366's actual harm — surfacing NotFound for a corrupt enum — is gone.
@@ -2780,7 +2895,10 @@ mod tests {
             "expected non-Migration error, got: {err:?}"
         );
         assert!(
-            matches!(err, MemoryError::Database(_)),
+            matches!(
+                err,
+                MemoryError::Storage(crate::error::StorageError::Backend(_))
+            ),
             "expected Database error, got: {err:?}"
         );
     }

--- a/memory-engine/lib/memory-engine/src/store/facts.rs
+++ b/memory-engine/lib/memory-engine/src/store/facts.rs
@@ -66,19 +66,20 @@ pub const fn fact_type_to_str(ft: &FactType) -> &'static str {
 ///
 /// What a *read-path* caller sees, end-to-end: the read sites ([`row_to_fact`],
 /// [`row_to_scoring_row`]) box this `Internal` into
-/// `rusqlite::Error::FromSqlConversionFailure`, which re-maps to
-/// [`MemoryError::Storage`] via its `#[from]`. So the surfaced top-level variant
-/// is `Database` (a *data* error — the correct class for corrupt stored data, and
-/// crucially **not** `NotFound`, which is exactly the conflation #366 reported),
-/// with this `Internal` preserved as the boxed source for diagnostics. The
-/// `Internal` value here is therefore the directly-observable error only for a
-/// *direct* caller of this helper; the read path re-classifies it to `Database`.
-/// On the `SQLite` backend a `CHECK(fact_type IN (…))` constraint additionally makes
-/// this arm unreachable through ordinary SQL — it fires only on genuine on-disk
-/// tampering or a backend without that constraint. Both surfaced behaviors are
-/// covered by tests (`corrupt_fact_type_read_path_surfaces_database_not_notfound`
-/// for the end-to-end path, `str_to_fact_type_rejects_unknown_as_internal` for the
-/// direct call).
+/// `rusqlite::Error::FromSqlConversionFailure`; the call site maps that rusqlite
+/// error via `.map_err(StorageError::backend)` and `?` lifts it to
+/// [`MemoryError::Storage`] (#926). So the surfaced top-level variant is
+/// `Storage(StorageError::Backend)` (a backend/data error — and crucially **not**
+/// `NotFound`, which is exactly the conflation #366 reported), with this
+/// `Internal`'s message preserved as a substring of the `Backend` string for
+/// diagnostics. The structured `Internal` value here is therefore the
+/// directly-observable error only for a *direct* caller of this helper; the read
+/// path re-classifies it to `Storage(Backend)`. On the `SQLite` backend a
+/// `CHECK(fact_type IN (…))` constraint additionally makes this arm unreachable
+/// through ordinary SQL — it fires only on genuine on-disk tampering or a backend
+/// without that constraint. Both surfaced behaviors are covered by tests
+/// (`corrupt_fact_type_read_path_surfaces_storage_not_notfound` for the end-to-end
+/// path, `str_to_fact_type_rejects_unknown_as_internal` for the direct call).
 fn str_to_fact_type(s: &str) -> Result<FactType> {
     s.parse::<FactType>()
         .map_err(|e| MemoryError::Internal(format!("corrupt stored fact_type: {e}")))
@@ -1698,23 +1699,24 @@ mod tests {
     /// isolated [`str_to_fact_type_rejects_unknown_as_internal`] test below only
     /// exercises the private helper, but every production caller (`row_to_fact`,
     /// `row_to_scoring_row`) boxes the helper's error into
-    /// `rusqlite::Error::FromSqlConversionFailure`, which re-maps to
-    /// [`MemoryError::Storage`] via its `#[from]`. So the helper's `Internal`
-    /// never reaches a read-path caller as the top-level variant.
+    /// `rusqlite::Error::FromSqlConversionFailure`; the call site maps that via
+    /// `.map_err(StorageError::backend)` and `?` lifts it to
+    /// [`MemoryError::Storage`] (#926). So the helper's `Internal` never reaches a
+    /// read-path caller as the top-level variant.
     ///
     /// What #366 actually demanded — *do not surface [`MemoryError::NotFound`] for
     /// a corrupt enum* (which lets a caller matching `NotFound` mistake a corrupt
     /// store for "no such fact") — is met **end-to-end**: the surfaced variant is
-    /// `Database`, a data error, which is the semantically correct class for
-    /// corrupt stored data, and is distinct from `NotFound`. The diagnostic
-    /// `Internal("corrupt stored fact_type: …")` is preserved as the boxed source.
+    /// `Storage(StorageError::Backend)`, a backend/data error distinct from
+    /// `NotFound`. The diagnostic `Internal("corrupt stored fact_type: …")`'s
+    /// message is preserved as a substring of the `Backend` string.
     ///
     /// Note the `SQLite` schema carries `CHECK(fact_type IN (…))`, so this corruption
     /// is unreachable through ordinary SQL — the test must
     /// `PRAGMA ignore_check_constraints` to simulate genuine on-disk tampering or a
     /// backend without the constraint (the exact scenario the helper guards).
     #[test]
-    fn corrupt_fact_type_read_path_surfaces_database_not_notfound() {
+    fn corrupt_fact_type_read_path_surfaces_storage_not_notfound() {
         let conn = setup();
         let store = FactStore::new(&conn, DIM);
         let id = store.insert(&make_fact("p", vec![0.0; DIM])).unwrap();
@@ -1732,14 +1734,15 @@ mod tests {
             .unwrap();
 
         let err = store.get(id).unwrap_err();
-        // The user-visible top-level variant is Database (the helper's Internal is
-        // boxed by FromSqlConversionFailure and re-mapped via `#[from]`).
+        // The user-visible top-level variant is Storage(Backend): the helper's
+        // Internal is boxed by FromSqlConversionFailure, then the call site maps it
+        // via StorageError::backend and `?` lifts StorageError into Storage (#926).
         assert!(
             matches!(
                 err,
                 MemoryError::Storage(crate::error::StorageError::Backend(_))
             ),
-            "read-path corrupt fact_type must surface Database, got {err:?}"
+            "read-path corrupt fact_type must surface Storage(Backend), got {err:?}"
         );
         // #366's actual harm — surfacing NotFound for a corrupt enum — is gone.
         assert!(
@@ -2888,8 +2891,8 @@ mod tests {
         .unwrap();
 
         let err = fs.next_due_time(now, &[]).unwrap_err();
-        // A row TEXT->timestamp conversion failure is a Database error, NOT a
-        // schema migration failure.
+        // A row TEXT->timestamp conversion failure surfaces as Storage(Backend), NOT
+        // a schema migration failure.
         assert!(
             !matches!(err, MemoryError::Migration(_)),
             "expected non-Migration error, got: {err:?}"
@@ -2899,7 +2902,7 @@ mod tests {
                 err,
                 MemoryError::Storage(crate::error::StorageError::Backend(_))
             ),
-            "expected Database error, got: {err:?}"
+            "expected Storage(Backend) error, got: {err:?}"
         );
     }
 

--- a/memory-engine/lib/memory-engine/src/store/lineage.rs
+++ b/memory-engine/lib/memory-engine/src/store/lineage.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
@@ -29,7 +30,7 @@ impl<'a> LineageStore<'a> {
     ///
     /// Returns `MemoryError::Lineage` if the `wisdom_fact_id` does not exist or
     /// is expired, or if any source fact ID does not exist.
-    /// Returns `MemoryError::Database` on insert failure (e.g., duplicate
+    /// Returns `MemoryError::Storage` on insert failure (e.g., duplicate
     /// `wisdom_fact_id`).
     pub fn insert(
         &self,
@@ -41,11 +42,14 @@ impl<'a> LineageStore<'a> {
         // fact is a tombstone and must not anchor fresh lineage. Doing the check
         // here turns an opaque FK `Database` error into a clear `Lineage` cause
         // and additionally rejects the expired case the FK cannot catch.
-        let wisdom_active: i64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM facts WHERE id = ?1 AND t_expired IS NULL",
-            params![record.wisdom_fact_id],
-            |r| r.get(0),
-        )?;
+        let wisdom_active: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM facts WHERE id = ?1 AND t_expired IS NULL",
+                params![record.wisdom_fact_id],
+                |r| r.get(0),
+            )
+            .map_err(StorageError::backend)?;
         if wisdom_active == 0 {
             return Err(MemoryError::Lineage(format!(
                 "wisdom fact {} does not exist or is expired; cannot record lineage",
@@ -58,11 +62,14 @@ impl<'a> LineageStore<'a> {
             let unique_ids: std::collections::BTreeSet<i64> =
                 record.source_fact_ids.iter().copied().collect();
             let ids_json = serde_json::to_string(&unique_ids)?;
-            let count: i64 = self.conn.query_row(
-                "SELECT COUNT(*) FROM facts WHERE id IN (SELECT value FROM json_each(?1))",
-                params![ids_json],
-                |r| r.get(0),
-            )?;
+            let count: i64 = self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM facts WHERE id IN (SELECT value FROM json_each(?1))",
+                    params![ids_json],
+                    |r| r.get(0),
+                )
+                .map_err(StorageError::backend)?;
             let expected = i64::try_from(unique_ids.len())
                 .map_err(|e| MemoryError::Internal(e.to_string()))?;
             if count != expected {
@@ -77,11 +84,13 @@ impl<'a> LineageStore<'a> {
         let source_ids_json = serde_json::to_string(&record.source_fact_ids)?;
         let prov_json = serde_json::to_string(provenance)?;
 
-        self.conn.execute(
-            "INSERT INTO lineage (wisdom_fact_id, source_fact_ids, provenance)
+        self.conn
+            .execute(
+                "INSERT INTO lineage (wisdom_fact_id, source_fact_ids, provenance)
              VALUES (?1, ?2, ?3)",
-            params![record.wisdom_fact_id, source_ids_json, prov_json],
-        )?;
+                params![record.wisdom_fact_id, source_ids_json, prov_json],
+            )
+            .map_err(StorageError::backend)?;
         Ok(self.conn.last_insert_rowid())
     }
 
@@ -92,21 +101,23 @@ impl<'a> LineageStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on insert failure.
+    /// Returns `MemoryError::Storage` on insert failure.
     pub fn insert_raw(&self, entry: &LineageSnapshotEntry) -> Result<()> {
         let source_ids_json = serde_json::to_string(&entry.source_fact_ids)?;
         let prov_json = serde_json::to_string(&entry.provenance)?;
 
-        self.conn.execute(
-            "INSERT INTO lineage (lineage_id, wisdom_fact_id, source_fact_ids, provenance)
+        self.conn
+            .execute(
+                "INSERT INTO lineage (lineage_id, wisdom_fact_id, source_fact_ids, provenance)
              VALUES (?1, ?2, ?3, ?4)",
-            params![
-                entry.lineage_id,
-                entry.wisdom_fact_id,
-                source_ids_json,
-                prov_json,
-            ],
-        )?;
+                params![
+                    entry.lineage_id,
+                    entry.wisdom_fact_id,
+                    source_ids_json,
+                    prov_json,
+                ],
+            )
+            .map_err(StorageError::backend)?;
         Ok(())
     }
 
@@ -120,10 +131,13 @@ impl<'a> LineageStore<'a> {
         &self,
         wisdom_fact_id: i64,
     ) -> Result<(LineageRecord, PromotionProvenance)> {
-        let mut stmt = self.conn.prepare(
-            "SELECT lineage_id, wisdom_fact_id, source_fact_ids, provenance
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT lineage_id, wisdom_fact_id, source_fact_ids, provenance
              FROM lineage WHERE wisdom_fact_id = ?1",
-        )?;
+            )
+            .map_err(StorageError::backend)?;
         let result = stmt.query_row(params![wisdom_fact_id], |row| {
             let lineage_id: i64 = row.get(0)?;
             let wfid: i64 = row.get(1)?;
@@ -147,7 +161,7 @@ impl<'a> LineageStore<'a> {
             Err(rusqlite::Error::QueryReturnedNoRows) => Err(MemoryError::Lineage(format!(
                 "no lineage record for wisdom fact {wisdom_fact_id}"
             ))),
-            Err(e) => Err(MemoryError::Database(e)),
+            Err(e) => Err(StorageError::backend(e).into()),
         }
     }
 
@@ -161,7 +175,8 @@ impl<'a> LineageStore<'a> {
     pub fn get_source_fact_ids(&self, wisdom_fact_id: i64) -> Result<Vec<i64>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT source_fact_ids FROM lineage WHERE wisdom_fact_id = ?1")?;
+            .prepare("SELECT source_fact_ids FROM lineage WHERE wisdom_fact_id = ?1")
+            .map_err(StorageError::backend)?;
         let result = stmt.query_row(params![wisdom_fact_id], |row| {
             let json: String = row.get(0)?;
             Ok(json)
@@ -171,7 +186,7 @@ impl<'a> LineageStore<'a> {
             Err(rusqlite::Error::QueryReturnedNoRows) => Err(MemoryError::Lineage(format!(
                 "no lineage record for wisdom fact {wisdom_fact_id}"
             ))),
-            Err(e) => Err(MemoryError::Database(e)),
+            Err(e) => Err(StorageError::backend(e).into()),
         }
     }
 
@@ -181,12 +196,15 @@ impl<'a> LineageStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn delete(&self, wisdom_fact_id: i64) -> Result<bool> {
-        let rows = self.conn.execute(
-            "DELETE FROM lineage WHERE wisdom_fact_id = ?1",
-            params![wisdom_fact_id],
-        )?;
+        let rows = self
+            .conn
+            .execute(
+                "DELETE FROM lineage WHERE wisdom_fact_id = ?1",
+                params![wisdom_fact_id],
+            )
+            .map_err(StorageError::backend)?;
         Ok(rows > 0)
     }
 
@@ -194,13 +212,16 @@ impl<'a> LineageStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn has_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
-        let count: i64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM lineage WHERE wisdom_fact_id = ?1",
-            params![wisdom_fact_id],
-            |r| r.get(0),
-        )?;
+        let count: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM lineage WHERE wisdom_fact_id = ?1",
+                params![wisdom_fact_id],
+                |r| r.get(0),
+            )
+            .map_err(StorageError::backend)?;
         Ok(count > 0)
     }
 
@@ -208,22 +229,25 @@ impl<'a> LineageStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     /// Returns `MemoryError::Serialization` on malformed stored JSON.
     pub fn for_each<F>(&self, mut f: F) -> Result<()>
     where
         F: FnMut(LineageSnapshotEntry) -> Result<()>,
     {
-        let mut stmt = self.conn.prepare(
-            "SELECT lineage_id, wisdom_fact_id, source_fact_ids, provenance
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT lineage_id, wisdom_fact_id, source_fact_ids, provenance
              FROM lineage ORDER BY lineage_id ASC",
-        )?;
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
-            let lineage_id: i64 = row.get(0)?;
-            let wisdom_fact_id: i64 = row.get(1)?;
-            let source_ids_json: String = row.get(2)?;
-            let prov_json: String = row.get(3)?;
+            )
+            .map_err(StorageError::backend)?;
+        let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+        while let Some(row) = rows.next().map_err(StorageError::backend)? {
+            let lineage_id: i64 = row.get(0).map_err(StorageError::backend)?;
+            let wisdom_fact_id: i64 = row.get(1).map_err(StorageError::backend)?;
+            let source_ids_json: String = row.get(2).map_err(StorageError::backend)?;
+            let prov_json: String = row.get(3).map_err(StorageError::backend)?;
             let source_fact_ids: Vec<i64> = serde_json::from_str(&source_ids_json)?;
             let provenance: PromotionProvenance = serde_json::from_str(&prov_json)?;
             // `lineage_id` lives on the snapshot entry (the row PK), not on the
@@ -379,7 +403,10 @@ mod tests {
 
         // Second insert with same wisdom_fact_id should fail (unique index)
         let err = store.insert(&new_rec, &test_provenance()).unwrap_err();
-        assert!(matches!(err, MemoryError::Database(_)));
+        assert!(matches!(
+            err,
+            MemoryError::Storage(crate::error::StorageError::Backend(_))
+        ));
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/store/schema/config.rs
+++ b/memory-engine/lib/memory-engine/src/store/schema/config.rs
@@ -5,6 +5,7 @@
 //! [`migrate`](super::migrate) and [`init_schema`](super::init_schema) for the
 //! lifecycle keys they seed.
 
+use crate::error::StorageError;
 use rusqlite::Connection;
 
 use crate::error::Result;
@@ -13,13 +14,17 @@ use crate::error::Result;
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure.
+/// Returns `MemoryError::Storage` on query failure.
 pub fn get_config(conn: &Connection, key: &str) -> Result<Option<String>> {
-    let mut stmt = conn.prepare("SELECT value FROM config WHERE key = ?1")?;
-    let mut rows = stmt.query_map([key], |row| row.get(0))?;
+    let mut stmt = conn
+        .prepare("SELECT value FROM config WHERE key = ?1")
+        .map_err(StorageError::backend)?;
+    let mut rows = stmt
+        .query_map([key], |row| row.get(0))
+        .map_err(StorageError::backend)?;
     match rows.next() {
         Some(Ok(val)) => Ok(Some(val)),
-        Some(Err(e)) => Err(e.into()),
+        Some(Err(e)) => Err(StorageError::backend(e).into()),
         None => Ok(None),
     }
 }
@@ -28,18 +33,22 @@ pub fn get_config(conn: &Connection, key: &str) -> Result<Option<String>> {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on query failure.
+/// Returns `MemoryError::Storage` on query failure.
 pub fn list_config(conn: &Connection) -> Result<std::collections::BTreeMap<String, String>> {
     use std::collections::BTreeMap;
-    let mut stmt = conn.prepare("SELECT key, value FROM config")?;
-    let rows = stmt.query_map([], |row| {
-        let key: String = row.get(0)?;
-        let value: String = row.get(1)?;
-        Ok((key, value))
-    })?;
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM config")
+        .map_err(StorageError::backend)?;
+    let rows = stmt
+        .query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(StorageError::backend)?;
     let mut map = BTreeMap::new();
     for row in rows {
-        let (key, value) = row?;
+        let (key, value) = row.map_err(StorageError::backend)?;
         map.insert(key, value);
     }
     Ok(map)
@@ -49,12 +58,13 @@ pub fn list_config(conn: &Connection) -> Result<std::collections::BTreeMap<Strin
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` on write failure.
+/// Returns `MemoryError::Storage` on write failure.
 pub fn set_config(conn: &Connection, key: &str, value: &str) -> Result<()> {
     conn.execute(
         "INSERT INTO config (key, value) VALUES (?1, ?2)
          ON CONFLICT(key) DO UPDATE SET value = excluded.value",
         rusqlite::params![key, value],
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }

--- a/memory-engine/lib/memory-engine/src/store/schema/migrations.rs
+++ b/memory-engine/lib/memory-engine/src/store/schema/migrations.rs
@@ -8,6 +8,7 @@
 //! schema at that version — never reference the live DDL constants from
 //! `mod.rs`, which may evolve in future versions.
 
+use crate::error::StorageError;
 use rusqlite::Connection;
 
 use crate::error::{MigrationError, Result};
@@ -27,19 +28,22 @@ pub(super) fn migrate_v1_to_v2(conn: &Connection) -> Result<()> {
             ON scopes(parent_id, label);
         -- Insert root scope (sentinel). Only root has parent_id=NULL.
         INSERT OR IGNORE INTO scopes (id, parent_id, label, depth) VALUES (1, NULL, 'root', 0);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     conn.execute_batch(
         "ALTER TABLE facts ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
          ALTER TABLE edges ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
          ALTER TABLE events ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
          ALTER TABLE summaries ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_facts_scope ON facts(scope_id);
          CREATE INDEX IF NOT EXISTS idx_edges_scope ON edges(scope_id);
          CREATE INDEX IF NOT EXISTS idx_events_scope ON events(scope_id);
          CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -54,7 +58,8 @@ pub(super) fn recreate_facts_fts_v3(conn: &Connection) -> Result<()> {
             tokenize='porter unicode61'
         );
         INSERT INTO facts_fts(rowid, content) SELECT id, content FROM facts;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     conn.execute_batch(
         "CREATE TRIGGER IF NOT EXISTS facts_fts_ai AFTER INSERT ON facts BEGIN
             INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content);
@@ -66,7 +71,8 @@ pub(super) fn recreate_facts_fts_v3(conn: &Connection) -> Result<()> {
             INSERT INTO facts_fts(facts_fts, rowid, content) VALUES ('delete', old.id, old.content);
             INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content);
         END;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -77,6 +83,10 @@ pub(super) fn recreate_facts_fts_v3(conn: &Connection) -> Result<()> {
 /// `PRAGMA foreign_keys = OFF` (handled by the migration framework).
 ///
 /// Rebuild order respects FK dependencies: events → facts → edges → summaries.
+#[allow(
+    clippy::too_many_lines,
+    reason = "#926 mapped each rusqlite seam call via `.map_err(StorageError::backend)`, whose line-wrapping pushed this already-long migration fn a few lines over 100 — mechanical verbosity, no added logic"
+)]
 pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
     // 1. Drop FTS triggers and virtual table (they reference facts)
     conn.execute_batch(
@@ -84,7 +94,8 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
          DROP TRIGGER IF EXISTS facts_fts_ad;
          DROP TRIGGER IF EXISTS facts_fts_au;
          DROP TABLE IF EXISTS facts_fts;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
 
     // 2. Rebuild events (no FK deps from other data tables)
     conn.execute_batch(
@@ -101,7 +112,8 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
             SELECT id, timestamp, event_type, payload, source, session_id, scope_id FROM events;
         DROP TABLE events;
         ALTER TABLE events_new RENAME TO events;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
 
     // 3. Rebuild facts (source_event_id references events)
     conn.execute_batch(
@@ -130,7 +142,8 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
             last_accessed, metadata, scope_id FROM facts;
         DROP TABLE facts;
         ALTER TABLE facts_new RENAME TO facts;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
 
     // 4. Rebuild edges (source/target_fact_id reference facts)
     conn.execute_batch(
@@ -150,7 +163,8 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
             t_created, t_expired, scope_id FROM edges;
         DROP TABLE edges;
         ALTER TABLE edges_new RENAME TO edges;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
 
     // 5. Rebuild summaries (no FK deps from other data tables)
     conn.execute_batch(
@@ -169,7 +183,8 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
             created_at, scope_id FROM summaries;
         DROP TABLE summaries;
         ALTER TABLE summaries_new RENAME TO summaries;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
 
     // 6+7. Recreate the FTS5 virtual table and its sync triggers.
     recreate_facts_fts_v3(conn)?;
@@ -189,7 +204,7 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_edges_scope ON edges(scope_id);
         CREATE INDEX IF NOT EXISTS idx_events_scope ON events(scope_id);
         CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);",
-    )?;
+    ).map_err(StorageError::backend)?;
 
     Ok(())
 }
@@ -200,32 +215,37 @@ pub(super) fn migrate_v3_to_v4(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "ALTER TABLE facts ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0;
          ALTER TABLE facts ADD COLUMN importance_score REAL NOT NULL DEFAULT 0.5;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     // Backfill: seed importance_score from base importance for existing rows
-    conn.execute("UPDATE facts SET importance_score = importance", [])?;
+    conn.execute("UPDATE facts SET importance_score = importance", [])
+        .map_err(StorageError::backend)?;
     conn.execute_batch(
         "ALTER TABLE events ADD COLUMN origin_node_id TEXT NOT NULL DEFAULT 'local';
          ALTER TABLE events ADD COLUMN sequence_id INTEGER NOT NULL DEFAULT 0;
          ALTER TABLE events ADD COLUMN created_at TEXT;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_facts_pinned ON facts(is_pinned) WHERE is_pinned = 1;
          CREATE INDEX IF NOT EXISTS idx_facts_importance_score ON facts(importance_score);
          CREATE INDEX IF NOT EXISTS idx_facts_t_valid_due ON facts(t_valid) WHERE t_valid IS NOT NULL AND t_expired IS NULL;
          CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, sequence_id);",
-    )?;
+    ).map_err(StorageError::backend)?;
     Ok(())
 }
 
 /// Add `event_revision` column for per-event-type envelope versioning.
 pub(super) fn migrate_v4_to_v5(conn: &Connection) -> Result<()> {
-    conn.execute_batch("ALTER TABLE events ADD COLUMN event_revision INTEGER NOT NULL DEFAULT 1;")?;
+    conn.execute_batch("ALTER TABLE events ADD COLUMN event_revision INTEGER NOT NULL DEFAULT 1;")
+        .map_err(StorageError::backend)?;
     Ok(())
 }
 
 /// Add `surfaced_at` column for tracking when due facts are first returned to consumers.
 pub(super) fn migrate_v5_to_v6(conn: &Connection) -> Result<()> {
-    conn.execute_batch("ALTER TABLE facts ADD COLUMN surfaced_at TEXT;")?;
+    conn.execute_batch("ALTER TABLE facts ADD COLUMN surfaced_at TEXT;")
+        .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -251,7 +271,8 @@ pub(super) fn migrate_v6_to_v7(conn: &Connection) -> Result<()> {
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_archive_manifest_path
             ON archive_manifest(pak_path);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -265,7 +286,8 @@ pub(super) fn migrate_v7_to_v8(conn: &Connection) -> Result<()> {
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_lineage_wisdom_fact_id
             ON lineage(wisdom_fact_id);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -308,7 +330,8 @@ pub(super) fn migrate_v8_to_v9(conn: &Connection) -> Result<()> {
 
         CREATE INDEX IF NOT EXISTS idx_checkpoints_scope
             ON session_checkpoints(scope_path);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -328,7 +351,8 @@ pub(super) fn migrate_v9_to_v10(conn: &Connection) -> Result<()> {
         "DROP INDEX IF EXISTS idx_activities_dedup;
          CREATE INDEX idx_activities_dedup
              ON activities(session_id, tool_name, args_hash, outcome_class, scope_id);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -339,7 +363,8 @@ pub(super) fn migrate_v9_to_v10(conn: &Connection) -> Result<()> {
 /// otherwise full-scan the table. The fresh-init path adds the same index via
 /// `INDEXES_DDL`, so fresh and migrated databases converge.
 pub(super) fn migrate_v10_to_v11(conn: &Connection) -> Result<()> {
-    conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_facts_created ON facts(t_created);")?;
+    conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_facts_created ON facts(t_created);")
+        .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -355,7 +380,8 @@ pub(super) fn migrate_v10_to_v11(conn: &Connection) -> Result<()> {
 /// write. The `DELETE` is idempotent (a no-op on a fresh v12 DB that never had the
 /// key), and runs inside the migration framework's per-step transaction.
 pub(super) fn migrate_v11_to_v12(conn: &Connection) -> Result<()> {
-    conn.execute_batch("DELETE FROM config WHERE key = 'embed_dim';")?;
+    conn.execute_batch("DELETE FROM config WHERE key = 'embed_dim';")
+        .map_err(StorageError::backend)?;
     Ok(())
 }
 
@@ -405,7 +431,8 @@ pub(super) fn migrate_v12_to_v13(conn: &Connection) -> Result<()> {
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_embedding_spaces_one_active
             ON embedding_spaces(status) WHERE status = 'active';",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
 
     // Fold a present legacy identity into one active 'default' row. The table was just
     // created empty in this same step, so a plain INSERT cannot conflict (the version
@@ -434,8 +461,10 @@ pub(super) fn migrate_v12_to_v13(conn: &Connection) -> Result<()> {
                     .transpose()?,
                 fp.element_type,
             ],
-        )?;
-        conn.execute_batch("DELETE FROM config WHERE key = 'embedding_meta';")?;
+        )
+        .map_err(StorageError::backend)?;
+        conn.execute_batch("DELETE FROM config WHERE key = 'embedding_meta';")
+            .map_err(StorageError::backend)?;
     }
     Ok(())
 }
@@ -457,6 +486,7 @@ pub(super) fn migrate_v13_to_v14(conn: &Connection) -> Result<()> {
             PRIMARY KEY (fact_id, space_id)
         ) WITHOUT ROWID;
         CREATE INDEX IF NOT EXISTS idx_fact_vectors_space ON fact_vectors(space_id);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     Ok(())
 }

--- a/memory-engine/lib/memory-engine/src/store/schema/mod.rs
+++ b/memory-engine/lib/memory-engine/src/store/schema/mod.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use std::path::Path;
 
 use rusqlite::Connection;
@@ -36,9 +37,9 @@ pub const STORAGE_EPOCH: u16 = 1;
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` if the connection or pragma setup fails.
+/// Returns `MemoryError::Storage` if the connection or pragma setup fails.
 pub fn open_connection(path: &str) -> Result<Connection> {
-    let conn = Connection::open(path)?;
+    let conn = Connection::open(path).map_err(StorageError::backend)?;
     set_pragmas(&conn)?;
     Ok(conn)
 }
@@ -51,13 +52,14 @@ pub fn open_connection(path: &str) -> Result<Connection> {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` if the connection or pragma setup fails.
+/// Returns `MemoryError::Storage` if the connection or pragma setup fails.
 pub fn open_connection_read_only(path: &str) -> Result<Connection> {
     use rusqlite::OpenFlags;
     let conn = Connection::open_with_flags(
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     set_pragmas_read_only(&conn)?;
     Ok(conn)
 }
@@ -66,9 +68,9 @@ pub fn open_connection_read_only(path: &str) -> Result<Connection> {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` if the connection or pragma setup fails.
+/// Returns `MemoryError::Storage` if the connection or pragma setup fails.
 pub fn open_memory() -> Result<Connection> {
-    let conn = Connection::open_in_memory()?;
+    let conn = Connection::open_in_memory().map_err(StorageError::backend)?;
     set_pragmas(&conn)?;
     Ok(conn)
 }
@@ -84,22 +86,29 @@ pub fn open_memory() -> Result<Connection> {
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Database` if any DDL statement fails.
+/// Returns `MemoryError::Storage` if any DDL statement fails.
 pub fn init_schema(conn: &Connection) -> Result<()> {
-    let is_fresh: bool = conn.query_row(
-        "SELECT COUNT(*) = 0 FROM sqlite_master WHERE type='table' AND name='config'",
-        [],
-        |r| r.get(0),
-    )?;
+    let is_fresh: bool = conn
+        .query_row(
+            "SELECT COUNT(*) = 0 FROM sqlite_master WHERE type='table' AND name='config'",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(StorageError::backend)?;
     if !is_fresh {
         return Ok(()); // existing DB — let migrate() handle evolution
     }
     // Fresh DB: create full latest schema
-    conn.execute_batch(TABLES_DDL)?;
-    conn.execute_batch(SCOPES_DDL)?;
-    conn.execute_batch(FTS5_DDL)?;
-    conn.execute_batch(TRIGGERS_DDL)?;
-    conn.execute_batch(INDEXES_DDL)?;
+    conn.execute_batch(TABLES_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(SCOPES_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(FTS5_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(TRIGGERS_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(INDEXES_DDL)
+        .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", &CURRENT_SCHEMA_VERSION.to_string())?;
     set_config(conn, "storage_epoch", &STORAGE_EPOCH.to_string())?;
     Ok(())
@@ -190,7 +199,9 @@ pub fn migrate(conn: &Connection, backup_dir: Option<&Path>) -> Result<()> {
                 set_foreign_keys(conn, false)?;
             }
             let result: Result<()> = (|| {
-                let tx = conn.unchecked_transaction()?;
+                let tx = conn
+                    .unchecked_transaction()
+                    .map_err(StorageError::backend)?;
                 migration(&tx)?;
                 if *disable_fk {
                     // Verify FK integrity BEFORE committing. PRAGMA foreign_key_check
@@ -200,7 +211,7 @@ pub fn migrate(conn: &Connection, backup_dir: Option<&Path>) -> Result<()> {
                     check_foreign_keys(&tx)?;
                 }
                 set_config(&tx, "schema_version", &target.to_string())?;
-                tx.commit()?;
+                tx.commit().map_err(StorageError::backend)?;
                 Ok(())
             })();
             if *disable_fk {
@@ -240,7 +251,7 @@ pub fn validate_schema_version(conn: &Connection) -> Result<()> {
             [],
             |r| r.get(0),
         )
-        .map_err(MemoryError::Database)?;
+        .map_err(StorageError::backend)?;
 
     if !has_config {
         return Err(MigrationError::Incompatible(

--- a/memory-engine/lib/memory-engine/src/store/schema/pragmas.rs
+++ b/memory-engine/lib/memory-engine/src/store/schema/pragmas.rs
@@ -3,6 +3,7 @@
 //! These set the durability/concurrency pragmas on freshly opened connections
 //! and toggle/verify foreign-key enforcement around table-rebuild migrations.
 
+use crate::error::StorageError;
 use rusqlite::Connection;
 
 use crate::error::{MigrationError, Result};
@@ -10,8 +11,8 @@ use crate::error::{MigrationError, Result};
 /// Pragmas safe for read-only connections — skip WAL and synchronous.
 pub(super) fn set_pragmas_read_only(conn: &Connection) -> Result<()> {
     for pragma in &["PRAGMA foreign_keys = ON", "PRAGMA busy_timeout = 5000"] {
-        let mut stmt = conn.prepare(pragma)?;
-        let _ = stmt.query([])?;
+        let mut stmt = conn.prepare(pragma).map_err(StorageError::backend)?;
+        let _ = stmt.query([]).map_err(StorageError::backend)?;
     }
     Ok(())
 }
@@ -25,9 +26,9 @@ pub(super) fn set_pragmas(conn: &Connection) -> Result<()> {
         "PRAGMA busy_timeout = 5000",
         "PRAGMA synchronous = NORMAL",
     ] {
-        let mut stmt = conn.prepare(pragma)?;
+        let mut stmt = conn.prepare(pragma).map_err(StorageError::backend)?;
         // Consume all rows (PRAGMAs return 0 or 1 rows).
-        let _ = stmt.query([])?;
+        let _ = stmt.query([]).map_err(StorageError::backend)?;
     }
     Ok(())
 }
@@ -38,14 +39,16 @@ pub(super) fn set_foreign_keys(conn: &Connection, enabled: bool) -> Result<()> {
     } else {
         "PRAGMA foreign_keys = OFF"
     };
-    conn.execute_batch(sql)?;
+    conn.execute_batch(sql).map_err(StorageError::backend)?;
     Ok(())
 }
 
 pub(super) fn check_foreign_keys(conn: &Connection) -> Result<()> {
-    let mut stmt = conn.prepare("PRAGMA foreign_key_check")?;
-    let mut rows = stmt.query([])?;
-    if rows.next()?.is_some() {
+    let mut stmt = conn
+        .prepare("PRAGMA foreign_key_check")
+        .map_err(StorageError::backend)?;
+    let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+    if rows.next().map_err(StorageError::backend)?.is_some() {
         return Err(MigrationError::Incompatible(
             "foreign key violations detected after table rebuild".to_string(),
         )

--- a/memory-engine/lib/memory-engine/src/store/schema/tests.rs
+++ b/memory-engine/lib/memory-engine/src/store/schema/tests.rs
@@ -46,10 +46,14 @@ fn index_exists(conn: &Connection, name: &str) -> bool {
 
 /// Test helper: creates v1 schema (Phase 1 tables only, no scopes, no `scope_id`).
 fn init_schema_v1(conn: &Connection) -> Result<()> {
-    conn.execute_batch(TABLES_V1_DDL)?;
-    conn.execute_batch(FTS5_DDL)?;
-    conn.execute_batch(TRIGGERS_DDL)?;
-    conn.execute_batch(INDEXES_V1_DDL)?;
+    conn.execute_batch(TABLES_V1_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(FTS5_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(TRIGGERS_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(INDEXES_V1_DDL)
+        .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "1")?;
     Ok(())
 }
@@ -122,11 +126,16 @@ CREATE INDEX IF NOT EXISTS idx_edges_expired ON edges(t_expired);
 
 /// Test helper: creates v2 schema (v1 + scopes + `scope_id` columns, no v3 columns).
 fn init_schema_v2(conn: &Connection) -> Result<()> {
-    conn.execute_batch(TABLES_V2_DDL)?;
-    conn.execute_batch(SCOPES_DDL)?;
-    conn.execute_batch(FTS5_DDL)?;
-    conn.execute_batch(TRIGGERS_DDL)?;
-    conn.execute_batch(INDEXES_V2_DDL)?;
+    conn.execute_batch(TABLES_V2_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(SCOPES_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(FTS5_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(TRIGGERS_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(INDEXES_V2_DDL)
+        .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "2")?;
     Ok(())
 }
@@ -211,11 +220,16 @@ CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);
 
 /// Test helper: creates v4 schema (v3 + `is_pinned`, `importance_score`, event envelope).
 fn init_schema_v4(conn: &Connection) -> Result<()> {
-    conn.execute_batch(TABLES_V4_DDL)?;
-    conn.execute_batch(SCOPES_DDL_V4)?;
-    conn.execute_batch(FTS5_DDL_V4)?;
-    conn.execute_batch(TRIGGERS_DDL_V4)?;
-    conn.execute_batch(INDEXES_V4_DDL)?;
+    conn.execute_batch(TABLES_V4_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(SCOPES_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(FTS5_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(TRIGGERS_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(INDEXES_V4_DDL)
+        .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "4")?;
     Ok(())
 }
@@ -343,11 +357,16 @@ CREATE INDEX IF NOT EXISTS idx_events_origin_seq ON events(origin_node_id, seque
 /// Frozen v5 schema for testing v5→v6 migration.
 /// Identical to v4 but with `event_revision` on events table.
 fn init_schema_v5(conn: &Connection) -> Result<()> {
-    conn.execute_batch(TABLES_V5_DDL)?;
-    conn.execute_batch(SCOPES_DDL_V4)?;
-    conn.execute_batch(FTS5_DDL_V4)?;
-    conn.execute_batch(TRIGGERS_DDL_V4)?;
-    conn.execute_batch(INDEXES_V4_DDL)?;
+    conn.execute_batch(TABLES_V5_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(SCOPES_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(FTS5_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(TRIGGERS_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(INDEXES_V4_DDL)
+        .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "5")?;
     Ok(())
 }
@@ -898,19 +917,22 @@ fn migration_v1_through_v3_preserves_data() {
 /// Creates a v2-migrated schema: v1 tables + ALTER TABLE `scope_id` (no FK).
 fn init_schema_v2_migrated(conn: &Connection) -> Result<()> {
     init_schema_v1(conn)?;
-    conn.execute_batch(SCOPES_DDL)?;
+    conn.execute_batch(SCOPES_DDL)
+        .map_err(StorageError::backend)?;
     conn.execute_batch(
         "ALTER TABLE facts ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
              ALTER TABLE edges ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
              ALTER TABLE events ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
              ALTER TABLE summaries ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_facts_scope ON facts(scope_id);
              CREATE INDEX IF NOT EXISTS idx_edges_scope ON edges(scope_id);
              CREATE INDEX IF NOT EXISTS idx_events_scope ON events(scope_id);
              CREATE INDEX IF NOT EXISTS idx_summaries_scope ON summaries(scope_id);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "2")?;
     Ok(())
 }
@@ -1895,12 +1917,18 @@ fn validate_schema_version_old_version_err() {
 
 /// Frozen v6 schema: v5 tables + `surfaced_at` on facts, no `archive_manifest`.
 fn init_schema_v6(conn: &Connection) -> Result<()> {
-    conn.execute_batch(TABLES_V5_DDL)?;
-    conn.execute_batch("ALTER TABLE facts ADD COLUMN surfaced_at TEXT;")?;
-    conn.execute_batch(SCOPES_DDL_V4)?;
-    conn.execute_batch(FTS5_DDL_V4)?;
-    conn.execute_batch(TRIGGERS_DDL_V4)?;
-    conn.execute_batch(INDEXES_V4_DDL)?;
+    conn.execute_batch(TABLES_V5_DDL)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch("ALTER TABLE facts ADD COLUMN surfaced_at TEXT;")
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(SCOPES_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(FTS5_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(TRIGGERS_DDL_V4)
+        .map_err(StorageError::backend)?;
+    conn.execute_batch(INDEXES_V4_DDL)
+        .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "6")?;
     Ok(())
 }
@@ -1980,8 +2008,10 @@ fn fresh_db_has_archive_manifest_table() {
 /// Create a v7 schema by initing v8 and removing lineage artifacts.
 fn init_schema_v7(conn: &Connection) -> Result<()> {
     init_schema(conn)?;
-    conn.execute_batch("DROP TABLE IF EXISTS lineage;")?;
-    conn.execute_batch("DROP INDEX IF EXISTS idx_lineage_wisdom_fact_id;")?;
+    conn.execute_batch("DROP TABLE IF EXISTS lineage;")
+        .map_err(StorageError::backend)?;
+    conn.execute_batch("DROP INDEX IF EXISTS idx_lineage_wisdom_fact_id;")
+        .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "7")?;
     Ok(())
 }
@@ -2058,13 +2088,20 @@ fn fresh_db_has_lineage_table() {
 /// Create a v8 schema by initing v9 and removing activity/checkpoint artifacts.
 fn init_schema_v8(conn: &Connection) -> Result<()> {
     init_schema(conn)?;
-    conn.execute_batch("DROP TABLE IF EXISTS session_checkpoints;")?;
-    conn.execute_batch("DROP TABLE IF EXISTS activities;")?;
-    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_session;")?;
-    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_dedup;")?;
-    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_scope_recent;")?;
-    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_status;")?;
-    conn.execute_batch("DROP INDEX IF EXISTS idx_checkpoints_scope;")?;
+    conn.execute_batch("DROP TABLE IF EXISTS session_checkpoints;")
+        .map_err(StorageError::backend)?;
+    conn.execute_batch("DROP TABLE IF EXISTS activities;")
+        .map_err(StorageError::backend)?;
+    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_session;")
+        .map_err(StorageError::backend)?;
+    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_dedup;")
+        .map_err(StorageError::backend)?;
+    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_scope_recent;")
+        .map_err(StorageError::backend)?;
+    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_status;")
+        .map_err(StorageError::backend)?;
+    conn.execute_batch("DROP INDEX IF EXISTS idx_checkpoints_scope;")
+        .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "8")?;
     Ok(())
 }
@@ -2194,11 +2231,13 @@ fn init_schema_v9_buggy_dedup_index(conn: &Connection) -> Result<()> {
     init_schema(conn)?;
     // Replace the (now-fixed 5-col) index with the original buggy 4-col form
     // to simulate a fresh-v9 database created before the corrective migration.
-    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_dedup;")?;
+    conn.execute_batch("DROP INDEX IF EXISTS idx_activities_dedup;")
+        .map_err(StorageError::backend)?;
     conn.execute_batch(
         "CREATE INDEX idx_activities_dedup
                 ON activities(session_id, tool_name, args_hash, outcome_class);",
-    )?;
+    )
+    .map_err(StorageError::backend)?;
     set_config(conn, "schema_version", "9")?;
     Ok(())
 }

--- a/memory-engine/lib/memory-engine/src/store/scopes.rs
+++ b/memory-engine/lib/memory-engine/src/store/scopes.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use rusqlite::Connection;
 
 use crate::error::{ConflictError, MemoryError, Result};
@@ -19,7 +20,7 @@ impl<'a> ScopeStore<'a> {
     /// # Errors
     ///
     /// Returns `MemoryError::NotFound` if no scope with `id` exists.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn get(&self, id: i64) -> Result<ScopeNode> {
         self.conn
             .query_row(
@@ -38,7 +39,7 @@ impl<'a> ScopeStore<'a> {
                 rusqlite::Error::QueryReturnedNoRows => {
                     MemoryError::NotFound(format!("scope id={id}"))
                 }
-                other => other.into(),
+                other => StorageError::backend(other).into(),
             })
     }
 
@@ -48,22 +49,24 @@ impl<'a> ScopeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn find_by_label(&self, parent_id: i64, label: &str) -> Result<Option<ScopeNode>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, parent_id, label, depth FROM scopes WHERE parent_id = ?1 AND label = ?2",
-        )?;
-        let mut rows = stmt.query_map(rusqlite::params![parent_id, label], |row| {
-            Ok(ScopeNode {
-                id: row.get(0)?,
-                parent_id: row.get(1)?,
-                label: row.get(2)?,
-                depth: row.get(3)?,
+        ).map_err(StorageError::backend)?;
+        let mut rows = stmt
+            .query_map(rusqlite::params![parent_id, label], |row| {
+                Ok(ScopeNode {
+                    id: row.get(0)?,
+                    parent_id: row.get(1)?,
+                    label: row.get(2)?,
+                    depth: row.get(3)?,
+                })
             })
-        })?;
+            .map_err(StorageError::backend)?;
         match rows.next() {
             Some(Ok(node)) => Ok(Some(node)),
-            Some(Err(e)) => Err(e.into()),
+            Some(Err(e)) => Err(StorageError::backend(e).into()),
             None => Ok(None),
         }
     }
@@ -81,13 +84,15 @@ impl<'a> ScopeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure (e.g. FK violation if
+    /// Returns `MemoryError::Storage` on SQL failure (e.g. FK violation if
     /// `parent_id` does not exist, or a UNIQUE constraint on `(parent_id, label)`).
     pub fn insert(&self, parent_id: i64, label: &str, depth: i64) -> Result<ScopeNode> {
-        self.conn.execute(
-            "INSERT INTO scopes (parent_id, label, depth) VALUES (?1, ?2, ?3)",
-            rusqlite::params![parent_id, label, depth],
-        )?;
+        self.conn
+            .execute(
+                "INSERT INTO scopes (parent_id, label, depth) VALUES (?1, ?2, ?3)",
+                rusqlite::params![parent_id, label, depth],
+            )
+            .map_err(StorageError::backend)?;
         let id = self.conn.last_insert_rowid();
         Ok(ScopeNode {
             id,
@@ -128,7 +133,7 @@ impl<'a> ScopeStore<'a> {
     /// Returns `MemoryError::Conflict` if `path` is empty or any segment is
     /// invalid (empty, contains `/`, has leading/trailing whitespace, or exceeds
     /// [`crate::scope::MAX_SEGMENT_LEN`] bytes).
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn ensure_path(&self, path: &str) -> Result<i64> {
         if path.is_empty() {
             return Err(MemoryError::Conflict(ConflictError::ScopeLabel(
@@ -144,17 +149,22 @@ impl<'a> ScopeStore<'a> {
             Self::validate_label(segment)?;
 
             // INSERT OR IGNORE: if the scope already exists, this is a no-op.
-            self.conn.execute(
-                "INSERT OR IGNORE INTO scopes (parent_id, label, depth) VALUES (?1, ?2, ?3)",
-                rusqlite::params![parent_id, segment, depth],
-            )?;
+            self.conn
+                .execute(
+                    "INSERT OR IGNORE INTO scopes (parent_id, label, depth) VALUES (?1, ?2, ?3)",
+                    rusqlite::params![parent_id, segment, depth],
+                )
+                .map_err(StorageError::backend)?;
 
             // SELECT: get the id (whether just inserted or already existed).
-            let id: i64 = self.conn.query_row(
-                "SELECT id FROM scopes WHERE parent_id = ?1 AND label = ?2",
-                rusqlite::params![parent_id, segment],
-                |row| row.get(0),
-            )?;
+            let id: i64 = self
+                .conn
+                .query_row(
+                    "SELECT id FROM scopes WHERE parent_id = ?1 AND label = ?2",
+                    rusqlite::params![parent_id, segment],
+                    |row| row.get(0),
+                )
+                .map_err(StorageError::backend)?;
 
             parent_id = id;
         }
@@ -166,21 +176,24 @@ impl<'a> ScopeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_all(&self) -> Result<Vec<ScopeNode>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, parent_id, label, depth FROM scopes ORDER BY id")?;
-        let rows = stmt.query_map([], |row| {
-            Ok(ScopeNode {
-                id: row.get(0)?,
-                parent_id: row.get(1)?,
-                label: row.get(2)?,
-                depth: row.get(3)?,
+            .prepare("SELECT id, parent_id, label, depth FROM scopes ORDER BY id")
+            .map_err(StorageError::backend)?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(ScopeNode {
+                    id: row.get(0)?,
+                    parent_id: row.get(1)?,
+                    label: row.get(2)?,
+                    depth: row.get(3)?,
+                })
             })
-        })?;
+            .map_err(StorageError::backend)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .map_err(|e| StorageError::backend(e).into())
     }
     /// Iterate all scopes row-by-row, calling `f` for each.
     ///
@@ -190,7 +203,7 @@ impl<'a> ScopeStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure, or propagates any
+    /// Returns `MemoryError::Storage` on SQL failure, or propagates any
     /// error returned by `f`.
     pub fn for_each<F>(&self, mut f: F) -> Result<()>
     where
@@ -198,14 +211,15 @@ impl<'a> ScopeStore<'a> {
     {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, parent_id, label, depth FROM scopes ORDER BY id")?;
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
+            .prepare("SELECT id, parent_id, label, depth FROM scopes ORDER BY id")
+            .map_err(StorageError::backend)?;
+        let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+        while let Some(row) = rows.next().map_err(StorageError::backend)? {
             let scope = ScopeNode {
-                id: row.get(0)?,
-                parent_id: row.get(1)?,
-                label: row.get(2)?,
-                depth: row.get(3)?,
+                id: row.get(0).map_err(StorageError::backend)?,
+                parent_id: row.get(1).map_err(StorageError::backend)?,
+                label: row.get(2).map_err(StorageError::backend)?,
+                depth: row.get(3).map_err(StorageError::backend)?,
             };
             f(scope)?;
         }

--- a/memory-engine/lib/memory-engine/src/store/summaries.rs
+++ b/memory-engine/lib/memory-engine/src/store/summaries.rs
@@ -1,3 +1,4 @@
+use crate::error::StorageError;
 use rusqlite::{Connection, params};
 
 use crate::error::{MemoryError, Result};
@@ -58,7 +59,7 @@ impl<'a> SummaryStore<'a> {
     ///
     /// Returns `MemoryError::EmbeddingDimension` if the embedding length
     /// doesn't match `embed_dim`.
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn insert(&self, summary: &NewSummary) -> Result<i64> {
         if summary.embedding.len() != self.embed_dim {
             return Err(MemoryError::EmbeddingDimension {
@@ -81,7 +82,7 @@ impl<'a> SummaryStore<'a> {
                 summary.created_at.to_rfc3339(),
                 summary.scope_id,
             ],
-        )?;
+        ).map_err(StorageError::backend)?;
         Ok(self.conn.last_insert_rowid())
     }
 
@@ -102,7 +103,7 @@ impl<'a> SummaryStore<'a> {
                 rusqlite::Error::QueryReturnedNoRows => {
                     MemoryError::NotFound(format!("summary {id}"))
                 }
-                other => MemoryError::Database(other),
+                other => StorageError::backend(other).into(),
             })
     }
 
@@ -110,15 +111,20 @@ impl<'a> SummaryStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_by_level(&self, level: &ConsolidationLevel) -> Result<Vec<Summary>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, embedding, level, source_fact_ids, created_at, scope_id
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, content, embedding, level, source_fact_ids, created_at, scope_id
              FROM summaries WHERE level = ?1",
-        )?;
+            )
+            .map_err(StorageError::backend)?;
         let summaries = stmt
-            .query_map(params![level_to_str(level)], |row| self.row_to_summary(row))?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .query_map(params![level_to_str(level)], |row| self.row_to_summary(row))
+            .map_err(StorageError::backend)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StorageError::backend)?;
         Ok(summaries)
     }
 
@@ -126,15 +132,20 @@ impl<'a> SummaryStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn list_all(&self) -> Result<Vec<Summary>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, embedding, level, source_fact_ids, created_at, scope_id
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, content, embedding, level, source_fact_ids, created_at, scope_id
              FROM summaries ORDER BY id ASC",
-        )?;
+            )
+            .map_err(StorageError::backend)?;
         let summaries = stmt
-            .query_map([], |row| self.row_to_summary(row))?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .query_map([], |row| self.row_to_summary(row))
+            .map_err(StorageError::backend)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StorageError::backend)?;
         Ok(summaries)
     }
 
@@ -146,19 +157,22 @@ impl<'a> SummaryStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure, or propagates any
+    /// Returns `MemoryError::Storage` on SQL failure, or propagates any
     /// error returned by `f`.
     pub fn for_each<F>(&self, mut f: F) -> Result<()>
     where
         F: FnMut(Summary) -> Result<()>,
     {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, content, embedding, level, source_fact_ids, created_at, scope_id
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, content, embedding, level, source_fact_ids, created_at, scope_id
              FROM summaries ORDER BY id ASC",
-        )?;
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
-            let summary = self.row_to_summary(row)?;
+            )
+            .map_err(StorageError::backend)?;
+        let mut rows = stmt.query([]).map_err(StorageError::backend)?;
+        while let Some(row) = rows.next().map_err(StorageError::backend)? {
+            let summary = self.row_to_summary(row).map_err(StorageError::backend)?;
             f(summary)?;
         }
         Ok(())
@@ -170,12 +184,15 @@ impl<'a> SummaryStore<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `MemoryError::Database` on SQL failure.
+    /// Returns `MemoryError::Storage` on SQL failure.
     pub fn delete_by_level(&self, level: &ConsolidationLevel) -> Result<usize> {
-        let count = self.conn.execute(
-            "DELETE FROM summaries WHERE level = ?1",
-            params![level_to_str(level)],
-        )?;
+        let count = self
+            .conn
+            .execute(
+                "DELETE FROM summaries WHERE level = ?1",
+                params![level_to_str(level)],
+            )
+            .map_err(StorageError::backend)?;
         Ok(count)
     }
 


### PR DESCRIPTION
## Summary

Decouples `rusqlite` from the L0 `me-types` crate by deleting the public `MemoryError::Database(#[from] rusqlite::Error)` variant. Backend driver errors now surface via `MemoryError::Storage(StorageError::Backend(String))`, mapped at each backend call site. This is the S2-start L0-hygiene prerequisite for the Wave 2 backend carve (epic #816) and the real unblocker for #633's `dep:rusqlite` feature-gating.

Fixes #926.

## Why

`MemoryError::Database(#[from] rusqlite::Error)` embedded the SQLite driver's error type in the workspace's public error enum. The orphan rule forced `impl From<rusqlite::Error> for MemoryError` to live in `me-types` (where `MemoryError` is defined), pinning `rusqlite` + bundled SQLite into L0 — compiled by **every** workspace crate, including a hypothetical Postgres-only build.

## What (Option 2 — the fuller #560 driver-free-error arc)

- **L0 (`me-types`):** delete the `Database` variant; add a generic `StorageError::backend(impl Display)` helper (takes any `Display`, so L0 needs no driver dep); drop `rusqlite` from `me-types/Cargo.toml`. `cargo tree -p me-types` → **0 rusqlite**.
- **Seam guarantee:** delete `storage::sqlite::map_seam_err`. The D4 "no driver type crosses the seam" invariant moves from a runtime boundary match (`block_read`/`block_write`/`for_each_streamed`) to **compiler-enforced source-mapping** via `.map_err(StorageError::backend)?`. The postgres backend's `pg_err` already worked this way — unaffected, and now the two backends are symmetric.
- **~430 call sites:** `rusqlite::Error` `?`-sites → `.map_err(StorageError::backend)?`; explicit constructions/matches repointed to `Storage(Backend)`. `#[non_exhaustive]` on `MemoryError` means only explicit `Database(_)` arms broke.
- **2 semantic corrections** (the deletion forced each mis-mapped site to declare its true kind): a `serde_json` failure that was wrapped as a *fake* `rusqlite::Error::ToSqlConversionFailure` now maps to `MemoryError::Serialization`. The `QueryReturnedNoRows`→`NotFound` inspections already lived in separate, untouched arms — no semantic distinction was collapsed.
- **179 doc references** repointed `MemoryError::Database` → `MemoryError::Storage` (fixes 23 intra-doc gate-blocking links, incl. one in `me-storage` the variant deletion broke).
- **ADR-0018:** approved public-API-break ledger extended 2 → 3 (this is the 3rd deliberate, gated Wave-2 break).

## Verification

- Full CI-exact §I gate: fmt, clippy (`-D warnings`, pedantic+nursery), build ×2, test (`--all-features`), doc ×2 (broken-intra-doc-link denied), `cargo deny`, **both MSRV `--tests --examples` poles** — all green.
- **Acceptance criteria (#926):** `me-types/Cargo.toml` has no `rusqlite`; no driver type in `me-types` public API; `cargo tree -p me-types` shows no `rusqlite`; full gate green.
- **anti-#903:** net **−1 test** — mcp `database_maps_to_internal` removed because its subject variant `MemoryError::Database` no longer exists; its behavior (a backend error → MCP `internal_error`) is preserved by the pre-existing `storage_maps_to_internal` (ex-`Database` errors now flow through `Storage`). Not a dark test.

## Blast radius

Behavior-preserving except the intentional `serde_json`→`Serialization` correction and the documented −1 test. Public API: one variant removed (gated, ADR-recorded). Consumers matching `MemoryError::Database(_)` migrate to `MemoryError::Storage(StorageError::Backend(_))`.

**MCP surface (one user-visible text change):** backend/SQL failures previously surfaced through the deleted `Database` arm as `"database error: …"`; they now flow through the pre-existing `Storage` arm as `"storage error: …"` — **same** `INTERNAL_ERROR` JSON-RPC code, only the human-readable message *prefix* changes (no machine-parseable contract moved). The `storage_maps_to_internal` test now pins the exact `"storage error:"` prefix, restoring — on the new text — the guard the removed `database_maps_to_internal` provided (this is why the net is −1 test, not −2: coverage was consolidated, not dropped).
