### PR TITLE
refactor: Wave 2 collateral quick-wins — #980 .pak double-hash · #979 me-archive surface · #969 DIM seeds · #991 docs⊇ci gate

### DIFF
--- a/memory-engine/lib/me-archive/src/lib.rs
+++ b/memory-engine/lib/me-archive/src/lib.rs
@@ -31,9 +31,8 @@
 
 pub mod manage;
 pub mod pak;
-mod search;
+pub mod search;
 pub mod types;
 
 pub use manage::{archive, list_archives, search_archives_fallback, verify_archives};
-pub use search::ArchiveSearchResult;
 pub use types::{ArchiveManifestEntry, ArchivePolicy, ArchiveStats, ArchiveVerifyResult};

--- a/memory-engine/lib/me-archive/src/lib.rs
+++ b/memory-engine/lib/me-archive/src/lib.rs
@@ -31,8 +31,9 @@
 
 pub mod manage;
 pub mod pak;
-pub mod search;
+mod search;
 pub mod types;
 
 pub use manage::{archive, list_archives, search_archives_fallback, verify_archives};
+pub use search::ArchiveSearchResult;
 pub use types::{ArchiveManifestEntry, ArchivePolicy, ArchiveStats, ArchiveVerifyResult};

--- a/memory-engine/lib/me-archive/src/manage.rs
+++ b/memory-engine/lib/me-archive/src/manage.rs
@@ -27,7 +27,7 @@ use me_types::types::archive::ARCHIVE_SCHEMA_VERSION;
 use me_types::types::search::MemoryQuery;
 use me_types::types::{Edge, Fact};
 
