### PR TITLE
refactor(storage): compile-enforce embedding-registry write atomicity via &Transaction (#1000)

### DIFF
--- a/memory-engine/lib/me-backend-sqlite/src/sqlite/consolidation.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/sqlite/consolidation.rs
@@ -1053,7 +1053,11 @@ mod tests {
         // Seed one active fact and stamp the store identity.
         let fact_id: i64 = {
             let conn = pool.write();
-            embedding_meta::record_if_absent(&conn, &fp, DIM).unwrap();
+            {
+                let tx = conn.unchecked_transaction().unwrap();
+                embedding_meta::record_if_absent(&tx, &fp, DIM).unwrap();
+                tx.commit().unwrap();
+            }
             FactStore::new(&conn, DIM)
                 .insert(&NewFact {
                     content: "victim".into(),

--- a/memory-engine/lib/me-backend-sqlite/src/sqlite/graph.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/sqlite/graph.rs
@@ -74,7 +74,9 @@ impl SqliteBackend {
         // `Transaction` object, matching `insert_fact`'s existing `unchecked_transaction`
         // pattern and satisfying `record_if_absent`'s `&Transaction` contract. Rollback is
         // by drop (no manual `ROLLBACK TO`/`RELEASE`, whose errors were previously
-        // swallowed). Safe: a `block_write` connection is fresh autocommit, never nested.
+        // swallowed). A `block_write` connection is in autocommit on the normal path
+        // (the `test-util` `raw_exec` seam aside — see the fingerprint-write methods'
+        // note), so `unchecked_transaction` begins a fresh tx, as `insert_fact` already does.
         let tx = conn
             .unchecked_transaction()
             .map_err(StorageError::backend)?;
@@ -251,8 +253,19 @@ impl FactGraph for SqliteBackend {
     ) -> Result<()> {
         let ids = ids.to_vec();
         let dim = self.embed_dim;
-        self.block_write(move |c| FactStore::new(c, dim).mark_dream_cycled(&ids, cycle_id, now))
-            .await
+        self.block_write(move |c| {
+            // #1000: `mark_dream_cycled` loops `merge_metadata` once per id, so a mid-loop
+            // failure (e.g. a missing id → NotFound) would autocommit a PREFIX of the
+            // markers and still return Err — wrongly excluding those facts from later
+            // cycles. Wrap the loop in a transaction: atomic-or-nothing. The cycle-apply
+            // path (consolidation.rs) already runs this inside an outer tx; this is the
+            // direct-port path's equivalent (flagged by cross-model review of #1000).
+            let tx = c.unchecked_transaction().map_err(StorageError::backend)?;
+            FactStore::new(&tx, dim).mark_dream_cycled(&ids, cycle_id, now)?;
+            tx.commit().map_err(StorageError::backend)?;
+            Ok(())
+        })
+        .await
     }
 
     // WRITE
@@ -678,8 +691,18 @@ impl FactGraph for SqliteBackend {
     // WRITE
     async fn ensure_scope_path(&self, path: &str) -> Result<i64> {
         let path = path.to_owned();
-        self.block_write(move |c| ScopeStore::new(c).ensure_path(&path))
-            .await
+        self.block_write(move |c| {
+            // #1000: `ensure_path` inserts one row per path segment in a loop, so wrap it
+            // in a transaction — a partial path is never committed (atomic-or-nothing),
+            // matching the batch-insert path that resolves scopes inside its own tx.
+            // (Partial creation is idempotent-recoverable, but the audit converts every
+            // multi-write helper uniformly.)
+            let tx = c.unchecked_transaction().map_err(StorageError::backend)?;
+            let id = ScopeStore::new(&tx).ensure_path(&path)?;
+            tx.commit().map_err(StorageError::backend)?;
+            Ok(id)
+        })
+        .await
     }
 
     // READ
@@ -1069,8 +1092,9 @@ impl FactGraph for SqliteBackend {
         self.block_write(move |conn| {
             // RAII transaction (#1000) — was a manual `SAVEPOINT ingest_bootstrap` dance;
             // now a `Transaction` object so `record_if_absent`'s `&Transaction` contract
-            // is met and rollback is by drop. Fresh autocommit conn (block_write), never
-            // nested.
+            // is met and rollback is by drop. A block_write conn is in autocommit on the
+            // normal path (the `test-util` `raw_exec` seam aside), so this begins a fresh
+            // tx, as `insert_fact` already does.
             let tx = conn
                 .unchecked_transaction()
                 .map_err(StorageError::backend)?;
@@ -1686,6 +1710,40 @@ mod tests {
         assert!(
             all.is_empty(),
             "rollback must leave no fact in the store; got {all:?}"
+        );
+    }
+
+    /// #1000: `mark_facts_dream_cycled` wraps its per-id `merge_metadata` loop in a
+    /// transaction, so a mid-batch failure rolls back the WHOLE batch. Without the wrap,
+    /// the first (valid) id would autocommit its `dream_cycle` marker and the call would
+    /// still return `Err` — silently excluding that fact from every later cycle. This is
+    /// the regression witness cross-model review of #1000 asked for; it is mutation-proof
+    /// (neutralize the `unchecked_transaction()` in `mark_facts_dream_cycled` and the
+    /// final assertion fails because `real_id` ends up stamped).
+    #[tokio::test]
+    async fn mark_facts_dream_cycled_rolls_back_on_partial_failure() {
+        let pool = Arc::new(ConnectionPool::open_memory(DIM).unwrap());
+        let be = backend(Arc::clone(&pool));
+        // One real fact, then mark it alongside a non-existent id: the loop stamps
+        // `real_id` first, then hits `NotFound` on 9999.
+        let real_id = be
+            .insert_fact_atomic(&fact("real", [0.1; DIM]), &fp(), DIM)
+            .await
+            .unwrap();
+        let err = be
+            .mark_facts_dream_cycled(&[real_id, 9999], 7, Utc::now())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::NotFound(_)),
+            "expected NotFound on the missing id, got {err:?}"
+        );
+        // CRUX: the whole batch rolled back — `real_id` must NOT carry a `dream_cycle`
+        // marker, so it is still eligible for future cycles.
+        let f = be.get_fact(real_id).await.unwrap();
+        assert!(
+            f.metadata.get("dream_cycle").is_none(),
+            "partial mark must roll back: real_id was stamped despite the batch failing"
         );
     }
 

--- a/memory-engine/lib/me-backend-sqlite/src/sqlite/graph.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/sqlite/graph.rs
@@ -69,18 +69,23 @@ impl SqliteBackend {
             )));
         }
 
-        // Verbatim body of ingest.rs:397-476: savepoint wrapping stamp +
-        // scope-resolve + per-fact insert.
-        conn.execute_batch("SAVEPOINT batch_insert")
+        // Wrap the stamp + scope-resolve + per-fact insert in one RAII transaction
+        // (#1000). Was a manual `SAVEPOINT batch_insert` string dance; now a
+        // `Transaction` object, matching `insert_fact`'s existing `unchecked_transaction`
+        // pattern and satisfying `record_if_absent`'s `&Transaction` contract. Rollback is
+        // by drop (no manual `ROLLBACK TO`/`RELEASE`, whose errors were previously
+        // swallowed). Safe: a `block_write` connection is fresh autocommit, never nested.
+        let tx = conn
+            .unchecked_transaction()
             .map_err(StorageError::backend)?;
 
         let result: Result<BatchInsertResult> = (|| {
             // Record the embedding identity on first write (#613), inside the
-            // savepoint so it commits atomically with the batch.
-            crate::store::embedding_meta::record_if_absent(conn, fingerprint, expected_dim)?;
+            // transaction so it commits atomically with the batch.
+            crate::store::embedding_meta::record_if_absent(&tx, fingerprint, expected_dim)?;
 
-            let scope_store = ScopeStore::new(conn);
-            let store = FactStore::new(conn, dim);
+            let scope_store = ScopeStore::new(&tx);
+            let store = FactStore::new(&tx, dim);
 
             // Resolve scopes INSIDE the savepoint so they roll back on error.
             // Deduplicate by path to avoid N redundant DB lookups.
@@ -129,13 +134,12 @@ impl SqliteBackend {
 
         match result {
             Ok(triple) => {
-                conn.execute_batch("RELEASE batch_insert")
-                    .map_err(StorageError::backend)?;
+                tx.commit().map_err(StorageError::backend)?;
                 Ok(triple)
             }
             Err(e) => {
-                let _ = conn.execute_batch("ROLLBACK TO batch_insert");
-                let _ = conn.execute_batch("RELEASE batch_insert");
+                // `tx` rolls back on drop — no manual `ROLLBACK TO`/`RELEASE`.
+                drop(tx);
                 Err(e)
             }
         }
@@ -1063,7 +1067,13 @@ impl FactGraph for SqliteBackend {
         let skip_if_present = skip_if_present.cloned();
         let fingerprint = fingerprint.clone();
         self.block_write(move |conn| {
-            conn.execute_batch("SAVEPOINT ingest_bootstrap").map_err(StorageError::backend)?;
+            // RAII transaction (#1000) — was a manual `SAVEPOINT ingest_bootstrap` dance;
+            // now a `Transaction` object so `record_if_absent`'s `&Transaction` contract
+            // is met and rollback is by drop. Fresh autocommit conn (block_write), never
+            // nested.
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(StorageError::backend)?;
             let outcome = (|| -> Result<BootstrapIngestOutcome> {
                 // Authoritative idempotency guard, checked FIRST inside the savepoint
                 // (under the write lock): a matching event ⟹ the batch is a no-op. This
@@ -1073,7 +1083,7 @@ impl FactGraph for SqliteBackend {
                 // the trim the facade's `count_events` early-out runs on the READ pool,
                 // racing this write. Re-checking here closes that TOCTOU (#816 B1).
                 if let Some(filter) = &skip_if_present
-                    && crate::store::events::EventStore::new(conn, &upcaster).count(filter)? > 0
+                    && crate::store::events::EventStore::new(&tx, &upcaster).count(filter)? > 0
                 {
                     return Ok(BootstrapIngestOutcome::Skipped);
                 }
@@ -1082,11 +1092,11 @@ impl FactGraph for SqliteBackend {
                 // facts keep their own `source_event_id` (`None`).
                 let marker_id = match &marker {
                     Some(marker) => {
-                        Some(crate::store::events::EventStore::new(conn, &upcaster).insert(marker)?)
+                        Some(crate::store::events::EventStore::new(&tx, &upcaster).insert(marker)?)
                     }
                     None => None,
                 };
-                let fact_store = FactStore::new(conn, expected_dim);
+                let fact_store = FactStore::new(&tx, expected_dim);
                 let mut out = Vec::with_capacity(facts.len());
                 let mut any_created = false;
                 for mut fact in facts {
@@ -1100,11 +1110,11 @@ impl FactGraph for SqliteBackend {
                     out.push((id, reinforced));
                 }
                 // #643: stamp the embedding identity only once a new vector has actually
-                // been written, at the tail of the savepoint so it commits atomically
+                // been written, at the tail of the transaction so it commits atomically
                 // with the facts it describes.
                 if any_created {
                     crate::store::embedding_meta::record_if_absent(
-                        conn,
+                        &tx,
                         &fingerprint,
                         expected_dim,
                     )?;
@@ -1113,18 +1123,13 @@ impl FactGraph for SqliteBackend {
             })();
             match outcome {
                 Ok(out) => {
-                    conn.execute_batch("RELEASE ingest_bootstrap").map_err(StorageError::backend)?;
+                    tx.commit().map_err(StorageError::backend)?;
                     Ok(out)
                 }
                 Err(e) => {
-                    // ROLLBACK TO restores the savepoint but keeps it open — RELEASE it
-                    // to close it and leave the writer out of an open transaction.
-                    if let Err(rb) = conn.execute_batch("ROLLBACK TO ingest_bootstrap") {
-                        tracing::warn!(error = %rb, "savepoint ROLLBACK TO ingest_bootstrap failed");
-                    }
-                    if let Err(rel) = conn.execute_batch("RELEASE ingest_bootstrap") {
-                        tracing::warn!(error = %rel, "savepoint RELEASE ingest_bootstrap (after rollback) failed");
-                    }
+                    // `tx` rolls back on drop — no manual `ROLLBACK TO`/`RELEASE` (whose
+                    // failures were previously only logged).
+                    drop(tx);
                     Err(e)
                 }
             }
@@ -1630,7 +1635,11 @@ mod tests {
         // Oracle: stamp identity + insert via direct FactStore.
         let oracle_id = {
             let conn = pool.write();
-            embedding_meta::record_if_absent(&conn, &fp(), DIM).unwrap();
+            {
+                let tx = conn.unchecked_transaction().unwrap();
+                embedding_meta::record_if_absent(&tx, &fp(), DIM).unwrap();
+                tx.commit().unwrap();
+            }
             FactStore::new(&conn, DIM)
                 .insert(&fact("oracle", [0.2; DIM]))
                 .unwrap()
@@ -1659,7 +1668,9 @@ mod tests {
         // Pre-stamp the store with fp(), then try to insert with a mismatched one.
         {
             let conn = pool.write();
-            embedding_meta::record_if_absent(&conn, &fp(), DIM).unwrap();
+            let tx = conn.unchecked_transaction().unwrap();
+            embedding_meta::record_if_absent(&tx, &fp(), DIM).unwrap();
+            tx.commit().unwrap();
         }
         let be = backend(Arc::clone(&pool));
         let err = be

--- a/memory-engine/lib/me-backend-sqlite/src/sqlite/schema.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/sqlite/schema.rs
@@ -19,7 +19,9 @@
 //! HNSW moves into the backend in #631).
 
 use async_trait::async_trait;
-#[cfg(feature = "test-util")]
+// Un-gated (#1000): the fingerprint-write trait methods below now open explicit
+// transactions and map their errors via `StorageError::backend` unconditionally, so this
+// import is no longer test-util-only.
 use me_types::error::StorageError;
 
 use super::SqliteBackend;
@@ -79,8 +81,18 @@ impl SchemaManager for SqliteBackend {
     // WRITE
     async fn store_embedding_fingerprint(&self, fp: &EmbeddingFingerprint) -> Result<()> {
         let fp = fp.clone();
-        self.block_write(move |c| embedding_meta::store(c, &fp))
-            .await
+        self.block_write(move |c| {
+            // #1000: `embedding_meta::store` re-stamps the active registry row via a
+            // two-statement UPDATE-or-INSERT. Run it in an explicit transaction so its
+            // atomicity is enforced by the `&Transaction` type, not merely by the
+            // block_write write-lock. Behavior-preserving: at a block_write boundary the
+            // connection is fresh autocommit, so this can never nest.
+            let tx = c.unchecked_transaction().map_err(StorageError::backend)?;
+            embedding_meta::store(&tx, &fp)?;
+            tx.commit().map_err(StorageError::backend)?;
+            Ok(())
+        })
+        .await
     }
 
     // WRITE
@@ -90,8 +102,15 @@ impl SchemaManager for SqliteBackend {
         expected_dim: usize,
     ) -> Result<EmbeddingFingerprint> {
         let candidate = candidate.clone();
-        self.block_write(move |c| embedding_meta::record_if_absent(c, &candidate, expected_dim))
-            .await
+        self.block_write(move |c| {
+            // #1000: see `store_embedding_fingerprint` — the write path re-stamps the
+            // registry, so wrap the record-if-absent in an explicit transaction.
+            let tx = c.unchecked_transaction().map_err(StorageError::backend)?;
+            let recorded = embedding_meta::record_if_absent(&tx, &candidate, expected_dim)?;
+            tx.commit().map_err(StorageError::backend)?;
+            Ok(recorded)
+        })
+        .await
     }
 
     // READ

--- a/memory-engine/lib/me-backend-sqlite/src/sqlite/schema.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/sqlite/schema.rs
@@ -85,8 +85,11 @@ impl SchemaManager for SqliteBackend {
             // #1000: `embedding_meta::store` re-stamps the active registry row via a
             // two-statement UPDATE-or-INSERT. Run it in an explicit transaction so its
             // atomicity is enforced by the `&Transaction` type, not merely by the
-            // block_write write-lock. Behavior-preserving: at a block_write boundary the
-            // connection is fresh autocommit, so this can never nest.
+            // block_write write-lock. Behavior-preserving: a block_write connection is in
+            // autocommit on every normal path, so this begins a fresh top-level tx. (The
+            // sole way an outer `BEGIN` could already be open is the `test-util` `raw_exec`
+            // seam — unused by any test, and the same premise `insert_fact` already relies
+            // on with its own `unchecked_transaction`.)
             let tx = c.unchecked_transaction().map_err(StorageError::backend)?;
             embedding_meta::store(&tx, &fp)?;
             tx.commit().map_err(StorageError::backend)?;

--- a/memory-engine/lib/me-backend-sqlite/src/store/embedding_meta.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/store/embedding_meta.rs
@@ -24,7 +24,7 @@
 //! the read-only counterpart used for the eager fail-fast check at consumer startup.
 //! The write-path call sites did not change when this landed.
 
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction};
 
 use me_types::error::{MemoryError, Result};
 use me_types::types::EmbeddingFingerprint;
@@ -52,8 +52,8 @@ pub fn load(conn: &Connection) -> Result<Option<EmbeddingFingerprint>> {
 ///
 /// Returns `MemoryError::Storage` on write failure or `MemoryError::Internal` if a
 /// dimension overflows `i64`.
-pub fn store(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
-    super::embedding_spaces::upsert_active_fingerprint(conn, fp)
+pub fn store(tx: &Transaction, fp: &EmbeddingFingerprint) -> Result<()> {
+    super::embedding_spaces::upsert_active_fingerprint(tx, fp)
 }
 
 /// Write-once recording of the identity on the first embedding write.
@@ -83,11 +83,16 @@ pub fn store(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
 /// recorded and `candidate.dim != expected_dim` (nothing is persisted); or any
 /// [`load`] / [`store`] error.
 pub fn record_if_absent(
-    conn: &Connection,
+    tx: &Transaction,
     candidate: &EmbeddingFingerprint,
     expected_dim: usize,
 ) -> Result<EmbeddingFingerprint> {
-    if let Some(stored) = load(conn)? {
+    // Takes `&Transaction` (#1000): the write path delegates to [`store`] →
+    // `upsert_active_fingerprint`, a multi-statement re-stamp whose atomicity the type
+    // system now enforces. The read-only present-branch also runs under the caller's tx
+    // (harmless) so both branches share one gate. `load` reads through the `Transaction`
+    // deref to `Connection`.
+    if let Some(stored) = load(tx)? {
         ensure_match(&stored, candidate)?;
         return Ok(stored);
     }
@@ -97,7 +102,7 @@ pub fn record_if_absent(
             actual: candidate.dim,
         });
     }
-    store(conn, candidate)?;
+    store(tx, candidate)?;
     Ok(candidate.clone())
 }
 
@@ -169,6 +174,32 @@ mod tests {
         let conn = open_memory().expect("open in-memory db");
         init_schema(&conn).expect("init schema");
         conn
+    }
+
+    // #1000: `store` / `record_if_absent` now take `&Transaction`. These same-named
+    // test shims (shadowing the `use super::*` glob) open a committed transaction over
+    // the test connection and delegate to the real `super::*` fns, so every assertion
+    // below reads exactly as before the conversion. On an error they leave the tx to
+    // roll back on drop (the error paths write nothing, so the "nothing persisted"
+    // assertions still hold).
+    fn store(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
+        let tx = conn.unchecked_transaction().expect("begin tx");
+        super::store(&tx, fp)?;
+        tx.commit().expect("commit");
+        Ok(())
+    }
+
+    fn record_if_absent(
+        conn: &Connection,
+        candidate: &EmbeddingFingerprint,
+        expected_dim: usize,
+    ) -> Result<EmbeddingFingerprint> {
+        let tx = conn.unchecked_transaction().expect("begin tx");
+        let out = super::record_if_absent(&tx, candidate, expected_dim);
+        if out.is_ok() {
+            tx.commit().expect("commit");
+        }
+        out
     }
 
     #[test]

--- a/memory-engine/lib/me-backend-sqlite/src/store/embedding_spaces.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/store/embedding_spaces.rs
@@ -29,7 +29,7 @@
 //!   rebuild hook before the new space serves reads.
 
 use me_types::error::StorageError;
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction};
 
 use me_types::error::{MemoryError, Result};
 use me_types::types::EmbeddingFingerprint;
@@ -284,15 +284,23 @@ pub fn activate(conn: &Connection, name: &str) -> Result<()> {
 /// reads the active row by status), so re-stamping the active row in place is the
 /// correct multi-space generalization.
 ///
+/// # Transaction (#1000)
+///
+/// Takes `&Transaction`, not `&Connection`: the re-stamp is a two-statement
+/// UPDATE-or-INSERT, so the type system now enforces that it runs inside a caller's
+/// transaction rather than relying on the `block_write` write-lock + the statements'
+/// mutual exclusion for its atomicity. `Transaction` derefs to `Connection`, so the
+/// bodies are unchanged.
+///
 /// # Errors
 ///
 /// Returns `MemoryError::Storage` on write failure or `MemoryError::Internal` if a
 /// dimension overflows `i64`.
-pub fn upsert_active_fingerprint(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
+pub fn upsert_active_fingerprint(tx: &Transaction, fp: &EmbeddingFingerprint) -> Result<()> {
     let (dim, base) = dims_to_sql(fp)?;
     // Re-stamp the current active row in place (at most one exists, by the partial
     // unique index), whatever its name.
-    let updated = conn
+    let updated = tx
         .execute(
             "UPDATE embedding_spaces
             SET model = ?1, provider = ?2, dim = ?3, matryoshka_base_dim = ?4, element_type = ?5
@@ -302,7 +310,7 @@ pub fn upsert_active_fingerprint(conn: &Connection, fp: &EmbeddingFingerprint) -
         .map_err(StorageError::backend)?;
     if updated == 0 {
         // No active space yet — seed the canonical `default` active row.
-        conn.execute(
+        tx.execute(
             "INSERT INTO embedding_spaces
                  (name, model, provider, dim, matryoshka_base_dim, element_type, status)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active')",
@@ -367,6 +375,17 @@ mod tests {
         let conn = open_memory().expect("open in-memory db");
         init_schema(&conn).expect("init schema");
         conn
+    }
+
+    // #1000: `upsert_active_fingerprint` now takes `&Transaction`. This same-named test
+    // shim (shadowing the `use super::*` glob) opens a committed tx over the test
+    // connection and delegates to `super::upsert_active_fingerprint`, so the call sites
+    // below are unchanged.
+    fn upsert_active_fingerprint(conn: &Connection, fp: &EmbeddingFingerprint) -> Result<()> {
+        let tx = conn.unchecked_transaction().expect("begin tx");
+        super::upsert_active_fingerprint(&tx, fp)?;
+        tx.commit().expect("commit");
+        Ok(())
     }
 
     #[test]

--- a/memory-engine/lib/me-backend-sqlite/src/store/schema/tests.rs
+++ b/memory-engine/lib/me-backend-sqlite/src/store/schema/tests.rs
@@ -2409,7 +2409,10 @@ fn read_only_open_reads_registry() {
         let conn = open_connection(path_str).unwrap();
         init_schema(&conn).unwrap();
         migrate(&conn, None).unwrap();
-        crate::store::embedding_meta::store(&conn, &fp).unwrap();
+        // #1000: embedding_meta::store takes &Transaction.
+        let tx = conn.unchecked_transaction().unwrap();
+        crate::store::embedding_meta::store(&tx, &fp).unwrap();
+        tx.commit().unwrap();
     }
     let ro = open_connection_read_only(path_str).unwrap();
     validate_schema_version(&ro).expect("a v13 store validates read-only");

--- a/memory-engine/lib/me-consolidate/src/pipeline.rs
+++ b/memory-engine/lib/me-consolidate/src/pipeline.rs
@@ -485,8 +485,14 @@ mod tests {
         // wins, instead of inheriting the no-op run's identity under #614 enforcement.
         let other =
             me_types::types::EmbeddingFingerprint::new("other-model", "other-provider", DIM);
-        let recorded =
-            me_backend_sqlite::store::embedding_meta::record_if_absent(&conn, &other, DIM).unwrap();
+        // #1000: record_if_absent takes &Transaction.
+        let recorded = {
+            let tx = conn.unchecked_transaction().unwrap();
+            let r = me_backend_sqlite::store::embedding_meta::record_if_absent(&tx, &other, DIM)
+                .unwrap();
+            tx.commit().unwrap();
+            r
+        };
         assert_eq!(
             recorded, other,
             "the first real writer wins after a no-op consolidation"

--- a/memory-engine/lib/memory-engine/src/inspect/restore.rs
+++ b/memory-engine/lib/memory-engine/src/inspect/restore.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction};
 
 use crate::error::{ConflictError, MemoryError, MigrationError, Result, StorageError};
 use crate::store::events::event_type_to_str;
@@ -442,7 +442,11 @@ fn restore_edges(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
 /// Returns [`MemoryError::Migration`] on a corrupt legacy `embedding_meta` value or an
 /// unrecognized space status, and [`MemoryError::Storage`]/[`MemoryError::Internal`] on
 /// insert failure (e.g. a second active space).
-fn restore_embedding_spaces(conn: &Connection, snapshot: &EngineSnapshot) -> Result<()> {
+// Takes `&Transaction` (#1000): `embedding_meta::store` re-stamps the registry via the
+// multi-statement `upsert_active_fingerprint`, now tx-typed. The whole restore already
+// runs inside `restore_snapshot_into`'s transaction, so this just threads that tx's type
+// through; `insert_active` reads through the `Transaction` deref to `Connection`.
+fn restore_embedding_spaces(tx: &Transaction, snapshot: &EngineSnapshot) -> Result<()> {
     if snapshot.embedding_spaces.is_empty() {
         if let Some(raw) = snapshot.config.get("embedding_meta") {
             let fp: crate::types::EmbeddingFingerprint =
@@ -451,14 +455,14 @@ fn restore_embedding_spaces(conn: &Connection, snapshot: &EngineSnapshot) -> Res
                         "corrupt legacy embedding_meta in snapshot: {e}"
                     ))
                 })?;
-            crate::store::embedding_meta::store(conn, &fp)?;
+            crate::store::embedding_meta::store(tx, &fp)?;
         }
         return Ok(());
     }
     for s in &snapshot.embedding_spaces {
         let status = crate::store::embedding_spaces::SpaceStatus::from_sql(&s.status)?;
         crate::store::embedding_spaces::insert_active(
-            conn,
+            tx,
             &crate::store::embedding_spaces::EmbeddingSpace {
                 name: s.name.clone(),
                 fingerprint: s.fingerprint.clone(),
@@ -913,7 +917,11 @@ mod tests {
             config,
         };
 
-        restore_embedding_spaces(&conn, &snapshot).unwrap();
+        {
+            let tx = conn.unchecked_transaction().unwrap();
+            restore_embedding_spaces(&tx, &snapshot).unwrap();
+            tx.commit().unwrap();
+        }
 
         assert_eq!(
             crate::store::embedding_meta::load(&conn).unwrap(),


### PR DESCRIPTION
## Summary

Completes the #938 store-layer `&Transaction` audit (tracked by #1000). The careful read-each-fn audit **falsified both of #999's confirmed candidates** — `promote_space`/`write_backfill_batch` are tx-*owners* (correctly stay `&Connection`), and `upsert_active_fingerprint` is safe-in-autocommit (mutually-exclusive statements + the `block_write` write-lock) with non-tx callers, so a naive conversion wasn't behavior-preserving.

Per the maintainer decision (**harden, not document-and-close**), this encodes the embedding-registry write atomicity in the type system so the re-stamp cannot run outside a transaction — the same defense-in-depth as #725 (`unwrap`-forbidding) and #938.

## Changes

- `upsert_active_fingerprint` + `embedding_meta::{store, record_if_absent}` → `&Transaction` (the tx threads from each caller; `record_if_absent` can't own its tx — it runs inside outer consolidation/graph txns).
- The two bare-autocommit trait methods (`store_embedding_fingerprint`, `record_embedding_fingerprint_if_absent`) now open an explicit `unchecked_transaction`.
- `graph.rs`'s two batch fns swap manual `SAVEPOINT` string dances for RAII `unchecked_transaction()` — matching `insert_fact`'s existing pattern and dropping the error-swallowing `let _ = ROLLBACK TO`.
- `inspect/restore.rs::restore_embedding_spaces` threads the `&Transaction` its caller already opens.

## Verification

Full canonical 12-line gate matrix GREEN; anti-#903 unchanged at **1988** (behavior-preserving). The batch rollback/parity tests (`insert_fact_atomic_rollback_on_fingerprint_mismatch`, `insert_fact_atomic_parity_with_direct_store`) still pass, proving the savepoint→tx conversion kept atomic rollback exact.

## Collateral

Surfaced 10 pre-existing broken intra-doc links in `me-backend-sqlite` (confirmed on `main@22d187d`; #1000 introduced none) — inventoried on #915 (the "widen rustdoc gate to `--workspace`" issue), not folded in here.

Closes #1000
