### PR TITLE
refactor(build): carve me-resolve crate from the memory-engine facade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "memory-engine/lib/me-backend-postgres",
     "memory-engine/lib/me-test-support",
     "memory-engine/lib/me-forget",
+    "memory-engine/lib/me-resolve",
     "memory-engine/lib/memory-engine",
     "memory-engine/lib/embed",
     "memory-engine/bin/cli",

--- a/memory-engine/lib/me-resolve/Cargo.toml
+++ b/memory-engine/lib/me-resolve/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "me-resolve"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+description = "Resolve primitive: bi-temporal arbiter-driven conflict resolution (Wave 2 #816 / S3, sub-PR 3)"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/dutiona/memory-engine"
+# Workspace-internal crate: never published, so it uses bare path-deps and is exempt
+# from cargo-deny's published-crate wildcard rule (plan §D.1).
+publish = false
+
+[dependencies]
+me-types = { path = "../me-types" }
+me-traits = { path = "../me-traits" }
+me-storage = { path = "../me-storage" }
+me-index = { path = "../me-index" }
+chrono = "0.4"
+parking_lot = "0.12"
+
+[lints]
+workspace = true

--- a/memory-engine/lib/me-resolve/src/lib.rs
+++ b/memory-engine/lib/me-resolve/src/lib.rs
@@ -28,7 +28,7 @@ const CONFLICT_EDGE_WEIGHT: f64 = 1.0;
 /// # Errors
 /// - [`me_types::error::MemoryError::EmbeddingReopenRequired`] — the handle is dim-fenced (#742).
 /// - Conflict/PayloadTooLarge — the candidate exceeds the size bound (`check_new_fact`).
-/// - NotFound — `old_id` missing or already expired (re-validated inside the atomic op; #335 TOCTOU guard).
+/// - `NotFound` — `old_id` missing or already expired (re-validated inside the atomic op; #335 TOCTOU guard).
 /// - Propagates arbiter / storage errors.
 // One match dispatches the 4 CRUD decisions; splitting per-arm helpers would
 // scatter the persist→graph-mirror ordering invariant across functions.

