### PR TITLE
refactor(build): hoist shared query+math vocabulary to me-types

### DIFF
--- a/memory-engine/lib/me-backend-sqlite/src/search/vector.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/search/vector.rs
@@ -49,29 +49,14 @@ static BRUTE_FORCE_WARN_ONCE: std::sync::Once = std::sync::Once::new();
 
 /// Compute the cosine similarity between two vectors.
 ///
-/// Returns 0.0 if either vector has zero magnitude (avoids NaN).
-///
-/// # Length mismatch
-///
-/// When `a.len() != b.len()` the similarity is computed over the first
-/// `min(a.len(), b.len())` components — the `zip` silently truncates to the
-/// shorter slice, so any trailing components of the longer slice are ignored.
-/// This function performs no length check; the **caller is responsible for
-/// passing equal-length vectors**. In-engine callers already enforce dimension
-/// uniformity at the store/query layer (e.g. `vector_search_filtered` rejects
-/// a wrongly-sized query, and stored embeddings are validated against
-/// `embed_dim`), so the truncation never fires on the real read path.
-#[must_use]
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    let (mut dot, mut norm_a, mut norm_b) = (0.0_f32, 0.0_f32, 0.0_f32);
-    for (&x, &y) in a.iter().zip(b.iter()) {
-        dot = x.mul_add(y, dot);
-        norm_a = x.mul_add(x, norm_a);
-        norm_b = y.mul_add(y, norm_b);
-    }
-    let denom = norm_a.sqrt() * norm_b.sqrt();
-    if denom == 0.0 { 0.0 } else { dot / denom }
-}
+/// Relocated to [`me_types::math::cosine_similarity`] (Wave 2 #816 / S4,
+/// sub-PR 3a) — it is pure math with no SQL/driver dependency, so keeping it
+/// here would have forced the forthcoming `me-archive` crate (an L3 leaf) to
+/// depend on this concrete backend crate just to reuse a scoring function.
+/// Re-exported so every existing `me_backend_sqlite::search::vector::cosine_similarity`
+/// / `crate::search::cosine_similarity` call site in this crate keeps resolving
+/// unchanged.
+pub use me_types::math::cosine_similarity;
 
 /// Brute-force vector similarity search over active facts.
 ///
@@ -225,77 +210,6 @@ mod tests {
     }
 
     #[test]
