### PR TITLE
chore(build): fix clippy::manual_assert_eq lint drift

### DIFF
--- a/memory-engine/lib/me-index/src/graph/memory_graph.rs
+++ b/memory-engine/lib/me-index/src/graph/memory_graph.rs
@@ -515,7 +515,7 @@ mod tests {
 
         g.remove_edge_by_id(10);
         assert_eq!(g.edge_count(), 1);
-        assert!(g.neighbors(1) == vec![3]);
+        assert_eq!(g.neighbors(1), vec![3]);
     }
 
     #[test]

--- a/memory-engine/lib/me-types/src/types/relation.rs
+++ b/memory-engine/lib/me-types/src/types/relation.rs
@@ -331,8 +331,8 @@ mod tests {
     #[test]
     fn partial_eq_reflexive_for_str_lhs() {
         // PartialEq<RelationType> for &str
-        assert!("co_session" == RelationType::CoSession);
-        assert!("supersedes" == RelationType::Supersedes);
+        assert_eq!("co_session", RelationType::CoSession);
+        assert_eq!("supersedes", RelationType::Supersedes);
         assert!("other" != RelationType::CoSession);
     }
 


### PR DESCRIPTION
## What

Fix the three `clippy::manual_assert_eq` sites that make `main` latently CI-red on Rust stable **1.97.0** (2026-07-07). Converts top-level `assert!(a == b)` → `assert_eq!(a, b)` in test code:

- `me-types/src/types/relation.rs:334-335`
- `me-index/src/graph/memory_graph.rs:518`

## Why

`clippy::manual_assert_eq` was promoted to a default `warn` in stable 1.97; the CI clippy job runs on the unpinned `dtolnay/rust-toolchain@stable`, so `-D warnings` now fails on code that merged green under 1.96. This blocks **every** open PR until fixed. Full root-cause in #965.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` → exit 0
- [x] `cargo fmt --all --check` → exit 0
- [x] `cargo test -p me-types -p me-index --all-features` → 0 failed

Closes #965
