### PR TITLE
refactor(consolidation): batch importance_score updates in apply_dedup (N+1 → bulk) (#895)

### DIFF
--- a/crates/me-backend-sqlite/src/consolidation/dedup.rs
+++ b/crates/me-backend-sqlite/src/consolidation/dedup.rs
@@ -43,9 +43,13 @@ use crate::store::facts::FactStore;
 ///
 /// # Errors
 ///
-/// Returns `MemoryError::Storage` on SQL failure, or `MemoryError::NotFound` from an
-/// importance update if a fact row is missing (facts are soft-deleted, so this does not
-/// fire for a merely-expired row).
+/// Returns `MemoryError::Storage` on SQL failure, or `MemoryError::NotFound` from a
+/// **base-importance** update if a fact row is missing (facts are soft-deleted, so this
+/// does not fire for a merely-expired row). The `importance_score` writes go through the
+/// bulk `update_importance_scores_bulk` (#895): a missing id is silently skipped rather
+/// than surfaced as `NotFound` (matching the prune path), and a non-finite score — which
+/// `compute_dedup` never produces, since it only carries forward already-finite stored
+/// scores — is rejected as `MemoryError::Conflict` before any row is touched.
 pub fn apply_dedup(
     tx: &Transaction,
     embed_dim: usize,
@@ -58,9 +62,11 @@ pub fn apply_dedup(
     for &(id, importance) in &computed.importance_updates {
         fact_store.update_base_importance(id, importance)?;
     }
-    for &(id, score) in &computed.importance_score_updates {
-        fact_store.update_importance_score(id, score)?;
-    }
+    // Materialize the inherited importance scores in one bulk UPDATE (#895) instead of an
+    // N+1 per-row loop — the same swap #392 made in the prune path (`prune_atomic`). We are
+    // inside the caller's transaction, so atomicity is unchanged: the whole batch commits or
+    // rolls back together, exactly as the loop did.
+    fact_store.update_importance_scores_bulk(&computed.importance_score_updates)?;
 
     // Snapshot each distinct survivor's liveness BEFORE expiring anything, so a survivor
     // this call itself expires (it may also be a loser in a merge chain) is not confused

--- a/crates/me-consolidate/src/pipeline/dedup.rs
+++ b/crates/me-consolidate/src/pipeline/dedup.rs
@@ -765,6 +765,59 @@ mod tests {
         );
     }
 
+    /// #895: `apply_dedup` writes the inherited `importance_score`s through a single
+    /// bulk `update_importance_scores_bulk` UPDATE instead of an N+1 per-row loop. This
+    /// exercises the bulk path with **more than one** score write in a single apply — two
+    /// mutually-dissimilar duplicate groups, each producing a distinct survivor that
+    /// inherits its loser's higher score — so `importance_score_updates` carries two
+    /// entries and both must land. A regression to a partial/mis-keyed bulk statement (or
+    /// a survivor missed by the `json_each` join) shows up as a wrong score on either
+    /// survivor.
+    #[test]
+    fn apply_dedup_bulk_updates_all_survivor_scores() {
+        let (conn, dim) = setup();
+        // Group 1 near [1,0,0,0]; A survives (higher base importance), B is the loser.
+        let a = insert_fact(&conn, dim, "A", vec![1.0, 0.0, 0.0, 0.0], 0.9);
+        let b = insert_fact(&conn, dim, "B", vec![0.99, 0.01, 0.0, 0.0], 0.3);
+        // Group 2 near [0,0,1,0] (orthogonal to group 1, so the groups never merge across);
+        // C survives (higher base importance), D is the loser.
+        let c = insert_fact(&conn, dim, "C", vec![0.0, 0.0, 1.0, 0.0], 0.9);
+        let d = insert_fact(&conn, dim, "D", vec![0.0, 0.01, 0.99, 0.0], 0.3);
+
+        // Each survivor starts LOW; its group's loser holds the higher score it must inherit.
+        let store = FactStore::new(&conn, dim);
+        store.update_importance_score(a, 0.2).unwrap();
+        store.update_importance_score(b, 0.8).unwrap(); // A inherits 0.8
+        store.update_importance_score(c, 0.1).unwrap();
+        store.update_importance_score(d, 0.7).unwrap(); // C inherits 0.7
+
+        let (removed, _) = dedup(&conn, dim, 0.90, NO_CAP, None, Utc::now())
+            .unwrap()
+            .expect_ran();
+        assert_eq!(removed, 2, "one loser per group collapses (B, D)");
+
+        // Both survivors remain, each carrying the score bulk-written in a single UPDATE.
+        let active = store.list_active(None).unwrap();
+        assert_eq!(active.len(), 2);
+        let score_of = |id: i64| {
+            active
+                .iter()
+                .find(|f| f.id == id)
+                .unwrap_or_else(|| panic!("survivor {id} must be active"))
+                .importance_score
+        };
+        assert!(
+            (score_of(a) - 0.8).abs() < f64::EPSILON,
+            "survivor A must inherit 0.8 via the bulk write, got {}",
+            score_of(a)
+        );
+        assert!(
+            (score_of(c) - 0.7).abs() < f64::EPSILON,
+            "survivor C must inherit 0.7 via the bulk write, got {}",
+            score_of(c)
+        );
+    }
+
     #[test]
     fn empty_db_dedup_is_noop() {
         let (conn, dim) = setup();


### PR DESCRIPTION
## What

`apply_dedup` materialized the inherited `importance_score` values with an N+1 per-row loop of `update_importance_score` (one prepared-statement exec + one B-tree write per survivor). This routes them through the existing `FactStore::update_importance_scores_bulk` — a single `json_each`-driven `UPDATE facts SET importance_score = s.value FROM json_each(?1) AS s WHERE facts.id = CAST(s.key AS INTEGER)`. It is the exact swap #392 made in the prune path (`prune_atomic`).

## Why behavior-preserving

- The bulk call stays **inside `apply_dedup`'s transaction**, so atomicity is unchanged — the whole batch commits or rolls back together, exactly as the loop did.
- The only observable deltas are on inputs a real caller cannot produce:
  - A **missing id** is now silently skipped rather than surfaced as `NotFound` (matching the prune path; facts are soft-deleted, so a missing importance-score row cannot occur for a live plan).
  - A **non-finite score** is rejected as a typed `MemoryError::Conflict` before any row is touched. `compute_dedup` only carries forward already-finite stored scores, so this is unreachable defense-in-depth.
- The `# Errors` doc on `apply_dedup` is updated to state this precisely. The separate `update_base_importance` loop is left untouched (out of scope — #895 targets only the `importance_score` N+1; no bulk base-importance helper exists yet — see PR notes for the collateral flag).

## Test

Adds `apply_dedup_bulk_updates_all_survivor_scores`: two mutually-dissimilar duplicate groups, each producing a distinct survivor that inherits its loser's higher score, so `importance_score_updates` carries **two** entries and both must land in the single bulk UPDATE. The existing `update_importance_scores_bulk` unit tests in `me-backend-sqlite` already cover the empty-slice no-op and the non-finite-rejection paths.

## Verification

Full local gate matrix run unpiped (CI is `workflow_dispatch`-only), all green: fmt, clippy `--workspace --all-targets --all-features -D warnings`, build (default + all-features), test `--workspace --all-features` (1990 passed / 0 failed / 81 ignored, +1 test vs main), facade `cargo check` (default + no-default), rustdoc (default + all-features), `cargo deny check`, `cargo +nightly fuzz build`.

Classification: Refactor (user-confirmed)

Closes #895