### PR TITLE
refactor(build): S6 — just linkmap/symbols legibility tooling + fuzz-crate gate (#942, #993)

### DIFF
--- a/.claude/skills/qa-sweep/SKILL.md
+++ b/.claude/skills/qa-sweep/SKILL.md
@@ -36,7 +36,10 @@ export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intr
 cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only; #915 widens to --workspace)
 cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain
+cargo +nightly fuzz build                                              # Fuzz gate (#993) — detached fuzz/ consumes the facade API; needs nightly + cargo-fuzz
 ```
+
+The last line is the **facade-API gate** (#993): `fuzz/` is a detached workspace that no `--workspace` command compiles, yet it consumes the facade public API by path — a removal or rename can break it silently. Needs nightly + cargo-fuzz (`just fuzz-build` wraps it); incremental (a seconds-long no-op when the facade is unchanged).
 
 The two facade-alone `cargo check`s are **not optional padding**: the `--workspace` builds cannot
 cover them, because feature unification turns `archive` on for the whole workspace. They are the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       # The detached `fuzz/` workspace builds into `fuzz/target`, which rust-cache's default
-      # (`. -> target`) does NOT cover — cache it explicitly so this nightly build is not cold
-      # on every dispatch (the #989 runner-minute motive that made CI manual).
+      # (`. -> target`) does NOT cover — cache it explicitly. Caveat: `@nightly` moves daily and
+      # rust-cache keys on the rustc commit, so this warms repeated dispatches on the SAME
+      # nightly, not across days — still worth it given the #989 runner-minute motive.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "fuzz -> target"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,28 @@ jobs:
       - name: cargo test (all features)
         run: cargo test --workspace --all-features
 
+  fuzz:
+    name: Fuzz build (#993)
+    runs-on: ubuntu-latest
+    # The detached `fuzz/` workspace (empty `[workspace]`) consumes the facade public API
+    # by path, but NO `--workspace` job compiles it — it needs nightly + the libFuzzer
+    # sanitizer runtime. This is the only gate that catches a facade API removal/rename
+    # breaking a real in-repo consumer. Mirrors `cargo +nightly fuzz build` in the local
+    # gate matrix (CLAUDE.md / AGENTS.md / GEMINI.md / qa-sweep). See #993.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      # The detached `fuzz/` workspace builds into `fuzz/target`, which rust-cache's default
+      # (`. -> target`) does NOT cover — cache it explicitly so this nightly build is not cold
+      # on every dispatch (the #989 runner-minute motive that made CI manual).
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "fuzz -> target"
+      - name: install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+      - name: cargo +nightly fuzz build
+        run: cargo +nightly fuzz build
+
   cargo-deny:
     name: Supply-chain (cargo-deny)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,10 @@ export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intr
 cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only)
 cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
+cargo +nightly fuzz build                                              # Fuzz gate (#993) — detached fuzz/ consumes the facade API; needs nightly + cargo-fuzz
 ```
 
-Run all of them after every change. Do not skip any, and do not substitute a weaker variant — with CI on manual dispatch, there is no second chance to catch it. The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code.
+Run all of them after every change. Do not skip any, and do not substitute a weaker variant — with CI on manual dispatch, there is no second chance to catch it. The last line is the **facade-API gate** (#993): `fuzz/` is a detached workspace that no `--workspace` command compiles, yet it consumes the facade public API by path — so a removal or rename can break it silently. It needs nightly + cargo-fuzz (`just fuzz-build` wraps it) and is incremental (a seconds-long no-op when the facade is unchanged). The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code.
 
 **Dispatching and monitoring CI** (it will not run itself):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ cargo fmt --check                     # format check
 cargo bench                           # Criterion benchmarks
 cargo doc --no-deps --open            # API reference
 uv run sphinx-build -b html docs docs/_build  # narrative docs (Python 3.12+)
+just --list                           # dev task runner (install: cargo install just) — linkmap / symbols / fuzz-build
 ```
 
 Feature flags: `backend-sqlite` (default; the in-process SQLite backend — a #633 marker today, since `rusqlite` is still unconditional), `backend-postgres` (the #633 `PgBackend`: `deadpool-postgres` pool + fresh v14 migration chain + `SchemaManager`), `ann` (HNSW vector search), `archive` (cold storage .pak files), `compress-gzip`, `compress-zstd`, `test-util` (cross-crate test-only port hooks). At least one backend feature must be enabled (a `compile_error!` in `lib.rs` enforces it). `tokio` is a **non-optional** dependency — the engine is async-native, so there is no `async` feature to toggle (#702). The `backend-postgres` live tests are `#[ignore]`-by-default (they need a Docker/Postgres testcontainer) and also require `test-util` (they drive the `raw_exec` failure-injection seam, which is `test-util`-gated since #816): `cargo test -p memory-engine --features backend-postgres,test-util -- --ignored`.
@@ -52,7 +53,10 @@ export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intr
 cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only; #915 widens to --workspace)
 cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
+cargo +nightly fuzz build                                              # Fuzz gate (#993) — detached fuzz/ consumes the facade API; needs nightly + cargo-fuzz
 ```
+
+The last line is the **facade-API gate** (#993): the `fuzz/` crate is a *deliberately detached* workspace (empty `[workspace]`, nightly + libFuzzer), so **no `--workspace` command compiles it** — yet it consumes `memory-engine` / `-embed` / `-mcp` public API by path. A facade removal or rename can therefore break a real in-repo consumer with nothing else noticing. It needs `nightly` + `cargo-fuzz` (`rustup toolchain install nightly; cargo install cargo-fuzz --locked`), and it is *incremental* — a seconds-long no-op when the facade is unchanged, a ~2-min rebuild exactly when it changed. `just fuzz-build` is the equivalent one-word wrapper.
 
 The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -34,7 +34,10 @@ export RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intr
 cargo doc --no-deps -p memory-engine                                   # Docs, default features (core crate only)
 cargo doc --no-deps -p memory-engine --all-features                    # Docs, all features
 cargo deny check                                                       # Supply-chain (advisories/licenses/bans/sources)
+cargo +nightly fuzz build                                              # Fuzz gate (#993) — detached fuzz/ consumes the facade API; needs nightly + cargo-fuzz
 ```
+
+The last line is the **facade-API gate** (#993): `fuzz/` is a detached workspace that no `--workspace` command compiles, yet it consumes the facade public API by path — so a removal or rename can break it silently. It needs nightly + cargo-fuzz (`just fuzz-build` wraps it) and is incremental (a seconds-long no-op when the facade is unchanged).
 
 The workflow also carries an **MSRV** job — `cargo +1.88 build --workspace --tests --examples` (default _and_ all-features); reproduce it locally if you touch let-chains or edition-sensitive code.
 

--- a/docs/design/adr/0018-wave2-crate-decomposition-memoryctx.md
+++ b/docs/design/adr/0018-wave2-crate-decomposition-memoryctx.md
@@ -223,12 +223,15 @@ yet. So the two things a freeze buys are both worth little today:
 > facade API types directly (`memory_engine::{ActivityFilterConfig, MemoryEngine}`,
 > `memory_engine::{Edge, Event, Fact}`, `memory_engine::fuzz_seam::*`).
 >
-> So a facade removal **can** break a real in-repository Rust consumer with **no gate
-> detecting it** — `cargo +nightly fuzz build` is the only thing that would, and it is
-> not in the gate matrix. That is a genuine hole, and it is a hole *today*, independent
-> of any freeze. It does not overturn the deferral (fuzz is in-repo, ours to fix, and a
+> So a facade removal **can** break a real in-repository Rust consumer that the
+> `--workspace` run never compiles, and **until #993 no gate detected it** —
+> `cargo +nightly fuzz build` is the only thing that would. That was a genuine hole,
+> independent of any freeze, and **#993 closed it**: the gate matrix (CLAUDE.md /
+> AGENTS.md / GEMINI.md / qa-sweep) and a dedicated `fuzz` CI job now
+> run `cargo +nightly fuzz build` (wrapped as `just fuzz-build`). It does not overturn the
+> deferral (fuzz is in-repo, ours to fix, and a
 > break is discoverable and repairable in the same PR — unlike a downstream consumer we
-> cannot touch), but the claim needed narrowing rather than defending. Tracked in **#993**.
+> cannot touch), but the claim needed narrowing rather than defending. Resolved in **#993**.
 > Surfaced by Codex in the #992 review; the original wording was mine and it was wrong.
 
 Meanwhile the cost is immediate and recurring: every *intentional* break — Phase 5 (#567),

--- a/justfile
+++ b/justfile
@@ -1,0 +1,91 @@
+# memory-engine — developer task runner.
+#
+# Wave 2 (#816 / S6, #942) legibility tooling: make the 18-crate link graph and
+# the shipped symbol surface inspectable, so the decomposition is legible in
+# practice — not just on paper. The crate split already delivered the structural
+# value; these recipes let you *see* it.
+#
+# Requires `just` (https://github.com/casey/just):  cargo install just
+# Individual recipes name any extra tooling they need and print an install hint
+# when it is missing, so a fresh clone degrades gracefully instead of erroring.
+
+# List the available recipes (runs on a bare `just`).
+default:
+    @just --list --unsorted
+
+# The link graph of the shipped facade: the layered crate DAG (normal edges = what
+# actually links, dev-deps excluded), each crate's contribution to binary size,
+# and the native system libraries the final link pulls in. This is the "can I SEE
+# the 18-crate split?" report the Wave 2 plan (#925 §8 / §11) calls for.
+
+# Report the crate DAG, per-crate binary-size split, and native link libs.
+linkmap:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    sep() { printf '\n── %s ──\n' "$1"; }
+
+    sep "Crate DAG — facade \`memory-engine\`, normal edges (the ship graph)"
+    cargo tree -p memory-engine --edges normal
+
+    sep "Per-crate contribution to the release \`memory-engine-cli\` binary"
+    if command -v cargo-bloat >/dev/null 2>&1; then
+        cargo bloat --release --crates --bin memory-engine-cli || echo "  (cargo bloat failed)"
+    else
+        echo "  (skipped — install with: cargo install cargo-bloat)"
+    fi
+
+    sep "Native static libs the final link requires"
+    # `--print native-static-libs` only emits for a `staticlib` crate-type, so override
+    # it for this one rustc invocation (the facade's real crate-type is untouched). Use a
+    # dedicated target-dir so this throwaway staticlib build does NOT invalidate the normal
+    # release artifacts `just symbols` shares.
+    nsl=$(cargo rustc -p memory-engine --release --quiet --lib --crate-type staticlib \
+        --target-dir target/linkmap-nsl -- --print native-static-libs 2>&1 || true)
+    if echo "$nsl" | grep -qi 'native-static-libs:'; then
+        echo "$nsl" | grep -i 'native-static-libs:'
+    elif echo "$nsl" | grep -qiE 'error(\[|:)'; then
+        echo "  (staticlib probe failed to compile — rerun verbose: cargo rustc -p memory-engine --release --lib --crate-type staticlib -- --print native-static-libs)"
+    else
+        echo "  (rustc reported none; run \`ldd target/release/memory-engine-cli\` for runtime shared libs)"
+    fi
+
+# The shipped symbol surface: the *dynamic* symbols the release binaries export for
+# dynamic linking (`nm -D`, Linux/ELF-specific). A fat static bin exports almost nothing
+# dynamically — that near-empty list IS the signal that it is self-contained. The `dylib`
+# ship mode that would make this surface explode into the ABI is deferred (#994); today
+# these are the default fat static bins.
+
+# Report exported dynamic symbols of the release cli + mcp binaries.
+symbols:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo build --release --bins
+    for art in target/release/memory-engine-cli target/release/memory-engine-mcp; do
+        name=$(basename "$art")
+        if [ ! -e "$art" ]; then printf '── %s: (not built) ──\n' "$name"; continue; fi
+        count=$(nm -D --defined-only "$art" 2>/dev/null | wc -l | tr -d ' ')
+        printf '── %s: %s exported dynamic symbols ──\n' "$name" "$count"
+        nm -D --defined-only "$art" 2>/dev/null | awk '{print "   " $NF}' | sort | head -30 || true
+        [ "${count:-0}" -gt 30 ] && echo "   … ($((count - 30)) more; full: nm -D --defined-only $art)" || true
+    done
+
+# The fuzz crate (`./fuzz`) is a DETACHED workspace: the repo-root
+# `cargo build --workspace` never compiles it, yet it consumes the facade public
+# API by path (memory-engine / -embed / -mcp). A facade API removal can break it
+# with no default gate noticing (#993). This recipe IS that gate — it builds
+# every fuzz target against the current facade. Needs a nightly toolchain +
+# cargo-fuzz; both guarded below with an install hint.
+
+# Build the detached fuzz targets against the facade API (#993 gate; needs nightly + cargo-fuzz).
+fuzz-build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! rustup toolchain list 2>/dev/null | grep -q nightly; then
+        echo "error: needs a nightly toolchain — rustup toolchain install nightly" >&2
+        exit 1
+    fi
+    if ! cargo +nightly fuzz --version >/dev/null 2>&1; then
+        echo "error: needs cargo-fuzz — cargo install cargo-fuzz --locked" >&2
+        exit 1
+    fi
+    cargo +nightly fuzz build

--- a/justfile
+++ b/justfile
@@ -39,21 +39,23 @@ linkmap:
     # it for this one rustc invocation (the facade's real crate-type is untouched). Use a
     # dedicated target-dir so this throwaway staticlib build does NOT invalidate the normal
     # release artifacts `just symbols` shares.
-    nsl=$(cargo rustc -p memory-engine --release --quiet --lib --crate-type staticlib \
-        --target-dir target/linkmap-nsl -- --print native-static-libs 2>&1 || true)
-    if echo "$nsl" | grep -qi 'native-static-libs:'; then
-        echo "$nsl" | grep -i 'native-static-libs:'
-    elif echo "$nsl" | grep -qiE 'error(\[|:)'; then
-        echo "  (staticlib probe failed to compile — rerun verbose: cargo rustc -p memory-engine --release --lib --crate-type staticlib -- --print native-static-libs)"
+    # Branch on cargo's real exit status (not a diagnostic-regex heuristic) so a genuine
+    # staticlib compile failure is never misreported as "no native libs"; match with a
+    # here-string, never `echo "$nsl" | grep`, which can take SIGPIPE on a large payload.
+    if nsl=$(cargo rustc -p memory-engine --release --quiet --lib --crate-type staticlib \
+        --target-dir target/linkmap-nsl -- --print native-static-libs 2>&1); then
+        grep -i 'native-static-libs:' <<<"$nsl" \
+            || echo "  (staticlib built, but rustc emitted no native-static-libs line)"
     else
-        echo "  (rustc reported none; run \`ldd target/release/memory-engine-cli\` for runtime shared libs)"
+        echo "  (staticlib probe failed to compile — rerun verbose: cargo rustc -p memory-engine --release --lib --crate-type staticlib -- --print native-static-libs)"
     fi
 
-# The shipped symbol surface: the *dynamic* symbols the release binaries export for
-# dynamic linking (`nm -D`, Linux/ELF-specific). A fat static bin exports almost nothing
-# dynamically — that near-empty list IS the signal that it is self-contained. The `dylib`
-# ship mode that would make this surface explode into the ABI is deferred (#994); today
-# these are the default fat static bins.
+# The shipped symbol surface: the *dynamic* symbols the release binaries EXPORT
+# (`nm -D --defined-only`, Linux/ELF-specific). A leaf executable exports almost nothing —
+# but a near-empty list means "provides no dynamic symbols", NOT "self-contained": the bins
+# still dynamically link system libs (libssl / libc / … — see `ldd`) while statically
+# linking the Rust crate graph. This exported surface only gets interesting for the deferred
+# `dylib` ship mode (#994), where the facade's ABI would show up here.
 
 # Report exported dynamic symbols of the release cli + mcp binaries.
 symbols:
@@ -63,6 +65,12 @@ symbols:
     for art in target/release/memory-engine-cli target/release/memory-engine-mcp; do
         name=$(basename "$art")
         if [ ! -e "$art" ]; then printf '── %s: (not built) ──\n' "$name"; continue; fi
+        # `nm -D` is Linux/ELF-specific; on a Mach-O/BSD `nm` it errors, which under
+        # `set -euo pipefail` would hard-crash the recipe. Guard so it degrades gracefully.
+        if ! nm -D --defined-only "$art" >/dev/null 2>&1; then
+            printf '── %s: dynamic-symbol listing unsupported here (needs Linux/ELF `nm -D`) ──\n' "$name"
+            continue
+        fi
         count=$(nm -D --defined-only "$art" 2>/dev/null | wc -l | tr -d ' ')
         printf '── %s: %s exported dynamic symbols ──\n' "$name" "$count"
         nm -D --defined-only "$art" 2>/dev/null | awk '{print "   " $NF}' | sort | head -30 || true


### PR DESCRIPTION
## Summary

**S6 — the last slice of the Wave 2 crate decomposition (#942)** — plus its collateral **fuzz-crate gate (#993)**. No production code changes: a new `justfile`, one CI job, and doc/matrix updates. The anti-#903 suite stays at **1975** tests.

## What / Why / How

**Legibility tooling (#942, S6's required half).** The 18-crate split is only legible if you can *see* the link graph. New `justfile`:
- `just linkmap` — the crate DAG (`cargo tree --edges normal`), per-crate binary-size contribution (`cargo bloat --release --crates`), and native link libs (`rustc --print native-static-libs`, via an isolated throwaway `staticlib` build in `target/linkmap-nsl` so it never churns the normal release artifacts).
- `just symbols` — the exported dynamic symbols of the release bins (`nm -D --defined-only`, guarded for non-Linux). A leaf executable exports ~nothing — this surface only gets interesting for the deferred #994 dylib.
- `just` documented as a dev prerequisite (CLAUDE.md).

**dylib ship mode (#942 spike) — DEFERRED to #994 per plan §G's box.** Probed: `crate-type=["rlib","dylib"]` builds cleanly and leaves default bins static, but (a) `-Cprefer-dynamic` bins are incompatible with the release `lto="thin"` profile (`error: cannot prefer dynamic linking when performing LTO`), and (b) the crate-type inflicts an always-on ~142M `.so` on every facade build with no clean opt-in (crate-type can't be feature/profile-gated). §11 lists deferral-with-tracking-issue as a co-equal success outcome. Crate-type reverted; #994 filed under #816 with the full probe record.

**Fuzz-crate gate (#993).** The detached `fuzz/` workspace consumes the facade public API by path, but no `--workspace` command compiles it — so a facade API removal could break a real in-repo consumer unnoticed. `cargo +nightly fuzz build` (confirmed passing on this branch) is now in the gate matrix (CLAUDE.md / AGENTS.md / GEMINI.md / qa-sweep — byte-identical) + a dedicated `fuzz` ci.yml job (cache scoped to `fuzz/target`) + a `just fuzz-build` wrapper. ADR-0018's narrowed claim updated to record the resolution.

## Super-review

Reviewed by 3 diverse-lens adversarial subagents (shell-correctness / CI-gate-integrity / decision-completeness) + **Codex** (external, `gpt-5.6-sol`) + `gemini-code-assist[bot]` — each *ran* the recipes/gate to verify, not just read. All findings triaged against source and fixed:
- subagents: 1 MED (CI rust-cache missed `fuzz/target`) + 6 LOW/NIT → `e3c5141`
- Codex: 1 MED (`nm -D` doesn't prove self-containment) + 2 LOW (native-libs probe status, moving-nightly cache caveat); gemini: 1 MED (non-Linux `nm -D` guard) → `5e2171a`

Codex's external pass caught what the Claude subagents blessed (the "self-contained" framing) and refined a subagent-suggested fix. agy timed out (degraded — Codex covered the external voice). All 4 review threads resolved.

## Test plan

- [x] `just linkmap` reports the crate DAG + per-crate bloat + `native-static-libs`
- [x] `just symbols` reports exported dynamic symbols of the release cli + mcp bins
- [x] `cargo +nightly fuzz build` passes (the #993 gate)
- [x] The fuzz matrix line is byte-identical across CLAUDE.md / AGENTS.md / GEMINI.md / qa-sweep and matches ci.yml
- [x] Full CI-exact gate matrix green; anti-#903 = 1975 exact

Closes #942. Closes #993. Refs #994.
