### PR TITLE
fix(retrieval): report immediate neighbours, not the whole component, in graph context (#901)

### DIFF
--- a/crates/me-index/src/graph/memory_graph.rs
+++ b/crates/me-index/src/graph/memory_graph.rs
@@ -212,6 +212,19 @@ impl MemoryGraph {
     /// (outgoing only) and [`connected_component`](Self::connected_component) (the whole
     /// *transitive* component): this is exactly the direct neighbors — the set the inspect
     /// graph-context reports, so it matches `degree` rather than the whole component (#901).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use me_index::{EdgeData, MemoryGraph};
+    /// let mut g = MemoryGraph::new();
+    /// let e = |edge_id| EdgeData { edge_id, relation_type: "relates".into(), weight: 1.0 };
+    /// g.add_edge(1, 2, e(1)); // outgoing: 1 -> 2
+    /// g.add_edge(3, 1, e(2)); // incoming: 3 -> 1
+    /// let mut neighbours = g.neighbors_undirected(1);
+    /// neighbours.sort_unstable();
+    /// assert_eq!(neighbours, vec![2, 3]); // both directions, distinct, self excluded
+    /// ```
     #[must_use]
     pub fn neighbors_undirected(&self, fact_id: i64) -> Vec<i64> {
         self.node_map.get(&fact_id).map_or_else(Vec::new, |&idx| {

--- a/crates/me-index/src/graph/memory_graph.rs
+++ b/crates/me-index/src/graph/memory_graph.rs
@@ -203,6 +203,29 @@ impl MemoryGraph {
         })
     }
 
+    /// Immediate (distance-1) neighbors of a fact — distinct fact ids reachable by a
+    /// single edge in EITHER direction (in or out), excluding the fact itself.
+    ///
+    /// This is the undirected 1-hop neighborhood, consistent with [`degree`](Self::degree)'s
+    /// in+out counting (modulo multi-edges / self-loops, which inflate the edge-count
+    /// degree but collapse to distinct nodes here). Contrast [`neighbors`](Self::neighbors)
+    /// (outgoing only) and [`connected_component`](Self::connected_component) (the whole
+    /// *transitive* component): this is exactly the direct neighbors — the set the inspect
+    /// graph-context reports, so it matches `degree` rather than the whole component (#901).
+    #[must_use]
+    pub fn neighbors_undirected(&self, fact_id: i64) -> Vec<i64> {
+        self.node_map.get(&fact_id).map_or_else(Vec::new, |&idx| {
+            let mut seen = HashSet::new();
+            self.graph
+                .neighbors_directed(idx, Direction::Outgoing)
+                .chain(self.graph.neighbors_directed(idx, Direction::Incoming))
+                .map(|ni| self.graph[ni])
+                // Exclude self-loops and dedup a neighbor linked in both directions.
+                .filter(|&id| id != fact_id && seen.insert(id))
+                .collect()
+        })
+    }
+
     /// Total degree (in + out) for importance scoring.
     #[must_use]
     pub fn degree(&self, fact_id: i64) -> usize {
@@ -484,6 +507,40 @@ mod tests {
         assert_eq!(g.degree(4), 1);
         // unknown node
         assert_eq!(g.degree(99), 0);
+    }
+
+    /// #901: `neighbors_undirected` is the distinct immediate (distance-1) in+out
+    /// neighbour set — the basis of the inspect graph-context's `neighbor_ids`. It
+    /// must dedup a bidirectionally-linked neighbour and exclude self-loops, unlike
+    /// `neighbors` (outgoing only) and `connected_component` (whole transitive component).
+    #[test]
+    fn neighbors_undirected_is_immediate_in_plus_out_deduped() {
+        let mut g = MemoryGraph::new();
+        g.add_edge(1, 2, make_edge_data(1, "a")); // out
+        g.add_edge(1, 3, make_edge_data(2, "b")); // out
+        g.add_edge(4, 1, make_edge_data(3, "c")); // in
+        // Bidirectional link to 5 — must appear EXACTLY ONCE (dedup across directions).
+        g.add_edge(1, 5, make_edge_data(4, "d"));
+        g.add_edge(5, 1, make_edge_data(5, "e"));
+        // Self-loop — must be excluded from node 1's own neighbourhood.
+        g.add_edge(1, 1, make_edge_data(6, "self"));
+
+        let mut n = g.neighbors_undirected(1);
+        n.sort_unstable();
+        assert_eq!(
+            n,
+            vec![2, 3, 4, 5],
+            "distinct immediate in+out neighbours; 5 counted once, self excluded"
+        );
+
+        // A node reached only via an incoming edge still sees its source.
+        assert_eq!(
+            g.neighbors_undirected(2),
+            vec![1],
+            "2's only neighbour is 1 (via the incoming 1->2 edge)"
+        );
+        // Absent node → empty.
+        assert!(g.neighbors_undirected(99).is_empty());
     }
 
     #[test]

--- a/crates/memory-engine/src/inspect/explain.rs
+++ b/crates/memory-engine/src/inspect/explain.rs
@@ -43,17 +43,20 @@ pub fn determine_state(fact: &Fact, now: DateTime<Utc>) -> FactState {
 
 pub fn build_graph_context(graph: &crate::graph::MemoryGraph, fact_id: i64) -> GraphContext {
     let degree = graph.degree(fact_id);
-    // Use connected_component to get ALL neighbors (in + out), consistent with degree.
-    // `neighbors()` only returns outgoing, which would be inconsistent with degree.
     let has_node = graph.has_node(fact_id);
-    let mut neighbor_ids: Vec<i64> = if has_node {
-        let component = graph.connected_component(fact_id);
-        component.into_iter().filter(|&id| id != fact_id).collect()
-    } else {
-        Vec::new()
-    };
+    // Immediate (distance-1) in+out neighbors — consistent with `degree`. This was
+    // `connected_component` (the whole *transitive* component minus self), which #901
+    // flagged as inconsistent with `degree`: a fact of degree 2 sitting in a larger
+    // component reported every transitively-reachable fact as a "neighbor".
+    let mut neighbor_ids = graph.neighbors_undirected(fact_id);
     neighbor_ids.sort_unstable();
-    let component_size = neighbor_ids.len() + usize::from(has_node);
+    // `component_size` stays the separate, broader transitive-component metric (the
+    // whole weakly-connected component including the fact itself).
+    let component_size = if has_node {
+        graph.connected_component(fact_id).len()
+    } else {
+        0
+    };
     GraphContext {
         degree,
         neighbor_ids,
@@ -339,27 +342,19 @@ mod tests {
         assert_eq!(ctx.component_size, 4);
     }
 
-    /// #459 / #901: documents the CURRENT behaviour that `build_graph_context`
-    /// returns the **entire weakly-connected component**, NOT the immediate
-    /// (distance-1) neighbours — and that this is *inconsistent* with `degree`,
-    /// which counts only distance-1 in+out edges.
+    /// #901 (fix): `neighbor_ids` is the **immediate (distance-1) in+out neighbour
+    /// set**, consistent with `degree` — NOT the whole weakly-connected component.
+    /// `component_size` remains the separate, broader transitive-component metric.
     ///
-    /// The star fixture in [`build_graph_context_with_neighbors`] cannot expose
-    /// this: in a star every component member is also a distance-1 neighbour of
-    /// the centre, so component-membership and immediate-neighbourhood coincide.
-    /// Here a deliberately **transitive** chain `A(10) -> B(20) -> C(30)` queried
-    /// from `A` separates them: `C` is distance-2 from `A` (NOT an immediate
-    /// neighbour), yet it appears in `neighbor_ids` because the helper walks the
-    /// whole component. `degree(A) == 1` (only the `A->B` edge) confirms the
-    /// distance-1 vs whole-component divergence.
-    ///
-    /// This asserts reality (the whole-component behaviour) rather than hiding it.
-    /// The degree-vs-component inconsistency — and whether `neighbor_ids` should
-    /// instead be the distance-1 neighbour set to match `degree` — is a
-    /// production design decision tracked in collateral issue #901; this test must
-    /// be updated to assert the distance-1 set if/when that fix lands.
+    /// The star fixture in [`build_graph_context_with_neighbors`] cannot discriminate
+    /// this: in a star every component member is also a distance-1 neighbour, so the
+    /// two coincide. Here a deliberately **transitive** chain `A(10) -> B(20) -> C(30)`
+    /// queried from `A` separates them: `C` is distance-2 from `A`, so it must appear
+    /// in `component_size` (the transitive metric) but NOT in `neighbor_ids` (the
+    /// immediate metric). This is the regression witness for the #901 fix — before it,
+    /// `neighbor_ids` walked the whole component and wrongly included `C(30)`.
     #[test]
-    fn build_graph_context_returns_whole_component_not_immediate_neighbours() {
+    fn build_graph_context_neighbor_ids_are_immediate_not_transitive() {
         let mut graph = MemoryGraph::new();
         let edge = |edge_id| EdgeData {
             edge_id,
@@ -375,32 +370,33 @@ mod tests {
         // `degree` is distance-1 in+out: A has only the single outgoing `A->B`.
         assert_eq!(ctx.degree, 1, "A has exactly one distance-1 edge (A->B)");
 
-        // `neighbor_ids` is the WHOLE component minus A — so it INCLUDES the
-        // transitive distance-2 node C(30), proving it is not the distance-1 set.
+        // `neighbor_ids` is now the IMMEDIATE neighbour set — B(20) only. The
+        // transitive distance-2 node C(30) must NOT appear (that was the #901 bug).
         assert_eq!(
             ctx.neighbor_ids,
-            vec![20, 30],
-            "whole connected component (incl. transitive C=30), NOT immediate neighbours"
+            vec![20],
+            "immediate (distance-1) neighbours only — B(20), not transitive C(30)"
         );
-        // Non-vacuous guard: the transitive node is the load-bearing assertion —
-        // a distance-1-only implementation (matching `degree`) would omit 30.
         assert!(
-            ctx.neighbor_ids.contains(&30),
-            "transitive distance-2 node C(30) must be present under current whole-component behaviour"
+            !ctx.neighbor_ids.contains(&30),
+            "transitive distance-2 node C(30) must NOT be an immediate neighbour (#901)"
         );
 
-        // The divergence made explicit: neighbour-set size (2) exceeds degree (1).
-        assert!(
-            ctx.neighbor_ids.len() > ctx.degree,
-            "component-derived neighbour set is broader than the distance-1 degree (tracked in #901)"
-        );
-
+        // Consistency restored: the immediate neighbour set size equals `degree`
+        // (both distance-1) — the divergence #901 flagged is gone.
         assert_eq!(
-            ctx.component_size,
-            ctx.neighbor_ids.len() + 1,
-            "neighbours + the fact itself"
+            ctx.neighbor_ids.len(),
+            ctx.degree,
+            "immediate neighbour count matches the distance-1 degree (#901 fixed)"
         );
-        assert_eq!(ctx.component_size, 3);
+
+        // `component_size` stays the broader transitive metric: A + B + C = 3, and it
+        // is genuinely larger than the immediate neighbourhood (`neighbor_ids` + self).
+        assert_eq!(ctx.component_size, 3, "whole transitive component A,B,C");
+        assert!(
+            ctx.component_size > ctx.neighbor_ids.len() + 1,
+            "component_size (transitive) is broader than the immediate neighbourhood"
+        );
     }
 
     /// #459: a node present in the graph but with no edges has degree 0, no


### PR DESCRIPTION
## Summary

`inspect::build_graph_context` filled `GraphContext.neighbor_ids` from `MemoryGraph::connected_component` — the whole weakly-connected component (every *transitively*-reachable fact) — which is inconsistent with the reported `degree` (immediate in+out edge count). A fact of degree 2 in a larger component reported every transitively-reachable fact as a "neighbour", so the `explain_fact` API (and the CLI/MCP surfaces that render it) misreported neighbours.

The old comment even reveals the misconception: *"use connected_component to get ALL neighbors ... consistent with degree"* — the transitive closure is **not** the immediate in+out neighbourhood.

## Fix

- New `MemoryGraph::neighbors_undirected(fact_id)` — distinct immediate (distance-1) in+out neighbours (dedups a bidirectionally-linked neighbour; excludes self-loops). Contrast `neighbors` (outgoing only) and `connected_component` (whole transitive component).
- `neighbor_ids` now uses it (matches `degree`). `component_size` is **preserved** as the separate, broader transitive metric (`connected_component().len()`) — no information lost; two distinct, each-correct metrics.

## Tests

TDD red→green: flipped the pre-existing #901 witness (`build_graph_context_neighbor_ids_are_immediate_not_transitive` — chain `A→B→C` from `A` now asserts `neighbor_ids == [B]`, not the transitive `[B,C]`; `component_size == 3` still covers the chain) + a direct `neighbors_undirected` unit test (bidirectional dedup + self-loop). No production consumer relied on the whole-component behaviour; **no insta snapshot changed**.

Full canonical gate matrix GREEN; anti-#903 1989 → 1990 (+1 unit test).

Closes #901
