### PR TITLE
chore(build): switch CI to manual dispatch + correct the docs that claim CI runs automatically

### DIFF
--- a/.claude/skills/qa-sweep/SKILL.md
+++ b/.claude/skills/qa-sweep/SKILL.md
@@ -16,10 +16,13 @@ Pairs with the global `super-qa`, `finish-pr`, and `address-issue` skills (those
 
 ---
 
-## 0. The authoritative gate (the CI contract)
+## 0. The authoritative gate (YOU run it — #989)
 
-CI (`.github/workflows/ci.yml`) is the single source of truth. Run the **exact** commands below;
-a local pass that diverges (weaker features, narrower scope, piped output) is a **false pass**.
+⚠️ **CI is `workflow_dispatch`-only. It does NOT run on push or PR.** So the commands below are
+not a pre-check with CI as the backstop — **they are the gate**, and nothing runs automatically to
+catch a sweep that skipped them. Run the **exact** commands; a local pass that diverges (weaker
+features, narrower scope, piped output — trap #1 masks the exit code) is a **false pass**, and now
+an *undetected* one. Treat a PR with no dispatched run as **unverified by machine**.
 
 ```bash
 cargo fmt --all --check                                                # Format
@@ -27,14 +30,30 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy 
 cargo build --workspace                                                # Build (default features)
 cargo build --workspace --all-features                                 # Build (all features)
 cargo test  --workspace --all-features                                 # Test
+cargo check -p memory-engine                                           # Facade-alone, default — the TRUE archive-OFF gate (#978)
+cargo check -p memory-engine --no-default-features --features backend-sqlite  # Facade-alone, no-default
 export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
 cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only; #915 widens to --workspace)
 cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain
 ```
 
-MSRV is **1.88** (let-chains). The MSRV CI job builds `--workspace --tests --examples` on exactly
-1.88, default _and_ all-features — a dev-dep needing newer Rust fails it.
+The two facade-alone `cargo check`s are **not optional padding**: the `--workspace` builds cannot
+cover them, because feature unification turns `archive` on for the whole workspace. They are the
+only thing that compiles the configuration downstream consumers get by default — added in #978
+after exactly that coverage vanished silently.
+
+**Dispatching and monitoring CI** (it will not run itself):
+
+```bash
+gh workflow run ci.yml --ref <branch>       # dispatch
+gh run list --workflow=ci.yml --limit 1     # find the run
+gh run watch <run-id>                       # follow it
+```
+
+MSRV is **1.88** (let-chains). The workflow's MSRV job builds `--workspace --tests --examples` on
+exactly 1.88, default _and_ all-features — a dev-dep needing newer Rust fails it. Reproduce it
+locally if you touch let-chains or edition-sensitive code; it will not run on its own either.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,22 @@
 name: CI
 
+# MANUAL DISPATCH ONLY (#989). CI does **not** run on push or pull_request — it runs
+# when someone asks it to:
+#
+#     gh workflow run ci.yml --ref <branch>          # dispatch
+#     gh run list --workflow=ci.yml --limit 1        # find it
+#     gh run watch <run-id>                          # follow it
+#
+# Why: GitHub-hosted runner minutes. A self-hosted runner is the intended long-term fix,
+# after which this reverts to `push: [main]` + `pull_request` — a one-line change.
+#
+# ⚠️ CONSEQUENCE, and it is not small: the local gate matrix in CLAUDE.md / AGENTS.md /
+# GEMINI.md is no longer a redundant pre-check with CI as the backstop. **It is now the
+# primary verification.** Nothing runs automatically to catch a matrix that was skipped,
+# run with narrower features, or piped (which masks the exit code — trap #1 = false green).
+# Those files say so explicitly; keep them in sync if this trigger changes.
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   fmt:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ No external services needed — SQLite is bundled via `rusqlite`.
 
 ## Verify
 
-These are the **exact** commands CI runs (`.github/workflows/ci.yml`). A local pass that diverges from them — weaker features, narrower scope, or piped output — is a **false pass**:
+⚠️ **CI is `workflow_dispatch`-only — it does NOT run on push or PR** (#989). This matrix is therefore the **primary** verification, not a pre-check with CI as a backstop: nothing runs automatically to catch you skipping it. `.github/workflows/ci.yml` runs these same commands *when dispatched* (`gh workflow run ci.yml --ref <branch>`). A local pass that diverges from them — weaker features, narrower scope, or piped output — is a **false pass**, and now an *undetected* one. Treat a PR with no CI run as **unverified by machine**:
 
 ```bash
 cargo fmt --all --check                                                # Format
@@ -32,7 +32,7 @@ cargo doc --no-deps -p memory-engine --all-features                    # Docs, a
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
-Run all of them after every change. Do not skip any, and do not substitute a weaker variant. CI also runs an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it if you touch let-chains or edition-sensitive code.
+Run all of them after every change. Do not skip any, and do not substitute a weaker variant — with CI on manual dispatch, there is no second chance to catch it. The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code.
 
 **Critical:** The workspace contains **4 crates** — `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can break the CLI, MCP, and embed crates silently if only the root crate is checked. Always use `--workspace`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy 
 cargo build --workspace                                                # Build (default features)
 cargo build --workspace --all-features                                 # Build (all features)
 cargo test  --workspace --all-features                                 # Test — --all-features is mandatory, or ann/archive/eval tests never run
+cargo check -p memory-engine                                           # Facade-alone, default features — the TRUE archive-OFF gate (#978)
+cargo check -p memory-engine --no-default-features --features backend-sqlite  # Facade-alone, no-default
 export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
 cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only)
 cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
@@ -33,6 +35,14 @@ cargo deny check                                                       # Supply-
 ```
 
 Run all of them after every change. Do not skip any, and do not substitute a weaker variant — with CI on manual dispatch, there is no second chance to catch it. The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code.
+
+**Dispatching and monitoring CI** (it will not run itself):
+
+```bash
+gh workflow run ci.yml --ref <branch>       # dispatch
+gh run list --workflow=ci.yml --limit 1     # find the run
+gh run watch <run-id>                       # follow it
+```
 
 **Critical:** The workspace contains **4 crates** — `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can break the CLI, MCP, and embed crates silently if only the root crate is checked. Always use `--workspace`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ uv run sphinx-build -b html docs docs/_build  # narrative docs (Python 3.12+)
 
 Feature flags: `backend-sqlite` (default; the in-process SQLite backend — a #633 marker today, since `rusqlite` is still unconditional), `backend-postgres` (the #633 `PgBackend`: `deadpool-postgres` pool + fresh v14 migration chain + `SchemaManager`), `ann` (HNSW vector search), `archive` (cold storage .pak files), `compress-gzip`, `compress-zstd`, `test-util` (cross-crate test-only port hooks). At least one backend feature must be enabled (a `compile_error!` in `lib.rs` enforces it). `tokio` is a **non-optional** dependency — the engine is async-native, so there is no `async` feature to toggle (#702). The `backend-postgres` live tests are `#[ignore]`-by-default (they need a Docker/Postgres testcontainer) and also require `test-util` (they drive the `raw_exec` failure-injection seam, which is `test-util`-gated since #816): `cargo test -p memory-engine --features backend-postgres,test-util -- --ignored`.
 
-**Verification gate — this is the CI contract** (`.github/workflows/ci.yml`); run it before every commit, especially when touching `error.rs`, `types/`, `traits.rs`, `lib.rs`, or any public API. These are the _exact_ commands CI runs — a local pass that diverges from them (weaker features, narrower scope, piped output) is a **false pass**:
+**Verification gate — YOU are the runner** (#989). ⚠️ **CI is `workflow_dispatch`-only — it does NOT run on push or PR.** So this matrix is not a redundant pre-check with CI as the backstop; **it is the primary verification, and nothing runs automatically to catch you skipping it.** Run it before every commit, especially when touching `error.rs`, `types/`, `traits.rs`, `lib.rs`, or any public API. `.github/workflows/ci.yml` runs these same commands *when dispatched* — a local pass that diverges (weaker features, narrower scope, piped output) is a **false pass**, and now an *undetected* one:
 
 ```bash
 cargo fmt --all --check                                                # Format
@@ -52,7 +52,17 @@ cargo doc --no-deps -p memory-engine --all-features                    # Docs, a
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
-CI also runs an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it if you touch let-chains or edition-sensitive code.
+The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code.
+
+**Dispatching CI** (it will not run itself):
+
+```bash
+gh workflow run ci.yml --ref <branch>       # dispatch
+gh run list --workflow=ci.yml --limit 1     # find the run
+gh run watch <run-id>                       # follow it
+```
+
+CI went manual to conserve GitHub-hosted runner minutes; a **self-hosted runner** is the intended long-term fix, after which the trigger reverts to `push: [main]` + `pull_request` (a one-line change). Until then, treat a PR with no CI run as **unverified by machine** — the only evidence it works is the matrix above, run by you, unpiped.
 
 The workspace contains **10 crates**: the Wave 2 (#816) core decomposition is S1+S2 done — `me-types` (L0 data + error vocabulary, incl. the embedding-space registry DTOs), `me-traits` (L0.5 consumer/contract traits), `me-storage` (L1 persistence port + `MemoryCtx` + `UpcasterRegistry`), `me-index` (L2 backend-free `MemoryGraph`/`ScopeTree` projections), `me-backend-sqlite` (L2 `SqliteBackend`: store + pool + search + snapshot I/O), and `me-backend-postgres` (L2 `PgBackend` skeleton, #633, optional behind `backend-postgres`) are now carved out as separate acyclic leaves; the `memory-engine` facade re-exports them (public API unchanged) and still holds the L3 primitives as modules (they carve into `me-{ingest,query,consolidate,forget,resolve,archive}` in slices S3–S6 — see ADR 0018 / #925). Plus `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`, which consume the facade's public API. `--workspace` is mandatory — a change to error variants, type definitions, or trait signatures can break the consumers silently if only one crate is checked.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy 
 cargo build --workspace                                                # Build (default features)
 cargo build --workspace --all-features                                 # Build (all features)
 cargo test  --workspace --all-features                                 # Test — NB: --all-features, or ann/archive/eval tests never run
+cargo check -p memory-engine                                           # Facade-alone, default features — the TRUE archive-OFF gate (#978)
+cargo check -p memory-engine --no-default-features --features backend-sqlite  # Facade-alone, no-default
 export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
 cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only; #915 widens to --workspace)
 cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -20,7 +20,7 @@ cargo bench                           # Criterion benchmarks
 cargo doc --no-deps --open            # API reference
 ```
 
-**Verification gate — the CI contract** (`.github/workflows/ci.yml`); run before every commit. These are the _exact_ commands CI runs. A local pass that diverges — weaker features, narrower scope, or **piped output** — is a **false pass**:
+**Verification gate — YOU are the runner** (#989). ⚠️ **CI is `workflow_dispatch`-only — it does NOT run on push or PR**, so this matrix is the **primary** verification, not a pre-check with CI as a backstop: nothing runs automatically to catch you skipping it. Run it before every commit. `.github/workflows/ci.yml` runs these same commands *when dispatched* (`gh workflow run ci.yml --ref <branch>`). A local pass that diverges — weaker features, narrower scope, or **piped output** — is a **false pass**, and now an *undetected* one. Treat a PR with no CI run as **unverified by machine**:
 
 ```bash
 cargo fmt --all --check                                                # Format
@@ -34,7 +34,7 @@ cargo doc --no-deps -p memory-engine --all-features                    # Docs, a
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
-CI also runs an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it if you touch let-chains or edition-sensitive code.
+The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code. Dispatch CI with `gh workflow run ci.yml --ref <branch>`; it will not run itself.
 
 The workspace contains **4 crates**: `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can silently break the CLI, MCP, and embed crates if only the root crate is checked. Always use `--workspace`.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -28,13 +28,23 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings   # Clippy 
 cargo build --workspace                                                # Build (default features)
 cargo build --workspace --all-features                                 # Build (all features)
 cargo test  --workspace --all-features                                 # Test — --all-features is mandatory, or ann/archive/eval tests never run
+cargo check -p memory-engine                                           # Facade-alone, default features — the TRUE archive-OFF gate (#978)
+cargo check -p memory-engine --no-default-features --features backend-sqlite  # Facade-alone, no-default
 export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"
 cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only)
 cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
 ```
 
-The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code. Dispatch CI with `gh workflow run ci.yml --ref <branch>`; it will not run itself.
+The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code.
+
+**Dispatching and monitoring CI** (it will not run itself):
+
+```bash
+gh workflow run ci.yml --ref <branch>       # dispatch
+gh run list --workflow=ci.yml --limit 1     # find the run
+gh run watch <run-id>                       # follow it
+```
 
 The workspace contains **4 crates**: `memory-engine` (core lib), `memory-engine-cli`, `memory-engine-mcp`, `memory-engine-embed`. Changes to `error.rs`, `types/`, `traits.rs`, or any public API in the core crate can silently break the CLI, MCP, and embed crates if only the root crate is checked. Always use `--workspace`.
 


### PR DESCRIPTION
## What

CI (`.github/workflows/ci.yml`) now runs **only on `workflow_dispatch`** — not on push, not on PR.

**Closes #989.**

```bash
gh workflow run ci.yml --ref <branch>       # dispatch
gh run list --workflow=ci.yml --limit 1     # find the run
gh run watch <run-id>                       # follow it
```

## Why

Conserving GitHub-hosted runner minutes. A **self-hosted runner** is the intended long-term fix; after it lands, this reverts to `push: [main]` + `pull_request` — a one-line change.

## Why this isn't a one-line commit

`CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` all described the gate matrix as **"the *exact* commands CI runs"**. The instant the trigger goes manual, that sentence tells every agent reading it that a green PR was machine-verified — **when nothing ran at all**.

That is exactly the defect class this repo keeps paying for: **a doc asserting a guard that no longer fires.** Recent instances: #987's docs teaching the rejected recursion-trap design; #986's `cargo public-api` "proof" that couldn't see what it claimed; the `.pak` schema gate whose halves were free to diverge. Flipping the trigger without the docs would have *manufactured* one deliberately.

## The consequence, stated where it will be read

**The local gate matrix stops being redundant and becomes the primary verification.**

Before: CI was the backstop that caught a skipped or weakened local run. Now there is no backstop. If the matrix is skipped, run with narrower features, or piped — trap #1, where the pipe discards cargo's exit code and yields a **false green** — *nothing else catches it*.

All three docs now say this plainly:

> **Verification gate — YOU are the runner.** ⚠️ CI is `workflow_dispatch`-only — it does **not** run on push or PR. So this matrix is not a redundant pre-check with CI as the backstop; **it is the primary verification, and nothing runs automatically to catch you skipping it.** … A local pass that diverges is a **false pass**, and now an *undetected* one. Treat a PR with no CI run as **unverified by machine**.

A **by-rule** grep sweep (for the stale claim itself, not per-file) caught two more sites beyond the three headline ones — both *"CI also runs an **MSRV** job"*. That method is deliberate: #987 taught that fixing the five sites you can see leaves the five you can't.

## Verification

The gate matrix — which **is** the gate now — run locally, unpiped:

| gate | result |
| --- | --- |
| `cargo fmt --all --check` | ✅ 0 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | ✅ 0 |
| `cargo test --workspace --all-features` | ✅ **1971 passed / 0 failed** |

YAML validated by parse: `triggers: {'workflow_dispatch': None}` · jobs intact (`fmt, clippy, docs, build, test, cargo-deny, msrv`).

**Sweep proof:** `grep -rn "exact commands CI runs\|CI also runs" CLAUDE.md AGENTS.md GEMINI.md` → **no matches**.

## Review findings — all accepted and fixed

Three reviewers converged on **the same defect, and it was mine**: the gate matrix this PR promotes to "the primary verification" was **missing two of CI's own commands**.

| Reviewer | Finding | Fix |
| --- | --- | --- |
| `chatgpt-codex-connector` (P2) | Matrix omits `cargo check -p memory-engine` ×2 — the archive-OFF gates | `11cefbf` |
| `[Codex Review]` (HIGH) | Same, independently — *"an agent can run every documented 'primary' command, report a local pass, and receive no automatic CI run to catch either"* | `11cefbf` |
| `[Codex Review]` (MEDIUM) | `.claude/skills/qa-sweep/SKILL.md` still called CI *"the single source of truth"* | `b3fbbee` |
| `gemini-code-assist` (×2 medium) | AGENTS.md / GEMINI.md lacked CLAUDE.md's dispatch-and-monitor block | `11cefbf` |

**Why the first one matters more than its severity suggests.** `ci.yml:85,87` run two facade-alone checks the matrix never listed — so *"these are the **exact** commands CI runs"* was **already false before this PR**. This PR doesn't create that; it makes it **load-bearing**, by promoting an incomplete matrix to the primary gate. And those two exist because of **#978**, where feature unification silently killed archive-OFF coverage — the config downstream consumers get by default. The guard added to catch a real defect would have gone unenforced by the very PR claiming to protect verification.

**And my "by-rule sweep" was scoped to three files** — by-*file* wearing a by-rule costume, the exact mistake I'd claimed to avoid. Codex caught `qa-sweep/SKILL.md` (tracked in git, so it ships to every clone, and it's the file a multi-PR QA session reads first). The sweep is now genuinely repo-wide:

```
.claude/skills/qa-sweep/SKILL.md   missing-vs-CI: NONE ✅
AGENTS.md                          missing-vs-CI: NONE ✅
CLAUDE.md                          missing-vs-CI: NONE ✅
GEMINI.md                          missing-vs-CI: NONE ✅
VERDICT: every gate matrix in the repo ⊇ CI ✅
```

**Blocker check cleared:** branch protection returns **404 "Branch not protected"**; effective rules and rulesets empty. A required status check that could no longer arrive would have blocked *every* future merge — it doesn't exist.

**Not fixed here → #991.** Nothing enforces `docs == ci.yml`. The drift was invisible while CI was the real gate; #989 removes that slack. The fix is a test that asserts the match, running under `cargo test --workspace --all-features` — the guard inside the matrix it guards.

## Test plan

- [x] `cargo fmt --all --check` — exit 0
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
- [x] `cargo test --workspace --all-features` — 1971 passed / 0 failed
- [x] `cargo check -p memory-engine` (newly added to the matrix) — exit 0
- [x] `cargo check -p memory-engine --no-default-features --features backend-sqlite` (newly added) — exit 0
- [x] `ci.yml` parses; trigger is `workflow_dispatch` only; all 7 jobs intact (`fmt, clippy, docs, build, test, cargo-deny, msrv`)
- [x] **Repo-wide** sweep: no surviving doc claim that CI runs automatically — 0 matches
- [x] **Every gate matrix in the repo covers every CI command** — verified mechanically, whitespace-normalised
- [x] Branch protection: 404 not-protected; no required check stranded