-use crate::pak::{hash_file, verify_pak, write_pak_and_hash};
+use crate::pak::{hash_file, write_pak_and_hash};
 use crate::search::{ArchiveSearchResult, is_within_archive_dir, search_archives};
 use crate::types::{
     ArchiveManifestEntry, ArchivePak, ArchivePolicy, ArchiveStats, ArchiveVerifyResult,
@@ -340,26 +340,27 @@ async fn commit_archive(
 }
 
 /// Verify a single `.pak` file against its manifest hash.
+///
+/// Hashes the file exactly once: a `.pak` can be up to the 4 GiB read cap, so the previous
+/// `verify_pak` (bool) + `hash_file` (for the message) sequence read + blake3'd it twice on
+/// the mismatch arm — a full second pass spent only to format an error string (#980).
 fn verify_single_archive(entry: &ArchiveManifestEntry, pak_path: &Path) -> ArchiveVerifyResult {
-    match verify_pak(pak_path, &entry.blake3_hash) {
-        Ok(true) => ArchiveVerifyResult {
+    match hash_file(pak_path) {
+        Ok(actual) if actual == entry.blake3_hash => ArchiveVerifyResult {
             manifest_id: entry.id,
             pak_path: entry.pak_path.clone(),
             ok: true,
             error: None,
         },
-        Ok(false) => {
-            let actual = hash_file(pak_path).unwrap_or_default();
-            ArchiveVerifyResult {
-                manifest_id: entry.id,
-                pak_path: entry.pak_path.clone(),
-                ok: false,
-                error: Some(format!(
-                    "hash mismatch: expected {}, got {actual}",
-                    entry.blake3_hash
-                )),
-            }
-        }
+        Ok(actual) => ArchiveVerifyResult {
+            manifest_id: entry.id,
+            pak_path: entry.pak_path.clone(),
+            ok: false,
+            error: Some(format!(
+                "hash mismatch: expected {}, got {actual}",
+                entry.blake3_hash
+            )),
+        },
         Err(e) => ArchiveVerifyResult {
             manifest_id: entry.id,
             pak_path: entry.pak_path.clone(),

--- a/memory-engine/lib/me-archive/src/pak.rs
+++ b/memory-engine/lib/me-archive/src/pak.rs
@@ -20,7 +20,7 @@ const MAX_PAK_DECOMPRESSED_SIZE: u64 = 4 * 1024 * 1024 * 1024;
 /// fails, or the parent directory does not exist. Returns [`ArchiveError::Codec`] if
 /// the zstd encoder cannot be created or finalized. Any I/O error propagates through
 /// `serde_json::to_writer` as [`MemoryError::Serialization`](me_types::error::MemoryError::Serialization).
-pub fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
+pub(crate) fn write_pak_and_hash(pak: &ArchivePak, path: &Path) -> Result<String> {
     let tmp_path = path.with_extension("pak.tmp");
 
     // O_EXCL: atomic creation — fails if the tmp file already exists, preventing
@@ -195,24 +195,13 @@ fn read_pak_capped(path: &Path, cap: u64) -> Result<ArchivePak> {
 /// # Errors
 ///
 /// Returns [`ArchiveError::Io`] if the file cannot be opened or read.
-pub fn hash_file(path: &Path) -> Result<String> {
+pub(crate) fn hash_file(path: &Path) -> Result<String> {
     let mut file = fs::File::open(path)
         .map_err(|e| ArchiveError::Io(format!("failed to read pak file for hashing: {e}")))?;
     let mut hasher = blake3::Hasher::new();
     std::io::copy(&mut file, &mut hasher)
         .map_err(|e| ArchiveError::Io(format!("failed to hash pak file: {e}")))?;
     Ok(hasher.finalize().to_hex().to_string())
-}
-
-/// Verify a `.pak` file's blake3 hash matches expected.
-///
-/// # Errors
-///
-/// Returns [`ArchiveError::Io`] if the file cannot be opened or read (propagated from
-/// [`hash_file`]).
-pub fn verify_pak(path: &Path, expected_hash: &str) -> Result<bool> {
-    let actual = hash_file(path)?;
-    Ok(actual == expected_hash)
 }
 
 /// Hashes bytes as they pass through to the inner writer.
@@ -272,13 +261,15 @@ mod tests {
     }
 
     #[test]
-    fn hash_and_verify() {
+    fn hash_file_is_stable() {
         let dir = tempfile::tempdir().unwrap();
         let pak_path = dir.path().join("test.pak");
         write_pak(&empty_pak(), &pak_path).unwrap();
         let hash = hash_file(&pak_path).unwrap();
-        assert!(verify_pak(&pak_path, &hash).unwrap());
-        assert!(!verify_pak(&pak_path, "wrong_hash").unwrap());
+        // Deterministic across reads — the property `verify_single_archive` relies on for
+        // its inline `hash == expected` compare (the `verify_pak` wrapper was removed, #979).
+        assert_eq!(hash_file(&pak_path).unwrap(), hash);
+        assert_ne!(hash, "wrong_hash");
     }
 
     #[test]

--- a/memory-engine/lib/me-archive/src/search.rs
+++ b/memory-engine/lib/me-archive/src/search.rs
@@ -85,7 +85,7 @@ impl Ord for MinScored {
 /// (`engine/archive.rs`) exercises it directly across the crate boundary (Wave 2
 /// #816 / S4, sub-PR 3b).
 #[must_use]
-pub fn is_within_archive_dir(pak_path: &str) -> bool {
+pub(crate) fn is_within_archive_dir(pak_path: &str) -> bool {
     Path::new(pak_path)
         .components()
         .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
@@ -132,7 +132,7 @@ const fn entry_is_prunable(_entry: &ArchiveManifestEntry, _query: &MemoryQuery) 
 /// Each `.pak` is opened via [`read_pak`], whose schema gate checks `me-types`'
 /// backend-independent `ARCHIVE_SCHEMA_VERSION` — the same constant the write side
 /// stamps. No backend schema version is involved (Wave 2 #816 / S4, sub-PR 3a).
-pub fn search_archives(
+pub(crate) fn search_archives(
     archive_dir: &Path,
     manifest_entries: &[ArchiveManifestEntry],
     query: &MemoryQuery,

--- a/memory-engine/lib/me-archive/src/search.rs
+++ b/memory-engine/lib/me-archive/src/search.rs
@@ -79,11 +79,10 @@ impl Ord for MinScored {
 /// for not-yet-existing files), and is purely lexical — no `canonicalize`, no
 /// TOCTOU window.
 ///
-/// `pub` (not `pub(crate)`): the **shared archive path-containment guard** — the
-/// sibling `verify_archives` (`crate::manage`) reuses this helper rather than
-/// re-deriving the check (#292), and the facade's retained regression test
-/// (`engine/archive.rs`) exercises it directly across the crate boundary (Wave 2
-/// #816 / S4, sub-PR 3b).
+/// The **shared archive path-containment guard**: `crate::manage`'s `verify_archives`
+/// reuses this helper rather than re-deriving the check (#292). `pub(crate)` — an
+/// implementation detail of me-archive, covered by this module's own traversal unit
+/// tests (the facade tests `verify_archives` end-to-end, not this helper directly; #979).
 #[must_use]
 pub(crate) fn is_within_archive_dir(pak_path: &str) -> bool {
     Path::new(pak_path)

--- a/memory-engine/lib/me-forget/src/policy.rs
+++ b/memory-engine/lib/me-forget/src/policy.rs
@@ -252,6 +252,9 @@ mod tests {
     use super::*;
     use chrono::Duration;
     use me_test_support::factory::ConformanceBackend;
+    // Seed embeddings at the SAME dim the SqliteFactory pool is provisioned with, so a
+    // future change to `DIM` can't silently desync the seed length from the pool (#969).
+    use me_test_support::fixtures::DIM;
     use me_types::types::FactType;
     use proptest::prelude::*;
     use std::collections::HashMap;
@@ -284,7 +287,7 @@ mod tests {
             id: 1,
             content: "important".into(),
             content_hash: "h1".into(),
-            embedding: vec![0.1; 4],
+            embedding: vec![0.1; DIM],
             fact_type: FactType::Semantic,
             t_created: now,
             t_expired: None,
@@ -306,7 +309,7 @@ mod tests {
             id: 2,
             content: "neglected".into(),
             content_hash: "h2".into(),
-            embedding: vec![0.2; 4],
+            embedding: vec![0.2; DIM],
             fact_type: FactType::Episodic,
             t_created: now - Duration::days(180),
             t_expired: None,
@@ -347,7 +350,7 @@ mod tests {
             id: 1,
             content: "test".into(),
             content_hash: "h".into(),
-            embedding: vec![0.1; 4],
+            embedding: vec![0.1; DIM],
             fact_type: FactType::Episodic,
             t_created: now - Duration::days(60),
             t_expired: None,
@@ -384,7 +387,7 @@ mod tests {
 
         let now = Utc::now();
         let old_time = now - Duration::days(100);
-        let embed_dim = 4;
+        let embed_dim = DIM;
 
         let storage = me_test_support::factory::SqliteFactory.make().await;
 
@@ -483,7 +486,7 @@ mod tests {
 
         let now = Utc::now();
         let old_time = now - Duration::days(200);
-        let embed_dim = 4;
+        let embed_dim = DIM;
 
         let storage = me_test_support::factory::SqliteFactory.make().await;
 
@@ -552,7 +555,7 @@ mod tests {
         use me_types::types::NewFact;
 
         let now = Utc::now();
-        let embed_dim = 4;
+        let embed_dim = DIM;
 
         let storage = me_test_support::factory::SqliteFactory.make().await;
 
@@ -628,7 +631,7 @@ mod tests {
         me_types::types::NewFact {
             content: format!("neglected {fact_type}"),
             content_hash: hash.into(),
-            embedding: vec![0.1; 4],
+            embedding: vec![0.1; DIM],
             fact_type,
             t_created: old_time,
             t_expired: None,
@@ -697,7 +700,7 @@ mod tests {
             id: 1,
             content: "knowledge".into(),
             content_hash: "h".into(),
-            embedding: vec![0.1; 4],
+            embedding: vec![0.1; DIM],
             fact_type: FactType::Semantic,
             t_created: now - Duration::days(500),
             t_expired: None,
@@ -793,7 +796,7 @@ mod tests {
 
         let now = Utc::now();
         let old_time = now - Duration::days(200);
-        let embed_dim = 4;
+        let embed_dim = DIM;
 
         let storage = me_test_support::factory::SqliteFactory.make().await;
 
@@ -1001,7 +1004,7 @@ mod tests {
             id: 1,
             content: "from the future".into(),
             content_hash: "hfut".into(),
-            embedding: vec![0.1; 4],
+            embedding: vec![0.1; DIM],
             fact_type: FactType::Episodic,
             t_created: now,
             t_expired: None,
@@ -1104,7 +1107,7 @@ mod tests {
                 id: 1,
                 content: "prop".into(),
                 content_hash: "hp".into(),
-                embedding: vec![0.1; 4],
+                embedding: vec![0.1; DIM],
                 fact_type: FactType::Episodic,
                 t_created: now,
                 t_expired: None,

--- a/memory-engine/lib/me-storage/src/cold_storage.rs
+++ b/memory-engine/lib/me-storage/src/cold_storage.rs
@@ -5,8 +5,8 @@
 //! NOT a [`StorageBackend`](crate::StorageBackend) supertrait bound, so
 //! the umbrella's type stays stable across feature sets. Only the manifest CRUD is
 //! on the trait; the `.pak` file mechanics (`write_pak_and_hash` / `read_pak` /
-//! `hash_file` / `verify_pak`) stay as feature-gated free functions in
-//! `archive/pak.rs` — filesystem/codec plumbing, not a port concern.
+//! `hash_file`) stay as feature-gated free functions in `archive/pak.rs` —
+//! filesystem/codec plumbing, not a port concern.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};

--- a/memory-engine/lib/memory-engine/Cargo.toml
+++ b/memory-engine/lib/memory-engine/Cargo.toml
@@ -185,6 +185,13 @@ path = "../../../tests/roundtrip_test.rs"
 name = "all_features_store"
 path = "../../../tests/all_features_store.rs"
 
+# #991: assert the docs' gate matrix (CLAUDE/AGENTS/GEMINI.md) is a superset of ci.yml's
+# cargo gates. Runs inside `cargo test --workspace --all-features`, the guard inside the
+# thing it guards. Not under a crate dir, so it needs explicit registration (autotests off).
+[[test]]
+name = "gate_matrix_parity"
+path = "../../../tests/gate_matrix_parity.rs"
+
 # --- examples (top-level ../../../examples/) ---
 [[example]]
 name = "basic_roundtrip"

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -122,7 +122,7 @@ impl MemoryEngine {
         &self,
         query: &crate::search::MemoryQuery,
         limit: usize,
-    ) -> Result<Option<crate::archive::ArchiveSearchResult>> {
+    ) -> Result<Option<crate::archive::search::ArchiveSearchResult>> {
         let Ok(archive_dir) = self.archive_dir() else {
             return Ok(None);
         };

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -122,7 +122,7 @@ impl MemoryEngine {
         &self,
         query: &crate::search::MemoryQuery,
         limit: usize,
-    ) -> Result<Option<crate::archive::search::ArchiveSearchResult>> {
+    ) -> Result<Option<crate::archive::ArchiveSearchResult>> {
         let Ok(archive_dir) = self.archive_dir() else {
             return Ok(None);
         };
@@ -526,16 +526,13 @@ mod tests {
     /// untrusted-blob surface this guard defends. The old lexical
     /// `pak_path.starts_with(&archive_dir)` check let `..` through (it does not
     /// resolve `..`), so the row was handed to the I/O path instead of being
-    /// flagged. The shared [`is_within_archive_dir`] containment check
-    /// (`me_archive::search`, `pub` for exactly this cross-crate reuse) rejects
-    /// it before any filesystem access.
+    /// flagged. me-archive's `is_within_archive_dir` containment check (crate-internal;
+    /// its own unit tests cover the traversal cases) rejects it before any filesystem access.
     // Uses the `raw_exec` failure-injection seam (test-util-gated since #816 A1), so this
     // test compiles only with `test-util` on — matching the sibling `commit_fails` test.
     #[cfg(feature = "test-util")]
     #[tokio::test]
     async fn verify_archives_rejects_path_traversal_manifest_entry() {
-        use crate::archive::search::is_within_archive_dir;
-
         let dir = tempfile::tempdir().unwrap();
         let engine = MemoryEngine::builder(DIM)
             .path(dir.path().join("traversal.db"))
@@ -544,13 +541,9 @@ mod tests {
 
         // A traversal path the legitimate write path can never produce. It is
         // crafted relative to `<db_parent>/archives`, so `archive_dir.join(..)`
-        // would resolve outside the archive directory entirely.
+        // would resolve outside the archive directory entirely. (me-archive's own
+        // `is_within_archive_dir` unit tests cover that this shape is rejected.)
         let evil_path = "../outside/escape.pak";
-        // Sanity: the shared guard considers this unsafe (the property under test).
-        assert!(
-            !is_within_archive_dir(evil_path),
-            "test fixture must be a path the containment guard rejects"
-        );
 
         // Inject the malicious manifest row directly — `commit_archive_atomic`
         // always generates a safe filename, so the only way to exercise the

--- a/tests/archive_test.rs
+++ b/tests/archive_test.rs
@@ -279,8 +279,8 @@ async fn verify_archives_detects_missing_pak() {
 /// `ok == false` with a "hash mismatch" error. Flips a single byte in place so
 /// the file size is unchanged — this proves the integrity check is a content
 /// hash, not a length/existence check. Mutation check: if `verify_single_archive`
-/// ignored `verify_pak`'s `Ok(false)` arm (or compared lengths instead of
-/// hashes), the same-length corrupted file would pass and these asserts fail.
+/// compared lengths instead of hashing (or skipped its mismatch arm), the
+/// same-length corrupted file would pass and these asserts fail.
 #[tokio::test]
 async fn verify_archives_detects_tampered_pak() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/gate_matrix_parity.rs
+++ b/tests/gate_matrix_parity.rs
@@ -5,12 +5,15 @@
 //! `GEMINI.md` *is* the verification, not a convenience mirror of CI. An incomplete matrix
 //! is an unenforced gate — exactly the drift #990 found by hand (two `cargo check` gates CI
 //! ran that the docs never listed). This guard runs inside `cargo test --workspace
-//! --all-features` (itself a matrix line), so it cannot be skipped by anyone who runs the
+//! --all-features` (itself a matrix line), so it can't be skipped by anyone who runs the
 //! gate at all — unlike a CI-based checker, which is useless while CI is manual.
 //!
-//! It fails the moment someone adds a `run: cargo …` gate to `ci.yml` without documenting
-//! it in all three matrices (docs may *add* commands — e.g. `cargo deny check`, which CI
-//! runs via an action rather than `run:` — but never omit one CI runs).
+//! The CI side is parsed as a YAML *subset* rather than line-scraped, because a guard with
+//! blind spots is worse than none (it fails *open* — a drift slips through green). It walks
+//! `jobs.<job>.steps[].run`, handling the real GitHub-Actions step forms: named
+//! (`run: cargo …`), nameless (`- run: cargo …`), block scalars (`run: |`), and quoted
+//! scalars; the `#`-comment strip is applied to BOTH sides so a valid trailing comment on a
+//! CI line can't fail the guard *closed*. The `parser_*` mutation tests below lock each form.
 
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -24,42 +27,108 @@ fn repo_root() -> PathBuf {
         .expect("repo root resolves from CARGO_MANIFEST_DIR")
 }
 
-/// Collapse the column-alignment padding the docs use (`cargo test··--workspace`) so it
-/// compares equal to CI's single-spaced form.
+/// Strip a trailing `# comment` and collapse the column-alignment padding the docs use
+/// (`cargo test··--workspace`) so both sides compare equal.
 fn norm(cmd: &str) -> String {
-    cmd.split_whitespace().collect::<Vec<_>>().join(" ")
+    cmd.split('#')
+        .next()
+        .unwrap_or("")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
-/// Every `cargo` gate command CI actually runs, minus two documented exceptions:
-/// - `cargo install …` — toolchain setup, not a gate (the fuzz job installs cargo-fuzz).
-/// - `… --tests --examples` — the MSRV job, deliberately documented as prose, not in the
-///   matrix block (#991).
+/// A `cargo` gate command — excludes `cargo install …` (toolchain setup, e.g. the fuzz
+/// job's cargo-fuzz install), which is not a gate.
+fn is_gate_cargo(cmd: &str) -> bool {
+    cmd.starts_with("cargo ") && !cmd.starts_with("cargo install ")
+}
+
+/// Record `raw` as a gate command unless it belongs to the `msrv` job (deliberately
+/// documented as prose, not in the matrix block — #991).
+fn push_cargo(raw: &str, job: &str, out: &mut BTreeSet<String>) {
+    if job == "msrv" {
+        return;
+    }
+    let cmd = norm(raw.trim().trim_matches('"').trim_matches('\''));
+    if is_gate_cargo(&cmd) {
+        out.insert(cmd);
+    }
+}
+
+/// Every `cargo` gate command CI actually runs, parsed as a YAML subset: walk each job's
+/// steps, handling named / nameless / block-scalar / quoted `run:` forms, scoping the MSRV
+/// exception to `jobs.msrv`.
 fn ci_gate_commands(ci_yml: &str) -> BTreeSet<String> {
-    ci_yml
-        .lines()
-        .filter_map(|l| l.trim().strip_prefix("run: "))
-        .map(str::trim)
-        .filter(|c| c.starts_with("cargo "))
-        .filter(|c| !c.starts_with("cargo install "))
-        .filter(|c| !c.contains("--tests --examples"))
-        .map(norm)
-        .collect()
+    let mut cmds = BTreeSet::new();
+    let mut in_jobs = false;
+    let mut job = String::new();
+    let mut block_indent: Option<usize> = None; // indent of an open `run: |` block header
+    for line in ci_yml.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        let trimmed = line.trim();
+        // Top-level key: only the `jobs:` map is relevant.
+        if indent == 0 {
+            in_jobs = trimmed == "jobs:";
+            job.clear();
+            block_indent = None;
+            continue;
+        }
+        if !in_jobs {
+            continue;
+        }
+        // Job header: `  <name>:` at 2-space indent (nothing else sits at that depth).
+        if indent == 2 && trimmed.ends_with(':') && !trimmed.contains(char::is_whitespace) {
+            job = trimmed.trim_end_matches(':').to_string();
+            block_indent = None;
+            continue;
+        }
+        // Body of an open `run: |` block scalar: deeper-indented lines are commands.
+        if let Some(bi) = block_indent {
+            if indent > bi {
+                push_cargo(trimmed, &job, &mut cmds);
+                continue;
+            }
+            block_indent = None; // dedent closes the block
+        }
+        // A `run:` step, named (`run: …`) or nameless (`- run: …`).
+        if let Some(body) = trimmed.trim_start_matches("- ").strip_prefix("run:") {
+            let body = body.trim();
+            if matches!(body, "|" | "|-" | ">" | ">-") {
+                block_indent = Some(indent);
+            } else {
+                push_cargo(body, &job, &mut cmds);
+            }
+        }
+    }
+    cmds
 }
 
-/// The `cargo` lines from a doc's gate-matrix fenced block (the one carrying the
-/// `cargo fmt --all --check` anchor), with trailing `# comments` and padding stripped.
+/// The `cargo` lines from a doc's gate-matrix fenced block. Fenced code blocks are the
+/// odd-indexed chunks of a ```` ``` ````-split; select the single one carrying the
+/// `cargo fmt --all --check` anchor (require exactly one, so a prose mention or a second
+/// example block can't silently substitute for the canonical gate block).
 fn doc_matrix_commands(doc: &str, doc_name: &str) -> BTreeSet<String> {
-    let block = doc
+    let gate_blocks: Vec<&str> = doc
         .split("```")
-        .find(|b| b.contains("cargo fmt --all --check"))
-        .unwrap_or_else(|| {
-            panic!("{doc_name}: no gate-matrix bash block (anchor `cargo fmt --all --check`) found")
-        });
-    block
+        .skip(1)
+        .step_by(2)
+        .filter(|b| b.contains("cargo fmt --all --check"))
+        .collect();
+    assert_eq!(
+        gate_blocks.len(),
+        1,
+        "{doc_name}: expected exactly ONE fenced code block carrying the \
+         `cargo fmt --all --check` gate anchor, found {}",
+        gate_blocks.len()
+    );
+    gate_blocks[0]
         .lines()
-        .map(|l| l.split('#').next().unwrap_or("").trim())
-        .filter(|c| c.starts_with("cargo "))
         .map(norm)
+        .filter(|c| c.starts_with("cargo "))
         .collect()
 }
 
@@ -85,4 +154,57 @@ fn docs_gate_matrix_is_a_superset_of_ci() {
              ci gate commands: {ci_cmds:#?}\n  doc matrix commands: {doc_cmds:#?}"
         );
     }
+}
+
+// --- parser mutation tests: each locks a `run:` form the guard must NOT miss (fail-open)
+//     or wrongly reject (fail-closed). Regressions here were real review findings on #996. ---
+
+#[test]
+fn parser_catches_nameless_single_line_run() {
+    let yml = "jobs:\n  x:\n    steps:\n      - run: cargo audit --workspace\n";
+    assert!(ci_gate_commands(yml).contains("cargo audit --workspace"));
+}
+
+#[test]
+fn parser_catches_block_scalar_run() {
+    let yml =
+        "jobs:\n  x:\n    steps:\n      - run: |\n          cargo test --workspace --secret-flag\n";
+    assert!(ci_gate_commands(yml).contains("cargo test --workspace --secret-flag"));
+}
+
+#[test]
+fn parser_catches_quoted_run() {
+    let yml = "jobs:\n  x:\n    steps:\n      - run: \"cargo deny check\"\n";
+    assert!(ci_gate_commands(yml).contains("cargo deny check"));
+}
+
+#[test]
+fn parser_scopes_msrv_exclusion_to_the_job() {
+    let msrv =
+        "jobs:\n  msrv:\n    steps:\n      - run: cargo build --workspace --tests --examples\n";
+    assert!(
+        ci_gate_commands(msrv).is_empty(),
+        "the msrv job's gates are excluded"
+    );
+    let build =
+        "jobs:\n  build:\n    steps:\n      - run: cargo build --workspace --tests --examples\n";
+    assert!(
+        ci_gate_commands(build).contains("cargo build --workspace --tests --examples"),
+        "an unrelated --tests --examples gate is NOT excluded"
+    );
+}
+
+#[test]
+fn parser_strips_trailing_comments_symmetrically() {
+    let yml = "jobs:\n  x:\n    steps:\n      - run: cargo build --workspace # keep this\n";
+    assert!(
+        ci_gate_commands(yml).contains("cargo build --workspace"),
+        "a trailing # comment on a CI run must not fail the guard closed"
+    );
+}
+
+#[test]
+fn parser_excludes_cargo_install_setup() {
+    let yml = "jobs:\n  x:\n    steps:\n      - run: cargo install cargo-fuzz --locked\n";
+    assert!(ci_gate_commands(yml).is_empty());
 }

--- a/tests/gate_matrix_parity.rs
+++ b/tests/gate_matrix_parity.rs
@@ -1,0 +1,88 @@
+//! #991: the documented gate matrix MUST be a superset of the cargo gate commands
+//! `.github/workflows/ci.yml` runs.
+//!
+//! CI is now `workflow_dispatch`-only (#989), so the matrix in `CLAUDE.md` / `AGENTS.md` /
+//! `GEMINI.md` *is* the verification, not a convenience mirror of CI. An incomplete matrix
+//! is an unenforced gate — exactly the drift #990 found by hand (two `cargo check` gates CI
+//! ran that the docs never listed). This guard runs inside `cargo test --workspace
+//! --all-features` (itself a matrix line), so it cannot be skipped by anyone who runs the
+//! gate at all — unlike a CI-based checker, which is useless while CI is manual.
+//!
+//! It fails the moment someone adds a `run: cargo …` gate to `ci.yml` without documenting
+//! it in all three matrices (docs may *add* commands — e.g. `cargo deny check`, which CI
+//! runs via an action rather than `run:` — but never omit one CI runs).
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+/// This test's crate manifest is at `<repo>/memory-engine/lib/memory-engine`; the docs and
+/// `ci.yml` it checks live at the repo root, three levels up.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .expect("repo root resolves from CARGO_MANIFEST_DIR")
+}
+
+/// Collapse the column-alignment padding the docs use (`cargo test··--workspace`) so it
+/// compares equal to CI's single-spaced form.
+fn norm(cmd: &str) -> String {
+    cmd.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Every `cargo` gate command CI actually runs, minus two documented exceptions:
+/// - `cargo install …` — toolchain setup, not a gate (the fuzz job installs cargo-fuzz).
+/// - `… --tests --examples` — the MSRV job, deliberately documented as prose, not in the
+///   matrix block (#991).
+fn ci_gate_commands(ci_yml: &str) -> BTreeSet<String> {
+    ci_yml
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("run: "))
+        .map(str::trim)
+        .filter(|c| c.starts_with("cargo "))
+        .filter(|c| !c.starts_with("cargo install "))
+        .filter(|c| !c.contains("--tests --examples"))
+        .map(norm)
+        .collect()
+}
+
+/// The `cargo` lines from a doc's gate-matrix fenced block (the one carrying the
+/// `cargo fmt --all --check` anchor), with trailing `# comments` and padding stripped.
+fn doc_matrix_commands(doc: &str, doc_name: &str) -> BTreeSet<String> {
+    let block = doc
+        .split("```")
+        .find(|b| b.contains("cargo fmt --all --check"))
+        .unwrap_or_else(|| {
+            panic!("{doc_name}: no gate-matrix bash block (anchor `cargo fmt --all --check`) found")
+        });
+    block
+        .lines()
+        .map(|l| l.split('#').next().unwrap_or("").trim())
+        .filter(|c| c.starts_with("cargo "))
+        .map(norm)
+        .collect()
+}
+
+#[test]
+fn docs_gate_matrix_is_a_superset_of_ci() {
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let ci_cmds = ci_gate_commands(&ci);
+    assert!(
+        !ci_cmds.is_empty(),
+        "parsed zero cargo gate commands from ci.yml — the parser broke, not the docs"
+    );
+
+    for doc_name in ["CLAUDE.md", "AGENTS.md", "GEMINI.md"] {
+        let doc = std::fs::read_to_string(root.join(doc_name))
+            .unwrap_or_else(|e| panic!("read {doc_name}: {e}"));
+        let doc_cmds = doc_matrix_commands(&doc, doc_name);
+        let missing: Vec<&String> = ci_cmds.difference(&doc_cmds).collect();
+        assert!(
+            missing.is_empty(),
+            "{doc_name}'s gate matrix omits cargo commands that ci.yml runs \
+             (the docs matrix must be a SUPERSET of CI — #991):\n  missing: {missing:#?}\n\n  \
+             ci gate commands: {ci_cmds:#?}\n  doc matrix commands: {doc_cmds:#?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Four Wave-2 collateral quick-wins, batched per plan #925 / the S6 handoff. Behaviour-preserving except #991 (a new test); the anti-#903 suite goes 1975 → **1976**.

`Classification: refactor (user-confirmed)`

## The four

**#980 — `verify_single_archive` hashes the `.pak` once** (`me-archive/manage.rs`). The mismatch arm ran `verify_pak` (which hashes) then `hash_file` *again* to format the message — a full second read + blake3 over a file up to the 4 GiB read cap, on an already-degraded corruption path. Hash once, compare inline.

**#979 — narrow me-archive's pub surface** (`me-archive/{pak,search,lib}.rs` + facade `engine/archive.rs`). The implementation helpers (`hash_file`, `search_archives`, `is_within_archive_dir`, `write_pak_and_hash`) were `pub` only because their modules are `pub` → now `pub(crate)`; `verify_pak` removed (dead after #980). The facade's redundant `is_within_archive_dir` sanity-assert dropped (me-archive already unit-tests the guard). `read_pak` fuzz seam stays `pub`. me-archive is `publish=false`, so this is workspace-internal encapsulation, no semver surface.

**#969 — seed me-forget test embeddings from `fixtures::DIM`** (`me-forget/policy.rs`). 11 inline magic-`4` seeds → the shared `DIM` the `SqliteFactory` pool is provisioned with, so a future `DIM` change can't silently desync seed length from pool dimension. me-forget is the *only* carved crate carrying the pattern (me-types excluded — L0 DTO tests, a `DIM` import would be a dependency cycle; the facade snapshot test excluded — intrinsic 4-dim literal vectors).

**#991 — enforce the docs' gate matrix ⊇ ci.yml** (`tests/gate_matrix_parity.rs`). A `#[test]` running under `cargo test --workspace --all-features` (the guard inside the thing it guards) that fails when a `run: cargo` gate is added to `ci.yml` but not to CLAUDE.md / AGENTS.md / GEMINI.md. Whitespace-normalised; excludes the MSRV job + `cargo install` setup; `cargo deny check` runs via a CI action so it stays legitimately doc-only. **Proven** both ways (passes on main, fails on injected drift).

## Test plan

- [x] `cargo test -p me-archive` (verify_single_archive + hash_file tests)
- [x] `cargo test -p me-forget` (seeds compile + pass, count unchanged)
- [x] #991 guard proven: passes on main, fails on an injected `ci.yml` drift
- [x] Full CI-exact gate matrix green; `clippy --all-features -D warnings` clean; anti-#903 = 1982

Closes #969. Closes #979. Closes #980. Closes #991.
