### PR TITLE
refactor(build): carve me-forget crate from the memory-engine facade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "memory-engine/lib/me-backend-sqlite",
     "memory-engine/lib/me-backend-postgres",
     "memory-engine/lib/me-test-support",
+    "memory-engine/lib/me-forget",
     "memory-engine/lib/memory-engine",
     "memory-engine/lib/embed",
     "memory-engine/bin/cli",

--- a/memory-engine/lib/me-forget/Cargo.toml
+++ b/memory-engine/lib/me-forget/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "me-forget"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+description = "Forget primitive: Ebbinghaus decay + multi-signal importance pruning (Wave 2 #816 / S3, sub-PR 2)"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/dutiona/memory-engine"
+# Workspace-internal crate: never published, so it uses bare path-deps and is exempt
+# from cargo-deny's published-crate wildcard rule (plan §D.1).
+publish = false
+
+[dependencies]
+me-types = { path = "../me-types" }
+me-storage = { path = "../me-storage" }
+me-index = { path = "../me-index" }
+parking_lot = "0.12"
+chrono = "0.4"
+
+[dev-dependencies]
+# Backend harness (SqliteFactory::make) — the reason me-test-support was carved first.
+me-test-support = { path = "../me-test-support" }
+proptest = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/memory-engine/lib/me-forget/src/lib.rs
+++ b/memory-engine/lib/me-forget/src/lib.rs
@@ -1,6 +1,7 @@
 //! Ebbinghaus decay and multi-signal importance scoring for fact pruning.
 //!
 //! Facts with computed importance below `ForgetPolicy::min_importance` get soft-deleted.
+#![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod policy;
 mod types;

--- a/memory-engine/lib/me-forget/src/policy.rs
+++ b/memory-engine/lib/me-forget/src/policy.rs
@@ -3,13 +3,14 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 
-use super::types::ForgetPolicy;
-use crate::error::Result;
-use crate::graph::MemoryGraph;
-use crate::storage::StorageBackend;
-use crate::store::facts::FactScoringRow;
-use crate::types::{Fact, FactType};
+use me_index::graph::MemoryGraph;
+use me_storage::StorageBackend;
+use me_types::error::Result;
+use me_types::types::FactScoringRow;
 use me_types::types::forgetting::PruneStats;
+use me_types::types::{Fact, FactType};
+
+use super::types::ForgetPolicy;
 
 /// Argument to `ln()` for access-frequency normalization: 100 + 1.
 /// Gives `ln(101)` as the divisor so that 100 accesses produce a full score of 1.0.
