### PR TITLE
refactor(core): single-source cache_scope_chain into me-index (#973)

### DIFF
--- a/docs/design/adr/0018-wave2-crate-decomposition-memoryctx.md
+++ b/docs/design/adr/0018-wave2-crate-decomposition-memoryctx.md
@@ -51,8 +51,13 @@ build on these boundaries have the durable _why_.
 
 4. **`me-index` stays a separate L2 crate** (graph + scope projections), not folded into
    `me-backend-sqlite`: projections are backend-agnostic, and #763's freshness registry
-   - #247/#243 context work want a backend-free, trait-free, mockable home. `me-index`
-     depends on `{me-storage, me-types}` only (no `me-traits`).
+   - #247/#243 context work want a backend-agnostic, mockable home. `me-index` depends on
+     `{me-storage, me-types}` — on the `me-storage` **port trait**, never a concrete
+     backend, so it never links SQLite/PG (DIP). The port edge exists for
+     `me_index::cache_scope_chain` (#973), which hydrates the `ScopeTree` from a leaf's
+     persisted ancestry via `StorageBackend::get_scope`; it single-sources a walk that was
+     otherwise duplicated in `me-ingest` + the facade. No *direct* `me-traits` dep —
+     `me-traits` enters only transitively through `me-storage`.
 
 5. **Orphan-module homes:** `limits` → `me-types`; `upcaster` (`UpcasterRegistry`) →
    `me-storage` (event-payload versioning the port applies on read; both backends

--- a/docs/reference/crate-layout.md
+++ b/docs/reference/crate-layout.md
@@ -64,6 +64,7 @@ graph TD
     storage --> types
     traits --> types
     index --> types
+    index --> storage
 ```
 
 **The invariant this diagram encodes** — read it before changing any edge: an **L3
@@ -72,11 +73,17 @@ primitive depends on the _port_ (`me-storage`), never on a concrete backend.** T
 swappable (epic #628) and the primitives testable without one. `cargo` enforces it:
 `cargo tree -p <L3 crate> --edges normal` must show no `me-backend-*`.
 
-`me-index` (L2) depends on **`me-types` only** — not `me-storage`, not `me-traits` — so
-the graph/scope projections stay backend-free, *storage*-free, trait-free, and mockable
-(ADR 0018 decision #4). The conn-based bulk loaders that hydrate them live facade-side in
-`engine/graph_load.rs`, precisely to keep that property. (Verified: `me-index/Cargo.toml`
-lists `me-types` + `petgraph` and nothing else.)
+`me-index` (L2) depends on `me-types` + the `me-storage` **port** — but **not** `me-traits`
+and **not** any concrete backend, so its graph/scope projections stay backend-**agnostic**
+and mockable. The port dep was added in **#973** for `me_index::cache_scope_chain`, which
+hydrates the `ScopeTree` from a leaf's persisted ancestry via `StorageBackend::get_scope`;
+because it depends on the port *trait* (DIP), not a backend, me-index still never links
+SQLite/PG. This makes the code match ADR 0018 decision #4, which already listed the
+`me-index → me-storage` edge (ahead of the code); #973 realizes it and records the
+rationale — collapsing the hydration-walk copy that the *pre-#973 storage-free code* had
+forced into `me-ingest` **and** the facade. The `MemoryGraph` bulk loaders still live
+facade-side in `engine/graph_load.rs`. (Verified acyclic: `me-storage` depends only on
+`me-types` + `me-traits`, never on `me-index`.)
 
 **`me-test-support`** is dev-only (`publish = false`, in `[dev-dependencies]` everywhere)
 and does not inflate the shipped graph.
@@ -214,7 +221,7 @@ L0→L4 DAG. The L0–L2 foundation crates, as separate workspace members under
 : The persistence **port**. Owns the `StorageBackend` umbrella supertrait over six bounded-context traits (`FactGraph`, `EventLog`, `SearchIndex`, `ConsolidationStore`, `SessionStore`, `SchemaManager`) + the feature-gated `ColdStorage`; the closed `FactFilter`/`TemporalFilter` query vocabulary; the `BackendCapabilities`/`LexicalRanker` tier signal; `MemoryCtx` (the universal capability handle — see the [architecture overview](../design/architecture-overview.md)); and `UpcasterRegistry` (event-payload versioning the port applies on read). No SQL string or driver type appears here — backends implement the traits and map driver errors to the driver-opaque `StorageError` at the seam. Depends on `{me-types, me-traits}`.
 
 `me-index` (L2 — `memory-engine/lib/me-index/`)
-: Backend-agnostic in-memory projections: `MemoryGraph` (the `petgraph`-backed knowledge graph, ex-`graph/`) and `ScopeTree` (the hierarchical scope cache, ex-`scope/`). Trait-free and mockable — depends only on `me-types`, not `me-traits` or `me-storage` (ADR 0018 decision #4) — so the #763 freshness registry and the #247/#243 context work get a backend-free home. Rebuilt from `me-types` DTOs by the facade's `engine::graph_load` glue on engine open.
+: Backend-agnostic in-memory projections: `MemoryGraph` (the `petgraph`-backed knowledge graph, ex-`graph/`) and `ScopeTree` (the hierarchical scope cache, ex-`scope/`) — plus `cache_scope_chain`, which hydrates the `ScopeTree` from persisted scope ancestry via the storage port (#973). Depends on `me-types` + the `me-storage` **port trait** (`get_scope`) — not `me-traits`, and never a concrete backend, so it stays backend-agnostic (DIP; realizes the `me-index → me-storage` edge ADR 0018 decision #4 already listed) and the #763 freshness registry / #247/#243 context work still get a backend-free home. `MemoryGraph` is rebuilt from `me-types` DTOs by the facade's `engine::graph_load` glue on engine open.
 
 `me-backend-sqlite` (L2 — `memory-engine/lib/me-backend-sqlite/`)
 : The `SqliteBackend` `StorageBackend` impl. Owns the `ConnectionPool` (N readers + 1 writer, ex-`pool/`), the `store/` table accessors + schema migrations (ex-`store/`), the `block_read`/`block_write`/`for_each_streamed` `spawn_blocking` seam, the FTS5/vector search cores (`search::fts`/`search::vector`; the RRF merge + the `MemoryQuery` API stay in the facade until `me-query`, S4), and the sidecar `.snapshot` file I/O. Depends on `{me-types, me-traits, me-storage}`.

--- a/memory-engine/lib/me-index/Cargo.toml
+++ b/memory-engine/lib/me-index/Cargo.toml
@@ -12,11 +12,20 @@ publish = false
 
 [dependencies]
 me-types = { path = "../me-types" }
+# The persistence PORT (L1) — for `cache_scope_chain`, which hydrates the `ScopeTree`
+# projection from a leaf's persisted scope ancestry via `StorageBackend::get_scope`
+# (#973). This is the port TRAIT, not a concrete backend, so me-index stays
+# backend-agnostic (DIP); the L2→L1 edge is acyclic (me-storage depends only on
+# me-types + me-traits). Revisits the S2 "me-index is storage-free" carve decision:
+# the duplication it forced (a copy of the hydration walk in me-ingest AND the facade)
+# is the debt this collapses.
+me-storage = { path = "../me-storage" }
 # No `[workspace.dependencies]` table exists in the root manifest (only
 # `[workspace.package]` / `[workspace.lints]`), so third-party deps are bare
 # versions here too, matching `me-storage`'s convention (its `chrono`/`serde_json`
 # are plain `version = "..."`, not `workspace = true`) rather than the facade-style
 # `workspace = true` the plan sketch assumed.
+parking_lot = "0.12"
 petgraph = "0.7"
 
 [dev-dependencies]

--- a/memory-engine/lib/me-index/src/lib.rs
+++ b/memory-engine/lib/me-index/src/lib.rs
@@ -14,4 +14,4 @@ pub mod graph;
 pub mod scope;
 
 pub use graph::{EdgeData, MemoryGraph};
-pub use scope::ScopeTree;
+pub use scope::{ScopeTree, cache_scope_chain};

--- a/memory-engine/lib/me-index/src/scope/mod.rs
+++ b/memory-engine/lib/me-index/src/scope/mod.rs
@@ -2,7 +2,79 @@
 
 pub mod tree;
 
+use parking_lot::RwLock;
+
+use me_storage::StorageBackend;
+use me_types::error::Result;
+
 pub use tree::ScopeTree;
+
+/// Hydrate the in-memory [`ScopeTree`] from a leaf scope's persisted ancestry.
+///
+/// Walks `parent_id` links up from `leaf_id` through the persistence **port**'s
+/// `get_scope` — stopping at the root or the first already-seen node
+/// (cycle guard) — collects the chain, then inserts it under one brief write lock.
+///
+/// Single-sourced here (#973): the ingest primitive (`me-ingest`), the facade's
+/// `MemoryEngine::cache_scope_chain`, its bootstrap path, and the dream-cycle scope
+/// mirroring all route to this one definition — collapsing the copy the S2 "me-index is
+/// storage-free" carve forced into `me-ingest` and the facade. me-index depends on the
+/// port **trait**, not a concrete backend, so it stays backend-agnostic (DIP).
+///
+/// # Send-safety
+///
+/// The `get_scope` awaits run with **no** lock held; the `scope_tree` write guard is taken
+/// only for the final synchronous insert loop (no `.await` inside), so the returned future
+/// stays `Send`.
+///
+/// # Errors
+///
+/// Propagates any failure from the port's `get_scope`.
+///
+/// # Examples
+///
+/// The `storage` argument is the persistence port (`&dyn StorageBackend`); consumers pass
+/// their `Arc<dyn StorageBackend>` by deref (`&*arc` / `&**arc_ref`). The example is
+/// `ignore`d because it needs a live backend:
+///
+/// ```ignore
+/// use parking_lot::RwLock;
+/// use me_index::{ScopeTree, cache_scope_chain};
+/// use me_storage::StorageBackend;
+///
+/// async fn hydrate(
+///     storage: &dyn StorageBackend,
+///     scope_tree: &RwLock<ScopeTree>,
+///     leaf_id: i64,
+/// ) -> me_types::error::Result<()> {
+///     // Insert `leaf_id` and all its ancestors (up to, but excluding, the root).
+///     cache_scope_chain(storage, scope_tree, leaf_id).await
+/// }
+/// ```
+pub async fn cache_scope_chain(
+    storage: &dyn StorageBackend,
+    scope_tree: &RwLock<ScopeTree>,
+    leaf_id: i64,
+) -> Result<()> {
+    let mut nodes = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut current = Some(leaf_id);
+    while let Some(node_id) = current {
+        if node_id == ScopeTree::root_id() || !seen.insert(node_id) {
+            break;
+        }
+        let node = storage.get_scope(node_id).await?;
+        current = node.parent_id;
+        nodes.push(node);
+    }
+    {
+        let mut tree = scope_tree.write();
+        for node in nodes {
+            tree.insert(node);
+        }
+    }
+    Ok(())
+}
 
 // `MAX_SEGMENT_LEN` + `validate_segment` live in `me-types` (Wave 2 #816 / S2): the
 // shared scope-segment SSOT must sit *below* both the in-memory index (read path,

--- a/memory-engine/lib/me-ingest/src/lib.rs
+++ b/memory-engine/lib/me-ingest/src/lib.rs
@@ -207,7 +207,7 @@ async fn insert_fact_with_embedding(
     let scope_id = match &req.scope {
         Some(path) => {
             let id = ctx.storage.ensure_scope_path(path).await?;
-            cache_scope_chain(ctx, scope_tree, id).await?;
+            me_index::cache_scope_chain(&**ctx.storage, scope_tree, id).await?;
             id
         }
         None => 1, // root scope
@@ -542,35 +542,6 @@ async fn compute_batch_pins(
         .collect())
 }
 
-/// Cache the scope chain from `leaf_id` up to (but excluding) the root into the
-/// in-memory `scope_tree`.
-///
-/// NOTE: duplicated with the facade's `MemoryEngine::cache_scope_chain`
-/// (`engine/mod.rs`) — a shared home is decided later, with me-consolidate's
-/// needs (#973). Do not fold this back into a cross-crate call; the facade copy
-/// stays put and is used unchanged by `bootstrap.rs`/`cognitive.rs`/
-/// `ensure_scope_path`.
-async fn cache_scope_chain(
-    ctx: MemoryCtx<'_>,
-    scope_tree: &RwLock<ScopeTree>,
-    leaf_id: i64,
-) -> Result<()> {
-    let mut nodes = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    let mut current = Some(leaf_id);
-    while let Some(node_id) = current {
-        if node_id == ScopeTree::root_id() || !seen.insert(node_id) {
-            break;
-        }
-        let node = ctx.storage.get_scope(node_id).await?;
-        current = node.parent_id;
-        nodes.push(node);
-    }
-    {
-        let mut tree = scope_tree.write();
-        for node in nodes {
-            tree.insert(node);
-        }
-    }
-    Ok(())
-}
+// `cache_scope_chain` was single-sourced into `me_index::cache_scope_chain` (#973), which
+// hydrates the `ScopeTree` from the persistence port; this crate and the facade both route
+// to it. The private copy that lived here is gone.

--- a/memory-engine/lib/memory-engine/src/engine/mod.rs
+++ b/memory-engine/lib/memory-engine/src/engine/mod.rs
@@ -625,28 +625,12 @@ impl MemoryEngine {
     /// though the facts are correctly persisted. [`ScopeTree::insert`] is
     /// idempotent by id, so re-inserting shared ancestors is a no-op.
     ///
-    /// The port walk (`get_scope`) is awaited up front into an owned `Vec`; the
-    /// `scope_tree` write guard is taken only afterward, so no lock is held
-    /// across `.await` (keeps the future `Send`).
+    /// Delegates to [`me_index::cache_scope_chain`] — the single home for the port
+    /// walk + `ScopeTree` hydration (#973). The port walk (`get_scope`) is awaited up
+    /// front into an owned `Vec` there; the `scope_tree` write guard is taken only
+    /// afterward, so no lock is held across `.await` (keeps the future `Send`).
     async fn cache_scope_chain(&self, leaf_id: i64) -> Result<()> {
-        let mut nodes = Vec::new();
-        let mut seen = std::collections::HashSet::new();
-        let mut current = Some(leaf_id);
-        while let Some(node_id) = current {
-            if node_id == ScopeTree::root_id() || !seen.insert(node_id) {
-                break;
-            }
-            let node = self.storage.get_scope(node_id).await?;
-            current = node.parent_id;
-            nodes.push(node);
-        }
-        {
-            let mut tree = self.scope_tree.write();
-            for node in nodes {
-                tree.insert(node);
-            }
-        }
-        Ok(())
+        me_index::cache_scope_chain(&*self.storage, &self.scope_tree, leaf_id).await
     }
 
     // --- Public API: Config ---


### PR DESCRIPTION
## Single-source `cache_scope_chain` into me-index (#973)

`cache_scope_chain` — hydrates the in-memory `ScopeTree` from a leaf scope's persisted ancestry via the storage port's `get_scope` — was **duplicated byte-for-byte** between the ingest primitive (`me-ingest`) and the facade (`MemoryEngine::cache_scope_chain`, used by bootstrap + dream-cycle scope mirroring). The copy was seeded intentionally during the S4 me-ingest carve because me-index was deliberately kept storage-free in S2; the shared-home decision was deferred here.

### Change — Option A (maintainer decision 2026-07-21)
One `me_index::cache_scope_chain(storage, scope_tree, leaf_id)`. me-index gains a dep on the **me-storage port** (the `StorageBackend` trait, for `get_scope`) + `parking_lot`.
- The S2 "me-index is storage-free" property was **carve scaffolding**. Depending on the port *trait* (DIP), not a concrete backend, keeps me-index **backend-agnostic** — it still never links SQLite/PG. Hydration is cohesive with the `ScopeTree` projection it fills.
- The L2→L1 edge is **acyclic** (me-storage depends only on me-types + me-traits — verified).
- me-index takes `&dyn StorageBackend`, so both `&Arc<dyn …>` callers coerce in.
- me-ingest's private copy is deleted; the facade's method becomes a one-line delegate (bootstrap/cognitive/ensure_scope_path call-sites unchanged).

Behavior-preserving — the walk + Send-safe collect-then-briefly-lock logic is relocated verbatim, validated by the existing facade + ingest scope-caching tests. This **revises ADR 0018 decision #4**'s storage-free stance (crate-layout.md updated; a follow-up will amend the ADR itself).

### Verification
Full 12-line gate matrix + per-crate `cargo doc -p me-index` (the new public fn's links — not covered by the facade `--no-deps` doc gate), all green — `test --workspace --all-features` (**1983 passed**, exact — behavior-preserving), clippy, deny, `cargo +nightly fuzz build`.

Closes #973

### ADR fix folded in (review finding)
The architecture reviewer found the premise was inverted: ADR 0018 decision #4 **already listed** the `me-index → me-storage` edge (it ran ahead of the pre-#973 storage-free code — a latent doc/code mismatch), so there was no "storage-free stance" in the ADR to revise. This PR corrects the ADR (records the `cache_scope_chain` rationale; replaces the stale "trait-free" with "no *direct* me-traits — transitive via me-storage") and makes the code match — folded in here rather than deferred.

Closes #1003