-    fn cosine_identical_vectors() {
-        let a = [1.0_f32, 0.0];
-        let b = [1.0_f32, 0.0];
-        let sim = cosine_similarity(&a, &b);
-        assert!((sim - 1.0).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn cosine_orthogonal_vectors() {
-        let a = [1.0_f32, 0.0];
-        let b = [0.0_f32, 1.0];
-        let sim = cosine_similarity(&a, &b);
-        assert!(sim.abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn cosine_opposite_vectors() {
-        let a = [1.0_f32, 0.0];
-        let b = [-1.0_f32, 0.0];
-        let sim = cosine_similarity(&a, &b);
-        assert!((sim - (-1.0)).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn cosine_mismatched_length_truncates_to_shorter() {
-        // Documented behavior (#479): `zip` truncates to the shorter slice, so
-        // the trailing component of `a` (9.9) is ignored and the result equals
-        // the equal-length computation over the common prefix.
-        let truncated = cosine_similarity(&[1.0_f32, 0.0, 9.9], &[1.0_f32, 0.0]);
-        let control = cosine_similarity(&[1.0_f32, 0.0], &[1.0_f32, 0.0]);
-        assert!(
-            (truncated - control).abs() < f32::EPSILON,
-            "trailing component of the longer slice must be ignored: \
-             truncated={truncated}, control={control}"
-        );
-        // The common prefix [1,0] vs [1,0] is identical, so the score is 1.0.
-        assert!((truncated - 1.0).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn cosine_mismatched_length_symmetric_truncation() {
-        // Truncation is independent of which argument is longer: swapping the
-        // operands yields the same prefix-only score.
-        let a_longer = cosine_similarity(&[1.0_f32, 2.0, 7.0], &[1.0_f32, 2.0]);
-        let b_longer = cosine_similarity(&[1.0_f32, 2.0], &[1.0_f32, 2.0, 7.0]);
-        let control = cosine_similarity(&[1.0_f32, 2.0], &[1.0_f32, 2.0]);
-        assert!((a_longer - control).abs() < f32::EPSILON);
-        assert!((b_longer - control).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn cosine_zero_vector_returns_zero() {
-        let a = [0.0_f32, 0.0];
-        let b = [1.0_f32, 0.0];
-        let sim = cosine_similarity(&a, &b);
-        assert!(sim.abs() < f32::EPSILON);
-        // Also both zero
-        let sim2 = cosine_similarity(&a, &a);
-        assert!(sim2.abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn cosine_empty_slices_return_zero() {
-        // Empty zip -> norm 0 -> denom 0 -> returns 0.0 (NaN-avoidance promise).
-        // Use abs-epsilon (not assert_eq!) to satisfy clippy::float_cmp under the
-        // CI `-D warnings` gate, matching the sibling zero-vector test convention.
-        assert!(cosine_similarity(&[], &[]).abs() < f32::EPSILON);
-        assert!(cosine_similarity(&[], &[1.0]).abs() < f32::EPSILON);
-    }
-
-    #[test]
     fn vector_search_rejects_wrong_query_dimension() {
         let conn = setup();
         let wrong_dim_query = [1.0_f32, 0.0]; // DIM is 4, query is 2
@@ -417,64 +331,5 @@ mod tests {
         // Sanity: with no scope filter the fact is found.
         let unscoped = vector_search(&conn, &query, DIM, 10, None, None).unwrap();
         assert_eq!(unscoped.len(), 1);
-    }
-
-    mod proptest_cosine {
-        use super::*;
-        use proptest::prelude::*;
-
-        // Bounded to avoid f32 overflow in squared-sum (x*x).
-        // Real embeddings are typically in [-1, 1] or small magnitudes.
-        fn bounded_f32() -> impl Strategy<Value = f32> {
-            -1e18_f32..1e18_f32
-        }
-
-        fn nonzero_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
-            proptest::collection::vec(bounded_f32(), 1..max_len)
-                .prop_filter("at least one nonzero", |v| v.iter().any(|&x| x != 0.0))
-        }
-
-        proptest! {
-            #[test]
-            fn symmetry(
-                a in proptest::collection::vec(bounded_f32(), 1..64usize),
-                b in proptest::collection::vec(bounded_f32(), 1..64usize),
-            ) {
-                let len = a.len().min(b.len());
-                let a = &a[..len];
-                let b = &b[..len];
-                let ab = cosine_similarity(a, b);
-                let ba = cosine_similarity(b, a);
-                prop_assert!((ab - ba).abs() < 1e-6,
-                    "symmetry violated: cos(a,b)={ab} != cos(b,a)={ba}");
-            }
-
-            #[test]
-            fn identical_vectors_equal_one(v in nonzero_vec(64)) {
-                let sim = cosine_similarity(&v, &v);
-                prop_assert!((sim - 1.0).abs() < 1e-5,
-                    "identical vectors should give 1.0, got {sim}");
-            }
-
-            #[test]
-            fn bounded(
-                a in proptest::collection::vec(bounded_f32(), 1..64usize),
-                b in proptest::collection::vec(bounded_f32(), 1..64usize),
-            ) {
-                let len = a.len().min(b.len());
-                let sim = cosine_similarity(&a[..len], &b[..len]);
-                prop_assert!((-1.0 - 1e-5..=1.0 + 1e-5).contains(&sim),
-                    "cosine similarity {sim} out of [-1, 1] bounds");
-            }
-
-            /// Anti-parallel vectors (v and -v) must yield cosine similarity of -1.0.
-            #[test]
-            fn antiparallel_vectors_equal_minus_one(v in nonzero_vec(64)) {
-                let neg: Vec<f32> = v.iter().map(|&x| -x).collect();
-                let sim = cosine_similarity(&v, &neg);
-                prop_assert!((sim - (-1.0)).abs() < 1e-5,
-                    "anti-parallel vectors should give -1.0, got {sim}");
-            }
-        }
     }
 }

--- a/memory-engine/lib/me-backend-sqlite/src/store/schema/mod.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/store/schema/mod.rs
@@ -23,6 +23,15 @@ pub use backup::backup_before_migration;
 pub use config::{get_config, list_config, set_config};
 
 /// Current schema version. Bump when adding migrations.
+///
+/// This is **`SQLite`'s physical migration counter** and nothing else. It is *not*
+/// comparable to another backend's (Postgres numbers its own migrations independently,
+/// `CURRENT_PG_SCHEMA_VERSION` = 1), and it is **not** the version stamped into a `.pak`
+/// archive — that is `me_types::types::archive::ARCHIVE_SCHEMA_VERSION`, a
+/// backend-independent *content*-schema version. Bumping this constant does **not** bump
+/// the archive one; if a migration also changes the shape of the `Fact`/`Edge` DTOs a
+/// `.pak` serializes, `ARCHIVE_SCHEMA_VERSION` must be bumped too (the `ArchivePak`
+/// serde-shape test in `archive/types.rs` reddens to remind you). (Wave 2 #816 / S4.)
 pub const CURRENT_SCHEMA_VERSION: u32 = 14;
 
 /// Storage epoch — coarse-grained compatibility gate.

--- a/memory-engine/lib/me-query/Cargo.toml
+++ b/memory-engine/lib/me-query/Cargo.toml
@@ -24,12 +24,6 @@ tokio = { version = "1", features = ["rt"] }
 # `assemble_results`'s failed-to-load-fact warning (moved verbatim from the facade).
 tracing = "0.1"
 
-[features]
-# `MemoryQuery::include_archives` (moved from the facade's `search/query.rs`) is
-# `#[cfg(feature = "archive")]`-gated; forward so `--all-features` compiles it. No
-# other moved item touches an archive-gated field.
-archive = ["me-types/archive"]
-
 [dev-dependencies]
 # Backend harness for the re-pointed behavior tests (XR-4d) — they exercise the
 # live port_hybrid_search against a real SqliteBackend.

--- a/memory-engine/lib/me-query/src/execute.rs
+++ b/memory-engine/lib/me-query/src/execute.rs
@@ -39,11 +39,10 @@ use me_types::error::{ConflictError, MemoryError, RerankerError, Result};
 use me_types::types::Fact;
 use me_types::types::ScopeQuery;
 use me_types::types::search::{
-    MatchType, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult,
+    MatchType, MemoryQuery, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult,
 };
 
 use crate::hybrid::port_hybrid_search;
-use crate::query::MemoryQuery;
 
 /// Map a `tokio::task::spawn_blocking` join failure (a panic or cancellation in the
 /// offloaded reranker call) to a `MemoryError`. Private copy of the facade's

--- a/memory-engine/lib/me-query/src/lib.rs
+++ b/memory-engine/lib/me-query/src/lib.rs
@@ -18,4 +18,9 @@ pub mod hybrid;
 
 pub use execute::{QueryExecution, execute_query};
 pub use hybrid::{port_hybrid_search, rrf_merge};
+/// Compatibility alias. `MemoryQuery` now lives in `me-types` (L0) — it is shared query
+/// vocabulary, consumed by more than one primitive (`me-archive` searches `.pak`s against
+/// it), so keeping it here would have forced an illegal L3→L3 edge. Re-exported so
+/// `me_query::MemoryQuery` keeps resolving for existing callers; new code should prefer
+/// the canonical `me_types::types::search::MemoryQuery`.
 pub use me_types::types::search::MemoryQuery;

--- a/memory-engine/lib/me-query/src/lib.rs
+++ b/memory-engine/lib/me-query/src/lib.rs
@@ -4,16 +4,18 @@
 //! Extracted from the facade in Wave 2 #816 / S4, sub-PR 2. The engine's
 //! `MemoryEngine::{query, execute_query}` are thin delegates over the free
 //! functions here.
+//!
+//! `MemoryQuery` moved down to `me-types` in sub-PR 3a (it is a pure data +
+//! builder DTO with zero `me-query`-internal dependencies — its sibling search
+//! vocabulary already lived in `me-types::types::search`, and the L3-to-L3 edge
+//! it forced onto the forthcoming `me-archive` crate was illegal). Re-exported
+//! below so `me_query::MemoryQuery` keeps resolving unchanged for every existing
+//! caller (the facade, this crate's own `execute.rs`, and downstream tests).
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 pub mod execute;
 pub mod hybrid;
-pub mod query;
 
-// `execute::query` (the free fn) is deliberately NOT flat-re-exported here: it would
-// collide with the `query` module (holding `MemoryQuery`) at the crate root, exactly
-// the naming tension the facade's original `search::query`/`engine::query` module
-// split existed to avoid. Callers reach it as `me_query::execute::query(...)`.
 pub use execute::{QueryExecution, execute_query};
 pub use hybrid::{port_hybrid_search, rrf_merge};
-pub use query::MemoryQuery;
+pub use me_types::types::search::MemoryQuery;

--- a/memory-engine/lib/me-types/src/lib.rs
+++ b/memory-engine/lib/me-types/src/lib.rs
@@ -20,6 +20,11 @@
 
 pub mod error;
 pub mod limits;
+/// Pure math primitives (`cosine_similarity`), shared across the workspace.
+///
+/// Wave 2 #816 / S4, sub-PR 3a — relocated from `me-backend-sqlite` so a
+/// primitive doesn't force a dependency on a concrete storage backend.
+pub mod math;
 /// Shared test-only factory helpers (`new_fact`/`new_event` family).
 ///
 /// Gated behind the `test-util` feature (Wave 2 #816, Commit 2 of the

--- a/memory-engine/lib/me-types/src/math.rs
+++ b/memory-engine/lib/me-types/src/math.rs
@@ -1,0 +1,170 @@
+//! Pure math primitives shared across the workspace.
+//!
+//! No SQL, no I/O, no `me-*` dependency of their own — homed at L0 (Wave 2 #816 /
+//! S4, sub-PR 3a) so retrieval (`me-query`), the SQLite backend
+//! (`me-backend-sqlite`), consolidation, and the forthcoming `me-archive` crate can
+//! all share one definition without any of them depending on a concrete storage
+//! backend. Relocated verbatim from `me-backend-sqlite/src/search/vector.rs`, where
+//! leaving it would have forced `me-archive` (an L3 leaf) to depend on a specific
+//! L2 backend crate just to reuse a scoring function.
+
+/// Compute the cosine similarity between two vectors.
+///
+/// Returns 0.0 if either vector has zero magnitude (avoids NaN).
+///
+/// # Length mismatch
+///
+/// When `a.len() != b.len()` the similarity is computed over the first
+/// `min(a.len(), b.len())` components — the `zip` silently truncates to the
+/// shorter slice, so any trailing components of the longer slice are ignored.
+/// This function performs no length check; the **caller is responsible for
+/// passing equal-length vectors**. In-engine callers already enforce dimension
+/// uniformity at the store/query layer (e.g. `vector_search_filtered` rejects
+/// a wrongly-sized query, and stored embeddings are validated against
+/// `embed_dim`), so the truncation never fires on the real read path.
+#[must_use]
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let (mut dot, mut norm_a, mut norm_b) = (0.0_f32, 0.0_f32, 0.0_f32);
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        dot = x.mul_add(y, dot);
+        norm_a = x.mul_add(x, norm_a);
+        norm_b = y.mul_add(y, norm_b);
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom == 0.0 { 0.0 } else { dot / denom }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cosine_identical_vectors() {
+        let a = [1.0_f32, 0.0];
+        let b = [1.0_f32, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_orthogonal_vectors() {
+        let a = [1.0_f32, 0.0];
+        let b = [0.0_f32, 1.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_opposite_vectors() {
+        let a = [1.0_f32, 0.0];
+        let b = [-1.0_f32, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim - (-1.0)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_mismatched_length_truncates_to_shorter() {
+        // Documented behavior (#479): `zip` truncates to the shorter slice, so
+        // the trailing component of `a` (9.9) is ignored and the result equals
+        // the equal-length computation over the common prefix.
+        let truncated = cosine_similarity(&[1.0_f32, 0.0, 9.9], &[1.0_f32, 0.0]);
+        let control = cosine_similarity(&[1.0_f32, 0.0], &[1.0_f32, 0.0]);
+        assert!(
+            (truncated - control).abs() < f32::EPSILON,
+            "trailing component of the longer slice must be ignored: \
+             truncated={truncated}, control={control}"
+        );
+        // The common prefix [1,0] vs [1,0] is identical, so the score is 1.0.
+        assert!((truncated - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_mismatched_length_symmetric_truncation() {
+        // Truncation is independent of which argument is longer: swapping the
+        // operands yields the same prefix-only score.
+        let a_longer = cosine_similarity(&[1.0_f32, 2.0, 7.0], &[1.0_f32, 2.0]);
+        let b_longer = cosine_similarity(&[1.0_f32, 2.0], &[1.0_f32, 2.0, 7.0]);
+        let control = cosine_similarity(&[1.0_f32, 2.0], &[1.0_f32, 2.0]);
+        assert!((a_longer - control).abs() < f32::EPSILON);
+        assert!((b_longer - control).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_zero_vector_returns_zero() {
+        let a = [0.0_f32, 0.0];
+        let b = [1.0_f32, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < f32::EPSILON);
+        // Also both zero
+        let sim2 = cosine_similarity(&a, &a);
+        assert!(sim2.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cosine_empty_slices_return_zero() {
+        // Empty zip -> norm 0 -> denom 0 -> returns 0.0 (NaN-avoidance promise).
+        // Use abs-epsilon (not assert_eq!) to satisfy clippy::float_cmp under the
+        // CI `-D warnings` gate, matching the sibling zero-vector test convention.
+        assert!(cosine_similarity(&[], &[]).abs() < f32::EPSILON);
+        assert!(cosine_similarity(&[], &[1.0]).abs() < f32::EPSILON);
+    }
+
+    mod proptest_cosine {
+        use super::*;
+        use proptest::prelude::*;
+
+        // Bounded to avoid f32 overflow in squared-sum (x*x).
+        // Real embeddings are typically in [-1, 1] or small magnitudes.
+        fn bounded_f32() -> impl Strategy<Value = f32> {
+            -1e18_f32..1e18_f32
+        }
+
+        fn nonzero_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+            proptest::collection::vec(bounded_f32(), 1..max_len)
+                .prop_filter("at least one nonzero", |v| v.iter().any(|&x| x != 0.0))
+        }
+
+        proptest! {
+            #[test]
+            fn symmetry(
+                a in proptest::collection::vec(bounded_f32(), 1..64usize),
+                b in proptest::collection::vec(bounded_f32(), 1..64usize),
+            ) {
+                let len = a.len().min(b.len());
+                let a = &a[..len];
+                let b = &b[..len];
+                let ab = cosine_similarity(a, b);
+                let ba = cosine_similarity(b, a);
+                prop_assert!((ab - ba).abs() < 1e-6,
+                    "symmetry violated: cos(a,b)={ab} != cos(b,a)={ba}");
+            }
+
+            #[test]
+            fn identical_vectors_equal_one(v in nonzero_vec(64)) {
+                let sim = cosine_similarity(&v, &v);
+                prop_assert!((sim - 1.0).abs() < 1e-5,
+                    "identical vectors should give 1.0, got {sim}");
+            }
+
+            #[test]
+            fn bounded(
+                a in proptest::collection::vec(bounded_f32(), 1..64usize),
+                b in proptest::collection::vec(bounded_f32(), 1..64usize),
+            ) {
+                let len = a.len().min(b.len());
+                let sim = cosine_similarity(&a[..len], &b[..len]);
+                prop_assert!((-1.0 - 1e-5..=1.0 + 1e-5).contains(&sim),
+                    "cosine similarity {sim} out of [-1, 1] bounds");
+            }
+
+            /// Anti-parallel vectors (v and -v) must yield cosine similarity of -1.0.
+            #[test]
+            fn antiparallel_vectors_equal_minus_one(v in nonzero_vec(64)) {
+                let neg: Vec<f32> = v.iter().map(|&x| -x).collect();
+                let sim = cosine_similarity(&v, &neg);
+                prop_assert!((sim - (-1.0)).abs() < 1e-5,
+                    "anti-parallel vectors should give -1.0, got {sim}");
+            }
+        }
+    }
+}

--- a/memory-engine/lib/me-types/src/types/archive.rs
+++ b/memory-engine/lib/me-types/src/types/archive.rs
@@ -7,6 +7,39 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Logical content-schema version of a `.pak` archive — **backend-independent**.
+///
+/// A `.pak` is a portable `zstd` + `serde_json` blob of `me-types` DTOs (facts and
+/// edges). Its compatibility gate therefore answers *"can this build deserialize and
+/// consume the pak's contents?"* — a question about the **DTO shape**, not about any
+/// backend's physical migration history. It is stamped on write
+/// (`ArchivePak::engine_schema_version`) and checked on read; both sides MUST use
+/// **this** constant, so they cannot drift apart.
+///
+/// # Why this is not a backend's schema version
+///
+/// It was previously taken from `me-backend-sqlite`'s `CURRENT_SCHEMA_VERSION`. That is a
+/// *`SQLite` migration counter*, and it is **not comparable across backends** — Postgres
+/// keeps its own, independently-numbered `CURRENT_PG_SCHEMA_VERSION` (= 1, while `SQLite`
+/// is at 14; see `me-backend-postgres`'s migration docs, which explicitly forbid "syncing"
+/// the two numbers). Binding a portable archive format to one backend's counter is a
+/// category error: it only appeared to work while `SQLite` was the sole backend. Sourcing
+/// both the write stamp and the read check from a single L0 constant keeps them symmetric
+/// **by construction**, and keeps `.pak` files portable across backends (the point of
+/// epic #628).
+///
+/// # Why the value is 14 and not 1
+///
+/// The numbering is **inherited, deliberately**. Every `.pak` written to date stamps the
+/// then-current `SQLite` schema version, and the read gate rejects a pak whose stamp is
+/// *greater* than what this build supports. Restarting the sequence at 1 would make every
+/// archive already on disk (stamped 14) read as "from the future" and be rejected — a
+/// silent data-loss regression. So the sequence continues from 14 and advances only when
+/// the `.pak` **content schema** changes.
+///
+/// (Wave 2 #816 / S4, sub-PR 3a.)
+pub const ARCHIVE_SCHEMA_VERSION: u32 = 14;
+
 /// A row from the `archive_manifest` table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArchiveManifestEntry {

--- a/memory-engine/lib/me-types/src/types/memory_query.rs
+++ b/memory-engine/lib/me-types/src/types/memory_query.rs
@@ -1,7 +1,21 @@
+//! [`MemoryQuery`] — the fluent query-builder DTO.
+//!
+//! Relocated here from `me-query` (Wave 2 #816 / S4, sub-PR 3a): it is pure data
+//! + builder logic (only `chrono` + sibling `me-types` vocabulary — zero
+//! `me-query`-internal dependencies), so it belongs beside its sibling search DTOs
+//! (`SearchQuery`, `SearchResult`, `QueryResponse`, …) in `types::search` rather
+//! than in the L3 retrieval crate. This is the prerequisite that lets the
+//! forthcoming `me-archive` crate (an L3 leaf) depend on `MemoryQuery` without
+//! creating an illegal L3-to-L3 sibling edge onto `me-query`.
+//!
+//! Kept as its own module (rather than folded directly into `search.rs`) purely
+//! for file-size hygiene; re-exported from [`super::search`] as the single public
+//! path `me_types::types::search::MemoryQuery`.
+
 use chrono::{DateTime, Utc};
 
-use me_types::types::search::SearchMode;
-use me_types::types::{FactType, ScopeQuery};
+use crate::types::search::SearchMode;
+use crate::types::{FactType, ScopeQuery};
 
 /// Default limit for queries when not explicitly set.
 const DEFAULT_LIMIT: usize = 50;
@@ -12,7 +26,7 @@ const DEFAULT_LIMIT: usize = 50;
 /// An empty query returns all temporally-valid active facts sorted by `importance_score`.
 /// Future-dated facts (`t_valid > now`) are excluded by default (scheduling model invariant).
 ///
-/// This is the `me-query`-internal builder type; a `MemoryEngine`-driven end-to-end
+/// This is the pure data + builder type; a `MemoryEngine`-driven end-to-end
 /// example (constructing an engine, adding a fact, and executing a query against it)
 /// lives on the facade's re-export at `memory_engine::MemoryQuery`, where the engine
 /// and its consumer traits are in scope.
@@ -20,7 +34,7 @@ const DEFAULT_LIMIT: usize = 50;
 /// # Examples
 ///
 /// ```
-/// use me_query::MemoryQuery;
+/// use me_types::types::search::MemoryQuery;
 ///
 /// let query = MemoryQuery::new()
 ///     .scope_subtree("user:michael")

--- a/memory-engine/lib/me-types/src/types/mod.rs
+++ b/memory-engine/lib/me-types/src/types/mod.rs
@@ -15,10 +15,11 @@ mod facts;
 pub mod forgetting;
 /// Inspection statistics + dump-format DTOs.
 pub mod inspect;
-/// [`MemoryQuery`](memory_query::MemoryQuery) — relocated from `me-query` (Wave 2 #816 / S4, sub-PR 3a).
+/// `MemoryQuery` — relocated from `me-query` (Wave 2 #816 / S4, sub-PR 3a).
 ///
-/// Private: re-exported as the single canonical path `types::search::MemoryQuery`
-/// from [`search`] rather than flat/duplicated here.
+/// Private: re-exported as the single canonical path [`crate::types::search::MemoryQuery`]
+/// rather than flat/duplicated here (this module itself is private, so it cannot carry a
+/// resolvable public intra-doc link back to its own contents).
 mod memory_query;
 mod provenance;
 mod relation;

--- a/memory-engine/lib/me-types/src/types/mod.rs
+++ b/memory-engine/lib/me-types/src/types/mod.rs
@@ -15,6 +15,10 @@ mod facts;
 pub mod forgetting;
 /// Inspection statistics + dump-format DTOs.
 pub mod inspect;
+/// [`MemoryQuery`](memory_query::MemoryQuery) — relocated from `me-query` (Wave 2
+/// #816 / S4, sub-PR 3a). Private: re-exported as the single canonical path
+/// `types::search::MemoryQuery` from [`search`] rather than flat/duplicated here.
+mod memory_query;
 mod provenance;
 mod relation;
 mod scope;

--- a/memory-engine/lib/me-types/src/types/mod.rs
+++ b/memory-engine/lib/me-types/src/types/mod.rs
@@ -15,9 +15,10 @@ mod facts;
 pub mod forgetting;
 /// Inspection statistics + dump-format DTOs.
 pub mod inspect;
-/// [`MemoryQuery`](memory_query::MemoryQuery) — relocated from `me-query` (Wave 2
-/// #816 / S4, sub-PR 3a). Private: re-exported as the single canonical path
-/// `types::search::MemoryQuery` from [`search`] rather than flat/duplicated here.
+/// [`MemoryQuery`](memory_query::MemoryQuery) — relocated from `me-query` (Wave 2 #816 / S4, sub-PR 3a).
+///
+/// Private: re-exported as the single canonical path `types::search::MemoryQuery`
+/// from [`search`] rather than flat/duplicated here.
 mod memory_query;
 mod provenance;
 mod relation;

--- a/memory-engine/lib/me-types/src/types/search.rs
+++ b/memory-engine/lib/me-types/src/types/search.rs
@@ -1,8 +1,8 @@
 //! Search/query result vocabulary — the DTOs the retrieval surface speaks.
 //!
 //! Pure data types (no `rusqlite`, no search logic): the query input
-//! (`SearchQuery`), the fluent query builder (`MemoryQuery`, re-exported from
-//! [`super::memory_query`] — Wave 2 #816 / S4, sub-PR 3a), the result
+//! (`SearchQuery`), the fluent query builder (`MemoryQuery`, re-exported from a
+//! private sibling module — Wave 2 #816 / S4, sub-PR 3a), the result
 //! (`SearchResult`/`MatchType`), the response (`QueryResponse`/`QueryDiagnostics`),
 //! the `SearchMode` selector, and the `RRF_K` fusion constant. Homed in `me-types`
 //! (Wave 2 #816) so the consumer traits (`Reranker` returns `Vec<SearchResult>`),
@@ -15,11 +15,11 @@ use crate::types::{Fact, FactType};
 
 /// The fluent query-builder DTO.
 ///
-/// Lives in its own file ([`super::memory_query`]) for size hygiene; re-exported
-/// here so it sits alongside its sibling search vocabulary at the single canonical
-/// path `me_types::types::search::MemoryQuery` (Wave 2 #816 / S4, sub-PR 3a —
-/// relocated from `me-query` to kill an illegal L3-to-L3 sibling edge from the
-/// forthcoming `me-archive` crate).
+/// Lives in its own (private) sibling file for size hygiene; re-exported here so
+/// it sits alongside its sibling search vocabulary at the single canonical path
+/// `me_types::types::search::MemoryQuery` (Wave 2 #816 / S4, sub-PR 3a — relocated
+/// from `me-query` to kill an illegal L3-to-L3 sibling edge from the forthcoming
+/// `me-archive` crate).
 pub use super::memory_query::MemoryQuery;
 
 /// How to combine search sources.

--- a/memory-engine/lib/me-types/src/types/search.rs
+++ b/memory-engine/lib/me-types/src/types/search.rs
@@ -13,11 +13,13 @@ use chrono::{DateTime, Utc};
 
 use crate::types::{Fact, FactType};
 
-/// The fluent query-builder DTO. Lives in its own file ([`super::memory_query`])
-/// for size hygiene; re-exported here so it sits alongside its sibling search
-/// vocabulary at the single canonical path `me_types::types::search::MemoryQuery`
-/// (Wave 2 #816 / S4, sub-PR 3a — relocated from `me-query` to kill an illegal
-/// L3-to-L3 sibling edge from the forthcoming `me-archive` crate).
+/// The fluent query-builder DTO.
+///
+/// Lives in its own file ([`super::memory_query`]) for size hygiene; re-exported
+/// here so it sits alongside its sibling search vocabulary at the single canonical
+/// path `me_types::types::search::MemoryQuery` (Wave 2 #816 / S4, sub-PR 3a —
+/// relocated from `me-query` to kill an illegal L3-to-L3 sibling edge from the
+/// forthcoming `me-archive` crate).
 pub use super::memory_query::MemoryQuery;
 
 /// How to combine search sources.

--- a/memory-engine/lib/me-types/src/types/search.rs
+++ b/memory-engine/lib/me-types/src/types/search.rs
@@ -1,16 +1,24 @@
 //! Search/query result vocabulary — the DTOs the retrieval surface speaks.
 //!
 //! Pure data types (no `rusqlite`, no search logic): the query input
-//! (`SearchQuery`), the result (`SearchResult`/`MatchType`), the response
-//! (`QueryResponse`/`QueryDiagnostics`), the `SearchMode` selector, and the
-//! `RRF_K` fusion constant. Homed in `me-types` (Wave 2 #816) so the consumer
-//! traits (`Reranker` returns `Vec<SearchResult>`), the backend, and the query
-//! crate all share one definition. The fusion *logic* (`rrf_merge`, hybrid search)
-//! stays in the retrieval layer.
+//! (`SearchQuery`), the fluent query builder (`MemoryQuery`, re-exported from
+//! [`super::memory_query`] — Wave 2 #816 / S4, sub-PR 3a), the result
+//! (`SearchResult`/`MatchType`), the response (`QueryResponse`/`QueryDiagnostics`),
+//! the `SearchMode` selector, and the `RRF_K` fusion constant. Homed in `me-types`
+//! (Wave 2 #816) so the consumer traits (`Reranker` returns `Vec<SearchResult>`),
+//! the backend, and the query crate all share one definition. The fusion *logic*
+//! (`rrf_merge`, hybrid search) stays in the retrieval layer.
 
 use chrono::{DateTime, Utc};
 
 use crate::types::{Fact, FactType};
+
+/// The fluent query-builder DTO. Lives in its own file ([`super::memory_query`])
+/// for size hygiene; re-exported here so it sits alongside its sibling search
+/// vocabulary at the single canonical path `me_types::types::search::MemoryQuery`
+/// (Wave 2 #816 / S4, sub-PR 3a — relocated from `me-query` to kill an illegal
+/// L3-to-L3 sibling edge from the forthcoming `me-archive` crate).
+pub use super::memory_query::MemoryQuery;
 
 /// How to combine search sources.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -48,8 +48,7 @@ me-resolve = { path = "../me-resolve" }
 # add_facts_batch, add_facts_batch_partial}` delegate to it directly.
 me-ingest = { path = "../me-ingest" }
 # L3 Query primitive: hybrid FTS5 + vector + RRF retrieval (Wave 2 #816 / S4,
-# sub-PR 2). `MemoryEngine::{query, execute_query}` delegate to it directly; the
-# facade's `search` module also re-exports its `hybrid`/`query` submodules.
+# sub-PR 2). `MemoryEngine::{query, execute_query}` delegate to it directly.
 me-query = { path = "../me-query" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -207,14 +206,17 @@ compress-zstd = ["dep:zstd", "me-backend-sqlite/compress-zstd"]
 # `engine/archive.rs`'s own `#[cfg(feature = "archive")]` prune path — is compiled in
 # lockstep with the facade's `archive` feature. Also forwards to
 # `me-backend-sqlite/archive` (Wave 2 #816 / S2, sub-PR 2a) so
-# `store/archive_manifest.rs` compiles in lockstep too.
+# `store/archive_manifest.rs` compiles in lockstep too. (`me-query/archive` was
+# dropped in Wave 2 #816 / S4, sub-PR 3a: it forwarded only for `MemoryQuery`'s
+# `#[cfg(feature = "archive")]` field, and `MemoryQuery` relocated to `me-types`
+# — already forwarded via `me-types/archive` above — so `me-query` itself no
+# longer has anything the feature needs to gate.)
 archive = [
     "compress-zstd",
     "me-types/archive",
     "me-storage/archive",
     "me-index/archive",
     "me-backend-sqlite/archive",
-    "me-query/archive",
 ]
 # The default in-process SQLite backend. NOTE (#633): this is a *marker* feature — it
 # does NOT yet gate `mod sqlite` or `rusqlite`. The engine open path hardcodes

--- a/memory-engine/lib/memory-engine/src/archive/pak.rs
+++ b/memory-engine/lib/memory-engine/src/archive/pak.rs
@@ -356,7 +356,7 @@ mod tests {
         );
 
         // Older schema version reads OK (backward-compat). empty_pak() already
-        // stamps engine_schema_version = 7 (< ARCHIVE_SCHEMA_VERSION = 9).
+        // stamps engine_schema_version = 7 (< ARCHIVE_SCHEMA_VERSION = 14).
         let older_path = dir.path().join("older.pak");
         let older = empty_pak();
         assert!(

--- a/memory-engine/lib/memory-engine/src/archive/pak.rs
+++ b/memory-engine/lib/memory-engine/src/archive/pak.rs
@@ -3,6 +3,8 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
+use me_types::types::archive::ARCHIVE_SCHEMA_VERSION;
+
 use crate::archive::types::{ArchivePak, CURRENT_PAK_VERSION};
 use crate::error::{ArchiveError, Result};
 
@@ -101,24 +103,26 @@ pub fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
 ///   newer than this build supports (forward-incompatible).
 /// - [`MemoryError::Archive`](crate::error::MemoryError::Archive) wrapping
 ///   [`ArchiveError::SchemaVersionUnsupported`] — the archive's
-///   `engine_schema_version` is newer than `supported_schema_version`.
+///   `engine_schema_version` is newer than [`ARCHIVE_SCHEMA_VERSION`].
 ///
 /// Older `pak_version` / `engine_schema_version` values are accepted
 /// (backward-compatible read); only newer ones are rejected.
 ///
-/// # `supported_schema_version`
+/// # Which version is checked
 ///
-/// The `.pak` records the schema version of *the store it was archived from*
-/// (`ArchivePak::engine_schema_version`), so the compat check belongs to
-/// whoever knows the active backend's schema version — this function takes it
-/// as a parameter rather than reaching for a concrete backend's constant
-/// (Wave 2 #816 / S4, sub-PR 3a). This is not DAG-appeasement: post-#634/#635 a
-/// Postgres-backed engine passes *its own* schema version here, where a
-/// hard-wired constant would have silently checked against `SQLite`'s instead.
-/// The facade's public `read_pak` wrapper (`lib.rs`) supplies
-/// `store::schema::CURRENT_SCHEMA_VERSION` for today's `SQLite`-only build.
-pub fn read_pak(path: &Path, supported_schema_version: u32) -> Result<ArchivePak> {
-    read_pak_capped(path, MAX_PAK_DECOMPRESSED_SIZE, supported_schema_version)
+/// The gate compares against [`ARCHIVE_SCHEMA_VERSION`] — the **backend-independent**
+/// logical content-schema version of the `.pak` format (L0, `me-types`). The *same*
+/// constant is stamped on write (`engine/archive.rs`'s `build_pak`), so the write and
+/// read sides are symmetric **by construction** and cannot drift apart.
+///
+/// It is deliberately **not** a backend's schema version. A `.pak` is a portable blob of
+/// `me-types` DTOs, so "can I read this pak?" is a question about DTO shape, not about
+/// any backend's migration history — and the backends' counters are not comparable
+/// (`SQLite` is at 14, Postgres independently at 1). Sourcing the check from a concrete
+/// backend would also put an L3→backend edge on the archive primitive.
+/// (Wave 2 #816 / S4, sub-PR 3a.)
+pub fn read_pak(path: &Path) -> Result<ArchivePak> {
+    read_pak_capped(path, MAX_PAK_DECOMPRESSED_SIZE)
 }
 
 /// Cap-parameterized core of [`read_pak`].
@@ -126,7 +130,7 @@ pub fn read_pak(path: &Path, supported_schema_version: u32) -> Result<ArchivePak
 /// Splitting the byte cap out as a parameter lets the cap-firing path be tested
 /// with a tiny limit instead of a real 4 GiB payload (#299). [`read_pak`] is the
 /// only non-test caller and always passes [`MAX_PAK_DECOMPRESSED_SIZE`].
-fn read_pak_capped(path: &Path, cap: u64, supported_schema_version: u32) -> Result<ArchivePak> {
+fn read_pak_capped(path: &Path, cap: u64) -> Result<ArchivePak> {
     let file = fs::File::open(path).map_err(|e| {
         ArchiveError::Io(format!("failed to open pak file {}: {e}", path.display()))
     })?;
@@ -167,10 +171,10 @@ fn read_pak_capped(path: &Path, cap: u64, supported_schema_version: u32) -> Resu
         }
         .into());
     }
-    if pak.engine_schema_version > supported_schema_version {
+    if pak.engine_schema_version > ARCHIVE_SCHEMA_VERSION {
         return Err(ArchiveError::SchemaVersionUnsupported {
             found: pak.engine_schema_version,
-            supported: supported_schema_version,
+            supported: ARCHIVE_SCHEMA_VERSION,
         }
         .into());
     }
@@ -217,7 +221,6 @@ mod tests {
     use super::*;
     use crate::archive::types::CURRENT_PAK_VERSION;
     use crate::error::MemoryError;
-    use crate::store::schema::CURRENT_SCHEMA_VERSION;
     use chrono::Utc;
 
     /// Write an `ArchivePak` as zstd-compressed JSON (test convenience wrapper).
@@ -245,7 +248,7 @@ mod tests {
         let pak_path = dir.path().join("test.pak");
         write_pak(&empty_pak(), &pak_path).unwrap();
         assert!(pak_path.exists());
-        let restored = read_pak(&pak_path, CURRENT_SCHEMA_VERSION).unwrap();
+        let restored = read_pak(&pak_path).unwrap();
         assert_eq!(restored.pak_version, CURRENT_PAK_VERSION);
         assert_eq!(restored.embed_dim, 3);
         assert!(restored.facts.is_empty());
@@ -287,10 +290,10 @@ mod tests {
         let pak_path = dir.path().join("future_pak.pak");
         let mut pak = empty_pak();
         pak.pak_version = CURRENT_PAK_VERSION + 1;
-        pak.engine_schema_version = CURRENT_SCHEMA_VERSION;
+        pak.engine_schema_version = ARCHIVE_SCHEMA_VERSION;
         write_pak(&pak, &pak_path).unwrap();
 
-        let err = read_pak(&pak_path, CURRENT_SCHEMA_VERSION).unwrap_err();
+        let err = read_pak(&pak_path).unwrap_err();
         let display = err.to_string();
         match err {
             MemoryError::Archive(ArchiveError::PakVersionUnsupported { found, supported }) => {
@@ -315,15 +318,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let pak_path = dir.path().join("future_schema.pak");
         let mut pak = empty_pak();
-        pak.engine_schema_version = CURRENT_SCHEMA_VERSION + 1;
+        pak.engine_schema_version = ARCHIVE_SCHEMA_VERSION + 1;
         write_pak(&pak, &pak_path).unwrap();
 
-        let err = read_pak(&pak_path, CURRENT_SCHEMA_VERSION).unwrap_err();
+        let err = read_pak(&pak_path).unwrap_err();
         let display = err.to_string();
         match err {
             MemoryError::Archive(ArchiveError::SchemaVersionUnsupported { found, supported }) => {
-                assert_eq!(found, CURRENT_SCHEMA_VERSION + 1);
-                assert_eq!(supported, CURRENT_SCHEMA_VERSION);
+                assert_eq!(found, ARCHIVE_SCHEMA_VERSION + 1);
+                assert_eq!(supported, ARCHIVE_SCHEMA_VERSION);
             }
             other => panic!("expected Archive(SchemaVersionUnsupported), got {other:?}"),
         }
@@ -345,24 +348,24 @@ mod tests {
         // Current versions read OK.
         let current_path = dir.path().join("current.pak");
         let mut current = empty_pak();
-        current.engine_schema_version = CURRENT_SCHEMA_VERSION;
+        current.engine_schema_version = ARCHIVE_SCHEMA_VERSION;
         write_pak(&current, &current_path).unwrap();
         assert!(
-            read_pak(&current_path, CURRENT_SCHEMA_VERSION).is_ok(),
+            read_pak(&current_path).is_ok(),
             "current versions must read"
         );
 
         // Older schema version reads OK (backward-compat). empty_pak() already
-        // stamps engine_schema_version = 7 (< CURRENT_SCHEMA_VERSION = 9).
+        // stamps engine_schema_version = 7 (< ARCHIVE_SCHEMA_VERSION = 9).
         let older_path = dir.path().join("older.pak");
         let older = empty_pak();
         assert!(
-            older.engine_schema_version < CURRENT_SCHEMA_VERSION,
+            older.engine_schema_version < ARCHIVE_SCHEMA_VERSION,
             "fixture must use an older schema version to exercise backward-compat"
         );
         write_pak(&older, &older_path).unwrap();
         assert!(
-            read_pak(&older_path, CURRENT_SCHEMA_VERSION).is_ok(),
+            read_pak(&older_path).is_ok(),
             "older versions must still read (backward-compat)"
         );
     }
@@ -373,7 +376,7 @@ mod tests {
     fn read_pak_nonexistent_path_errors_io() {
         let dir = tempfile::tempdir().unwrap();
         let ghost = dir.path().join("ghost.pak");
-        let err = read_pak(&ghost, CURRENT_SCHEMA_VERSION).unwrap_err();
+        let err = read_pak(&ghost).unwrap_err();
         let display = err.to_string();
         match err {
             MemoryError::Archive(ArchiveError::Io(msg)) => {
@@ -395,7 +398,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path().join("garbage.pak");
         std::fs::write(&p, b"this is plainly not a zstd stream").unwrap();
-        let err = read_pak(&p, CURRENT_SCHEMA_VERSION).unwrap_err();
+        let err = read_pak(&p).unwrap_err();
         // `zstd::Decoder::new` does NOT eagerly validate the frame header — the
         // bad magic surfaces *lazily* on the first read, inside
         // `serde_json::from_reader`, which wraps the decoder I/O error as a serde
@@ -420,7 +423,7 @@ mod tests {
         enc.write_all(b"this is not json").unwrap();
         enc.finish().unwrap();
 
-        let err = read_pak(&p, CURRENT_SCHEMA_VERSION).unwrap_err();
+        let err = read_pak(&p).unwrap_err();
         assert!(
             matches!(err, MemoryError::Serialization(_)),
             "expected Serialization for invalid JSON, got {err:?}"
@@ -439,7 +442,7 @@ mod tests {
         write_pak(&empty_pak(), &p).unwrap();
 
         // empty_pak()'s JSON is well over 1 byte, so a 1-byte cap trips reliably.
-        let err = read_pak_capped(&p, 1, CURRENT_SCHEMA_VERSION).unwrap_err();
+        let err = read_pak_capped(&p, 1).unwrap_err();
         match err {
             MemoryError::Archive(ArchiveError::PakTooLarge { cap }) => {
                 assert_eq!(cap, 1, "PakTooLarge must carry the cap that was exceeded");
@@ -450,7 +453,7 @@ mod tests {
         // Sanity: the SAME file reads fine under the real (4 GiB) cap, so the error
         // above is purely the cap firing — not a corrupt fixture.
         assert!(
-            read_pak(&p, CURRENT_SCHEMA_VERSION).is_ok(),
+            read_pak(&p).is_ok(),
             "fixture must read fine under the production cap"
         );
     }
@@ -480,7 +483,7 @@ mod tests {
         // A cap set to EXACTLY the decompressed length must read successfully —
         // the inclusive contract. This is the assertion that FAILS under the
         // pre-fix `take(decoder, cap)` (it would trip the bomb guard at limit 0).
-        let restored = read_pak_capped(&p, decompressed_len, CURRENT_SCHEMA_VERSION)
+        let restored = read_pak_capped(&p, decompressed_len)
             .expect("a pak whose size equals the cap must read (inclusive cap)");
         assert_eq!(restored.pak_version, CURRENT_PAK_VERSION);
     }
@@ -509,7 +512,7 @@ mod tests {
 
         // cap = len - 1 means the payload is exactly one byte over the cap.
         let cap = decompressed_len - 1;
-        let err = read_pak_capped(&p, cap, CURRENT_SCHEMA_VERSION).unwrap_err();
+        let err = read_pak_capped(&p, cap).unwrap_err();
         match err {
             MemoryError::Archive(ArchiveError::PakTooLarge { cap: reported }) => {
                 assert_eq!(reported, cap, "PakTooLarge must carry the exceeded cap");

--- a/memory-engine/lib/memory-engine/src/archive/pak.rs
+++ b/memory-engine/lib/memory-engine/src/archive/pak.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 
 use crate::archive::types::{ArchivePak, CURRENT_PAK_VERSION};
 use crate::error::{ArchiveError, Result};
-use crate::store::schema::CURRENT_SCHEMA_VERSION;
 
 /// Maximum decompressed `.pak` size (4 GiB) — prevents decompression bombs.
 const MAX_PAK_DECOMPRESSED_SIZE: u64 = 4 * 1024 * 1024 * 1024;
@@ -102,12 +101,24 @@ pub fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
 ///   newer than this build supports (forward-incompatible).
 /// - [`MemoryError::Archive`](crate::error::MemoryError::Archive) wrapping
 ///   [`ArchiveError::SchemaVersionUnsupported`] — the archive's
-///   `engine_schema_version` is newer than this build supports.
+///   `engine_schema_version` is newer than `supported_schema_version`.
 ///
 /// Older `pak_version` / `engine_schema_version` values are accepted
 /// (backward-compatible read); only newer ones are rejected.
-pub fn read_pak(path: &Path) -> Result<ArchivePak> {
-    read_pak_capped(path, MAX_PAK_DECOMPRESSED_SIZE)
+///
+/// # `supported_schema_version`
+///
+/// The `.pak` records the schema version of *the store it was archived from*
+/// (`ArchivePak::engine_schema_version`), so the compat check belongs to
+/// whoever knows the active backend's schema version — this function takes it
+/// as a parameter rather than reaching for a concrete backend's constant
+/// (Wave 2 #816 / S4, sub-PR 3a). This is not DAG-appeasement: post-#634/#635 a
+/// Postgres-backed engine passes *its own* schema version here, where a
+/// hard-wired constant would have silently checked against `SQLite`'s instead.
+/// The facade's public `read_pak` wrapper (`lib.rs`) supplies
+/// `store::schema::CURRENT_SCHEMA_VERSION` for today's `SQLite`-only build.
+pub fn read_pak(path: &Path, supported_schema_version: u32) -> Result<ArchivePak> {
+    read_pak_capped(path, MAX_PAK_DECOMPRESSED_SIZE, supported_schema_version)
 }
 
 /// Cap-parameterized core of [`read_pak`].
@@ -115,7 +126,7 @@ pub fn read_pak(path: &Path) -> Result<ArchivePak> {
 /// Splitting the byte cap out as a parameter lets the cap-firing path be tested
 /// with a tiny limit instead of a real 4 GiB payload (#299). [`read_pak`] is the
 /// only non-test caller and always passes [`MAX_PAK_DECOMPRESSED_SIZE`].
-fn read_pak_capped(path: &Path, cap: u64) -> Result<ArchivePak> {
+fn read_pak_capped(path: &Path, cap: u64, supported_schema_version: u32) -> Result<ArchivePak> {
     let file = fs::File::open(path).map_err(|e| {
         ArchiveError::Io(format!("failed to open pak file {}: {e}", path.display()))
     })?;
@@ -156,10 +167,10 @@ fn read_pak_capped(path: &Path, cap: u64) -> Result<ArchivePak> {
         }
         .into());
     }
-    if pak.engine_schema_version > CURRENT_SCHEMA_VERSION {
+    if pak.engine_schema_version > supported_schema_version {
         return Err(ArchiveError::SchemaVersionUnsupported {
             found: pak.engine_schema_version,
-            supported: CURRENT_SCHEMA_VERSION,
+            supported: supported_schema_version,
         }
         .into());
     }
@@ -206,6 +217,7 @@ mod tests {
     use super::*;
     use crate::archive::types::CURRENT_PAK_VERSION;
     use crate::error::MemoryError;
+    use crate::store::schema::CURRENT_SCHEMA_VERSION;
     use chrono::Utc;
 
     /// Write an `ArchivePak` as zstd-compressed JSON (test convenience wrapper).
@@ -233,7 +245,7 @@ mod tests {
         let pak_path = dir.path().join("test.pak");
         write_pak(&empty_pak(), &pak_path).unwrap();
         assert!(pak_path.exists());
-        let restored = read_pak(&pak_path).unwrap();
+        let restored = read_pak(&pak_path, CURRENT_SCHEMA_VERSION).unwrap();
         assert_eq!(restored.pak_version, CURRENT_PAK_VERSION);
         assert_eq!(restored.embed_dim, 3);
         assert!(restored.facts.is_empty());
@@ -271,7 +283,6 @@ mod tests {
 
     #[test]
     fn read_pak_rejects_future_pak_version() {
-        use crate::store::schema::CURRENT_SCHEMA_VERSION;
         let dir = tempfile::tempdir().unwrap();
         let pak_path = dir.path().join("future_pak.pak");
         let mut pak = empty_pak();
@@ -279,7 +290,7 @@ mod tests {
         pak.engine_schema_version = CURRENT_SCHEMA_VERSION;
         write_pak(&pak, &pak_path).unwrap();
 
-        let err = read_pak(&pak_path).unwrap_err();
+        let err = read_pak(&pak_path, CURRENT_SCHEMA_VERSION).unwrap_err();
         let display = err.to_string();
         match err {
             MemoryError::Archive(ArchiveError::PakVersionUnsupported { found, supported }) => {
@@ -301,14 +312,13 @@ mod tests {
 
     #[test]
     fn read_pak_rejects_future_schema_version() {
-        use crate::store::schema::CURRENT_SCHEMA_VERSION;
         let dir = tempfile::tempdir().unwrap();
         let pak_path = dir.path().join("future_schema.pak");
         let mut pak = empty_pak();
         pak.engine_schema_version = CURRENT_SCHEMA_VERSION + 1;
         write_pak(&pak, &pak_path).unwrap();
 
-        let err = read_pak(&pak_path).unwrap_err();
+        let err = read_pak(&pak_path, CURRENT_SCHEMA_VERSION).unwrap_err();
         let display = err.to_string();
         match err {
             MemoryError::Archive(ArchiveError::SchemaVersionUnsupported { found, supported }) => {
@@ -330,7 +340,6 @@ mod tests {
 
     #[test]
     fn read_pak_accepts_current_and_older_versions() {
-        use crate::store::schema::CURRENT_SCHEMA_VERSION;
         let dir = tempfile::tempdir().unwrap();
 
         // Current versions read OK.
@@ -339,7 +348,7 @@ mod tests {
         current.engine_schema_version = CURRENT_SCHEMA_VERSION;
         write_pak(&current, &current_path).unwrap();
         assert!(
-            read_pak(&current_path).is_ok(),
+            read_pak(&current_path, CURRENT_SCHEMA_VERSION).is_ok(),
             "current versions must read"
         );
 
@@ -353,7 +362,7 @@ mod tests {
         );
         write_pak(&older, &older_path).unwrap();
         assert!(
-            read_pak(&older_path).is_ok(),
+            read_pak(&older_path, CURRENT_SCHEMA_VERSION).is_ok(),
             "older versions must still read (backward-compat)"
         );
     }
@@ -364,7 +373,7 @@ mod tests {
     fn read_pak_nonexistent_path_errors_io() {
         let dir = tempfile::tempdir().unwrap();
         let ghost = dir.path().join("ghost.pak");
-        let err = read_pak(&ghost).unwrap_err();
+        let err = read_pak(&ghost, CURRENT_SCHEMA_VERSION).unwrap_err();
         let display = err.to_string();
         match err {
             MemoryError::Archive(ArchiveError::Io(msg)) => {
@@ -386,7 +395,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path().join("garbage.pak");
         std::fs::write(&p, b"this is plainly not a zstd stream").unwrap();
-        let err = read_pak(&p).unwrap_err();
+        let err = read_pak(&p, CURRENT_SCHEMA_VERSION).unwrap_err();
         // `zstd::Decoder::new` does NOT eagerly validate the frame header — the
         // bad magic surfaces *lazily* on the first read, inside
         // `serde_json::from_reader`, which wraps the decoder I/O error as a serde
@@ -411,7 +420,7 @@ mod tests {
         enc.write_all(b"this is not json").unwrap();
         enc.finish().unwrap();
 
-        let err = read_pak(&p).unwrap_err();
+        let err = read_pak(&p, CURRENT_SCHEMA_VERSION).unwrap_err();
         assert!(
             matches!(err, MemoryError::Serialization(_)),
             "expected Serialization for invalid JSON, got {err:?}"
@@ -430,7 +439,7 @@ mod tests {
         write_pak(&empty_pak(), &p).unwrap();
 
         // empty_pak()'s JSON is well over 1 byte, so a 1-byte cap trips reliably.
-        let err = read_pak_capped(&p, 1).unwrap_err();
+        let err = read_pak_capped(&p, 1, CURRENT_SCHEMA_VERSION).unwrap_err();
         match err {
             MemoryError::Archive(ArchiveError::PakTooLarge { cap }) => {
                 assert_eq!(cap, 1, "PakTooLarge must carry the cap that was exceeded");
@@ -441,7 +450,7 @@ mod tests {
         // Sanity: the SAME file reads fine under the real (4 GiB) cap, so the error
         // above is purely the cap firing — not a corrupt fixture.
         assert!(
-            read_pak(&p).is_ok(),
+            read_pak(&p, CURRENT_SCHEMA_VERSION).is_ok(),
             "fixture must read fine under the production cap"
         );
     }
@@ -471,7 +480,7 @@ mod tests {
         // A cap set to EXACTLY the decompressed length must read successfully —
         // the inclusive contract. This is the assertion that FAILS under the
         // pre-fix `take(decoder, cap)` (it would trip the bomb guard at limit 0).
-        let restored = read_pak_capped(&p, decompressed_len)
+        let restored = read_pak_capped(&p, decompressed_len, CURRENT_SCHEMA_VERSION)
             .expect("a pak whose size equals the cap must read (inclusive cap)");
         assert_eq!(restored.pak_version, CURRENT_PAK_VERSION);
     }
@@ -500,7 +509,7 @@ mod tests {
 
         // cap = len - 1 means the payload is exactly one byte over the cap.
         let cap = decompressed_len - 1;
-        let err = read_pak_capped(&p, cap).unwrap_err();
+        let err = read_pak_capped(&p, cap, CURRENT_SCHEMA_VERSION).unwrap_err();
         match err {
             MemoryError::Archive(ArchiveError::PakTooLarge { cap: reported }) => {
                 assert_eq!(reported, cap, "PakTooLarge must carry the exceeded cap");

--- a/memory-engine/lib/memory-engine/src/archive/search.rs
+++ b/memory-engine/lib/memory-engine/src/archive/search.rs
@@ -128,9 +128,9 @@ const fn entry_is_prunable(_entry: &ArchiveManifestEntry, _query: &MemoryQuery) 
 /// Returns `MemoryError::Serialization` if a `.pak` file's JSON is corrupt or
 /// truncated (surfaced by `read_pak` during decompression and deserialization).
 ///
-/// `supported_schema_version` is threaded through to [`read_pak`] for its
-/// backend-schema compat check (Wave 2 #816 / S4, sub-PR 3a) — the caller
-/// supplies the active backend's current schema version.
+/// Each `.pak` is opened via [`read_pak`], whose schema gate checks `me-types`'
+/// backend-independent `ARCHIVE_SCHEMA_VERSION` — the same constant the write side
+/// stamps. No backend schema version is involved (Wave 2 #816 / S4, sub-PR 3a).
 pub fn search_archives(
     archive_dir: &Path,
     manifest_entries: &[ArchiveManifestEntry],

--- a/memory-engine/lib/memory-engine/src/archive/search.rs
+++ b/memory-engine/lib/memory-engine/src/archive/search.rs
@@ -13,8 +13,8 @@ use crate::archive::pak::read_pak;
 use crate::archive::types::ArchiveManifestEntry;
 use crate::error::Result;
 use crate::search::MemoryQuery;
-use crate::search::vector::cosine_similarity;
 use crate::types::search::{MatchType, SearchResult};
+use me_types::math::cosine_similarity;
 
 /// Summary result from scanning archives.
 pub struct ArchiveSearchResult {
@@ -136,7 +136,6 @@ pub fn search_archives(
     manifest_entries: &[ArchiveManifestEntry],
     query: &MemoryQuery,
     limit: usize,
-    supported_schema_version: u32,
 ) -> Result<ArchiveSearchResult> {
     let start = Instant::now();
     // Bounded min-heap: never holds more than `limit` matches at once. The
@@ -166,7 +165,7 @@ pub fn search_archives(
             continue;
         }
 
-        let pak = read_pak(&pak_path, supported_schema_version)?;
+        let pak = read_pak(&pak_path)?;
         paks_scanned += 1;
 
         for fact in &pak.facts {
@@ -276,9 +275,9 @@ mod tests {
     use super::*;
     use crate::archive::pak::write_pak_and_hash;
     use crate::archive::types::{ArchivePak, CURRENT_PAK_VERSION};
-    use crate::store::schema::CURRENT_SCHEMA_VERSION;
     use crate::types::{Fact, FactType};
     use chrono::Utc;
+    use me_types::types::archive::ARCHIVE_SCHEMA_VERSION;
 
     /// Build a minimal `Fact` for archive-search fixtures.
     ///
@@ -313,7 +312,7 @@ mod tests {
     fn pak_with(facts: Vec<Fact>) -> ArchivePak {
         ArchivePak {
             pak_version: CURRENT_PAK_VERSION,
-            engine_schema_version: CURRENT_SCHEMA_VERSION,
+            engine_schema_version: ARCHIVE_SCHEMA_VERSION,
             embed_dim: facts.first().map_or(0, |f| f.embedding.len()),
             created_at: Utc::now(),
             facts,
@@ -368,8 +367,7 @@ mod tests {
         let entry = write_entry(dir.path(), "a.pak", &pak);
 
         let query = MemoryQuery::new().text("brown");
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
 
         assert_eq!(out.paks_scanned, 1);
         assert_eq!(out.results.len(), 1);
@@ -390,8 +388,7 @@ mod tests {
         let entry = write_entry(dir.path(), "vec.pak", &pak);
 
         let query = MemoryQuery::new().embedding(vec![1.0, 0.0]);
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
 
         // Orthogonal fact has cos == 0.0 which is not > 0.0, so it does not match.
         assert_eq!(out.results.len(), 1);
@@ -408,8 +405,7 @@ mod tests {
         // Query embedding has a different length than the fact embedding, so the
         // vector branch is skipped; with no text either, nothing matches.
         let query = MemoryQuery::new().embedding(vec![1.0, 0.0, 0.0]);
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
 
         assert!(out.results.is_empty());
     }
@@ -428,8 +424,7 @@ mod tests {
         let query = MemoryQuery::new()
             .text("matching")
             .embedding(vec![1.0, 0.0]);
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
 
         assert_eq!(out.results.len(), 1);
         // 1.0 (text) + 1.0 (cosine) == 2.0.
@@ -448,8 +443,7 @@ mod tests {
         let entry = write_entry(dir.path(), "all.pak", &pak);
 
         let query = MemoryQuery::new();
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
 
         assert_eq!(out.results.len(), 2);
         assert!(out.results.iter().all(|r| (r.score - 1.0).abs() < 1e-6));
@@ -468,8 +462,7 @@ mod tests {
         let entry = write_entry(dir.path(), "types.pak", &pak);
 
         let query = MemoryQuery::new().fact_type(FactType::Semantic);
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
 
         assert_eq!(out.results.len(), 1);
         assert_eq!(out.results[0].fact.id, 2);
@@ -512,8 +505,7 @@ mod tests {
         };
 
         let query = MemoryQuery::new();
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
 
         assert_eq!(out.paks_scanned, 0, "traversal entry must not be read");
         assert!(out.results.is_empty());
@@ -546,14 +538,7 @@ mod tests {
         };
 
         let query = MemoryQuery::new();
-        let out = search_archives(
-            dir.path(),
-            &[present, absent],
-            &query,
-            10,
-            CURRENT_SCHEMA_VERSION,
-        )
-        .expect("search");
+        let out = search_archives(dir.path(), &[present, absent], &query, 10).expect("search");
 
         assert_eq!(out.paks_scanned, 1, "only the present pak is read");
         assert_eq!(out.results.len(), 1);
@@ -577,8 +562,7 @@ mod tests {
         );
 
         let query = MemoryQuery::new().text("apple");
-        let out = search_archives(dir.path(), &[e1, e2], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[e1, e2], &query, 10).expect("search");
 
         assert_eq!(out.paks_scanned, 2);
         assert_eq!(out.results.len(), 2);
@@ -606,21 +590,14 @@ mod tests {
         let query = MemoryQuery::new().embedding(vec![1.0, 0.0]);
 
         // Full set: descending by score.
-        let full = search_archives(
-            dir.path(),
-            std::slice::from_ref(&entry),
-            &query,
-            10,
-            CURRENT_SCHEMA_VERSION,
-        )
-        .expect("search");
+        let full =
+            search_archives(dir.path(), std::slice::from_ref(&entry), &query, 10).expect("search");
         assert_eq!(full.results.len(), 3);
         let order: Vec<i64> = full.results.iter().map(|r| r.fact.id).collect();
         assert_eq!(order, vec![1, 3, 2], "descending by cosine score");
 
         // limit < candidates: keep the top-2 highest-scored only.
-        let capped = search_archives(dir.path(), &[entry], &query, 2, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let capped = search_archives(dir.path(), &[entry], &query, 2).expect("search");
         assert_eq!(capped.results.len(), 2);
         let capped_ids: Vec<i64> = capped.results.iter().map(|r| r.fact.id).collect();
         assert_eq!(capped_ids, vec![1, 3], "top-2 by score retained");
@@ -636,8 +613,7 @@ mod tests {
         );
 
         let query = MemoryQuery::new();
-        let out = search_archives(dir.path(), &[entry], &query, 0, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 0).expect("search");
 
         assert!(out.results.is_empty());
         // The pak is still scanned even when limit == 0.
@@ -670,8 +646,7 @@ mod tests {
         );
 
         let query = MemoryQuery::new().text("apple");
-        let out = search_archives(dir.path(), &[e1, e2], &query, 2, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[e1, e2], &query, 2).expect("search");
 
         assert_eq!(out.paks_scanned, 2);
         // Six candidates, but only `limit` retained.
@@ -720,8 +695,7 @@ mod tests {
         );
         assert!(!entry_is_prunable(&entry, &query));
 
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
         assert_eq!(out.paks_scanned, 1);
         assert_eq!(out.results.len(), 1);
         assert_eq!(out.results[0].fact.id, 42);
@@ -760,8 +734,7 @@ mod tests {
         // axis against a valid-time window is unsound — the fact must survive.
         assert!(!entry_is_prunable(&entry, &query));
 
-        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
-            .expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
         assert_eq!(
             out.paks_scanned, 1,
             "the pak must still be read, not pruned"

--- a/memory-engine/lib/memory-engine/src/archive/search.rs
+++ b/memory-engine/lib/memory-engine/src/archive/search.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use crate::archive::pak::read_pak;
 use crate::archive::types::ArchiveManifestEntry;
 use crate::error::Result;
-use crate::search::query::MemoryQuery;
+use crate::search::MemoryQuery;
 use crate::search::vector::cosine_similarity;
 use crate::types::search::{MatchType, SearchResult};
 

--- a/memory-engine/lib/memory-engine/src/archive/search.rs
+++ b/memory-engine/lib/memory-engine/src/archive/search.rs
@@ -127,11 +127,16 @@ const fn entry_is_prunable(_entry: &ArchiveManifestEntry, _query: &MemoryQuery) 
 /// Returns `MemoryError::Archive` on I/O or decompression failure.
 /// Returns `MemoryError::Serialization` if a `.pak` file's JSON is corrupt or
 /// truncated (surfaced by `read_pak` during decompression and deserialization).
+///
+/// `supported_schema_version` is threaded through to [`read_pak`] for its
+/// backend-schema compat check (Wave 2 #816 / S4, sub-PR 3a) — the caller
+/// supplies the active backend's current schema version.
 pub fn search_archives(
     archive_dir: &Path,
     manifest_entries: &[ArchiveManifestEntry],
     query: &MemoryQuery,
     limit: usize,
+    supported_schema_version: u32,
 ) -> Result<ArchiveSearchResult> {
     let start = Instant::now();
     // Bounded min-heap: never holds more than `limit` matches at once. The
@@ -161,7 +166,7 @@ pub fn search_archives(
             continue;
         }
 
-        let pak = read_pak(&pak_path)?;
+        let pak = read_pak(&pak_path, supported_schema_version)?;
         paks_scanned += 1;
 
         for fact in &pak.facts {
@@ -363,7 +368,8 @@ mod tests {
         let entry = write_entry(dir.path(), "a.pak", &pak);
 
         let query = MemoryQuery::new().text("brown");
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert_eq!(out.paks_scanned, 1);
         assert_eq!(out.results.len(), 1);
@@ -384,7 +390,8 @@ mod tests {
         let entry = write_entry(dir.path(), "vec.pak", &pak);
 
         let query = MemoryQuery::new().embedding(vec![1.0, 0.0]);
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         // Orthogonal fact has cos == 0.0 which is not > 0.0, so it does not match.
         assert_eq!(out.results.len(), 1);
@@ -401,7 +408,8 @@ mod tests {
         // Query embedding has a different length than the fact embedding, so the
         // vector branch is skipped; with no text either, nothing matches.
         let query = MemoryQuery::new().embedding(vec![1.0, 0.0, 0.0]);
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert!(out.results.is_empty());
     }
@@ -420,7 +428,8 @@ mod tests {
         let query = MemoryQuery::new()
             .text("matching")
             .embedding(vec![1.0, 0.0]);
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert_eq!(out.results.len(), 1);
         // 1.0 (text) + 1.0 (cosine) == 2.0.
@@ -439,7 +448,8 @@ mod tests {
         let entry = write_entry(dir.path(), "all.pak", &pak);
 
         let query = MemoryQuery::new();
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert_eq!(out.results.len(), 2);
         assert!(out.results.iter().all(|r| (r.score - 1.0).abs() < 1e-6));
@@ -458,7 +468,8 @@ mod tests {
         let entry = write_entry(dir.path(), "types.pak", &pak);
 
         let query = MemoryQuery::new().fact_type(FactType::Semantic);
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert_eq!(out.results.len(), 1);
         assert_eq!(out.results[0].fact.id, 2);
@@ -501,7 +512,8 @@ mod tests {
         };
 
         let query = MemoryQuery::new();
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert_eq!(out.paks_scanned, 0, "traversal entry must not be read");
         assert!(out.results.is_empty());
@@ -534,7 +546,14 @@ mod tests {
         };
 
         let query = MemoryQuery::new();
-        let out = search_archives(dir.path(), &[present, absent], &query, 10).expect("search");
+        let out = search_archives(
+            dir.path(),
+            &[present, absent],
+            &query,
+            10,
+            CURRENT_SCHEMA_VERSION,
+        )
+        .expect("search");
 
         assert_eq!(out.paks_scanned, 1, "only the present pak is read");
         assert_eq!(out.results.len(), 1);
@@ -558,7 +577,8 @@ mod tests {
         );
 
         let query = MemoryQuery::new().text("apple");
-        let out = search_archives(dir.path(), &[e1, e2], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[e1, e2], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert_eq!(out.paks_scanned, 2);
         assert_eq!(out.results.len(), 2);
@@ -586,14 +606,21 @@ mod tests {
         let query = MemoryQuery::new().embedding(vec![1.0, 0.0]);
 
         // Full set: descending by score.
-        let full =
-            search_archives(dir.path(), std::slice::from_ref(&entry), &query, 10).expect("search");
+        let full = search_archives(
+            dir.path(),
+            std::slice::from_ref(&entry),
+            &query,
+            10,
+            CURRENT_SCHEMA_VERSION,
+        )
+        .expect("search");
         assert_eq!(full.results.len(), 3);
         let order: Vec<i64> = full.results.iter().map(|r| r.fact.id).collect();
         assert_eq!(order, vec![1, 3, 2], "descending by cosine score");
 
         // limit < candidates: keep the top-2 highest-scored only.
-        let capped = search_archives(dir.path(), &[entry], &query, 2).expect("search");
+        let capped = search_archives(dir.path(), &[entry], &query, 2, CURRENT_SCHEMA_VERSION)
+            .expect("search");
         assert_eq!(capped.results.len(), 2);
         let capped_ids: Vec<i64> = capped.results.iter().map(|r| r.fact.id).collect();
         assert_eq!(capped_ids, vec![1, 3], "top-2 by score retained");
@@ -609,7 +636,8 @@ mod tests {
         );
 
         let query = MemoryQuery::new();
-        let out = search_archives(dir.path(), &[entry], &query, 0).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 0, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert!(out.results.is_empty());
         // The pak is still scanned even when limit == 0.
@@ -642,7 +670,8 @@ mod tests {
         );
 
         let query = MemoryQuery::new().text("apple");
-        let out = search_archives(dir.path(), &[e1, e2], &query, 2).expect("search");
+        let out = search_archives(dir.path(), &[e1, e2], &query, 2, CURRENT_SCHEMA_VERSION)
+            .expect("search");
 
         assert_eq!(out.paks_scanned, 2);
         // Six candidates, but only `limit` retained.
@@ -691,7 +720,8 @@ mod tests {
         );
         assert!(!entry_is_prunable(&entry, &query));
 
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
         assert_eq!(out.paks_scanned, 1);
         assert_eq!(out.results.len(), 1);
         assert_eq!(out.results[0].fact.id, 42);
@@ -730,7 +760,8 @@ mod tests {
         // axis against a valid-time window is unsound — the fact must survive.
         assert!(!entry_is_prunable(&entry, &query));
 
-        let out = search_archives(dir.path(), &[entry], &query, 10).expect("search");
+        let out = search_archives(dir.path(), &[entry], &query, 10, CURRENT_SCHEMA_VERSION)
+            .expect("search");
         assert_eq!(
             out.paks_scanned, 1,
             "the pak must still be read, not pruned"

--- a/memory-engine/lib/memory-engine/src/archive/types.rs
+++ b/memory-engine/lib/memory-engine/src/archive/types.rs
@@ -26,8 +26,15 @@ pub const CURRENT_PAK_VERSION: u32 = 2;
 pub struct ArchivePak {
     /// On-disk format version; checked on read against [`CURRENT_PAK_VERSION`].
     pub pak_version: u32,
-    /// Schema version of the engine that wrote this pak; used for forward-compatibility
-    /// checks on read.
+    /// **Content**-schema version of this pak — `me_types`' backend-independent
+    /// `ARCHIVE_SCHEMA_VERSION`, stamped on write and checked on read
+    /// (forward-compatibility: a pak from a *newer* content schema is rejected).
+    ///
+    /// Despite the field's historical name, this is **not** the writing engine's backend
+    /// schema version. A `.pak` is a portable `zstd` + JSON blob of `me-types` DTOs, so
+    /// its compat gate is about DTO shape, not any backend's migration counter (which are
+    /// not even comparable across backends). The name is retained because renaming it
+    /// would break the on-disk format. (Wave 2 #816 / S4, sub-PR 3a.)
     pub engine_schema_version: u32,
     /// Embedding dimension of the facts stored in this pak. Must match the engine's
     /// configured `embed_dim` before any vectors are compared.
@@ -111,6 +118,149 @@ mod tests {
         let diff = now - policy.expired_before;
         assert_eq!(diff.num_days(), 30);
         assert_eq!(policy.min_facts, 100);
+    }
+
+    /// Fully-populated `ArchivePak` for the serde-shape guard below.
+    ///
+    /// Both DTO literals enumerate **every** field explicitly — deliberately no
+    /// `..Default::default()`. That is the enforcement mechanism: adding a field to `Fact`
+    /// or `Edge` makes this stop compiling (E0063), so nobody can change a `.pak`'s
+    /// serialized shape without being confronted with the question the guard asks.
+    fn shape_fixture_pak() -> ArchivePak {
+        use crate::types::{Edge, Fact};
+
+        let now = Utc::now();
+        ArchivePak {
+            pak_version: CURRENT_PAK_VERSION,
+            engine_schema_version: 7,
+            embed_dim: 3,
+            created_at: now,
+            facts: vec![Fact {
+                id: 1,
+                content: "shape".into(),
+                content_hash: "h".into(),
+                embedding: vec![0.0; 3],
+                fact_type: FactType::Semantic,
+                t_created: now,
+                t_expired: None,
+                t_valid: None,
+                t_invalid: None,
+                source_event_id: None,
+                base_importance: 0.5,
+                importance_score: 0.5,
+                access_count: 0,
+                last_accessed: now,
+                metadata: serde_json::json!({}),
+                scope_id: 1,
+                is_pinned: false,
+                surfaced_at: None,
+            }],
+            edges: vec![Edge {
+                id: 1,
+                source_fact_id: 1,
+                target_fact_id: 2,
+                relation_type: "related".into(),
+                weight: 1.0,
+                t_created: now,
+                t_expired: None,
+                scope_id: 1,
+            }],
+        }
+    }
+
+    /// Golden serde-shape guard for the `.pak` payload (Wave 2 #816 / S4, sub-PR 3a).
+    ///
+    /// # Why this test exists
+    ///
+    /// `ARCHIVE_SCHEMA_VERSION` (the version stamped into every `.pak` and checked on
+    /// read) is a **content**-schema version: it must be bumped whenever the serialized
+    /// shape of a pak's DTOs changes. Nothing in the type system enforces that, and the
+    /// failure is **silent**: `Fact` does not `deny_unknown_fields` and several of its
+    /// fields are `#[serde(default)]`, so a newer build that adds a field would write
+    /// paks still stamped with the old version, and an older build would accept them
+    /// (`stamp <= supported`) while quietly dropping the new field.
+    ///
+    /// Previously the stamp was inherited from `SQLite`'s `CURRENT_SCHEMA_VERSION`, so
+    /// *any* migration moved it — over-approximating, but it made the guard automatic.
+    /// Decoupling the archive from a backend counter (the right call — a `.pak` is a
+    /// portable DTO blob, not a backend artifact) removed that automatic bump. This test
+    /// puts the enforcement back into the **structure** instead of relying on a
+    /// maintainer remembering: change a serialized field name in `ArchivePak`, `Fact`, or
+    /// `Edge`, and this reddens.
+    ///
+    /// If it fails, that is the question being asked: **does this shape change break
+    /// older readers?** If yes, bump `ARCHIVE_SCHEMA_VERSION`. If no (e.g. a purely
+    /// additive `#[serde(default)]` field older readers can ignore), update the expected
+    /// key set below and say why in the commit message.
+    #[test]
+    fn archive_pak_serde_shape_is_pinned() {
+        let value = serde_json::to_value(shape_fixture_pak()).expect("pak serializes");
+        let keys = |v: &serde_json::Value| -> Vec<String> {
+            let mut k: Vec<String> = v
+                .as_object()
+                .expect("object")
+                .keys()
+                .map(ToString::to_string)
+                .collect();
+            k.sort();
+            k
+        };
+
+        assert_eq!(
+            keys(&value),
+            vec![
+                "created_at",
+                "edges",
+                "embed_dim",
+                "engine_schema_version",
+                "facts",
+                "pak_version",
+            ],
+            "ArchivePak's serialized shape changed — bump ARCHIVE_SCHEMA_VERSION if this \
+             breaks older readers, or update this expectation and justify the compat"
+        );
+        assert_eq!(
+            keys(&value["facts"][0]),
+            vec![
+                "access_count",
+                "base_importance",
+                "content",
+                "content_hash",
+                "embedding",
+                "fact_type",
+                "id",
+                "importance_score",
+                "is_pinned",
+                "last_accessed",
+                "metadata",
+                "scope_id",
+                "source_event_id",
+                "surfaced_at",
+                "t_created",
+                "t_expired",
+                "t_invalid",
+                "t_valid",
+            ],
+            "Fact's serialized shape changed — a .pak embeds Fact verbatim. Bump \
+             ARCHIVE_SCHEMA_VERSION if older readers cannot consume this, or update this \
+             expectation and justify the compat"
+        );
+        assert_eq!(
+            keys(&value["edges"][0]),
+            vec![
+                "id",
+                "relation_type",
+                "scope_id",
+                "source_fact_id",
+                "t_created",
+                "t_expired",
+                "target_fact_id",
+                "weight",
+            ],
+            "Edge's serialized shape changed — a .pak embeds Edge verbatim. Bump \
+             ARCHIVE_SCHEMA_VERSION if older readers cannot consume this, or update this \
+             expectation and justify the compat"
+        );
     }
 
     #[test]

--- a/memory-engine/lib/memory-engine/src/consolidation/cluster.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/cluster.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 use crate::error::Result;
-use crate::search::vector::cosine_similarity;
+use me_types::math::cosine_similarity;
 // Used by this file's own `#[cfg(test)]` module (via `use super::*`) to verify writes
 // `apply_clusters` (now in me-backend-sqlite) made — not by any production fn here.
 #[cfg(test)]

--- a/memory-engine/lib/memory-engine/src/consolidation/dedup.rs
+++ b/memory-engine/lib/memory-engine/src/consolidation/dedup.rs
@@ -7,10 +7,10 @@ use rusqlite::Connection;
 
 #[cfg(test)]
 use crate::error::Result;
-use crate::search::vector::cosine_similarity;
 #[cfg(test)]
 use crate::store::facts::FactStore;
 use crate::types::Fact;
+use me_types::math::cosine_similarity;
 
 /// Floating-point tolerance for the dedup similarity comparison.
 ///

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -14,8 +14,8 @@ use crate::archive::types::{
     CURRENT_PAK_VERSION,
 };
 use crate::error::{ArchiveError, MemoryError, Result};
-use crate::store::schema::CURRENT_SCHEMA_VERSION;
 use crate::types::{Edge, Fact};
+use me_types::types::archive::ARCHIVE_SCHEMA_VERSION;
 
 use super::MemoryEngine;
 
@@ -200,7 +200,7 @@ impl MemoryEngine {
     fn build_pak(&self, facts: &[Fact], edges: &[Edge]) -> ArchivePak {
         ArchivePak {
             pak_version: CURRENT_PAK_VERSION,
-            engine_schema_version: CURRENT_SCHEMA_VERSION,
+            engine_schema_version: ARCHIVE_SCHEMA_VERSION,
             embed_dim: self.embed_dim,
             created_at: Utc::now(),
             facts: facts.to_vec(),
@@ -341,13 +341,7 @@ impl MemoryEngine {
         if entries.is_empty() {
             return Ok(None);
         }
-        let result = crate::archive::search::search_archives(
-            &archive_dir,
-            &entries,
-            query,
-            limit,
-            CURRENT_SCHEMA_VERSION,
-        )?;
+        let result = crate::archive::search::search_archives(&archive_dir, &entries, query, limit)?;
         Ok(Some(result))
     }
 
@@ -802,6 +796,53 @@ mod tests {
              through to the I/O (file-not-found) path"
         );
         assert_eq!(result.pak_path, evil_path);
+    }
+
+    /// Write/read schema-version **symmetry** (Wave 2 #816 / S4, sub-PR 3a).
+    ///
+    /// The `.pak` schema gate is a *split* guard: `build_pak` **stamps** a version, and
+    /// `read_pak` **rejects** anything newer than the version it supports. Those two
+    /// halves must be sourced from the SAME constant, or they are free to drift apart.
+    ///
+    /// They very nearly did. The stamp used to come from `me-backend-sqlite`'s
+    /// `CURRENT_SCHEMA_VERSION` (= 14) while the read gate was being parameterized "so a
+    /// Postgres engine can pass its own version" — but Postgres numbers its migrations
+    /// independently (`CURRENT_PG_SCHEMA_VERSION` = 1). A PG-backed engine would then
+    /// stamp 14, check against 1, and refuse to read the pak *it had just written*; the
+    /// archive fallback swallows that error as best-effort (`tracing::warn!`), so every
+    /// archived fact would silently vanish from every query. Both sides now read
+    /// `me_types`' backend-independent `ARCHIVE_SCHEMA_VERSION`.
+    ///
+    /// This test pins the invariant directly: **what the write side stamps is exactly
+    /// what the read side accepts.**
+    #[tokio::test]
+    async fn pak_write_stamp_matches_read_gate() {
+        use crate::archive::pak::read_pak;
+
+        let dir = tempfile::tempdir().unwrap();
+        let engine = MemoryEngine::builder(DIM)
+            .path(dir.path().join("symmetry.db"))
+            .build()
+            .unwrap();
+
+        // The WRITE side: whatever `build_pak` stamps.
+        let pak = engine.build_pak(&[], &[]);
+        assert_eq!(
+            pak.engine_schema_version, ARCHIVE_SCHEMA_VERSION,
+            "build_pak must stamp the backend-independent ARCHIVE_SCHEMA_VERSION, not a \
+             backend's migration counter"
+        );
+
+        // The READ side must accept it. If the two halves ever diverge (e.g. one is
+        // re-pointed at a backend constant), `read_pak` returns SchemaVersionUnsupported
+        // and this fails — instead of silently dropping archived facts at runtime.
+        let path = dir.path().join("symmetry.pak");
+        write_pak_and_hash(&pak, &path).unwrap();
+        let restored = read_pak(&path).expect(
+            "the read gate must accept a pak the write side just stamped — a failure here \
+             means the write stamp and the read gate no longer share one constant",
+        );
+        assert_eq!(restored.engine_schema_version, ARCHIVE_SCHEMA_VERSION);
     }
 
     /// #117 regression (Wave 2 #816 / S4 sub-PR 2): a *provided-but-missing* scope must

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -341,7 +341,13 @@ impl MemoryEngine {
         if entries.is_empty() {
             return Ok(None);
         }
-        let result = crate::archive::search::search_archives(&archive_dir, &entries, query, limit)?;
+        let result = crate::archive::search::search_archives(
+            &archive_dir,
+            &entries,
+            query,
+            limit,
+            CURRENT_SCHEMA_VERSION,
+        )?;
         Ok(Some(result))
     }
 

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -815,6 +815,21 @@ mod tests {
     ///
     /// This test pins the invariant directly: **what the write side stamps is exactly
     /// what the read side accepts.**
+    ///
+    /// # What it cannot catch (do not over-trust it)
+    ///
+    /// Both assertions compare *values*, and `ARCHIVE_SCHEMA_VERSION` and `SQLite`'s
+    /// `CURRENT_SCHEMA_VERSION` currently hold the **same** value (14 — see
+    /// `ARCHIVE_SCHEMA_VERSION`'s docs for why they must coincide today). So re-pointing
+    /// the write stamp back at the backend constant is *value-invisible* and this test
+    /// would still pass. It becomes a live tripwire only once the two diverge (i.e. when
+    /// `SQLite` reaches v15: the stamp would then exceed the gate and the `expect` below
+    /// fires). It is therefore a **delayed** guard, not an immediate one.
+    ///
+    /// The genuinely structural guard arrives with sub-PR 3b: once `build_pak` moves into
+    /// `me-archive` — a crate with no dependency on `me-backend-sqlite` — the backend
+    /// constant becomes *unnameable* from either half, and the coupling is enforced by the
+    /// crate boundary rather than by this assertion.
     #[tokio::test]
     async fn pak_write_stamp_matches_read_gate() {
         use crate::archive::pak::read_pak;

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -331,7 +331,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::Archive` on `.pak` I/O or decompression failure.
     pub(crate) async fn search_archives_fallback(
         &self,
-        query: &crate::search::query::MemoryQuery,
+        query: &crate::search::MemoryQuery,
         limit: usize,
     ) -> Result<Option<crate::archive::search::ArchiveSearchResult>> {
         let Ok(archive_dir) = self.archive_dir() else {
@@ -811,7 +811,7 @@ mod tests {
     /// cannot pass vacuously (the "verification theater" trap).
     #[tokio::test]
     async fn scope_miss_suppresses_unscoped_archive_fallback() {
-        use crate::search::query::MemoryQuery;
+        use crate::search::MemoryQuery;
 
         let dir = tempfile::tempdir().unwrap();
         let engine = MemoryEngine::builder(DIM)

--- a/memory-engine/lib/memory-engine/src/engine/cycle/dbscan.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cycle/dbscan.rs
@@ -8,8 +8,8 @@
 //! cluster's seed set is expanded in discovery order, so the same input always yields
 //! the same clusters.
 
-use crate::search::vector::cosine_similarity;
 use crate::types::FactId;
+use me_types::math::cosine_similarity;
 
 /// Upper bound on points fed to DBSCAN in one call. Above this the O(N²) pairwise
 /// cosine neighbour scan is skipped with a warning. Set well below the consolidation

--- a/memory-engine/lib/memory-engine/src/engine/dormant.rs
+++ b/memory-engine/lib/memory-engine/src/engine/dormant.rs
@@ -1,6 +1,6 @@
 use crate::error::{MemoryError, Result};
-use crate::search::vector::cosine_similarity;
 use crate::types::Fact;
+use me_types::math::cosine_similarity;
 
 use super::MemoryEngine;
 

--- a/memory-engine/lib/memory-engine/src/engine/query.rs
+++ b/memory-engine/lib/memory-engine/src/engine/query.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::search::query::MemoryQuery;
+use crate::search::MemoryQuery;
 use crate::types::search::{QueryDiagnostics, QueryResponse, SearchQuery, SearchResult};
 
 use super::MemoryEngine;

--- a/memory-engine/lib/memory-engine/src/engine/tests.rs
+++ b/memory-engine/lib/memory-engine/src/engine/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::forgetting::ForgetPolicy;
 use crate::graph::MemoryGraph;
 use crate::resume::context::ResumeConfig;
-use crate::search::query::MemoryQuery;
+use crate::search::MemoryQuery;
 use crate::traits::{
     ConflictArbiter, ConsolidationConfig, CrudDecision, EmbeddingProvider, PersistenceClassifier,
     SummarizableContent, SummaryGenerator,

--- a/memory-engine/lib/memory-engine/src/lib.rs
+++ b/memory-engine/lib/memory-engine/src/lib.rs
@@ -324,6 +324,11 @@ pub use engine::cycle::{
 ///   fn` inside the `#[cfg(feature = "archive")] pub(crate) mod archive`, so it is
 ///   unreachable from the fuzz crate without this seam (#421); the entry is therefore
 ///   `archive`-gated to match the module. Every input yields `Ok`/`Err`, never a panic.
+///   `archive::pak::read_pak` itself takes a `supported_schema_version` parameter
+///   (Wave 2 #816 / S4, sub-PR 3a — the compat check is backend-specific, not a
+///   shared L0 concern), so this seam re-exposes a thin wrapper of the pre-existing
+///   single-argument signature that injects `store::schema::CURRENT_SCHEMA_VERSION`
+///   (the facade's own backend), rather than a bare `pub use`.
 ///
 /// This module compiles to nothing on a normal build, so it adds no public API
 /// to the shipped crate.
@@ -331,7 +336,11 @@ pub use engine::cycle::{
 #[doc(hidden)]
 pub mod fuzz_seam {
     #[cfg(feature = "archive")]
-    pub use crate::archive::pak::read_pak;
+    pub fn read_pak(
+        path: &std::path::Path,
+    ) -> crate::error::Result<crate::archive::types::ArchivePak> {
+        crate::archive::pak::read_pak(path, crate::store::schema::CURRENT_SCHEMA_VERSION)
+    }
     pub use crate::bootstrap::parse::{parse_content_blocks, parse_session_file};
     pub use crate::inspect::restore::read_snapshot;
     pub use crate::search::fts::fuzz_fts_query;

--- a/memory-engine/lib/memory-engine/src/lib.rs
+++ b/memory-engine/lib/memory-engine/src/lib.rs
@@ -182,8 +182,9 @@ pub use resume::{ResumeConfig, ResumeContext};
 /// End-to-end example: build an engine, add a fact, and retrieve it with
 /// [`MemoryQuery`]'s fluent builder.
 ///
-/// `me-query` (where `MemoryQuery` is defined) has no dependency on this facade
-/// crate — its own doctest is a minimal, builder-only example. This richer,
+/// `MemoryQuery` is defined in `me-types` (L0) — shared query vocabulary consumed by
+/// several primitives — and neither it nor `me-query` depends on this facade crate, so
+/// their own doctests are minimal, builder-only examples. This richer,
 /// `MemoryEngine`-driven example lives here instead, where the engine and its
 /// consumer traits are naturally in scope.
 ///
@@ -324,11 +325,9 @@ pub use engine::cycle::{
 ///   fn` inside the `#[cfg(feature = "archive")] pub(crate) mod archive`, so it is
 ///   unreachable from the fuzz crate without this seam (#421); the entry is therefore
 ///   `archive`-gated to match the module. Every input yields `Ok`/`Err`, never a panic.
-///   `archive::pak::read_pak` itself takes a `supported_schema_version` parameter
-///   (Wave 2 #816 / S4, sub-PR 3a — the compat check is backend-specific, not a
-///   shared L0 concern), so this seam re-exposes a thin wrapper of the pre-existing
-///   single-argument signature that injects `store::schema::CURRENT_SCHEMA_VERSION`
-///   (the facade's own backend), rather than a bare `pub use`.
+///   Its `.pak` schema gate checks `me_types`'s backend-independent
+///   `ARCHIVE_SCHEMA_VERSION` (Wave 2 #816 / S4, sub-PR 3a) — the same constant the
+///   write side stamps — so the signature is unchanged and this stays a bare `pub use`.
 ///
 /// This module compiles to nothing on a normal build, so it adds no public API
 /// to the shipped crate.
@@ -336,11 +335,7 @@ pub use engine::cycle::{
 #[doc(hidden)]
 pub mod fuzz_seam {
     #[cfg(feature = "archive")]
-    pub fn read_pak(
-        path: &std::path::Path,
-    ) -> crate::error::Result<crate::archive::types::ArchivePak> {
-        crate::archive::pak::read_pak(path, crate::store::schema::CURRENT_SCHEMA_VERSION)
-    }
+    pub use crate::archive::pak::read_pak;
     pub use crate::bootstrap::parse::{parse_content_blocks, parse_session_file};
     pub use crate::inspect::restore::read_snapshot;
     pub use crate::search::fts::fuzz_fts_query;

--- a/memory-engine/lib/memory-engine/src/search/mod.rs
+++ b/memory-engine/lib/memory-engine/src/search/mod.rs
@@ -29,7 +29,7 @@
 //! (verified: `grep -rn VectorSearchStrategy src` matches only this note).
 #[cfg(fuzzing)]
 pub(crate) use me_backend_sqlite::search::fts;
-pub(crate) use me_backend_sqlite::search::{strategy, vector};
+pub(crate) use me_backend_sqlite::search::strategy;
 
 // --- Genuinely-public surface (re-exported at the crate root by `lib.rs`) ---
 //
@@ -44,5 +44,5 @@ pub use crate::types::search::{
 // API, but the top-level benches/tests (which compile as separate crates and
 // therefore cannot see `pub(crate)`) consume them via `memory_engine::search::*`.
 // They are kept `pub` for those out-of-crate consumers only.
+pub use me_types::math::cosine_similarity;
 pub use strategy::SearchConfig;
-pub use vector::cosine_similarity;

--- a/memory-engine/lib/memory-engine/src/search/mod.rs
+++ b/memory-engine/lib/memory-engine/src/search/mod.rs
@@ -15,7 +15,7 @@
 //! re-exported directly from `crate::types::search` below rather than through a
 //! `query` submodule; internal callers (`engine/archive.rs`/`engine/query.rs`/
 //! `engine/tests.rs`/`archive/search.rs`) reach it as `crate::search::MemoryQuery`.
-//! `ann`/`filter_sql` and the `FilterSql`/`fts_count_expired`/
+//! `ann`/`filter_sql`/`vector` and the `FilterSql`/`fts_count_expired`/
 //! `fts_search_filtered`/`vector_search_filtered` flat re-exports are NOT re-exported
 //! here — their only callers (`storage::sqlite::{search_index, convert}`) moved to
 //! `me-backend-sqlite` too, so nothing in the facade reaches them anymore (production

--- a/memory-engine/lib/memory-engine/src/search/mod.rs
+++ b/memory-engine/lib/memory-engine/src/search/mod.rs
@@ -7,10 +7,15 @@
 //! hybrid search + the `MemoryQuery` builder) carved into [`me_query`] in turn
 //! (Wave 2 #816 / S4, sub-PR 2); the facade's `engine/query.rs` now calls
 //! `me_query::execute::{query, execute_query}` directly rather than routing through a
-//! `crate::search::hybrid` re-export, so only `query` (still reached as
-//! `crate::search::query::MemoryQuery` by `engine/archive.rs`/`engine/tests.rs`/
-//! `archive/search.rs`) is re-exported below; `hybrid` has no facade call site left
-//! and is dropped. `ann`/`filter_sql` and the `FilterSql`/`fts_count_expired`/
+//! `crate::search::hybrid` re-export, so `hybrid` has no facade call site left and is
+//! dropped. `query` (the module holding `MemoryQuery`) is dropped too, one layer
+//! further down (Wave 2 #816 / S4, sub-PR 3a): `MemoryQuery` relocated from `me-query`
+//! to `me-types` (a pure data + builder DTO with zero `me-query`-internal
+//! dependencies, sitting beside its sibling search vocabulary), so it is now
+//! re-exported directly from `crate::types::search` below rather than through a
+//! `query` submodule; internal callers (`engine/archive.rs`/`engine/query.rs`/
+//! `engine/tests.rs`/`archive/search.rs`) reach it as `crate::search::MemoryQuery`.
+//! `ann`/`filter_sql` and the `FilterSql`/`fts_count_expired`/
 //! `fts_search_filtered`/`vector_search_filtered` flat re-exports are NOT re-exported
 //! here — their only callers (`storage::sqlite::{search_index, convert}`) moved to
 //! `me-backend-sqlite` too, so nothing in the facade reaches them anymore (production
@@ -25,7 +30,6 @@
 #[cfg(fuzzing)]
 pub(crate) use me_backend_sqlite::search::fts;
 pub(crate) use me_backend_sqlite::search::{strategy, vector};
-pub(crate) use me_query::query;
 
 // --- Genuinely-public surface (re-exported at the crate root by `lib.rs`) ---
 //
@@ -33,9 +37,8 @@ pub(crate) use me_query::query;
 // below is an impl-internal helper kept `pub(crate)` so it stays reachable from
 // other engine modules without leaking onto the public API (#365).
 pub use crate::types::search::{
-    MatchType, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult,
+    MatchType, MemoryQuery, QueryDiagnostics, QueryResponse, SearchMode, SearchQuery, SearchResult,
 };
-pub use query::MemoryQuery;
 
 // `SearchConfig` and `cosine_similarity` are not part of the engine's facade
 // API, but the top-level benches/tests (which compile as separate crates and


### PR DESCRIPTION
## What

**S4 sub-PR 3a of 5** — a **layer-correction relocation**. No new crate, no public-API break. It is the prerequisite that makes sub-PR 3b (carving `me-archive` as a clean L3 leaf) legal.

## Why

Triage-against-current-main, run *before* writing the me-archive carve spec, surfaced a **DAG blocker the #925 plan did not anticipate**: the archive code reaches three items sitting in the wrong layer.

| item archive needs | was in | layer | edge it would force |
|---|---|---|---|
| `MemoryQuery` | `me-query` | **L3** | `me-archive → me-query` = **L3→L3 sibling edge — ILLEGAL** |
| `cosine_similarity` | `me-backend-sqlite` | L2 | `me-archive →` **concrete backend** |
| `CURRENT_SCHEMA_VERSION` | `me-backend-sqlite` | L2 | `me-archive →` **concrete backend** |

The two L2 edges are the insidious ones: **legal by layer number, architecturally fatal**. They would drag **rusqlite + bundled SQLite into a Postgres-only build**, silently gutting epic #628 while every gate stayed green.

## The changes

**1. `MemoryQuery` → `me-types`.** A pure data+builder DTO (verified: zero `me-query`-internal deps) whose **entire sibling vocabulary** — `SearchQuery`, `SearchResult`, `QueryDiagnostics`, `QueryResponse`, `SearchMode`, `MatchType` — was *already* in me-types. It was the odd one out. `me-query` re-exports it, so `me_query::MemoryQuery` still resolves. Kills the L3→L3 edge.
  - Consequence: `me-query`'s `archive` feature is dropped (its only job was gating `MemoryQuery::include_archives`, which now rides me-types' pre-existing `archive` feature — the same one already gating `QueryDiagnostics`' archive fields).

**2. `cosine_similarity` → `me-types`.** Pure math, no SQL/driver. **All five consumers and the public re-export are re-pointed** to `me_types::math`, so the facade no longer reaches a backend for math. This also unblocks **sub-PR 4** — `consolidation/{dedup,cluster}` (me-consolidate's move-set) consume it too.

**3. The `.pak` schema gate is now backend-independent.** ⚠️ **Corrected assumption:** `CURRENT_SCHEMA_VERSION = 14` is **not** a cross-backend contract — Postgres numbers its migrations independently (`CURRENT_PG_SCHEMA_VERSION = 1`, and its docs explicitly forbid "syncing" the two). Binding a **portable archive format** to one backend's migration counter is a category error that only worked while SQLite was the sole backend: a `.pak` is a zstd+JSON blob of `me-types` DTOs, so *"can this build read this pak?"* is a question about **DTO shape**.
  - New `me_types::types::archive::ARCHIVE_SCHEMA_VERSION` (L0, backend-independent). **Both** the write stamp and the read gate read that one constant → symmetric **by construction**, and the guard stays structurally unbypassable (`read_pak`'s original signature is unchanged; no parameter, no wrapper).
  - The value stays **14** deliberately: the gate rejects stamps *greater* than supported, so restarting at 1 would make every `.pak` already on disk read as "from the future" and be rejected.

## Review

Full 4-voice gate. **Codex: LGTM. agy: LGTM.** The adversarial pass found a **MEDIUM** (the cosine hoist had re-pointed *zero* call sites — the PR's own purpose was unmet) and a **latent HIGH** (the `.pak` gate's write and read halves were free to diverge; a PG engine would stamp 14, check against 1, and fail to read the pak it just wrote — with the archive fallback swallowing the error, **silently dropping every archived fact**). Fixed in `4fb6758`.

A **second** adversarial round then attacked that fix and found three more: it had traded a structural coupling for an unenforced maintainer obligation, its regression test could not detect the regression (both constants equal 14, so a re-point is value-invisible), and a stale doc still carried the wrong instruction. Fixed in `80fc051` — including `archive_pak_serde_shape_is_pinned`, a golden test that pins the serialized shape of `ArchivePak`/`Fact`/`Edge` so a DTO change **fails to compile** rather than relying on someone remembering to bump the version.

Collateral **#977** (under epic #628): the **snapshot** compat gate is this gate's identical twin and is still split across backends. Filed separately, not folded in.

## Test plan

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace` (default + `--all-features`)
- [x] `cargo test --workspace --all-features` — **1970 passed / 0 failed**
      (base 1968, **+2** deliberate: `pak_write_stamp_matches_read_gate` and `archive_pak_serde_shape_is_pinned`; a test-fn-name set-diff vs base confirms nothing went dark)
- [x] `cargo test --workspace --features archive` **alone** — green (the config `--all-features` structurally masks; this is where a feature-gating regression would surface)
- [x] `cargo build -p memory-engine --no-default-features --features backend-sqlite` (archive **off**) — green
- [x] `cargo doc` (facade + me-types, `-D broken_intra_doc_links -D private_intra_doc_links`)
- [x] DAG: `me-types` has **zero `me-*` dependencies** — still a true L0 leaf

## Public API

**No break.** `memory_engine::search::MemoryQuery`, `memory_engine::search::cosine_similarity`, and `read_pak`'s signature all resolve exactly as at base. One *additive* path appears (`memory_engine::types::search::MemoryQuery`), consistent with its sibling DTOs, which already sit at both paths.

Refs #940