@@ -150,7 +151,7 @@ pub fn compute_importance(
 ///
 /// Loads the lightweight active-scoring projection through the port, scores every
 /// fact against the in-memory graph degree, expires the sub-threshold unpinned /
-/// non-exempt set atomically below the seam ([`StorageBackend::prune_atomic`]), then
+/// non-exempt set atomically below the seam ([`me_storage::FactGraph::prune_atomic`]), then
 /// reconciles the in-memory graph. Pinned facts and decay-exempt fact types are
 /// unforgettable — they still get a materialized score but bypass the expiry filter.
 ///
@@ -250,14 +251,10 @@ pub async fn prune(
 mod tests {
     use super::*;
     use chrono::Duration;
+    use me_test_support::factory::ConformanceBackend;
+    use me_types::types::FactType;
     use proptest::prelude::*;
     use std::collections::HashMap;
-
-    use crate::pool::ConnectionPool;
-    use crate::storage::StorageBackend;
-    use crate::storage::sqlite::SqliteBackend;
-    use crate::store::upcaster::UpcasterRegistry;
-    use crate::types::FactType;
 
     #[tokio::test]
     async fn decay_at_zero_is_one() {
@@ -383,17 +380,13 @@ mod tests {
 
     #[tokio::test]
     async fn prune_expires_low_importance_facts() {
-        use crate::types::NewFact;
+        use me_types::types::NewFact;
 
         let now = Utc::now();
         let old_time = now - Duration::days(100);
         let embed_dim = 4;
 
-        let backend = std::sync::Arc::new(SqliteBackend::from_pool(
-            std::sync::Arc::new(ConnectionPool::open_memory(embed_dim).unwrap()),
-            std::sync::Arc::new(UpcasterRegistry::new()),
-        ));
-        let storage: std::sync::Arc<dyn StorageBackend> = backend.clone();
+        let storage = me_test_support::factory::SqliteFactory.make().await;
 
         // Insert 3 facts directly with varying importance and recency.
 
@@ -486,17 +479,13 @@ mod tests {
 
     #[tokio::test]
     async fn prune_skips_pinned_facts() {
-        use crate::types::NewFact;
+        use me_types::types::NewFact;
 
         let now = Utc::now();
         let old_time = now - Duration::days(200);
         let embed_dim = 4;
 
-        let backend = std::sync::Arc::new(SqliteBackend::from_pool(
-            std::sync::Arc::new(ConnectionPool::open_memory(embed_dim).unwrap()),
-            std::sync::Arc::new(UpcasterRegistry::new()),
-        ));
-        let storage: std::sync::Arc<dyn StorageBackend> = backend.clone();
+        let storage = me_test_support::factory::SqliteFactory.make().await;
 
         // Pinned fact with low importance and old age — would normally be pruned
         storage
@@ -560,16 +549,12 @@ mod tests {
 
     #[tokio::test]
     async fn prune_materializes_importance_scores() {
-        use crate::types::NewFact;
+        use me_types::types::NewFact;
 
         let now = Utc::now();
         let embed_dim = 4;
 
-        let backend = std::sync::Arc::new(SqliteBackend::from_pool(
-            std::sync::Arc::new(ConnectionPool::open_memory(embed_dim).unwrap()),
-            std::sync::Arc::new(UpcasterRegistry::new()),
-        ));
-        let storage: std::sync::Arc<dyn StorageBackend> = backend.clone();
+        let storage = me_test_support::factory::SqliteFactory.make().await;
 
         storage
             .insert_fact(&NewFact {
@@ -638,9 +623,9 @@ mod tests {
         fact_type: FactType,
         hash: &str,
         now: DateTime<Utc>,
-    ) -> crate::types::NewFact {
+    ) -> me_types::types::NewFact {
         let old_time = now - Duration::days(200);
-        crate::types::NewFact {
+        me_types::types::NewFact {
             content: format!("neglected {fact_type}"),
             content_hash: hash.into(),
             embedding: vec![0.1; 4],
@@ -662,13 +647,8 @@ mod tests {
     #[tokio::test]
     async fn prune_exempts_knowledge_shaped_types_by_default() {
         let now = Utc::now();
-        let embed_dim = 4;
 
-        let backend = std::sync::Arc::new(SqliteBackend::from_pool(
-            std::sync::Arc::new(ConnectionPool::open_memory(embed_dim).unwrap()),
-            std::sync::Arc::new(UpcasterRegistry::new()),
-        ));
-        let storage: std::sync::Arc<dyn StorageBackend> = backend.clone();
+        let storage = me_test_support::factory::SqliteFactory.make().await;
 
         // Identical neglect across the three types; only Episodic may decay away.
         storage
@@ -747,13 +727,8 @@ mod tests {
     #[tokio::test]
     async fn explicit_half_life_override_wins_over_exemption() {
         let now = Utc::now();
-        let embed_dim = 4;
 
-        let backend = std::sync::Arc::new(SqliteBackend::from_pool(
-            std::sync::Arc::new(ConnectionPool::open_memory(embed_dim).unwrap()),
-            std::sync::Arc::new(UpcasterRegistry::new()),
-        ));
-        let storage: std::sync::Arc<dyn StorageBackend> = backend.clone();
+        let storage = me_test_support::factory::SqliteFactory.make().await;
         storage
             .insert_fact(&neglected_fact(FactType::Semantic, "ks", now))
             .await
@@ -813,18 +788,14 @@ mod tests {
                   block; this is a single-threaded test with no contention"
     )]
     async fn prune_cascades_edges_and_reconciles_graph() {
-        use crate::graph::EdgeData;
-        use crate::types::{NewEdge, NewFact};
+        use me_index::graph::EdgeData;
+        use me_types::types::{NewEdge, NewFact};
 
         let now = Utc::now();
         let old_time = now - Duration::days(200);
         let embed_dim = 4;
 
-        let backend = std::sync::Arc::new(SqliteBackend::from_pool(
-            std::sync::Arc::new(ConnectionPool::open_memory(embed_dim).unwrap()),
-            std::sync::Arc::new(UpcasterRegistry::new()),
-        ));
-        let storage: std::sync::Arc<dyn StorageBackend> = backend.clone();
+        let storage = me_test_support::factory::SqliteFactory.make().await;
 
         // Seed a fact with the shared embed dim + scope. Built fresh per call so
         // each fact can vary its type/importance/recency.
@@ -994,13 +965,8 @@ mod tests {
     #[tokio::test]
     async fn prune_empty_store_returns_zero_stats() {
         let now = Utc::now();
-        let embed_dim = 4;
 
-        let backend = std::sync::Arc::new(SqliteBackend::from_pool(
-            std::sync::Arc::new(ConnectionPool::open_memory(embed_dim).unwrap()),
-            std::sync::Arc::new(UpcasterRegistry::new()),
-        ));
-        let storage: std::sync::Arc<dyn StorageBackend> = backend.clone();
+        let storage = me_test_support::factory::SqliteFactory.make().await;
 
         // Insert nothing — the store is empty.
         let graph = parking_lot::RwLock::new(MemoryGraph::new());

--- a/memory-engine/lib/me-forget/src/types.rs
+++ b/memory-engine/lib/me-forget/src/types.rs
@@ -5,10 +5,11 @@
 //! because it isn't a trait — `traits.rs` declares the consumer behaviour
 //! contracts, while this is the concrete forgetting-layer type it configures.
 //! The output type `PruneStats` (pure data) has moved to `me-types` (Wave 2
-//! #816 E.4b Phase B); re-exported from `forgetting::mod` as
+//! #816 E.4b Phase B); re-exported from this crate's root (`me-forget`, Wave
+//! 2 #816 / S3) as `me_forget::PruneStats`, and from the facade as
 //! `crate::forgetting::PruneStats`.
 
-use crate::error::Result;
+use me_types::error::Result;
 
 /// Policy for forgetting/pruning stale facts.
 ///
@@ -39,7 +40,7 @@ pub struct ForgetPolicy {
     pub half_life_days: f64,
     /// Per-`FactType` half-life overrides. E.g., Episodic=30, Procedural=365.
     /// An explicit entry here wins over `decay_exempt_types`.
-    pub half_life_overrides: std::collections::HashMap<crate::types::FactType, f64>,
+    pub half_life_overrides: std::collections::HashMap<me_types::types::FactType, f64>,
     /// Fact types exempt from decay-driven forgetting altogether.
     ///
     /// Content predicate: a type belongs here iff its facts' truth is
@@ -51,7 +52,7 @@ pub struct ForgetPolicy {
     /// are time-indexed experience records and decay by design.
     ///
     /// Default: `{Semantic, Procedural}`.
-    pub decay_exempt_types: std::collections::HashSet<crate::types::FactType>,
+    pub decay_exempt_types: std::collections::HashSet<me_types::types::FactType>,
     /// Threshold below which facts are expired (default: 0.1).
     pub min_importance: f64,
     /// Weight for recency signal (Ebbinghaus decay). Default: 0.3.
@@ -70,8 +71,8 @@ impl Default for ForgetPolicy {
             half_life_days: 69.0,
             half_life_overrides: std::collections::HashMap::new(),
             decay_exempt_types: [
-                crate::types::FactType::Semantic,
-                crate::types::FactType::Procedural,
+                me_types::types::FactType::Semantic,
+                me_types::types::FactType::Procedural,
             ]
             .into_iter()
             .collect(),
@@ -91,7 +92,7 @@ impl ForgetPolicy {
     /// `half_life_overrides` entry — an explicit override wins, re-enabling
     /// finite-half-life decay for that type.
     #[must_use]
-    pub fn is_decay_exempt(&self, fact_type: &crate::types::FactType) -> bool {
+    pub fn is_decay_exempt(&self, fact_type: &me_types::types::FactType) -> bool {
         self.decay_exempt_types.contains(fact_type)
             && !self.half_life_overrides.contains_key(fact_type)
     }
@@ -102,7 +103,7 @@ impl ForgetPolicy {
     ///
     /// Returns `MemoryError::Conflict` if any parameter is out of range.
     pub fn validate(&self) -> Result<()> {
-        use crate::error::{ConflictError, MemoryError};
+        use me_types::error::{ConflictError, MemoryError};
 
         if !self.half_life_days.is_finite() || self.half_life_days <= 0.0 {
             return Err(MemoryError::Conflict(ConflictError::PolicyParameter(
@@ -145,7 +146,7 @@ impl ForgetPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::FactType;
+    use me_types::types::FactType;
 
     // --- ForgetPolicy::default() ---
 

--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -37,6 +37,9 @@ me-backend-sqlite = { path = "../me-backend-sqlite" }
 # pulled only by `backend-postgres` — so a `backend-sqlite`-only build never compiles
 # `tokio-postgres`/`deadpool-postgres`.
 me-backend-postgres = { path = "../me-backend-postgres", optional = true }
+# L3 Forget primitive: Ebbinghaus decay + multi-signal importance pruning (Wave 2
+# #816 / S3, sub-PR 2). The facade re-exports it as `crate::forgetting`.
+me-forget = { path = "../me-forget" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/memory-engine/lib/memory-engine/src/lib.rs
+++ b/memory-engine/lib/memory-engine/src/lib.rs
@@ -125,7 +125,10 @@ pub use me_types::types; // relocated to me-types (Wave 2 #816); see `error` abo
 #[cfg(feature = "archive")]
 pub(crate) mod archive;
 pub(crate) mod consolidation;
-pub(crate) mod forgetting;
+// `forgetting` is relocated to the L3 `me-forget` crate (Wave 2 #816 / S3, sub-PR
+// 2). The re-export preserves `pub(crate)` visibility and every internal
+// `crate::forgetting::*` path (`ForgetPolicy`, `PruneStats`, `prune`).
+pub(crate) use me_forget as forgetting;
 // `graph` + `scope` are relocated to the L2 `me-index` crate (Wave 2 #816 / S2): the
 // backend-free in-memory projections (`MemoryGraph`, `ScopeTree`). The re-export
 // preserves `crate::graph::*` / `crate::scope::*` for every internal call site.


### PR DESCRIPTION
## What

Wave 2 (#816) slice **S3, sub-PR 2**: carve the **Forget** primitive out of the `memory-engine` facade into a new `publish = false` L3 crate **`me-forget`**.

- `forgetting/{mod,types,policy}.rs` (1561 LOC) → `me-forget` (`mod.rs` → `lib.rs`); every `crate::` import repaths to `me-{types,storage,index}`.
- `engine/forgetting.rs` (53L thin `MemoryEngine::forget()`) **stays** in the facade; the facade swaps `pub(crate) mod forgetting;` → `pub(crate) use me_forget as forgetting;` (keeps `crate::forgetting::{ForgetPolicy, PruneStats, prune}` resolving; the public `pub use forgetting::{ForgetPolicy, PruneStats}` is preserved — **public API unchanged**).

## Why

Clean L3 decomposition (ADR-0018 / #925). Production is **port-only** — `me-forget` depends on `me-storage` (`StorageBackend` port) + `me-index` (`MemoryGraph`) + `me-types`, never a concrete backend.

**First real consumer of `me-test-support`:** the ~7 test backend-construction sites (`SqliteBackend::from_pool(ConnectionPool::open_memory(4), UpcasterRegistry::new())`) now use `me_test_support::SqliteFactory::make()` — the harness carved in sub-PR 1 (#967). The fine-grained custom `NewFact` seeding stays via the port's `insert_fact`.

`FactScoringRow` was already relocated to me-types (#629), so it's a repath, not a relocation.

## Anti-#903 / DAG invariants

- `cargo test --workspace --all-features` = **1967 passed / 0 failed** — unchanged (baselined `main@4c25e3c` before the carve; provably-zero delta). `me-forget` localized = 38 passed / 0 failed.
- `cargo tree -p me-forget -i memory-engine` → no match = **zero back-deps** on the facade.

## Test plan

- [x] `cargo fmt --all --check` → exit 0
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` → exit 0
- [x] `cargo build --workspace` (default) + `--all-features` → exit 0
- [x] `cargo test --workspace --all-features` → 1967 / 0 (independently re-run)
- [x] `cargo test -p me-forget --all-features` → 38 / 0
- [x] `cargo doc --no-deps -p memory-engine --all-features` + `-p me-forget --all-features` → exit 0
- [x] `cargo tree -p me-forget` → zero back-deps

Refs #939
