### PR TITLE
enhancement(core): fail-fast read-only gate (ctx.ensure_writable) on every write primitive (#972)

### DIFF
--- a/memory-engine/lib/me-archive/src/manage.rs
+++ b/memory-engine/lib/me-archive/src/manage.rs
@@ -8,12 +8,13 @@
 //! `archive_dir()` helper stay facade concerns — the facade resolves the archive
 //! directory, a sibling of the DB file, and passes it in as `archive_dir: &Path`).
 //!
-//! [`archive`]'s pre-flight checks (`ensure_open`, the read-only fail-fast, and the
-//! file-backed check) also stay in the facade's delegate rather than moving here: the
-//! file-backed check must run *before* `archive_dir` can even be resolved (it is not
-//! reachable through [`MemoryCtx`]), so preserving the original's exact check order and
-//! error messages requires the facade to own the whole pre-flight sequence, not just the
-//! path resolution. See the facade's `engine/archive.rs` for that sequence.
+//! [`archive`] now self-gates the `MemoryCtx`-reachable pre-flight — `ctx.ensure_open()`
+//! then `ctx.ensure_writable()` (#972) — so a read-only engine fails fast here, at the
+//! primitive entry, like every other write primitive. The **file-backed** check stays in
+//! the facade's delegate: it must run *before* `archive_dir` can even be resolved, and
+//! `archive_dir` is not reachable through [`MemoryCtx`], so the facade owns that half of
+//! the sequence (and keeps its own `ensure_open`/read-only checks as archive-style
+//! defence-in-depth). See the facade's `engine/archive.rs`.
 
 use std::path::{Path, PathBuf};
 
@@ -63,6 +64,8 @@ use crate::types::{
 ///
 /// # Errors
 ///
+/// Returns `MemoryError::ReadOnly` if the engine is read-only (checked first, #972 — before
+/// the candidate scan + cold-storage write).
 /// Returns `MemoryError::Archive` on I/O failure.
 /// Returns `MemoryError::Storage` on SQL failure.
 pub async fn archive(
@@ -85,9 +88,12 @@ pub async fn archive(
     // drops embedding scoring for it: permanent, silent cold-storage corruption.
     //
     // (Read-only is *also* caught below the seam — `block_write` → `try_write()` →
-    // `MemoryError::ReadOnly` — so `ctx.ensure_writable()` is not added here; that gate is
-    // tracked systemically across all write primitives in #972.)
+    // `MemoryError::ReadOnly`.)
     ctx.ensure_open()?;
+    // Fail fast on a read-only engine before the candidate scan + cold-storage write
+    // (#972, uniform across every write primitive) — same `ReadOnly` error, moved earlier
+    // before the wasted read; a deliberate, benign behavior change.
+    ctx.ensure_writable()?;
 
     let (candidate_facts, candidate_edges) = ctx
         .storage

--- a/memory-engine/lib/me-cognitive/src/apply.rs
+++ b/memory-engine/lib/me-cognitive/src/apply.rs
@@ -44,6 +44,12 @@ pub async fn apply_cycle_report(
     report: &CycleReport,
 ) -> Result<ApplyResult> {
     ctx.ensure_open()?;
+    // Fail fast on a read-only engine before validating + applying the deltas (#972,
+    // uniform across every write primitive). This is the apply path `run_dream_cycle`
+    // defers the write to; the `# Errors` contract above already promises `ReadOnly`.
+    // Same error the below-seam `apply_cycle_deltas_atomic` → `try_write()` returns,
+    // moved earlier before the read-only snapshot.
+    ctx.ensure_writable()?;
     let (result, supersede_edges, _expired_ids, _to_index) = ctx
         .storage
         .apply_cycle_deltas_atomic(report, ctx.embed_dim, upcaster_registry)
@@ -127,6 +133,32 @@ mod tests {
             report,
         )
         .await
+    }
+
+    /// Regression witness for the #972 fail-fast read-only gate on the apply path.
+    ///
+    /// `apply_cycle_report` is the write that `run_dream_cycle` defers to. A `read_only`
+    /// handle must reject it with `ReadOnly` *before* validating/applying deltas. The
+    /// backend is genuinely writable — only `MemoryCtx.read_only` is set — so without the
+    /// `ctx.ensure_writable()?` gate an empty report would apply and return `Ok` (the
+    /// below-seam `try_write()` only trips on a truly read-only pool). Mutation-witness:
+    /// delete the gate and this fails.
+    #[tokio::test]
+    async fn apply_cycle_report_read_only_fails_fast() {
+        let engine = engine().await;
+        let empty = report(vec![], vec![]);
+        let err = apply_cycle_report(
+            engine.ctx_read_only(),
+            &engine.graph,
+            &engine.upcaster_registry,
+            &empty,
+        )
+        .await
+        .expect_err("a read-only handle must reject apply_cycle_report before touching storage");
+        assert!(
+            matches!(err, MemoryError::ReadOnly),
+            "expected ReadOnly, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/memory-engine/lib/me-cognitive/src/cognitive.rs
+++ b/memory-engine/lib/me-cognitive/src/cognitive.rs
@@ -65,10 +65,10 @@ pub async fn run_dream_cycle<'a>(
     cycle: &dyn DreamCycle,
 ) -> Result<CycleReport> {
     ctx.ensure_open()?;
-    // Verify write access up front (apply happens separately).
-    if ctx.read_only {
-        return Err(MemoryError::ReadOnly);
-    }
+    // Verify write access up front — applying the returned report will write, so fail
+    // fast here rather than after the (potentially expensive) cycle run. Uniform with
+    // every other write primitive via `ctx.ensure_writable()` (#972).
+    ctx.ensure_writable()?;
     let cycle_ctx = build_cycle_context(ctx, dream).await?;
     cycle.run(&cycle_ctx).await
 }
@@ -110,6 +110,12 @@ pub async fn run_dream_cycle_guarded<'a>(
     cycle: &dyn DreamCycle,
 ) -> Result<CycleOutcome> {
     ctx.ensure_open()?;
+    // Fail fast on a read-only engine: the skip path advances the caller-write cursor
+    // (a `set_config` write). The run path returns an UNAPPLIED `CycleReport` (the caller
+    // applies it later via `apply_cycle_report`), so this gate also spares running a
+    // full cycle whose result could never be applied on a read-only engine (#972, uniform
+    // via `ctx.ensure_writable()`).
+    ctx.ensure_writable()?;
     // Cursor read + max-id read + (skip-only) advance via the port. These are
     // separate port calls rather than one lock-held critical section: per the
     // deferral contract this is benign — a caller write landing between the reads

--- a/memory-engine/lib/me-cognitive/src/test_support.rs
+++ b/memory-engine/lib/me-cognitive/src/test_support.rs
@@ -69,6 +69,18 @@ impl TestEngine {
         }
     }
 
+    /// Like [`Self::ctx`] but with `read_only: true` — for the #972 fail-fast witnesses.
+    /// The backend itself stays writable, so a primitive that skips `ctx.ensure_writable()`
+    /// would still succeed; that is what makes these tests real mutation-witnesses.
+    pub fn ctx_read_only(&self) -> MemoryCtx<'_> {
+        MemoryCtx {
+            storage: &self.storage,
+            embed_dim: self.embed_dim,
+            read_only: true,
+            reopen_required: &self.reopen_required,
+        }
+    }
+
     /// Record an embedding-space identity (#613) directly, mirroring what the
     /// facade's `add_fact` stamps as a side effect of its first live-embedder write.
     /// Needed before applying any delta that carries a **pre-computed** vector

--- a/memory-engine/lib/me-consolidate/src/lib.rs
+++ b/memory-engine/lib/me-consolidate/src/lib.rs
@@ -78,9 +78,9 @@ use me_types::error::Result;
 /// is the **first** check, and this function is its sole enforcement point (the facade
 /// delegate has no pre-flight of its own).
 ///
-/// Returns `MemoryError::ReadOnly` if the engine was opened read-only — surfaced *below
-/// the seam*, when the write phase reaches the pool's `try_write()` guard, not as a
-/// pre-flight (see the note at the fence check).
+/// Returns `MemoryError::ReadOnly` if the engine was opened read-only — checked as a
+/// pre-flight at entry via `ctx.ensure_writable()` (#972), before phase 1's read, rather
+/// than late at the below-seam `try_write()`.
 ///
 /// Propagates errors from any consolidation pass, the `SummaryGenerator`, or the
 /// `EmbeddingProvider`.
@@ -103,14 +103,15 @@ pub async fn consolidate(
     // carve moved it here, and here is where it lives now.
     //
     // Base's pre-carve `MemoryEngine::consolidate` called ONLY `self.ensure_open()`
-    // (the #742 read-fence) — never an explicit read-only pre-check. `ReadOnly` is
-    // caught below the seam instead (`apply_plan`'s write → `block_write` →
-    // `try_write()` → `MemoryError::ReadOnly`), so `ctx.ensure_writable()` is
-    // deliberately NOT added here either: adding it would be a behavior change (a
-    // read-only run would now fail before phase 1's read instead of during phase 3's
-    // write), not a faithful extraction. That gate is tracked systemically across all
-    // write primitives in #972.
+    // (the #742 read-fence) — `ReadOnly` was caught below the seam instead
+    // (`apply_plan`'s write → `block_write` → `try_write()` → `MemoryError::ReadOnly`).
     ctx.ensure_open()?;
+    // Fail fast on a read-only engine before phase 1's read + the consumer's
+    // summarize/embed IO (#972, uniform across every write primitive). The error is the
+    // same `ReadOnly`; this only moves it earlier, before the wasted read/IO — a
+    // deliberate, benign behavior change (previously the run reached phase 3's write
+    // before failing).
+    ctx.ensure_writable()?;
     // Phase 1 — READ: snapshot the active set + watermark below the seam.
     let snapshot = ctx
         .storage

--- a/memory-engine/lib/me-forget/src/policy.rs
+++ b/memory-engine/lib/me-forget/src/policy.rs
@@ -166,8 +166,9 @@ pub fn compute_importance(
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Conflict` if the policy fails validation, or
-/// `MemoryError::Storage` on a backend failure.
+/// Returns `MemoryError::ReadOnly` if the engine is read-only (checked first, #972 — takes
+/// precedence over the policy validation below), `MemoryError::Conflict` if the policy fails
+/// validation, or `MemoryError::Storage` on a backend failure.
 ///
 /// # Example
 ///
@@ -198,12 +199,17 @@ pub async fn prune(
     // cycle). `prune` is a `pub` primitive reachable by callers other than the facade
     // delegate, so the fence is the primitive's own floor, not the wrapper's alone.
     // Base enforced it inside `MemoryEngine::forget` (`self.ensure_open()`), which
-    // still calls it as archive-style defence-in-depth. `ctx.ensure_writable()` is
-    // deliberately NOT added: base never pre-checked read-only either — `ReadOnly` is
-    // caught below the seam (`prune_atomic`'s write → `block_write` → `try_write()`),
-    // so adding a fail-fast here would be a behavior change, not an alignment. That
-    // gate is tracked systemically across all write primitives in #972.
+    // still calls it as archive-style defence-in-depth.
     ctx.ensure_open()?;
+    // Fail fast on a read-only engine, as the fundamental write-capability precondition
+    // (#972, uniform across every write primitive — checked before the request itself).
+    // `ReadOnly` was previously surfaced only below the seam by `prune_atomic`'s
+    // `try_write()`; checking here additionally skips the O(N) active-set scan. Deliberate
+    // precedence change: a read-only engine now rejects with `ReadOnly` *before*
+    // `policy.validate()` — an invalid policy on a read-only engine reports `ReadOnly`
+    // rather than the policy error, since no policy can be applied to a store you cannot
+    // write. Locked by `prune_read_only_fails_fast`.
+    ctx.ensure_writable()?;
     policy.validate()?;
 
     // Prune must evaluate the *entire* active set (importance is global). The
@@ -277,8 +283,10 @@ mod tests {
     /// (`prune_fenced_by_reopen_required`) with a local non-zero `AtomicUsize`.
     static NO_REOPEN: AtomicUsize = AtomicUsize::new(0);
 
-    /// Build the always-open [`MemoryCtx`] `prune` now takes (#970). `embed_dim`/
-    /// `read_only` are carried for signature uniformity — `prune` uses neither.
+    /// Build the always-open, writable [`MemoryCtx`] the happy-path `prune` tests take.
+    /// `read_only: false` matters since #972 — `prune` now checks `ctx.ensure_writable()`;
+    /// the read-only path has its own witness (`prune_read_only_fails_fast`). `embed_dim`
+    /// is still unused by `prune`, carried for signature uniformity.
     fn test_ctx(storage: &Arc<dyn StorageBackend>) -> MemoryCtx<'_> {
         MemoryCtx {
             storage,
@@ -313,6 +321,32 @@ mod tests {
         assert!(
             matches!(err, MemoryError::EmbeddingReopenRequired { new_dim } if new_dim == 384),
             "expected EmbeddingReopenRequired {{ new_dim: 384 }}, got {err:?}"
+        );
+    }
+
+    /// Regression witness for the #972 fail-fast read-only gate `prune` self-guards.
+    ///
+    /// A `read_only` handle must reject `prune` with `ReadOnly` *before* touching storage.
+    /// The backend here is genuinely writable — only the `MemoryCtx.read_only` flag is set —
+    /// so without the `ctx.ensure_writable()?` gate `prune` would run to completion and
+    /// return `Ok` (the storage-level `try_write()` fence only trips on a truly read-only
+    /// pool). That makes this a real mutation-witness: delete the gate and this test fails.
+    #[tokio::test]
+    async fn prune_read_only_fails_fast() {
+        let storage = me_test_support::factory::SqliteFactory.make().await;
+        let graph = RwLock::new(MemoryGraph::new());
+        let ctx = MemoryCtx {
+            storage: &storage,
+            embed_dim: DIM,
+            read_only: true,
+            reopen_required: &NO_REOPEN,
+        };
+        let err = prune(ctx, &graph, &ForgetPolicy::default(), Utc::now())
+            .await
+            .expect_err("a read-only handle must reject prune before touching storage");
+        assert!(
+            matches!(err, MemoryError::ReadOnly),
+            "expected ReadOnly, got {err:?}"
         );
     }
 

--- a/memory-engine/lib/me-ingest/src/lib.rs
+++ b/memory-engine/lib/me-ingest/src/lib.rs
@@ -26,6 +26,11 @@ use me_types::types::{AddFactRequest, ClassifierInput, EmbeddingFingerprint, New
 /// Returns `MemoryError::Storage` on insert failure.
 pub async fn ingest(ctx: MemoryCtx<'_>, event: &NewEvent) -> Result<i64> {
     ctx.ensure_open()?;
+    // Read-only rejects here — the fundamental write-capability precondition, checked
+    // before request validation, embedding, and the write (#972). On a read-only engine
+    // `ReadOnly` therefore takes precedence over payload/request validation, and even a
+    // no-op (empty batch) rejects: a write method on a read-only handle is a misuse.
+    ctx.ensure_writable()?;
     check_json_size(&event.payload, "event payload")?;
     ctx.storage.insert_event(event).await
 }
@@ -69,6 +74,11 @@ pub async fn add_fact(
     classifier: Option<Arc<dyn PersistenceClassifier>>,
 ) -> Result<i64> {
     ctx.ensure_open()?;
+    // Read-only rejects here — the fundamental write-capability precondition, checked
+    // before request validation, embedding, and the write (#972). On a read-only engine
+    // `ReadOnly` therefore takes precedence over payload/request validation, and even a
+    // no-op (empty batch) rejects: a write method on a read-only handle is a misuse.
+    ctx.ensure_writable()?;
     validate_add_fact_request(req)?;
     // Embed off the async executor (the provider call may be a blocking HTTP
     // round-trip; running it inline would park the runtime thread, and a
@@ -111,6 +121,11 @@ pub async fn add_fact_precomputed(
     classifier: Option<Arc<dyn PersistenceClassifier>>,
 ) -> Result<i64> {
     ctx.ensure_open()?;
+    // Read-only rejects here — the fundamental write-capability precondition, checked
+    // before request validation, embedding, and the write (#972). On a read-only engine
+    // `ReadOnly` therefore takes precedence over payload/request validation, and even a
+    // no-op (empty batch) rejects: a write method on a read-only handle is a misuse.
+    ctx.ensure_writable()?;
     validate_add_fact_request(req)?;
     // The caller's declared fingerprint is treated exactly like a live
     // provider's: the atomic insert records-if-absent (and #614-rejects a
@@ -254,6 +269,11 @@ pub async fn add_facts_batch(
     classifier: Option<Arc<dyn PersistenceClassifier>>,
 ) -> Result<Vec<i64>> {
     ctx.ensure_open()?;
+    // Read-only rejects here — the fundamental write-capability precondition, checked
+    // before request validation, embedding, and the write (#972). On a read-only engine
+    // `ReadOnly` therefore takes precedence over payload/request validation, and even a
+    // no-op (empty batch) rejects: a write method on a read-only handle is a misuse.
+    ctx.ensure_writable()?;
     if entries.is_empty() {
         return Ok(Vec::new());
     }
@@ -297,6 +317,11 @@ pub async fn add_facts_batch_partial(
     classifier: Option<Arc<dyn PersistenceClassifier>>,
 ) -> Result<Vec<std::result::Result<i64, MemoryError>>> {
     ctx.ensure_open()?;
+    // Read-only rejects here — the fundamental write-capability precondition, checked
+    // before request validation, embedding, and the write (#972). On a read-only engine
+    // `ReadOnly` therefore takes precedence over payload/request validation, and even a
+    // no-op (empty batch) rejects: a write method on a read-only handle is a misuse.
+    ctx.ensure_writable()?;
     if entries.is_empty() {
         return Ok(Vec::new());
     }

--- a/memory-engine/lib/me-resolve/src/lib.rs
+++ b/memory-engine/lib/me-resolve/src/lib.rs
@@ -27,6 +27,8 @@ const CONFLICT_EDGE_WEIGHT: f64 = 1.0;
 ///
 /// # Errors
 /// - [`me_types::error::MemoryError::EmbeddingReopenRequired`] — the handle is dim-fenced (#742).
+/// - `ReadOnly` — the engine is read-only (checked first, #972 — takes precedence over the
+///   size check and the `old_id` lookup below, both of which are skipped on a read-only engine).
 /// - Conflict/PayloadTooLarge — the candidate exceeds the size bound (`check_new_fact`).
 /// - `NotFound` — `old_id` missing or already expired (re-validated inside the atomic op; #335 TOCTOU guard).
 /// - Propagates arbiter / storage errors.
@@ -42,6 +44,15 @@ pub async fn resolve_conflict(
     now: DateTime<Utc>,
 ) -> Result<ConflictResolution> {
     ctx.ensure_open()?;
+    // Fail fast on a read-only engine, as the fundamental write-capability precondition
+    // (#972). This skips the consumer's `ConflictArbiter` (possibly network / LLM work)
+    // and the `get_fact(old_id)` read entirely — the write below the seam would otherwise
+    // reject with `ReadOnly` only after those side-effects fired. Deliberate precedence
+    // change: on a read-only engine `ReadOnly` now takes precedence over `check_new_fact`'s
+    // size bound and over the `old_id` lookup — an oversized candidate or a missing/expired
+    // `old_id` reports `ReadOnly` rather than `Conflict`/`NotFound`, since neither can be
+    // resolved against a store you cannot write.
+    ctx.ensure_writable()?;
     // The candidate fact is persisted verbatim on an Add/Update decision, so
     // it is a consumer ingest path and must respect the same size bound as
     // `add_fact` (issue #572 / L10).

--- a/memory-engine/lib/memory-engine/src/engine/activity.rs
+++ b/memory-engine/lib/memory-engine/src/engine/activity.rs
@@ -45,6 +45,7 @@ impl MemoryEngine {
         embedder: Option<Arc<dyn EmbeddingProvider>>,
         filter_config: &ActivityFilterConfig,
     ) -> Result<RecordActivityResult> {
+        self.ensure_writable()?; // #972: fail fast before filtering/embedding + the activity write
         // Step 1: Filter decision (no locks needed).
         let decision = apply_filter(
             &req.tool_name,
@@ -168,6 +169,7 @@ impl MemoryEngine {
         summary: Option<&str>,
         metadata: Option<serde_json::Value>,
     ) -> Result<()> {
+        self.ensure_writable()?; // #972: fail fast before the activity read + the checkpoint write
         // Find last activity_id for this session. `list_activities_by_session`
         // orders by `last_seen DESC`, so the first row of a 1-row page is the
         // most-recent activity — same row the old raw SQL `ORDER BY last_seen

--- a/memory-engine/lib/memory-engine/src/engine/archive.rs
+++ b/memory-engine/lib/memory-engine/src/engine/archive.rs
@@ -4,20 +4,19 @@
 //! here as `crate::archive`, matching the `pool`/`store`/`graph`/`scope`/`forgetting`
 //! carve convention). Each public method below resolves this engine's `MemoryCtx` +
 //! cold-storage handle + in-memory graph + archive directory, then delegates to the
-//! corresponding `me_archive` free function. `archive()`'s pre-flight checks
-//! (`ensure_open`, the read-only fail-fast, and the file-backed check) stay here rather
-//! than moving into `me_archive::archive`: the file-backed check must run *before*
-//! `archive_dir` can even be resolved, and `MemoryCtx` carries no path state — so
-//! preserving the original's exact check order and error messages requires this
-//! delegate to own the whole pre-flight sequence (see `me_archive::manage`'s module
-//! docs for the mirror of this note).
+//! corresponding `me_archive` free function. The `MemoryCtx`-reachable pre-flight (the
+//! `ensure_open` fence + the read-only fail-fast) now self-gates inside
+//! `me_archive::archive` (#972); this delegate keeps its own copy as defence-in-depth and
+//! additionally owns the **file-backed** check, which must run *before* `archive_dir` can
+//! be resolved and which `MemoryCtx` carries no path state for (see `me_archive::manage`'s
+//! module docs for the mirror of this note).
 
 use std::path::PathBuf;
 
 use crate::archive::types::{
     ArchiveManifestEntry, ArchivePolicy, ArchiveStats, ArchiveVerifyResult,
 };
-use crate::error::{ArchiveError, MemoryError, Result};
+use crate::error::{ArchiveError, Result};
 
 use super::MemoryEngine;
 
@@ -58,10 +57,10 @@ impl MemoryEngine {
         self.ensure_open()?;
         // Fail fast on read-only engines before any filesystem I/O — the atomic
         // commit below the seam checks this too, but we want to avoid writing an
-        // orphan .pak file that would never be committed.
-        if self.read_only {
-            return Err(MemoryError::ReadOnly);
-        }
+        // orphan .pak file that would never be committed. Uses the shared
+        // `ensure_writable()` helper (#972) for consistency with every other
+        // facade write method, rather than an ad-hoc `read_only` check.
+        self.ensure_writable()?;
 
         if !self.is_file_backed() {
             return Err(ArchiveError::NotFileBacked(

--- a/memory-engine/lib/memory-engine/src/engine/bootstrap.rs
+++ b/memory-engine/lib/memory-engine/src/engine/bootstrap.rs
@@ -226,6 +226,7 @@ impl MemoryEngine {
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
         self.ensure_open()?;
+        self.ensure_writable()?; // #972: fail fast before parsing/extraction + the per-session ingests
         let scope_id = self
             .resolve_bootstrap_scope(config.scope.as_deref())
             .await?;
@@ -259,6 +260,7 @@ impl MemoryEngine {
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
         self.ensure_open()?;
+        self.ensure_writable()?; // #972: fail fast before parsing/extraction + the per-session ingests
         let scope_id = self
             .resolve_bootstrap_scope(config.scope.as_deref())
             .await?;
@@ -342,6 +344,7 @@ impl MemoryEngine {
         classifier: Option<Arc<dyn PersistenceClassifier>>,
     ) -> Result<crate::bootstrap::BootstrapReport> {
         self.ensure_open()?;
+        self.ensure_writable()?; // #972: fail fast before parsing/extraction + the per-session ingests
         let scope_id = self
             .resolve_bootstrap_scope(config.scope.as_deref())
             .await?;

--- a/memory-engine/lib/memory-engine/src/engine/conflict.rs
+++ b/memory-engine/lib/memory-engine/src/engine/conflict.rs
@@ -30,7 +30,10 @@ impl MemoryEngine {
     /// # Errors
     ///
     /// - [`MemoryError::ReadOnly`](crate::error::MemoryError::ReadOnly) — the
-    ///   engine was opened in read-only mode.
+    ///   engine was opened in read-only mode. Checked **first** (#972, the fundamental
+    ///   write-capability precondition), so on a read-only engine it takes precedence
+    ///   over every error below — a read-only conflict resolution reports `ReadOnly`
+    ///   regardless of the candidate's size or whether `old_id` exists.
     /// - [`MemoryError::Conflict`](crate::error::MemoryError::Conflict) wrapping
     ///   [`ConflictError::PayloadTooLarge`](crate::error::ConflictError::PayloadTooLarge)
     ///   — the candidate `new_fact` exceeds the size bound enforced by
@@ -41,8 +44,9 @@ impl MemoryEngine {
     ///   transaction*: `Update`/`Delete` change zero rows under their
     ///   `t_expired IS NULL` expiry, and `Add` re-validates `old_id` is still
     ///   active before creating its edge (the #335 read→write TOCTOU guard). A
-    ///   missing `old_id` is rejected at lookup. All cases are indistinguishable to
-    ///   the caller (each yields `NotFound`).
+    ///   missing `old_id` is rejected at lookup. On a writable engine all cases are
+    ///   indistinguishable to the caller (each yields `NotFound`); on a read-only engine
+    ///   `ReadOnly` takes precedence (the lookup is skipped — see above).
     /// - Propagates any error returned by the [`ConflictArbiter`] or the
     ///   underlying database operations.
     ///

--- a/memory-engine/lib/memory-engine/src/engine/consolidation.rs
+++ b/memory-engine/lib/memory-engine/src/engine/consolidation.rs
@@ -3,10 +3,10 @@
 //! Extracted into the [`me_consolidate`] crate (Wave 2 #816 / S4, sub-PR 4 — the final
 //! S4 sub-PR, closes #940). `MemoryEngine::consolidate` resolves this engine's
 //! `MemoryCtx` + in-memory graph, then delegates to `me_consolidate::consolidate`.
-//! Base's pre-carve `consolidate` called only `self.ensure_open()` (the #742
-//! read-fence) — no explicit read-only pre-check — so the delegate stays a one-line
-//! forward with no pre-flight of its own; see `me_consolidate::consolidate`'s own doc
-//! for why `ReadOnly` is caught below the seam instead.
+//! The delegate stays a one-line forward with no pre-flight of its own; the primitive
+//! self-gates — `ctx.ensure_open()?` then `ctx.ensure_writable()?` (#972), so a read-only
+//! engine fails fast with `ReadOnly` before phase 1's read, not late at the below-seam
+//! `try_write()`. See `me_consolidate::consolidate`'s own doc.
 
 use std::sync::Arc;
 

--- a/memory-engine/lib/memory-engine/src/engine/forgetting.rs
+++ b/memory-engine/lib/memory-engine/src/engine/forgetting.rs
@@ -38,6 +38,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Storage` if the update fails.
     pub async fn pin_fact(&self, id: i64) -> Result<()> {
+        self.ensure_writable()?;
         self.storage.set_fact_pinned(id, true).await
     }
 
@@ -48,6 +49,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Storage` if the update fails.
     pub async fn unpin_fact(&self, id: i64) -> Result<()> {
+        self.ensure_writable()?;
         self.storage.set_fact_pinned(id, false).await
     }
 }

--- a/memory-engine/lib/memory-engine/src/engine/graph.rs
+++ b/memory-engine/lib/memory-engine/src/engine/graph.rs
@@ -43,6 +43,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::NotFound` if `scope` is `Some` but the path
     /// does not exist.
     pub async fn link_session_facts(&self, session_id: &str, scope: Option<&str>) -> Result<usize> {
+        self.ensure_writable()?; // #972: fail fast before the active-facts read + edge writes
         // Resolve scope path → subtree IDs (short-lived read lock, dropped at the
         // end of the match arm so no guard is held across the awaits below).
         let scope_ids: Vec<i64> = match scope {
@@ -130,6 +131,7 @@ impl MemoryEngine {
     /// - [`MemoryError::Storage`] on SQL
     ///   failure.
     pub async fn expire_edge(&self, edge_id: i64) -> Result<()> {
+        self.ensure_writable()?;
         let now = Utc::now();
         // DB write below the seam first. On NotFound/ReadOnly/Database the graph
         // is deliberately left untouched (no edge transitioned to expired).

--- a/memory-engine/lib/memory-engine/src/engine/lineage.rs
+++ b/memory-engine/lib/memory-engine/src/engine/lineage.rs
@@ -76,6 +76,7 @@ impl MemoryEngine {
     ///
     /// Returns `MemoryError::ReadOnly` if the engine is read-only.
     pub async fn delete_lineage(&self, wisdom_fact_id: i64) -> Result<bool> {
+        self.ensure_writable()?;
         self.storage.delete_lineage(wisdom_fact_id).await
     }
 }

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -556,6 +556,15 @@ impl MemoryEngine {
     /// Returns `MemoryError::Storage` if the fingerprint read or sidecar write
     /// fails.
     pub async fn flush_snapshot(&self) -> Result<bool> {
+        // A read-only engine made no in-memory writes, so its graph/scope already match
+        // the DB — there is nothing to persist. No-op on `close()` here (like the fenced
+        // case below), rather than erroring the way a bare `ensure_writable()` would: a
+        // read-only engine must still close cleanly (#972). The other facade writes fail
+        // fast; this lifecycle method is the deliberate exception.
+        if self.read_only {
+            self.closed.store(true, Ordering::Release);
+            return Ok(false);
+        }
         // Fenced by a different-dim reconstruction → no sidecar (see doc above).
         if self.reopen_required.load(Ordering::Acquire) != 0 {
             self.closed.store(true, Ordering::Release);
@@ -658,6 +667,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Storage` on write failure.
     pub async fn set_config(&self, key: &str, value: &str) -> Result<()> {
+        self.ensure_writable()?;
         self.storage.set_config(key, value).await
     }
 
@@ -692,6 +702,25 @@ impl MemoryEngine {
             0 => Ok(()),
             new_dim => Err(MemoryError::EmbeddingReopenRequired { new_dim }),
         }
+    }
+
+    /// The fail-fast write gate for the facade's own write methods (#972).
+    ///
+    /// The L3 primitives self-gate with [`MemoryCtx::ensure_writable`]; this is the
+    /// facade-level equivalent for the write methods that delegate straight to
+    /// `self.storage` (bypassing the primitives) — `pin_fact`, `set_config`,
+    /// `ensure_scope_path`, `record_*`, etc. Called at their entry so a read-only engine
+    /// rejects with `ReadOnly` before any read or write, instead of late at the
+    /// below-seam `try_write()`. Same `read_only` flag the port pool reports.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::ReadOnly`] if the engine was opened read-only.
+    const fn ensure_writable(&self) -> Result<()> {
+        if self.read_only {
+            return Err(MemoryError::ReadOnly);
+        }
+        Ok(())
     }
 
     /// Test-only: arm the reconstruction dimension fence directly, so the read-safety
@@ -742,6 +771,7 @@ impl MemoryEngine {
     /// Returns `MemoryError::ReadOnly` if the engine was opened read-only.
     /// Returns `MemoryError::Storage` on insert failure.
     pub async fn ensure_scope_path(&self, path: &str) -> Result<i64> {
+        self.ensure_writable()?;
         let id = self.storage.ensure_scope_path(path).await?;
         self.cache_scope_chain(id).await?;
         Ok(id)

--- a/memory-engine/lib/memory-engine/src/engine/outcome.rs
+++ b/memory-engine/lib/memory-engine/src/engine/outcome.rs
@@ -24,6 +24,7 @@ impl MemoryEngine {
     /// - [`MemoryError::ReadOnly`](crate::MemoryError::ReadOnly) if the engine is read-only.
     /// - [`MemoryError::Storage`](crate::MemoryError::Storage) on insert failure.
     pub async fn record_outcome(&self, fact_id: i64, outcome: Outcome) -> Result<i64> {
+        self.ensure_writable()?; // #972: fail fast before the get_fact read + the event write
         // Validate fact exists via the port — propagate DB errors as-is,
         // only remap NotFound for a clearer message.
         self.storage.get_fact(fact_id).await.map(|_| ())?;

--- a/memory-engine/lib/memory-engine/src/engine/reconstruct.rs
+++ b/memory-engine/lib/memory-engine/src/engine/reconstruct.rs
@@ -118,6 +118,11 @@ impl MemoryEngine {
         new_fingerprint: &EmbeddingFingerprint,
         embedder: &Arc<dyn EmbeddingProvider>,
     ) -> Result<PromoteOutcome> {
+        // Read-only is the fundamental write-capability precondition — checked before the
+        // fingerprint misconfiguration check below, so a read-only engine reports
+        // `ReadOnly` rather than `EmbeddingDimension` (#972). reconstruct re-embeds the
+        // whole active set: it is a write.
+        self.ensure_writable()?;
         // Fail fast on a genuine misconfiguration: the declared target identity's
         // dimension must match what the provider actually produces. (A target dim
         // that differs from the engine's *current* dim is the whole point of #742

--- a/tests/read_only_test.rs
+++ b/tests/read_only_test.rs
@@ -1,9 +1,21 @@
 #![allow(clippy::unwrap_used)] // test/bench code: panic-on-unwrap is the intended failure signal (#725)
 
-use memory_engine::{MemoryEngine, MemoryError};
+use memory_engine::{EmbeddingFingerprint, EmbeddingProvider, MemoryEngine, MemoryError};
 use tempfile::tempdir;
 
 const DIM: usize = 4;
+
+/// Minimal embedder for the read-only empty-batch test. It is never actually invoked
+/// (the read-only gate fires before any embedding), so the bodies are trivial.
+struct NoopEmbedder;
+impl EmbeddingProvider for NoopEmbedder {
+    fn embed(&self, _text: &str) -> memory_engine::Result<Vec<f32>> {
+        Ok(vec![0.0; DIM])
+    }
+    fn fingerprint(&self) -> EmbeddingFingerprint {
+        EmbeddingFingerprint::new("noop", "test", DIM)
+    }
+}
 
 #[tokio::test]
 async fn open_read_only_on_initialized_db() {
@@ -70,6 +82,162 @@ async fn read_only_engine_rejects_writes() {
         .await
         .unwrap_err();
     assert!(matches!(err, MemoryError::ReadOnly));
+}
+
+/// #972: the facade's own write methods (which delegate straight to `self.storage`,
+/// bypassing the L3 primitives) fail fast with `ReadOnly` via `self.ensure_writable()` —
+/// before any read/work — rather than late at the below-seam `try_write()`. Locks the
+/// gate on the facade surface a cross-model (agy) review flagged as ungated.
+#[tokio::test]
+async fn read_only_engine_rejects_facade_writes() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    {
+        let _e = MemoryEngine::builder(DIM)
+            .path(db_path.clone())
+            .build()
+            .unwrap();
+    }
+    let engine = MemoryEngine::builder(DIM)
+        .path(db_path)
+        .read_only(true)
+        .build()
+        .unwrap();
+
+    // Each of these delegates to self.storage and now self-gates on read_only.
+    assert!(matches!(
+        engine.pin_fact(1).await.unwrap_err(),
+        MemoryError::ReadOnly
+    ));
+    assert!(matches!(
+        engine.unpin_fact(1).await.unwrap_err(),
+        MemoryError::ReadOnly
+    ));
+    assert!(matches!(
+        engine.expire_edge(1).await.unwrap_err(),
+        MemoryError::ReadOnly
+    ));
+    assert!(matches!(
+        engine.delete_lineage(1).await.unwrap_err(),
+        MemoryError::ReadOnly
+    ));
+    assert!(matches!(
+        engine.ensure_scope_path("a/b").await.unwrap_err(),
+        MemoryError::ReadOnly
+    ));
+    // record_outcome does a get_fact READ before writing; the gate must precede it —
+    // ReadOnly, not the NotFound the (skipped) fact lookup would otherwise raise.
+    assert!(matches!(
+        engine
+            .record_outcome(999, memory_engine::Outcome::Positive)
+            .await
+            .unwrap_err(),
+        MemoryError::ReadOnly
+    ));
+    // link_session_facts does a scope/active-facts READ before its edge writes.
+    assert!(matches!(
+        engine.link_session_facts("s1", None).await.unwrap_err(),
+        MemoryError::ReadOnly
+    ));
+
+    // flush_snapshot is the deliberate exception: a read-only engine has nothing to
+    // persist, so close() is a clean no-op (Ok(false)), NOT a ReadOnly error.
+    assert!(!engine.flush_snapshot().await.unwrap());
+}
+
+/// #972 crux lock: an EMPTY `add_facts_batch` on a read-only engine returns `ReadOnly`
+/// (it was `Ok(vec![])` pre-#972). The gate sits at the primitive entry, BEFORE the
+/// empty-input short-circuit — so even a no-op write call on a read-only handle is
+/// rejected. Pins the deliberate `Ok -> Err` behavior a cross-model review (Codex) asked
+/// to lock rather than leave commentary-only.
+#[tokio::test]
+async fn read_only_engine_rejects_empty_batch() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    {
+        let _e = MemoryEngine::builder(DIM)
+            .path(db_path.clone())
+            .build()
+            .unwrap();
+    }
+    let engine = MemoryEngine::builder(DIM)
+        .path(db_path)
+        .read_only(true)
+        .build()
+        .unwrap();
+    let embedder: std::sync::Arc<dyn EmbeddingProvider> = std::sync::Arc::new(NoopEmbedder);
+    let err = engine
+        .add_facts_batch(&[], embedder.clone(), None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, MemoryError::ReadOnly),
+        "empty batch on a read-only engine must be ReadOnly, got {err:?}"
+    );
+    // The separately-implemented partial variant has the same entry gate: its empty
+    // return also sits below the gate, so the OUTER Result is Err(ReadOnly).
+    let err = engine
+        .add_facts_batch_partial(&[], embedder, None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, MemoryError::ReadOnly),
+        "empty partial batch on a read-only engine must be ReadOnly, got {err:?}"
+    );
+}
+
+/// #972: `reconstruct` and the `bootstrap_*` family are public write APIs that do
+/// substantial work (fingerprint validation; file parsing + consumer extraction) before
+/// the write. They now fail fast at entry with `ReadOnly`. In particular this locks the
+/// `bootstrap_directory` fix: it used to catch the per-session `ReadOnly`, log it, and
+/// return `Ok(aggregate)` — silently swallowing the error it documents.
+#[tokio::test]
+async fn read_only_engine_rejects_reconstruct_and_bootstrap() {
+    use std::sync::Arc;
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    {
+        let _e = MemoryEngine::builder(DIM)
+            .path(db_path.clone())
+            .build()
+            .unwrap();
+    }
+    let engine = MemoryEngine::builder(DIM)
+        .path(db_path)
+        .read_only(true)
+        .build()
+        .unwrap();
+    let embedder: Arc<dyn EmbeddingProvider> = Arc::new(NoopEmbedder);
+
+    // reconstruct: `ReadOnly` takes precedence over the fingerprint dim check
+    // (capability-first). The target fingerprint is deliberately MISMATCHED (`DIM + 1`
+    // vs the embedder's `DIM`) so the ordering is mutation-proven: without the entry
+    // gate, the dim check would fire first and return `EmbeddingDimension`, failing this
+    // assertion. The test stays green ONLY because `ensure_writable()` runs first.
+    let fp = EmbeddingFingerprint::new("noop", "test", DIM + 1);
+    let err = engine.reconstruct(&fp, &embedder).await.unwrap_err();
+    assert!(
+        matches!(err, MemoryError::ReadOnly),
+        "reconstruct on a read-only engine must be ReadOnly, got {err:?}"
+    );
+
+    // bootstrap_directory: fails fast at entry rather than swallowing per-session ReadOnly
+    // and returning Ok. Empty session dir → the ReadOnly must still surface.
+    let sessions = tempdir().unwrap();
+    let err = engine
+        .bootstrap_directory(
+            sessions.path(),
+            embedder,
+            Arc::new(memory_engine::KeywordExtractor),
+            &memory_engine::BootstrapConfig::default(),
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, MemoryError::ReadOnly),
+        "bootstrap_directory on a read-only engine must be ReadOnly (not a swallowed Ok), got {err:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Fail-fast read-only gate on every write primitive (#972)

Write primitives took the read-only failure **late**, below the seam: a read-only engine ran each primitive's reads — and for `resolve_conflict`, the consumer `ConflictArbiter` (possibly network/LLM work) — before `try_write()` finally rejected with `MemoryError::ReadOnly`. `MemoryCtx` already carries `ensure_writable()` for exactly this; the S3/S4 carves deferred it and tracked the coordinated sweep here.

### Change — uniform `ctx.ensure_writable()?` at entry (right after `ensure_open()`)
**12 write primitives** across me-ingest (×5), me-resolve, me-forget, me-consolidate, me-archive, and me-cognitive (`run_dream_cycle` — replacing a hand-rolled `if ctx.read_only`; `run_dream_cycle_guarded`; and **`apply_cycle_report`** — the delta-apply write `run_dream_cycle` defers to, *added during review*). me-query (reads) is correctly untouched. The me-consolidate + me-archive comments that deferred this to #972 are resolved.

### ⚠️ Behavior change — deliberate & documented, NOT merely timing
`ReadOnly` is treated as the **fundamental write-capability precondition**, checked before the request itself. So on a read-only engine it now takes **precedence** over request validation and over the (now-skipped) reads:
- read-only + oversized payload → `ReadOnly` (was `PayloadTooLarge`)
- read-only + invalid `ForgetPolicy` → `ReadOnly` (was the policy error)
- read-only + missing `old_id` (resolve) → `ReadOnly` (was `NotFound`)
- read-only + **empty** `add_facts_batch` → `ReadOnly` (was `Ok(vec![])`) — a write method on a read-only handle is a misuse regardless of arguments

Rationale (maintainer decision 2026-07-21): DIP + Law of Demeter — a write primitive asserts its own precondition against the `MemoryCtx` gate, not the backend pool's distant `try_write()`; and a read-only handle can't write *regardless* of request validity, so surfacing `ReadOnly` first is the most useful answer. Every site comment, the `test_ctx` doc, and `conflict.rs`'s `# Errors` precedence note are updated to state this honestly (the correctness reviewer flagged the original comments as over-claiming "timing-only").

### Regression witnesses (mutation-proven)
`me-forget::prune_read_only_fails_fast` and `me-cognitive::apply_cycle_report_read_only_fails_fast` — a `read_only` handle over a genuinely-writable backend, asserting `ReadOnly` before any storage touch. Each passes with its gate and **fails without it** (the storage `try_write()` fence alone doesn't trip on a writable pool), so the gate can't silently regress.

### Review — gate: Full (degraded externals)
2 diverse-lens subagents (correctness + completeness). **Correctness** flagged the over-claimed "timing-only" framing (→ honest docs above) and confirmed the mechanism sound. **Completeness** caught the `apply_cycle_report` BLOCKER (→ gated + witnessed). **Both external reviewers were unavailable this round — Codex hit its usage limit (until Jul 26) and agy timed out in print-mode** — so this is a subagent-carried degraded review; flagging loudly for maintainer scrutiny of the behavior change.

### Verification
Full 12-line gate matrix, all green — `test --workspace --all-features` (**1985 passed**; 1983 main + the 2 witnesses), `clippy --all-features -D warnings`, doc×2 (incl. the updated `conflict.rs` links), deny, `cargo +nightly fuzz build`. Facade `read_only_test` (6) still passes.

Closes #972