--- a/memory-engine/lib/me-resolve/src/lib.rs
+++ b/memory-engine/lib/me-resolve/src/lib.rs
@@ -42,15 +42,31 @@ pub async fn resolve_conflict(
     now: DateTime<Utc>,
 ) -> Result<ConflictResolution> {
     ctx.ensure_open()?;
+    // The candidate fact is persisted verbatim on an Add/Update decision, so
+    // it is a consumer ingest path and must respect the same size bound as
+    // `add_fact` (issue #572 / L10).
     me_types::limits::check_new_fact(new_fact)?;
 
+    // Read the old fact through the port (was `FactStore::get` inside the old
+    // free-function transaction).
     let old_fact = ctx.storage.get_fact(old_id).await?;
+
+    // Build a temporary Fact from NewFact for the arbiter (it needs both as Fact).
     let new_as_fact = Fact::from_new_for_arbiter(new_fact);
+
+    // CONSUMER TRAIT — the main loop drives this; left exactly as-is (rule 5).
     let decision = arbiter.arbitrate(&old_fact, &new_as_fact)?;
 
+    // The arbiter's decision (consumer trait) is made above. The DB writes it
+    // implies now run in ONE transaction below the seam via
+    // `resolve_conflict_atomic` — restoring the all-or-nothing semantics the
+    // cutover's per-call port decomposition had lost (a mid-sequence failure could
+    // otherwise leave the old fact expired+invalidated with no inserted successor =
+    // silent data loss). The in-memory graph is mirrored only AFTER the commit.
     let relation = match decision {
         CrudDecision::Add => CONFLICT_SUPPLEMENTS_RELATION,
         CrudDecision::Update => CONFLICT_CONTRADICTS_RELATION,
+        // Delete/Noop create no edge; the relation string is unused by the port.
         CrudDecision::Delete | CrudDecision::Noop => "",
     };
 

--- a/memory-engine/lib/me-resolve/src/lib.rs
+++ b/memory-engine/lib/me-resolve/src/lib.rs
@@ -1,0 +1,112 @@
+//! Bi-temporal conflict resolution: arbiter-driven CRUD on contradicting facts.
+//!
+//! Extracted from the facade in Wave 2 #816 / S3. The engine's
+//! `MemoryEngine::resolve_conflict` is a one-line delegate over
+//! [`resolve_conflict`], which operates on a [`MemoryCtx`] + the in-memory graph.
+
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+
+use me_index::graph::{EdgeData, MemoryGraph};
+use me_storage::MemoryCtx;
+use me_traits::{ConflictArbiter, ConflictResolution, CrudDecision};
+use me_types::error::Result;
+use me_types::types::{Fact, NewFact, RelationType};
+
+/// Relation for the edge created when both facts coexist (`Add`). Stable on-wire / DB string.
+const CONFLICT_SUPPLEMENTS_RELATION: &str = "supplements";
+/// Relation for the edge created when the new fact supersedes the old (`Update`). Stable on-wire / DB string.
+const CONFLICT_CONTRADICTS_RELATION: &str = "contradicts";
+/// Default weight for conflict-resolution edges (former `crate::conflict::temporal::DEFAULT_EDGE_WEIGHT`).
+const CONFLICT_EDGE_WEIGHT: f64 = 1.0;
+
+/// Resolve a conflict between an existing fact and a candidate new fact.
+///
+/// Delegates the decision to the consumer-provided [`ConflictArbiter`]; the graph
+/// is mirrored only after the persistence op commits.
+///
+/// # Errors
+/// - [`me_types::error::MemoryError::EmbeddingReopenRequired`] — the handle is dim-fenced (#742).
+/// - Conflict/PayloadTooLarge — the candidate exceeds the size bound (`check_new_fact`).
+/// - NotFound — `old_id` missing or already expired (re-validated inside the atomic op; #335 TOCTOU guard).
+/// - Propagates arbiter / storage errors.
+// One match dispatches the 4 CRUD decisions; splitting per-arm helpers would
+// scatter the persist→graph-mirror ordering invariant across functions.
+#[allow(clippy::too_many_lines)]
+pub async fn resolve_conflict(
+    ctx: MemoryCtx<'_>,
+    graph: &RwLock<MemoryGraph>,
+    arbiter: &dyn ConflictArbiter,
+    old_id: i64,
+    new_fact: &NewFact,
+    now: DateTime<Utc>,
+) -> Result<ConflictResolution> {
+    ctx.ensure_open()?;
+    me_types::limits::check_new_fact(new_fact)?;
+
+    let old_fact = ctx.storage.get_fact(old_id).await?;
+    let new_as_fact = Fact::from_new_for_arbiter(new_fact);
+    let decision = arbiter.arbitrate(&old_fact, &new_as_fact)?;
+
+    let relation = match decision {
+        CrudDecision::Add => CONFLICT_SUPPLEMENTS_RELATION,
+        CrudDecision::Update => CONFLICT_CONTRADICTS_RELATION,
+        CrudDecision::Delete | CrudDecision::Noop => "",
+    };
+
+    let (new_fact_id, edge_id) = ctx
+        .storage
+        .resolve_conflict_atomic(
+            decision,
+            old_id,
+            new_fact,
+            relation,
+            CONFLICT_EDGE_WEIGHT,
+            now,
+        )
+        .await?;
+
+    // Mirror the in-memory graph AFTER the commit (no guard held across `.await`).
+    {
+        let mut g = graph.write();
+        match decision {
+            CrudDecision::Add => {
+                if let (Some(new_id), Some(edge_id)) = (new_fact_id, edge_id) {
+                    g.add_edge(
+                        new_id,
+                        old_id,
+                        EdgeData {
+                            edge_id,
+                            relation_type: RelationType::from(relation),
+                            weight: CONFLICT_EDGE_WEIGHT,
+                        },
+                    );
+                }
+            }
+            CrudDecision::Update => {
+                g.remove_edges_by_fact(old_id);
+                if let (Some(new_id), Some(edge_id)) = (new_fact_id, edge_id) {
+                    g.add_edge(
+                        new_id,
+                        old_id,
+                        EdgeData {
+                            edge_id,
+                            relation_type: RelationType::from(relation),
+                            weight: CONFLICT_EDGE_WEIGHT,
+                        },
+                    );
+                }
+            }
+            CrudDecision::Delete => {
+                g.remove_edges_by_fact(old_id);
+            }
+            CrudDecision::Noop => {}
+        }
+    }
+
+    Ok(ConflictResolution {
+        decision,
+        old_fact_id: old_id,
+        new_fact_id,
+    })
+}

--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -40,6 +40,9 @@ me-backend-postgres = { path = "../me-backend-postgres", optional = true }
 # L3 Forget primitive: Ebbinghaus decay + multi-signal importance pruning (Wave 2
 # #816 / S3, sub-PR 2). The facade re-exports it as `crate::forgetting`.
 me-forget = { path = "../me-forget" }
+# L3 Resolve primitive: bi-temporal arbiter-driven conflict resolution (Wave 2
+# #816 / S3, sub-PR 3). `MemoryEngine::resolve_conflict` delegates to it directly.
+me-resolve = { path = "../me-resolve" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/memory-engine/lib/memory-engine/src/engine/conflict.rs
+++ b/memory-engine/lib/memory-engine/src/engine/conflict.rs
@@ -1,23 +1,12 @@
 use chrono::Utc;
 
 use crate::error::Result;
-use crate::graph::EdgeData;
-use crate::traits::{ConflictArbiter, ConflictResolution, CrudDecision};
-use crate::types::{NewFact, RelationType};
+use crate::traits::{ConflictArbiter, ConflictResolution};
+use crate::types::NewFact;
 
 use super::MemoryEngine;
 
 impl MemoryEngine {
-    /// Relation type for the edge created when both facts coexist (`Add`). Stable
-    /// on-wire / DB string — must not change.
-    const CONFLICT_SUPPLEMENTS_RELATION: &str = "supplements";
-    /// Relation type for the edge created when the new fact supersedes the old
-    /// one (`Update`). Stable on-wire / DB string — must not change.
-    const CONFLICT_CONTRADICTS_RELATION: &str = "contradicts";
-    /// Default weight for conflict-resolution edges (ported verbatim from the
-    /// former `crate::conflict::temporal::DEFAULT_EDGE_WEIGHT`).
-    const CONFLICT_EDGE_WEIGHT: f64 = 1.0;
-
     /// Resolve a conflict between an existing fact and a candidate new fact.
     ///
     /// Delegates the decision to the consumer-provided [`ConflictArbiter`].
@@ -84,100 +73,20 @@ impl MemoryEngine {
     ///     Ok(())
     /// }
     /// ```
-    // One match dispatches the 4 CRUD decisions; splitting per-arm helpers would
-    // scatter the persist→graph-mirror ordering invariant across functions.
-    #[allow(clippy::too_many_lines)]
     pub async fn resolve_conflict(
         &self,
         arbiter: &dyn ConflictArbiter,
         old_id: i64,
         new_fact: &NewFact,
     ) -> Result<ConflictResolution> {
-        self.ensure_open()?;
-        // The candidate fact is persisted verbatim on an Add/Update decision, so
-        // it is a consumer ingest path and must respect the same size bound as
-        // `add_fact` (issue #572 / L10).
-        crate::limits::check_new_fact(new_fact)?;
-
-        let now = Utc::now();
-
-        // Read the old fact through the port (was `FactStore::get` inside the old
-        // free-function transaction).
-        let old_fact = self.storage.get_fact(old_id).await?;
-
-        // Build a temporary Fact from NewFact for the arbiter (it needs both as Fact).
-        let new_as_fact = crate::types::Fact::from_new_for_arbiter(new_fact);
-
-        // CONSUMER TRAIT — the main loop drives this; left exactly as-is (rule 5).
-        let decision = arbiter.arbitrate(&old_fact, &new_as_fact)?;
-
-        // The arbiter's decision (consumer trait) is made above, engine-side. The DB
-        // writes it implies now run in ONE transaction below the seam via
-        // `resolve_conflict_atomic` — restoring the all-or-nothing semantics the
-        // cutover's per-call port decomposition had lost (a mid-sequence failure could
-        // otherwise leave the old fact expired+invalidated with no inserted successor =
-        // silent data loss). The in-memory graph is mirrored only AFTER the commit.
-        let relation = match decision {
-            CrudDecision::Add => Self::CONFLICT_SUPPLEMENTS_RELATION,
-            CrudDecision::Update => Self::CONFLICT_CONTRADICTS_RELATION,
-            // Delete/Noop create no edge; the relation string is unused by the port.
-            CrudDecision::Delete | CrudDecision::Noop => "",
-        };
-
-        let (new_fact_id, edge_id) = self
-            .storage
-            .resolve_conflict_atomic(
-                decision,
-                old_id,
-                new_fact,
-                relation,
-                Self::CONFLICT_EDGE_WEIGHT,
-                now,
-            )
-            .await?;
-
-        // Mirror the in-memory graph AFTER the commit (no guard held across `.await`).
-        {
-            let mut graph = self.graph.write();
-            match decision {
-                CrudDecision::Add => {
-                    if let (Some(new_id), Some(edge_id)) = (new_fact_id, edge_id) {
-                        graph.add_edge(
-                            new_id,
-                            old_id,
-                            EdgeData {
-                                edge_id,
-                                relation_type: RelationType::from(relation),
-                                weight: Self::CONFLICT_EDGE_WEIGHT,
-                            },
-                        );
-                    }
-                }
-                CrudDecision::Update => {
-                    graph.remove_edges_by_fact(old_id);
-                    if let (Some(new_id), Some(edge_id)) = (new_fact_id, edge_id) {
-                        graph.add_edge(
-                            new_id,
-                            old_id,
-                            EdgeData {
-                                edge_id,
-                                relation_type: RelationType::from(relation),
-                                weight: Self::CONFLICT_EDGE_WEIGHT,
-                            },
-                        );
-                    }
-                }
-                CrudDecision::Delete => {
-                    graph.remove_edges_by_fact(old_id);
-                }
-                CrudDecision::Noop => {}
-            }
-        }
-
-        Ok(ConflictResolution {
-            decision,
-            old_fact_id: old_id,
-            new_fact_id,
-        })
+        me_resolve::resolve_conflict(
+            self.mem_ctx(),
+            &self.graph,
+            arbiter,
+            old_id,
+            new_fact,
+            Utc::now(),
+        )
+        .await
     }
 }

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -11,8 +11,8 @@ use crate::graph::MemoryGraph;
 use crate::pool::ConnectionPool;
 use crate::scope::ScopeTree;
 use crate::search::strategy::SearchConfig;
-use crate::storage::StorageBackend;
 use crate::storage::sqlite::SqliteBackend;
+use crate::storage::{MemoryCtx, StorageBackend};
 use crate::store::upcaster::UpcasterRegistry;
 use crate::traits::{EmbeddingProvider, Reranker};
 use crate::types::search::{MatchType, SearchResult};
@@ -708,6 +708,16 @@ impl MemoryEngine {
     #[cfg(test)]
     pub(crate) fn storage(&self) -> &Arc<dyn StorageBackend> {
         &self.storage
+    }
+
+    /// Build the universal capability handle L3 primitive free functions receive (Wave 2 §B).
+    pub(crate) fn mem_ctx(&self) -> MemoryCtx<'_> {
+        MemoryCtx {
+            storage: &self.storage,
+            embed_dim: self.embed_dim,
+            read_only: self.read_only,
+            reopen_required: &self.reopen_required,
+        }
     }
 
     // --- Public API: Scope management ---


### PR DESCRIPTION
## What

Wave 2 (#816) slice **S3, sub-PR 3 (final)**: carve the **Resolve** primitive out of the `memory-engine` facade into a new `publish = false` L3 crate **`me-resolve`**.

- **Extract** `MemoryEngine::resolve_conflict`'s body (`engine/conflict.rs`) into `me_resolve::resolve_conflict` — a free function over **`MemoryCtx`**:
  ```rust
  pub async fn resolve_conflict(ctx: MemoryCtx<'_>, graph: &RwLock<MemoryGraph>,
                                arbiter: &dyn ConflictArbiter, old_id: i64,
                                new_fact: &NewFact, now: DateTime<Utc>) -> Result<ConflictResolution>
  ```
- Add `MemoryEngine::mem_ctx()` — the builder that bundles the facade's private state into the L3 capability handle. `engine/conflict.rs` becomes a one-line delegate `me_resolve::resolve_conflict(self.mem_ctx(), &self.graph, …)` that **keeps the rich rustdoc + doctest** (public API unchanged).

## Why

Clean L3 decomposition (ADR-0018 / #925). Unlike me-forget (#968, a git-mv of a pre-existing free fn), this is a **method→free-function extraction** — `resolve_conflict` was an `impl MemoryEngine` method. It is the **first fresh extraction**, so it adopts **`MemoryCtx`** (the S1-locked "universal capability handle every primitive receives") and the `mem_ctx()` seam — setting the template S4's four remaining extractions (me-query/me-ingest/me-consolidate/me-archive) will follow.

### Scope corrections vs the S3 plan snapshot (triaged against current main)
- `engine/equivalence.rs` is the **#541 builder-equivalence test harness** (reads private engine state), unrelated to conflict resolution — **stays** in the facade.
- `conflict::temporal` was already refactored into the `CONFLICT_EDGE_WEIGHT` impl-const — **nothing to move**.
- The ~13 `resolve_conflict_*` tests + `proptest_conflict` **stay facade-level** — they exercise the delegate and transitively cover the extracted free fn (plan §H.3 default).

## Anti-#903 / DAG invariants

- `cargo test --workspace --all-features` = **1967 passed / 0 failed** — **exact, unchanged**. An extraction relocates no tests, so the total must not drift (contrast me-forget's +38 move).
- `cargo test -p me-resolve --all-features` = **0 tests** (tests stay facade-level, by design).
- `cargo tree -p me-resolve -i memory-engine` → no match = **zero back-deps** on the facade. Deps: me-types + me-traits + me-storage + me-index + chrono + parking_lot.

## Behavior preservation (extraction — reviewer focus)

- `self.ensure_open()` → `ctx.ensure_open()` (identical reopen-fence check). `ctx.ensure_writable()` deliberately **not** added — ReadOnly stays enforced downstream in `resolve_conflict_atomic`.
- Graph-mirror `match decision { … }` block copied **verbatim** (guard renamed `g`, `Self::CONFLICT_EDGE_WEIGHT` → module const); `edge_id` shadowing preserved.
- `now` is now a parameter (delegate passes `Utc::now()`); the persist→graph-mirror ordering is intact.

## Follow-up

- **#970** — align `me_forget::prune` to the same `MemoryCtx` signature (me-forget predates MemoryCtx; small, mechanical, best done now that `mem_ctx()` exists).

## Test plan

- [x] `cargo fmt --all --check` → exit 0
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` → exit 0
- [x] `cargo build --workspace` (default) + `--all-features` → exit 0
- [x] `cargo test --workspace --all-features` → 1967 / 0 (independently re-run)
- [x] `cargo test -p me-resolve --all-features` → 0 tests (by design)
- [x] `cargo doc --no-deps -p memory-engine --all-features` + `-p me-resolve --all-features` → exit 0
- [x] `cargo tree -p me-resolve` → zero back-deps

Closes #939
