### PR TITLE
refactor(core): Wave 2 post-carve polish wave (#943) + &Transaction hardening (#938)

### DIFF
--- a/docs/reference/crate-layout.md
+++ b/docs/reference/crate-layout.md
@@ -1,7 +1,7 @@
 # Crate Layout
 
 Where things live in the `memory-engine` **workspace**. Wave 2 (#816) **decomposed** the
-former single core crate into an acyclic DAG of per-concern crates. **S1–S5 are done** —
+former single core crate into an acyclic DAG of per-concern crates. **S1–S6 are done** —
 all **18 crates** exist:
 
 - **L0** `me-types` · **L0.5** `me-traits` · **L1** `me-storage` (the port)
@@ -12,9 +12,10 @@ all **18 crates** exist:
 - plus `me-test-support` (dev-only) and three facade consumers: `memory-engine-cli`,
   `memory-engine-mcp`, `memory-engine-embed`
 
-Only **S6** (#942 — the `dylib` ship-mode spike + legibility tooling) remains. This page is
-the "where does X live _now_" reference: the crate DAG, a per-crate table, and the module
-map of what lives inside the facade.
+S6 (#942 legibility tooling + #993 the fuzz-crate facade-API gate) has landed; the `dylib`
+ship-mode spike was carved out to its own follow-up (#994). This page is the "where does X
+live _now_" reference: the crate DAG, a per-crate table, and the module map of what lives
+inside the facade.
 
 The locked structural decisions are in
 [ADR 0018](../design/adr/0018-wave2-crate-decomposition-memoryctx.md).
@@ -138,7 +139,7 @@ crate where ADR 0018 assigns one — where it does not, the module stays facade-
 until a later slice. (`store/`, `storage/sqlite/`, `storage/postgres/`, `graph/`, `scope/`,
 and `pool/` — the S2 scope — are **no longer facade modules**; they physically live in
 `me-backend-sqlite`, `me-backend-postgres`, and `me-index` now. See
-[the extracted crates](#the-extracted-crates-s1--s2) below.)
+[the extracted crates](#the-extracted-crates) below.)
 
 `engine`
 : Facade over all memory primitives. Defines `MemoryEngine` (the main entry point) and `EngineConfig`. The engine is async-native: its DB-touching methods are `async fn` that `.await` an `Arc<dyn StorageBackend>` port, so thread safety and blocking-IO offload live in the backend (`spawn_blocking`); the in-memory caches the engine still owns stay `RwLock`-protected. `engine::conflict` holds the bi-temporal `MemoryEngine::resolve_conflict` (delegated to the consumer `ConflictArbiter`) → **me-resolve**. `engine::query` → **me-query**; `engine::ingest` → **me-ingest**; `engine::forgetting` → **me-forget**; `engine::archive` → **me-archive**. `MemoryCtx` and its `ensure_open`/`ensure_writable` gates were relocated **out** of `engine::mod` into `me-storage` in S1.
@@ -197,9 +198,10 @@ and `pool/` — the S2 scope — are **no longer facade modules**; they physical
 - `inspect::dump` -- JSON snapshot serialization and SQLite `VACUUM INTO` backup.
 - `inspect::statistics` -- SQL count queries for aggregate statistics.
 
-## The extracted crates (S1 + S2)
+## The extracted crates
 
-The six L0–L2 crates that already exist as separate workspace members under
+The Wave 2 (#816) decomposition is complete (S1–S6): **18 crates** in a strictly-acyclic
+L0→L4 DAG. The L0–L2 foundation crates, as separate workspace members under
 `memory-engine/lib/`:
 
 `me-types` (L0 — `memory-engine/lib/me-types/`)
@@ -219,6 +221,36 @@ The six L0–L2 crates that already exist as separate workspace members under
 
 `me-backend-postgres` (L2 — `memory-engine/lib/me-backend-postgres/`)
 : The `PgBackend` `StorageBackend` impl (#633 skeleton): a `deadpool-postgres` pool + a fresh v14-logical migration chain (native FK constraints, `GENERATED ALWAYS AS IDENTITY` ids, a `tsvector` generated column + GIN index, `vector(N)` pgvector columns) + the `SchemaManager` lifecycle/identity/config core. Inspection and the #623 background-reconstruction methods are `MemoryError::NotImplemented` stubs; data CRUD is #634, lexical+vector search and the conformance-arm flip are #635. Depends only on `{me-types, me-storage}` — **not** `me-backend-sqlite` (no backend-to-backend edge). Optional: pulled by the facade's `backend-postgres` feature so a `backend-sqlite`-only build never compiles `tokio-postgres`/`deadpool-postgres`.
+
+The L3 primitive crates (`memory-engine/lib/`), each a free-function primitive over the
+`me-storage` **port** (never a concrete backend — the facade selects the backend). Acyclic
+siblings: no L3 crate depends on another.
+
+`me-ingest` (L3 — `memory-engine/lib/me-ingest/`)
+: The append-only event log + fact-derivation primitives (`ingest`, `add_fact`, `add_fact_precomputed`, `add_facts_batch`). Takes `MemoryCtx` + the `ScopeTree`; delegates embedding/classification to the consumer traits. Depends on `{me-types, me-traits, me-storage, me-index}`.
+
+`me-query` (L3 — `memory-engine/lib/me-query/`)
+: The hybrid retrieval primitive: FTS5 + vector + graph candidates merged by RRF (`query`, `execute_query`). Takes `MemoryCtx` + `ScopeTree`; the SQL search cores live below the seam in the backend. Depends on `{me-types, me-traits, me-storage, me-index}`.
+
+`me-consolidate` (L3 — `memory-engine/lib/me-consolidate/`)
+: The three-pass consolidation pipeline (dedup → cluster → global), lock-free compute + atomic apply (#409). The SQL-touching load/apply halves live in `me-backend-sqlite`; the pure `compute_plan` stays here. Depends on `{me-types, me-traits, me-storage, me-index}`.
+
+`me-forget` (L3 — `memory-engine/lib/me-forget/`)
+: The Ebbinghaus-decay + multi-signal-importance prune primitive (`prune`, `compute_importance`). Scores the active set against in-memory graph degree and soft-expires the sub-threshold set atomically below the seam. Depends on `{me-types, me-storage, me-index}`.
+
+`me-resolve` (L3 — `memory-engine/lib/me-resolve/`)
+: The bi-temporal conflict-arbitration primitive (`resolve_conflict`): a single-transaction CRUD dispatch over the consumer `ConflictArbiter`'s decision, mirroring the in-memory graph only after commit. Depends on `{me-types, me-traits, me-storage, me-index}`.
+
+`me-archive` (L3 — `memory-engine/lib/me-archive/`, feature `archive`)
+: The cold-storage `.pak` primitive (`archive`, `list_archives`, `search_archives_fallback`) over the feature-gated `ColdStorage` port. Depends on `{me-types, me-storage, me-index}`.
+
+`me-cognitive` (L3 — `memory-engine/lib/me-cognitive/`)
+: The Phase-5 dream cycle (#981): `run_dream_cycle` / `run_dream_cycle_guarded` over the `DreamCtx` capability bag + `CycleCtx` read-set, plus the selectable `LlmDreamCycle` backend. Depends on `{me-types, me-traits, me-storage, me-index}`.
+
+`memory-engine` (L4 — `memory-engine/lib/memory-engine/`)
+: The facade. Owns `MemoryEngine` + its builder/bootstrap/inspect/reconstruct/resume, selects the concrete backend, wires the L3 primitives together (`mem_ctx()`), and owns the re-export surface below. Depends on every crate above.
+
+Plus `me-test-support` (dev-only, `memory-engine/lib/me-test-support/`) — cross-crate test doubles + the `SqliteFactory` conformance harness — and the three consumers of the facade's public API: `memory-engine-cli` (`memory-engine/bin/cli/`), `memory-engine-mcp` (`memory-engine/bin/mcp/`), and `memory-engine-embed` (`memory-engine/lib/embed/`, the HTTP embedding provider).
 
 ## Re-exports from the facade `lib.rs`
 

--- a/memory-engine/bin/mcp/tests/snapshots/depth_shaping__explain_fact_sparse.snap
+++ b/memory-engine/bin/mcp/tests/snapshots/depth_shaping__explain_fact_sparse.snap
@@ -1,6 +1,5 @@
 ---
 source: memory-engine-mcp/tests/depth_shaping.rs
-assertion_line: 197
 expression: body
 ---
 fact_id: 1

--- a/memory-engine/bin/mcp/tests/snapshots/depth_shaping__get_fact_sparse.snap
+++ b/memory-engine/bin/mcp/tests/snapshots/depth_shaping__get_fact_sparse.snap
@@ -1,6 +1,5 @@
 ---
 source: memory-engine-mcp/tests/depth_shaping.rs
-assertion_line: 112
 expression: body
 ---
 content: Rust is a systems programming language with zero-cost abstractions

--- a/memory-engine/bin/mcp/tests/snapshots/depth_shaping__list_due_sparse.snap
+++ b/memory-engine/bin/mcp/tests/snapshots/depth_shaping__list_due_sparse.snap
@@ -1,6 +1,5 @@
 ---
 source: memory-engine-mcp/tests/depth_shaping.rs
-assertion_line: 454
 expression: body
 ---
 count: 0

--- a/memory-engine/bin/mcp/tests/snapshots/depth_shaping__resume_context_sparse.snap
+++ b/memory-engine/bin/mcp/tests/snapshots/depth_shaping__resume_context_sparse.snap
@@ -1,6 +1,5 @@
 ---
 source: memory-engine-mcp/tests/depth_shaping.rs
-assertion_line: 372
 expression: body
 ---
 due: []

--- a/memory-engine/lib/me-backend-sqlite/src/consolidation/cluster.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/consolidation/cluster.rs
@@ -4,7 +4,7 @@
 //! `#[cfg(test)]`-only `cluster_fusion` wrapper (composing `compute_clusters` +
 //! `apply_clusters` for that file's unit tests) keeps resolving unchanged.
 
-use rusqlite::Connection;
+use rusqlite::Transaction;
 
 use me_types::error::Result;
 use me_types::types::{ConsolidationLevel, NewSummary};
@@ -21,8 +21,8 @@ use crate::store::summaries::SummaryStore;
 ///
 /// Returns `MemoryError::Storage` on SQL failure, or `MemoryError::Serialization` on
 /// JSON serialization failure.
-pub fn apply_clusters(conn: &Connection, embed_dim: usize, summaries: &[NewSummary]) -> Result<()> {
-    let summary_store = SummaryStore::new(conn, embed_dim);
+pub fn apply_clusters(tx: &Transaction, embed_dim: usize, summaries: &[NewSummary]) -> Result<()> {
+    let summary_store = SummaryStore::new(tx, embed_dim);
     summary_store.delete_by_level(&ConsolidationLevel::Cluster)?;
     for summary in summaries {
         summary_store.insert(summary)?;

--- a/memory-engine/lib/me-backend-sqlite/src/consolidation/dedup.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/consolidation/dedup.rs
@@ -5,7 +5,7 @@
 //! resolving unchanged.
 
 use chrono::{DateTime, Utc};
-use rusqlite::Connection;
+use rusqlite::Transaction;
 
 use me_types::error::{MemoryError, Result};
 use me_types::types::consolidation::DedupComputed;
@@ -47,13 +47,13 @@ use crate::store::facts::FactStore;
 /// importance update if a fact row is missing (facts are soft-deleted, so this does not
 /// fire for a merely-expired row).
 pub fn apply_dedup(
-    conn: &Connection,
+    tx: &Transaction,
     embed_dim: usize,
     computed: &DedupComputed,
     now: DateTime<Utc>,
 ) -> Result<DedupApplied> {
-    let fact_store = FactStore::new(conn, embed_dim);
-    let edge_store = EdgeStore::new(conn);
+    let fact_store = FactStore::new(tx, embed_dim);
+    let edge_store = EdgeStore::new(tx);
 
     for &(id, importance) in &computed.importance_updates {
         fact_store.update_base_importance(id, importance)?;

--- a/memory-engine/lib/me-backend-sqlite/src/consolidation/global.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/consolidation/global.rs
@@ -4,7 +4,7 @@
 //! `#[cfg(test)]`-only `global_integration` wrapper (composing `compute_global` +
 //! `apply_global` for that file's unit tests) keeps resolving unchanged.
 
-use rusqlite::Connection;
+use rusqlite::Transaction;
 
 use me_types::error::Result;
 use me_types::types::{ConsolidationLevel, NewSummary};
@@ -21,11 +21,11 @@ use crate::store::summaries::SummaryStore;
 /// Returns `MemoryError::Storage` on SQL failure, or `MemoryError::Serialization` on
 /// JSON serialization failure.
 pub fn apply_global(
-    conn: &Connection,
+    tx: &Transaction,
     embed_dim: usize,
     summary: Option<&NewSummary>,
 ) -> Result<()> {
-    let summary_store = SummaryStore::new(conn, embed_dim);
+    let summary_store = SummaryStore::new(tx, embed_dim);
     summary_store.delete_by_level(&ConsolidationLevel::Global)?;
     if let Some(s) = summary {
         summary_store.insert(s)?;

--- a/memory-engine/lib/me-backend-sqlite/src/store/schema/migrations.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/store/schema/migrations.rs
@@ -9,14 +9,14 @@
 //! `mod.rs`, which may evolve in future versions.
 
 use me_types::error::StorageError;
-use rusqlite::Connection;
+use rusqlite::Transaction;
 
 use me_types::error::{MigrationError, Result};
 
-pub(super) fn migrate_v1_to_v2(conn: &Connection) -> Result<()> {
+pub(super) fn migrate_v1_to_v2(tx: &Transaction) -> Result<()> {
     // Frozen snapshot of SCOPES_DDL at v2 — do not reference the global constant,
     // which may evolve in future schema versions.
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE TABLE IF NOT EXISTS scopes (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             parent_id INTEGER REFERENCES scopes(id),
@@ -30,14 +30,14 @@ pub(super) fn migrate_v1_to_v2(conn: &Connection) -> Result<()> {
         INSERT OR IGNORE INTO scopes (id, parent_id, label, depth) VALUES (1, NULL, 'root', 0);",
     )
     .map_err(StorageError::backend)?;
-    conn.execute_batch(
+    tx.execute_batch(
         "ALTER TABLE facts ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
          ALTER TABLE edges ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
          ALTER TABLE events ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;
          ALTER TABLE summaries ADD COLUMN scope_id INTEGER NOT NULL DEFAULT 1;",
     )
     .map_err(StorageError::backend)?;
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_facts_scope ON facts(scope_id);
          CREATE INDEX IF NOT EXISTS idx_edges_scope ON edges(scope_id);
          CREATE INDEX IF NOT EXISTS idx_events_scope ON events(scope_id);
@@ -49,8 +49,8 @@ pub(super) fn migrate_v1_to_v2(conn: &Connection) -> Result<()> {
 
 /// Recreate the FTS5 virtual table and its sync triggers for the v3 schema
 /// (inlined frozen snapshot), repopulating from the rebuilt facts table.
-pub(super) fn recreate_facts_fts_v3(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+pub(super) fn recreate_facts_fts_v3(tx: &Transaction) -> Result<()> {
+    tx.execute_batch(
         "CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
             content,
             content='facts',
@@ -60,7 +60,7 @@ pub(super) fn recreate_facts_fts_v3(conn: &Connection) -> Result<()> {
         INSERT INTO facts_fts(rowid, content) SELECT id, content FROM facts;",
     )
     .map_err(StorageError::backend)?;
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE TRIGGER IF NOT EXISTS facts_fts_ai AFTER INSERT ON facts BEGIN
             INSERT INTO facts_fts(rowid, content) VALUES (new.id, new.content);
         END;
@@ -87,9 +87,9 @@ pub(super) fn recreate_facts_fts_v3(conn: &Connection) -> Result<()> {
     clippy::too_many_lines,
     reason = "#926 mapped each rusqlite seam call via `.map_err(StorageError::backend)`, whose line-wrapping pushed this already-long migration fn a few lines over 100 — mechanical verbosity, no added logic"
 )]
-pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
+pub(super) fn migrate_v2_to_v3(tx: &Transaction) -> Result<()> {
     // 1. Drop FTS triggers and virtual table (they reference facts)
-    conn.execute_batch(
+    tx.execute_batch(
         "DROP TRIGGER IF EXISTS facts_fts_ai;
          DROP TRIGGER IF EXISTS facts_fts_ad;
          DROP TRIGGER IF EXISTS facts_fts_au;
@@ -98,7 +98,7 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
     .map_err(StorageError::backend)?;
 
     // 2. Rebuild events (no FK deps from other data tables)
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE TABLE events_new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             timestamp TEXT NOT NULL,
@@ -116,7 +116,7 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
     .map_err(StorageError::backend)?;
 
     // 3. Rebuild facts (source_event_id references events)
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE TABLE facts_new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             content TEXT NOT NULL,
@@ -146,7 +146,7 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
     .map_err(StorageError::backend)?;
 
     // 4. Rebuild edges (source/target_fact_id reference facts)
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE TABLE edges_new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             source_fact_id INTEGER NOT NULL REFERENCES facts(id),
@@ -167,7 +167,7 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
     .map_err(StorageError::backend)?;
 
     // 5. Rebuild summaries (no FK deps from other data tables)
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE TABLE summaries_new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             content TEXT NOT NULL,
@@ -187,10 +187,10 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
     .map_err(StorageError::backend)?;
 
     // 6+7. Recreate the FTS5 virtual table and its sync triggers.
-    recreate_facts_fts_v3(conn)?;
+    recreate_facts_fts_v3(tx)?;
 
     // 8. Recreate indexes (inlined for v3 — frozen snapshot)
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id) WHERE session_id IS NOT NULL;
         CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
         CREATE INDEX IF NOT EXISTS idx_facts_expired ON facts(t_expired);
@@ -211,22 +211,22 @@ pub(super) fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
 
 /// Add Phase 3b columns: `is_pinned`, `importance_score` on facts,
 /// and event envelope fields on events.
-pub(super) fn migrate_v3_to_v4(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+pub(super) fn migrate_v3_to_v4(tx: &Transaction) -> Result<()> {
+    tx.execute_batch(
         "ALTER TABLE facts ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0;
          ALTER TABLE facts ADD COLUMN importance_score REAL NOT NULL DEFAULT 0.5;",
     )
     .map_err(StorageError::backend)?;
     // Backfill: seed importance_score from base importance for existing rows
-    conn.execute("UPDATE facts SET importance_score = importance", [])
+    tx.execute("UPDATE facts SET importance_score = importance", [])
         .map_err(StorageError::backend)?;
-    conn.execute_batch(
+    tx.execute_batch(
         "ALTER TABLE events ADD COLUMN origin_node_id TEXT NOT NULL DEFAULT 'local';
          ALTER TABLE events ADD COLUMN sequence_id INTEGER NOT NULL DEFAULT 0;
          ALTER TABLE events ADD COLUMN created_at TEXT;",
     )
     .map_err(StorageError::backend)?;
-    conn.execute_batch(
+    tx.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_facts_pinned ON facts(is_pinned) WHERE is_pinned = 1;
          CREATE INDEX IF NOT EXISTS idx_facts_importance_score ON facts(importance_score);
          CREATE INDEX IF NOT EXISTS idx_facts_t_valid_due ON facts(t_valid) WHERE t_valid IS NOT NULL AND t_expired IS NULL;
@@ -236,15 +236,15 @@ pub(super) fn migrate_v3_to_v4(conn: &Connection) -> Result<()> {
 }
 
 /// Add `event_revision` column for per-event-type envelope versioning.
-pub(super) fn migrate_v4_to_v5(conn: &Connection) -> Result<()> {
-    conn.execute_batch("ALTER TABLE events ADD COLUMN event_revision INTEGER NOT NULL DEFAULT 1;")
+pub(super) fn migrate_v4_to_v5(tx: &Transaction) -> Result<()> {
+    tx.execute_batch("ALTER TABLE events ADD COLUMN event_revision INTEGER NOT NULL DEFAULT 1;")
         .map_err(StorageError::backend)?;
     Ok(())
 }
 
 /// Add `surfaced_at` column for tracking when due facts are first returned to consumers.
-pub(super) fn migrate_v5_to_v6(conn: &Connection) -> Result<()> {
-    conn.execute_batch("ALTER TABLE facts ADD COLUMN surfaced_at TEXT;")
+pub(super) fn migrate_v5_to_v6(tx: &Transaction) -> Result<()> {
+    tx.execute_batch("ALTER TABLE facts ADD COLUMN surfaced_at TEXT;")
         .map_err(StorageError::backend)?;
     Ok(())
 }
@@ -254,8 +254,8 @@ pub(super) fn migrate_v5_to_v6(conn: &Connection) -> Result<()> {
 /// The table is created unconditionally (not gated on the `archive` feature)
 /// so that schema version is consistent regardless of feature flags. The Rust
 /// code that reads/writes this table is gated behind `#[cfg(feature = "archive")]`.
-pub(super) fn migrate_v6_to_v7(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+pub(super) fn migrate_v6_to_v7(tx: &Transaction) -> Result<()> {
+    tx.execute_batch(
         "CREATE TABLE IF NOT EXISTS archive_manifest (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             pak_path TEXT NOT NULL,
@@ -276,8 +276,8 @@ pub(super) fn migrate_v6_to_v7(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn migrate_v7_to_v8(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+pub(super) fn migrate_v7_to_v8(tx: &Transaction) -> Result<()> {
+    tx.execute_batch(
         "CREATE TABLE IF NOT EXISTS lineage (
             lineage_id INTEGER PRIMARY KEY AUTOINCREMENT,
             wisdom_fact_id INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
@@ -291,8 +291,8 @@ pub(super) fn migrate_v7_to_v8(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn migrate_v8_to_v9(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+pub(super) fn migrate_v8_to_v9(tx: &Transaction) -> Result<()> {
+    tx.execute_batch(
         "CREATE TABLE IF NOT EXISTS activities (
             id               INTEGER PRIMARY KEY AUTOINCREMENT,
             session_id       TEXT    NOT NULL,
@@ -346,8 +346,8 @@ pub(super) fn migrate_v8_to_v9(conn: &Connection) -> Result<()> {
 /// This corrective migration unconditionally drops and recreates the index in
 /// the canonical 5-column form. `DROP INDEX IF EXISTS` makes it idempotent and
 /// safe regardless of which 4- or 5-column variant a v9 database already has.
-pub(super) fn migrate_v9_to_v10(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+pub(super) fn migrate_v9_to_v10(tx: &Transaction) -> Result<()> {
+    tx.execute_batch(
         "DROP INDEX IF EXISTS idx_activities_dedup;
          CREATE INDEX idx_activities_dedup
              ON activities(session_id, tool_name, args_hash, outcome_class, scope_id);",
@@ -362,8 +362,8 @@ pub(super) fn migrate_v9_to_v10(conn: &Connection) -> Result<()> {
 /// ordering by `t_created` (recency scans, memarch #42's horizon sweep) would
 /// otherwise full-scan the table. The fresh-init path adds the same index via
 /// `INDEXES_DDL`, so fresh and migrated databases converge.
-pub(super) fn migrate_v10_to_v11(conn: &Connection) -> Result<()> {
-    conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_facts_created ON facts(t_created);")
+pub(super) fn migrate_v10_to_v11(tx: &Transaction) -> Result<()> {
+    tx.execute_batch("CREATE INDEX IF NOT EXISTS idx_facts_created ON facts(t_created);")
         .map_err(StorageError::backend)?;
     Ok(())
 }
@@ -379,8 +379,8 @@ pub(super) fn migrate_v10_to_v11(conn: &Connection) -> Result<()> {
 /// every subsequent write). The identity is re-established on the next embedding
 /// write. The `DELETE` is idempotent (a no-op on a fresh v12 DB that never had the
 /// key), and runs inside the migration framework's per-step transaction.
-pub(super) fn migrate_v11_to_v12(conn: &Connection) -> Result<()> {
-    conn.execute_batch("DELETE FROM config WHERE key = 'embed_dim';")
+pub(super) fn migrate_v11_to_v12(tx: &Transaction) -> Result<()> {
+    tx.execute_batch("DELETE FROM config WHERE key = 'embed_dim';")
         .map_err(StorageError::backend)?;
     Ok(())
 }
@@ -416,8 +416,8 @@ struct V12Fingerprint {
 /// gates the step on `version < target`.
 ///
 /// Frozen DDL snapshot — never reference the live `TABLES_DDL` constant in `mod.rs`.
-pub(super) fn migrate_v12_to_v13(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+pub(super) fn migrate_v12_to_v13(tx: &Transaction) -> Result<()> {
+    tx.execute_batch(
         "CREATE TABLE IF NOT EXISTS embedding_spaces (
             name                TEXT    PRIMARY KEY,
             model               TEXT    NOT NULL,
@@ -437,11 +437,11 @@ pub(super) fn migrate_v12_to_v13(conn: &Connection) -> Result<()> {
     // Fold a present legacy identity into one active 'default' row. The table was just
     // created empty in this same step, so a plain INSERT cannot conflict (the version
     // gate makes the step run-once) — no ON CONFLICT needed.
-    if let Some(raw) = super::get_config(conn, "embedding_meta")? {
+    if let Some(raw) = super::get_config(tx, "embedding_meta")? {
         let fp: V12Fingerprint = serde_json::from_str(&raw).map_err(|e| {
             MigrationError::Incompatible(format!("corrupt embedding_meta during v12->v13: {e}"))
         })?;
-        conn.execute(
+        tx.execute(
             "INSERT INTO embedding_spaces
                  (name, model, provider, dim, matryoshka_base_dim, element_type, status)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active')",
@@ -463,7 +463,7 @@ pub(super) fn migrate_v12_to_v13(conn: &Connection) -> Result<()> {
             ],
         )
         .map_err(StorageError::backend)?;
-        conn.execute_batch("DELETE FROM config WHERE key = 'embedding_meta';")
+        tx.execute_batch("DELETE FROM config WHERE key = 'embedding_meta';")
             .map_err(StorageError::backend)?;
     }
     Ok(())
@@ -477,8 +477,8 @@ pub(super) fn migrate_v12_to_v13(conn: &Connection) -> Result<()> {
 /// read-path change. `fact_vectors` is populated only by reconstruction: the `populating`
 /// space during backfill, and the previous active space (now `deprecated`) retained after a
 /// promote for rollback. Frozen DDL snapshot — never reference the live `TABLES_DDL`.
-pub(super) fn migrate_v13_to_v14(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+pub(super) fn migrate_v13_to_v14(tx: &Transaction) -> Result<()> {
+    tx.execute_batch(
         "CREATE TABLE IF NOT EXISTS fact_vectors (
             fact_id   INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
             space_id  TEXT    NOT NULL REFERENCES embedding_spaces(name) ON DELETE CASCADE,

--- a/memory-engine/lib/me-backend-sqlite/src/store/schema/mod.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/store/schema/mod.rs
@@ -1,7 +1,7 @@
 use me_types::error::StorageError;
 use std::path::Path;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction};
 
 use me_types::error::{MemoryError, MigrationError, Result};
 
@@ -125,7 +125,12 @@ pub fn init_schema(conn: &Connection) -> Result<()> {
 
 // --- Migration framework ---
 
-type MigrationFn = fn(&Connection) -> Result<()>;
+// Migrations run inside the per-step transaction opened by `migrate` (#938): the type is
+// `fn(&Transaction)`, not `fn(&Connection)`, so a migration physically cannot be invoked
+// against a bare auto-committing connection — the multi-statement table rebuilds must be
+// all-or-nothing. (The connection-level FK pragma toggles stay outside the tx, on
+// `&Connection`, since `PRAGMA foreign_keys` is not transactional.)
+type MigrationFn = fn(&Transaction) -> Result<()>;
 
 /// `(function, disable_foreign_keys)` — set second element to `true` for
 /// table-rebuild migrations that DROP and recreate tables with FK references.

--- a/memory-engine/lib/me-backend-sqlite/src/store/schema/snapshots/me_backend_sqlite__store__schema__tests__schema_v11.snap
+++ b/memory-engine/lib/me-backend-sqlite/src/store/schema/snapshots/me_backend_sqlite__store__schema__tests__schema_v11.snap
@@ -1,6 +1,5 @@
 ---
 source: memory-engine/lib/me-backend-sqlite/src/store/schema/tests.rs
-assertion_line: 1526
 expression: schema
 ---
 -- index: idx_activities_dedup

--- a/memory-engine/lib/me-backend-sqlite/src/store/schema/snapshots/me_backend_sqlite__store__schema__tests__schema_v11_migration_chain.snap
+++ b/memory-engine/lib/me-backend-sqlite/src/store/schema/snapshots/me_backend_sqlite__store__schema__tests__schema_v11_migration_chain.snap
@@ -1,6 +1,5 @@
 ---
 source: memory-engine/lib/me-backend-sqlite/src/store/schema/tests.rs
-assertion_line: 1736
 expression: actual
 ---
 -- index: idx_activities_dedup

--- a/memory-engine/lib/me-consolidate/src/pipeline/cluster.rs
+++ b/memory-engine/lib/me-consolidate/src/pipeline/cluster.rs
@@ -5,6 +5,10 @@
 use rusqlite::Connection;
 
 use me_types::error::Result;
+// Test-only: `cluster_fusion` opens a tx (the #938 `&Transaction` apply contract) and
+// maps the open/commit errors, exactly like production `apply_plan` below the seam.
+#[cfg(test)]
+use me_types::error::StorageError;
 use me_types::math::cosine_similarity;
 // Used by this file's own `#[cfg(test)]` module (via `use super::*`) to verify writes
 // `apply_clusters` (in me-backend-sqlite) made — not by any production fn here.
@@ -152,7 +156,13 @@ fn cluster_fusion(
 ) -> Result<usize> {
     let computed = compute_clusters(facts, generator, embedder, params)?;
     if computed.ran {
-        apply_clusters(conn, params.embed_dim, &computed.summaries)?;
+        // `apply_clusters` now requires an open transaction (#938); open one here exactly
+        // as production `apply_plan` does below the seam.
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(StorageError::backend)?;
+        apply_clusters(&tx, params.embed_dim, &computed.summaries)?;
+        tx.commit().map_err(StorageError::backend)?;
     }
     Ok(computed.summaries.len())
 }

--- a/memory-engine/lib/me-consolidate/src/pipeline/dedup.rs
+++ b/memory-engine/lib/me-consolidate/src/pipeline/dedup.rs
@@ -8,7 +8,7 @@ use rusqlite::Connection;
 #[cfg(test)]
 use me_backend_sqlite::store::facts::FactStore;
 #[cfg(test)]
-use me_types::error::Result;
+use me_types::error::{Result, StorageError};
 use me_types::math::cosine_similarity;
 use me_types::types::Fact;
 
@@ -204,7 +204,13 @@ fn local_dedup(
             active_count: active_facts.len(),
         });
     }
-    let expired_ids = apply_dedup(conn, embed_dim, &computed, now)?.expired;
+    // Mirror the production apply path: the multi-write `apply_dedup` now requires an open
+    // transaction (#938), so open one here exactly as `apply_plan` does below the seam.
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(StorageError::backend)?;
+    let expired_ids = apply_dedup(&tx, embed_dim, &computed, now)?.expired;
+    tx.commit().map_err(StorageError::backend)?;
     Ok(DedupOutcome::Ran {
         removed: expired_ids.len(),
         expired_ids,

--- a/memory-engine/lib/me-consolidate/src/pipeline/global.rs
+++ b/memory-engine/lib/me-consolidate/src/pipeline/global.rs
@@ -5,6 +5,10 @@
 use rusqlite::Connection;
 
 use me_types::error::Result;
+// Test-only: `global_integration` opens a tx (the #938 `&Transaction` apply contract) and
+// maps the open/commit errors, exactly like production `apply_plan` below the seam.
+#[cfg(test)]
+use me_types::error::StorageError;
 // Test-only for the same reason as `Connection` above: `global_integration` and this
 // file's own test module (via `use super::*`) are the only remaining callers.
 #[cfg(test)]
@@ -110,7 +114,13 @@ fn global_integration(
         })
         .collect();
     let global = compute_global(&cluster_summaries, generator, embedder, embed_dim, now)?;
-    apply_global(conn, embed_dim, global.as_ref())?;
+    // `apply_global` now requires an open transaction (#938); open one here exactly as
+    // production `apply_plan` does below the seam.
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(StorageError::backend)?;
+    apply_global(&tx, embed_dim, global.as_ref())?;
+    tx.commit().map_err(StorageError::backend)?;
     Ok(usize::from(global.is_some()))
 }
 

--- a/memory-engine/lib/memory-engine/src/engine/bootstrap.rs
+++ b/memory-engine/lib/memory-engine/src/engine/bootstrap.rs
@@ -210,7 +210,7 @@ impl MemoryEngine {
     /// and the (possibly blocking) embedder/extractor calls run on a blocking thread;
     /// only the atomic ingest touches the DB.
     ///
-    /// For LLM-powered extraction, provide a custom [`SessionExtractor`](crate::bootstrap::SessionExtractor).
+    /// For LLM-powered extraction, provide a custom [`SessionExtractor`].
     /// The default [`KeywordExtractor`](crate::bootstrap::KeywordExtractor) requires no LLM.
     ///
     /// # Errors

--- a/memory-engine/lib/memory-engine/src/engine/cognitive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/cognitive.rs
@@ -272,10 +272,10 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// - [`MemoryError::ReadOnly`] if the engine is read-only.
-    /// - [`MemoryError::Cycle`](crate::error::MemoryError::Cycle) if any delta fails validation.
+    /// - [`MemoryError::Cycle`] if any delta fails validation.
     /// - [`MemoryError::EmbeddingDimension`] if an
     ///   `AddFact`/`Promote`/`Synthesize` embedding does not match the engine dimension.
-    /// - [`MemoryError::Storage`](crate::error::MemoryError::Storage) on a backend failure.
+    /// - [`MemoryError::Storage`] on a backend failure.
     pub async fn apply_cycle_report(
         &self,
         report: &crate::cognitive::CycleReport,

--- a/memory-engine/lib/memory-engine/src/engine/graph.rs
+++ b/memory-engine/lib/memory-engine/src/engine/graph.rs
@@ -121,13 +121,13 @@ impl MemoryEngine {
     ///
     /// # Errors
     ///
-    /// - [`MemoryError::ReadOnly`](crate::error::MemoryError::ReadOnly) — the
+    /// - [`MemoryError::ReadOnly`] — the
     ///   engine was opened read-only (the backend rejects the write; the graph is
     ///   left untouched).
-    /// - [`MemoryError::NotFound`](crate::error::MemoryError::NotFound) — no
+    /// - [`MemoryError::NotFound`] — no
     ///   *active* edge with `edge_id` exists (unknown id, or already expired); the
     ///   write affected 0 rows, so the graph is not modified.
-    /// - [`MemoryError::Storage`](crate::error::MemoryError::Storage) on SQL
+    /// - [`MemoryError::Storage`] on SQL
     ///   failure.
     pub async fn expire_edge(&self, edge_id: i64) -> Result<()> {
         let now = Utc::now();

--- a/memory-engine/lib/memory-engine/src/inspect/snapshots/memory_engine__inspect__explain__tests__snapshot_active_fact_explanation.snap
+++ b/memory-engine/lib/memory-engine/src/inspect/snapshots/memory_engine__inspect__explain__tests__snapshot_active_fact_explanation.snap
@@ -1,6 +1,5 @@
 ---
 source: src/inspect/explain.rs
-assertion_line: 419
 expression: explanation
 ---
 fact_id: 1


### PR DESCRIPTION
## Wave 2 post-carve polish wave (#943) + &Transaction hardening (#938)

The designated post-carve API-polish wave. Triaged against current `main` first: **4 of the 8 listed items were already done or moot** (schema-version re-export ✅, me-traits dev-dep ✅, `from_pool` must stay `pub`, the three `must_use` ctors never existed). The 4 genuinely-remaining items, all low-risk:

### `refactor(storage): thread &Transaction through multi-op store helpers (#938)`
Multi-write helpers took `&Connection` and relied on the caller to wrap them in a tx — correct at runtime, unenforced by the type. Converted to `&rusqlite::Transaction` (derefs to `&Connection`, so bodies are unchanged) so a bare-`&Connection` caller becomes a **compile error**. Two families, both already invoked inside an open tx:
- **consolidation** `apply_dedup`/`apply_clusters`/`apply_global` (the gemini-on-#936 targets) — `apply_plan` already passes `&tx`; the three `#[cfg(test)]` wrappers now open their own tx, exercising the production atomic path.
- **the schema migration framework** (extended in review, per Codex) — `MigrationFn = fn(&Transaction)` + all 13 `migrate_v*` steps + `recreate_facts_fts_v3`. The `migrate` runner already opened an `unchecked_transaction` per step. Tests drive migrations via the chain runner, so **no test call-site changes**.

Left on `&Connection` deliberately (the tx *boundary*, and the non-transactional `PRAGMA foreign_keys` toggles): `apply_plan`, `migrate`, `set_foreign_keys`. Behavior-preserving — **554 tests pass** (506 me-backend-sqlite + 48 me-consolidate).

### `test(core): strip legacy insta assertion_line from snapshots`
Noise that churns on unrelated refactors, not emitted by modern insta (ignored on read). Stripped from all **7** snapshots carrying it (issue named 2; 5 more had the same debt).

### `docs(core): drop 6 redundant explicit intra-doc link targets`
`[`Foo`](path)` → `[`Foo`]`. Clears `rustdoc::redundant_explicit_links`. (The one non-imported `KeywordExtractor` link is correctly kept explicit.)

### `docs(core): refresh crate-layout.md inventory + Wave-2 status`
The "(S1 + S2) / six crates" section + the "S1–S5 done, only S6 remains" opener both contradicted reality. Retitled, fixed to 18 crates / S1–S6 done (S6 = #942 + #993; dylib → #994), added the 7 L3 primitives + facade + consumers.

### Review — gate: Full
Codex (external) + 2 diverse-lens subagents (transaction-correctness / polish-completeness). Codex R1 found 2 real items (both fixed: #938 migration-framework scope; crate-layout opener); the 12 gemini-bot "revert to `&Connection`" comments are declined as false positives (they contradict #938's explicit intent, confirmed correct by Codex + the rust-specialist review). All 14 threads resolved.

### Verification
Full 12-line gate matrix, unpiped, all green — `test --workspace --all-features` (**1982 passed**, exact — no new tests), `clippy --all-features -D warnings`, `doc` (redundant-links gate clean), `cargo +nightly fuzz build`. Re-run green after the review extension.

Closes #943
Closes #938 (the two atomicity-critical multi-op families — the #936-flagged consolidation helpers + the migration framework)
Refs #1000 (the remaining broad store-layer multi-op audit, split out as its own focused issue)
