### PR TITLE
fix(mcp): reject present-but-wrong-type scalar params instead of silently defaulting (#842)

### DIFF
--- a/crates/memory-engine-mcp/src/tools/handlers/cognitive.rs
+++ b/crates/memory-engine-mcp/src/tools/handlers/cognitive.rs
@@ -88,7 +88,7 @@ pub async fn handle_get_recent_insights(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let project_path = get_str(args, "project_path")
+    let project_path = get_str(args, "project_path")?
         .ok_or_else(|| ErrorData::invalid_params("missing 'project_path'", None))?;
     // The schema declares `limit` as an integer `minimum: 1`; the MCP layer does not
     // validate args against the schema, so enforce it here. A present-but-malformed

--- a/crates/memory-engine-mcp/src/tools/handlers/outcome.rs
+++ b/crates/memory-engine-mcp/src/tools/handlers/outcome.rs
@@ -11,9 +11,9 @@ pub async fn handle_record_outcome(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let fact_id = get_i64(args, "fact_id")
+    let fact_id = get_i64(args, "fact_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
-    let outcome_str = get_str(args, "outcome")
+    let outcome_str = get_str(args, "outcome")?
         .ok_or_else(|| ErrorData::invalid_params("missing outcome", None))?;
     let outcome = parse_outcome(&outcome_str)?;
 
@@ -33,7 +33,7 @@ pub async fn handle_outcome_counts(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let fact_id = get_i64(args, "fact_id")
+    let fact_id = get_i64(args, "fact_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
 
     let counts = engine

--- a/crates/memory-engine-mcp/src/tools/handlers/p0.rs
+++ b/crates/memory-engine-mcp/src/tools/handlers/p0.rs
@@ -28,16 +28,16 @@ pub async fn handle_ingest(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let event_type_str = get_str(args, "event_type")
+    let event_type_str = get_str(args, "event_type")?
         .ok_or_else(|| ErrorData::invalid_params("missing event_type", None))?;
     let event_type = parse_event_type(&event_type_str)?;
     let payload = args.get("payload").cloned().unwrap_or_else(|| json!({}));
-    let source =
-        get_str(args, "source").ok_or_else(|| ErrorData::invalid_params("missing source", None))?;
-    let session_id = get_str(args, "session_id");
+    let source = get_str(args, "source")?
+        .ok_or_else(|| ErrorData::invalid_params("missing source", None))?;
+    let session_id = get_str(args, "session_id")?;
     let timestamp = crate::tools::parse::get_datetime(args, "timestamp")?.unwrap_or_else(Utc::now);
 
-    let scope_id = match get_str(args, "scope") {
+    let scope_id = match get_str(args, "scope")? {
         Some(path) => engine
             .ensure_scope_path(&path)
             .await
@@ -67,17 +67,17 @@ pub async fn handle_add_fact(
     embedder: Option<&Arc<HttpEmbeddingProvider>>,
     embed_dim: usize,
 ) -> Result<CallToolResult, ErrorData> {
-    let content = get_str(args, "content")
+    let content = get_str(args, "content")?
         .ok_or_else(|| ErrorData::invalid_params("missing content", None))?;
-    let fact_type = match get_str(args, "fact_type") {
+    let fact_type = match get_str(args, "fact_type")? {
         Some(s) => parse_fact_type(&s)?,
         None => FactType::Semantic,
     };
-    let source_event_id = get_i64(args, "source_event_id");
-    let scope = get_str(args, "scope");
+    let source_event_id = get_i64(args, "source_event_id")?;
+    let scope = get_str(args, "scope")?;
 
     // Validate importance range
-    let importance = get_f64(args, "base_importance");
+    let importance = get_f64(args, "base_importance")?;
     if let Some(imp) = importance
         && !(0.0..=1.0).contains(&imp)
     {
@@ -93,7 +93,7 @@ pub async fn handle_add_fact(
         return Err(ValidationError::TemporalInconsistency.into());
     }
 
-    let pinned = get_bool(args, "pinned");
+    let pinned = get_bool(args, "pinned")?;
     let metadata = args.get("metadata").cloned();
 
     // Pre-computed embedding or server-side embedding. `parse_embedding` rejects a
@@ -159,7 +159,7 @@ pub async fn handle_query(
     let mut query = memory_engine::MemoryQuery::new();
 
     // Parse and validate search mode (if explicit)
-    let explicit_mode = match get_str(args, "mode") {
+    let explicit_mode = match get_str(args, "mode")? {
         Some(s) => Some(parse_search_mode(&s)?),
         None => None,
     };
@@ -181,7 +181,7 @@ pub async fn handle_query(
             .map_err(to_mcp_error)?;
     }
 
-    if let Some(text) = get_str(args, "text") {
+    if let Some(text) = get_str(args, "text")? {
         query = query.text(text.clone());
 
         // Determine effective mode for embedding decision
@@ -237,8 +237,8 @@ pub async fn handle_query(
     }
 
     // Scope
-    if let Some(scope) = get_str(args, "scope") {
-        let scope_mode = get_str(args, "scope_mode").unwrap_or_else(|| "subtree".to_owned());
+    if let Some(scope) = get_str(args, "scope")? {
+        let scope_mode = get_str(args, "scope_mode")?.unwrap_or_else(|| "subtree".to_owned());
         query = match scope_mode.as_str() {
             "subtree" => query.scope_subtree(scope),
             "exact" => query.scope_exact(scope),
@@ -269,19 +269,19 @@ pub async fn handle_query(
         (None, None) => {}
     }
 
-    if let Some(ft) = get_str(args, "fact_type") {
+    if let Some(ft) = get_str(args, "fact_type")? {
         query = query.fact_type(parse_fact_type(&ft)?);
     }
-    if let Some(min) = get_f64(args, "min_importance") {
+    if let Some(min) = get_f64(args, "min_importance")? {
         query = query.min_importance_score(min);
     }
-    if get_bool(args, "pinned_only").unwrap_or(false) {
+    if get_bool(args, "pinned_only")?.unwrap_or(false) {
         query = query.pinned_only();
     }
     if let Some(limit) = limit {
         query = query.limit(limit);
     }
-    if get_bool(args, "include_expired_probe").unwrap_or(false) {
+    if get_bool(args, "include_expired_probe")?.unwrap_or(false) {
         query = query.include_expired_probe();
     }
 
@@ -305,11 +305,11 @@ pub async fn handle_resume_context(
     let depth_level = get_depth(args)?;
 
     let config = ResumeConfig {
-        scope_path: get_str(args, "scope"),
+        scope_path: get_str(args, "scope")?,
         now: Some(Utc::now()),
         pinned_cap: get_usize(args, "pinned_cap")?.unwrap_or(50),
         high_importance_cap: get_usize(args, "high_importance_cap")?.unwrap_or(20),
-        high_importance_min: get_f64(args, "high_importance_min").unwrap_or(0.7),
+        high_importance_min: get_f64(args, "high_importance_min")?.unwrap_or(0.7),
         due_cap: get_usize(args, "due_cap")?.unwrap_or(10),
         recent_cap: get_usize(args, "recent_cap")?.unwrap_or(10),
     };
@@ -325,7 +325,7 @@ pub async fn handle_list_due(
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
     let depth_level = get_depth(args)?;
-    let scope = get_str(args, "scope");
+    let scope = get_str(args, "scope")?;
 
     let facts = engine
         .list_due(Utc::now(), scope.as_deref())
@@ -344,7 +344,7 @@ pub async fn handle_next_due_time(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let scope = get_str(args, "scope");
+    let scope = get_str(args, "scope")?;
     let next = engine
         .next_due_time(scope.as_deref())
         .await
@@ -357,7 +357,7 @@ pub async fn handle_explain_fact(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let fact_id = get_i64(args, "fact_id")
+    let fact_id = get_i64(args, "fact_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
     let depth_level = get_depth(args)?;
 
@@ -371,7 +371,7 @@ pub async fn handle_get_fact(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let fact_id = get_i64(args, "fact_id")
+    let fact_id = get_i64(args, "fact_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
     let depth_level = get_depth(args)?;
 
@@ -429,12 +429,12 @@ pub async fn handle_flush_insights(
             continue;
         };
 
-        let Some(content) = get_str(obj, "content") else {
+        let Some(content) = get_str(obj, "content")? else {
             failed.push(json!({ "index": i, "error": "missing content" }));
             continue;
         };
 
-        let fact_type = match get_str(obj, "fact_type") {
+        let fact_type = match get_str(obj, "fact_type")? {
             Some(s) => match parse_fact_type(&s) {
                 Ok(ft) => ft,
                 Err(e) => {
@@ -445,8 +445,8 @@ pub async fn handle_flush_insights(
             None => FactType::Semantic,
         };
 
-        let scope = get_str(obj, "scope");
-        let importance = get_f64(obj, "base_importance");
+        let scope = get_str(obj, "scope")?;
+        let importance = get_f64(obj, "base_importance")?;
 
         if let Some(imp) = importance
             && !(0.0..=1.0).contains(&imp)

--- a/crates/memory-engine-mcp/src/tools/handlers/p0.rs
+++ b/crates/memory-engine-mcp/src/tools/handlers/p0.rs
@@ -388,6 +388,12 @@ pub async fn handle_statistics(engine: &MemoryEngine) -> Result<CallToolResult, 
     ok_json(value)
 }
 
+// The per-entry validation loop is a single linear parse→validate→collect flow whose
+// per-field error arms (each malformed field → indexed `failed` entry + `continue`) read
+// worse split across helpers. It crossed the 100-line soft cap when #842 made the scalar
+// getters fallible per-entry here (explicit `match` arms instead of a `?`), matching
+// `handle_query`'s existing exemption.
+#[allow(clippy::too_many_lines)]
 pub async fn handle_flush_insights(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
@@ -429,24 +435,53 @@ pub async fn handle_flush_insights(
             continue;
         };
 
-        let Some(content) = get_str(obj, "content")? else {
-            failed.push(json!({ "index": i, "error": "missing content" }));
-            continue;
+        // #842: this is a per-entry BATCH loop with partial-failure semantics — a
+        // malformed entry lands in `failed` and its valid siblings still flush. So a
+        // getter's present-but-wrong-type error must become a `failed` entry + `continue`
+        // here, NOT `?`-propagate out and abort the whole batch (which the uniform sweep
+        // would have done). Every request-level handler keeps the `?`; only this loop
+        // catches.
+        let content = match get_str(obj, "content") {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                failed.push(json!({ "index": i, "error": "missing content" }));
+                continue;
+            }
+            Err(e) => {
+                failed.push(json!({ "index": i, "error": e.message.to_string() }));
+                continue;
+            }
         };
 
-        let fact_type = match get_str(obj, "fact_type")? {
-            Some(s) => match parse_fact_type(&s) {
+        let fact_type = match get_str(obj, "fact_type") {
+            Ok(Some(s)) => match parse_fact_type(&s) {
                 Ok(ft) => ft,
                 Err(e) => {
                     failed.push(json!({ "index": i, "error": e.to_string() }));
                     continue;
                 }
             },
-            None => FactType::Semantic,
+            Ok(None) => FactType::Semantic,
+            Err(e) => {
+                failed.push(json!({ "index": i, "error": e.message.to_string() }));
+                continue;
+            }
         };
 
-        let scope = get_str(obj, "scope")?;
-        let importance = get_f64(obj, "base_importance")?;
+        let scope = match get_str(obj, "scope") {
+            Ok(v) => v,
+            Err(e) => {
+                failed.push(json!({ "index": i, "error": e.message.to_string() }));
+                continue;
+            }
+        };
+        let importance = match get_f64(obj, "base_importance") {
+            Ok(v) => v,
+            Err(e) => {
+                failed.push(json!({ "index": i, "error": e.message.to_string() }));
+                continue;
+            }
+        };
 
         if let Some(imp) = importance
             && !(0.0..=1.0).contains(&imp)

--- a/crates/memory-engine-mcp/src/tools/handlers/p1.rs
+++ b/crates/memory-engine-mcp/src/tools/handlers/p1.rs
@@ -113,7 +113,7 @@ pub async fn handle_dump_state(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let format_str = get_str(args, "format").unwrap_or_else(|| "json".to_owned());
+    let format_str = get_str(args, "format")?.unwrap_or_else(|| "json".to_owned());
 
     let ext = match format_str.as_str() {
         "json" => "json",
@@ -123,7 +123,7 @@ pub async fn handle_dump_state(
         }
     };
 
-    let path = match get_str(args, "path") {
+    let path = match get_str(args, "path")? {
         Some(p) => validate_dump_path(&PathBuf::from(p))?,
         None => default_dump_path(&std::env::temp_dir(), ext),
     };
@@ -146,7 +146,7 @@ pub async fn handle_pin_fact(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let fact_id = get_i64(args, "fact_id")
+    let fact_id = get_i64(args, "fact_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
 
     engine.pin_fact(fact_id).await.map_err(to_mcp_error)?;
@@ -158,7 +158,7 @@ pub async fn handle_unpin_fact(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let fact_id = get_i64(args, "fact_id")
+    let fact_id = get_i64(args, "fact_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
 
     engine.unpin_fact(fact_id).await.map_err(to_mcp_error)?;

--- a/crates/memory-engine-mcp/src/tools/handlers/p2.rs
+++ b/crates/memory-engine-mcp/src/tools/handlers/p2.rs
@@ -37,8 +37,8 @@ pub async fn handle_replay_events(
         return Err(ErrorData::invalid_params("since must be <= until", None));
     }
 
-    let id_start = get_i64(args, "id_range_start");
-    let id_end = get_i64(args, "id_range_end");
+    let id_start = get_i64(args, "id_range_start")?;
+    let id_end = get_i64(args, "id_range_end")?;
     let id_range = match (id_start, id_end) {
         (Some(s), Some(e)) => {
             if s > e {
@@ -58,8 +58,8 @@ pub async fn handle_replay_events(
         }
     };
 
-    let session_id = get_str(args, "session_id");
-    let event_type = match get_str(args, "event_type") {
+    let session_id = get_str(args, "session_id")?;
+    let event_type = match get_str(args, "event_type")? {
         Some(s) => Some(parse_event_type(&s)?),
         None => None,
     };
@@ -74,8 +74,8 @@ pub async fn handle_replay_events(
         Some(n) => Some(n),
         None => Some(100),
     };
-    let upcast = get_bool(args, "upcast").unwrap_or(false);
-    let order = match get_str(args, "order") {
+    let upcast = get_bool(args, "upcast")?.unwrap_or(false);
+    let order = match get_str(args, "order")? {
         Some(s) => parse_replay_order(&s)?,
         None => ReplayOrder::InsertionOrder,
     };
@@ -104,7 +104,7 @@ pub async fn handle_fact_history(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let fact_id = get_i64(args, "fact_id")
+    let fact_id = get_i64(args, "fact_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing fact_id", None))?;
     let depth_level = get_depth(args)?;
 
@@ -171,9 +171,9 @@ pub async fn handle_bootstrap_session(
         }
     };
     let config = BootstrapConfig {
-        scope: get_str(args, "scope"),
+        scope: get_str(args, "scope")?,
         max_turns: get_usize(args, "max_turns")?.unwrap_or(0),
-        skip_existing: get_bool(args, "skip_existing").unwrap_or(true),
+        skip_existing: get_bool(args, "skip_existing")?.unwrap_or(true),
         redact: true,
         denylist,
         // #293 hostile-input caps (max_session_bytes / max_entries): the MCP

--- a/crates/memory-engine-mcp/src/tools/handlers/session.rs
+++ b/crates/memory-engine-mcp/src/tools/handlers/session.rs
@@ -21,17 +21,17 @@ pub async fn handle_record_activity(
     filter_config: &memory_engine::ActivityFilterConfig,
 ) -> Result<CallToolResult, ErrorData> {
     let tool_name =
-        get_str(args, "tool").ok_or_else(|| ErrorData::invalid_params("missing tool", None))?;
-    let session_id = get_str(args, "session_id")
+        get_str(args, "tool")?.ok_or_else(|| ErrorData::invalid_params("missing tool", None))?;
+    let session_id = get_str(args, "session_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing session_id", None))?;
     let tool_args = args.get("args").cloned().unwrap_or_else(|| json!({}));
-    let result_summary = get_str(args, "result");
+    let result_summary = get_str(args, "result")?;
     let timestamp = get_datetime(args, "timestamp")?.unwrap_or_else(Utc::now);
-    let scope = get_str(args, "scope");
+    let scope = get_str(args, "scope")?;
     // `OutcomeClass::from_str` is infallible (the open `Other` arm captures any
     // value), so an arbitrary JSON string maps cleanly; `None` defers to the
     // engine's `OutcomeClass::Success` default.
-    let outcome_class = get_str(args, "outcome_class").map(|s| {
+    let outcome_class = get_str(args, "outcome_class")?.map(|s| {
         let Ok(class) = s.parse::<memory_engine::OutcomeClass>();
         class
     });
@@ -67,10 +67,10 @@ pub async fn handle_checkpoint_session(
     args: &serde_json::Map<String, Value>,
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
-    let session_id = get_str(args, "session_id")
+    let session_id = get_str(args, "session_id")?
         .ok_or_else(|| ErrorData::invalid_params("missing session_id", None))?;
-    let scope = get_str(args, "scope");
-    let summary = get_str(args, "summary");
+    let scope = get_str(args, "scope")?;
+    let summary = get_str(args, "summary")?;
     let metadata = args.get("metadata").cloned();
 
     engine
@@ -89,7 +89,7 @@ pub async fn handle_load_context(
     engine: &MemoryEngine,
 ) -> Result<CallToolResult, ErrorData> {
     let scope =
-        get_str(args, "scope").ok_or_else(|| ErrorData::invalid_params("missing scope", None))?;
+        get_str(args, "scope")?.ok_or_else(|| ErrorData::invalid_params("missing scope", None))?;
     let activity_limit = get_usize(args, "activity_limit")?.unwrap_or(20);
     let fact_limit = get_usize(args, "fact_limit")?.unwrap_or(10);
     let depth_level = get_depth(args)?;

--- a/crates/memory-engine-mcp/src/tools/parse.rs
+++ b/crates/memory-engine-mcp/src/tools/parse.rs
@@ -17,20 +17,51 @@ use serde_json::{Map, Value};
 use crate::depth::Depth;
 use crate::error::ValidationError;
 
-pub fn get_str(args: &Map<String, Value>, key: &str) -> Option<String> {
-    args.get(key).and_then(Value::as_str).map(String::from)
+// Each scalar getter distinguishes *absent* (`Ok(None)` — the caller may apply its
+// default) from *present-but-wrong-type* (`Err(invalid_params)`), rather than the old
+// `and_then(Value::as_*)` that collapsed both to `None` and let an untrusted caller's
+// wrong-typed value silently become the server's default (#842 — the type-mismatch twin
+// of the #339 negative-value fix). `null` is treated as absent, matching JSON's
+// "unset" idiom and the pre-#842 behavior (`as_*` returned `None` for `null`).
+
+pub fn get_str(args: &Map<String, Value>, key: &str) -> Result<Option<String>, ErrorData> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_str()
+            .map(|s| Some(s.to_owned()))
+            .ok_or_else(|| ErrorData::invalid_params(format!("{key} must be a string"), None)),
+    }
 }
 
-pub fn get_i64(args: &Map<String, Value>, key: &str) -> Option<i64> {
-    args.get(key).and_then(Value::as_i64)
+pub fn get_i64(args: &Map<String, Value>, key: &str) -> Result<Option<i64>, ErrorData> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| ErrorData::invalid_params(format!("{key} must be an integer"), None)),
+    }
 }
 
-pub fn get_f64(args: &Map<String, Value>, key: &str) -> Option<f64> {
-    args.get(key).and_then(Value::as_f64)
+pub fn get_f64(args: &Map<String, Value>, key: &str) -> Result<Option<f64>, ErrorData> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_f64()
+            .map(Some)
+            .ok_or_else(|| ErrorData::invalid_params(format!("{key} must be a number"), None)),
+    }
 }
 
-pub fn get_bool(args: &Map<String, Value>, key: &str) -> Option<bool> {
-    args.get(key).and_then(Value::as_bool)
+pub fn get_bool(args: &Map<String, Value>, key: &str) -> Result<Option<bool>, ErrorData> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_bool()
+            .map(Some)
+            .ok_or_else(|| ErrorData::invalid_params(format!("{key} must be a boolean"), None)),
+    }
 }
 
 /// Read an optional non-negative integer parameter.
@@ -40,7 +71,7 @@ pub fn get_bool(args: &Map<String, Value>, key: &str) -> Option<bool> {
 /// silently dropped (#339): dropping it would let the engine fall back to its
 /// own default — e.g. returning more results than an untrusted caller asked for.
 pub fn get_usize(args: &Map<String, Value>, key: &str) -> Result<Option<usize>, ErrorData> {
-    get_i64(args, key).map_or(Ok(None), |v| {
+    get_i64(args, key)?.map_or(Ok(None), |v| {
         usize::try_from(v).map(Some).map_err(|_| {
             ErrorData::invalid_params(format!("{key} must be a non-negative integer"), None)
         })
@@ -51,7 +82,7 @@ pub fn get_datetime(
     args: &Map<String, Value>,
     key: &str,
 ) -> Result<Option<DateTime<Utc>>, ErrorData> {
-    get_str(args, key).map_or(Ok(None), |s| {
+    get_str(args, key)?.map_or(Ok(None), |s| {
         s.parse::<DateTime<Utc>>()
             .map(Some)
             .map_err(|e| ErrorData::invalid_params(format!("invalid {key}: {e}"), None))
@@ -118,13 +149,13 @@ pub fn parse_declared_fingerprint(
     args: &Map<String, Value>,
     dim: usize,
 ) -> Result<EmbeddingFingerprint, ErrorData> {
-    let model = get_str(args, "model").ok_or_else(|| {
+    let model = get_str(args, "model")?.ok_or_else(|| {
         ErrorData::invalid_params(
             "a pre-computed `embedding` requires a declared `model` (the model that produced it)",
             None,
         )
     })?;
-    let provider = get_str(args, "provider").ok_or_else(|| {
+    let provider = get_str(args, "provider")?.ok_or_else(|| {
         ErrorData::invalid_params(
             "a pre-computed `embedding` requires a declared `provider` (e.g. \"tei\", \"ollama\")",
             None,
@@ -460,9 +491,9 @@ pub fn validate_dump_path(p: &std::path::Path) -> Result<PathBuf, ErrorData> {
 #[cfg(test)]
 mod tests {
     use super::{
-        default_dump_name, default_dump_path, get_datetime, get_usize, parse_consolidate_config,
-        parse_embedding, parse_event_type, parse_fact_type, parse_outcome, require_f64_if_present,
-        validate_dump_path,
+        default_dump_name, default_dump_path, get_bool, get_datetime, get_f64, get_i64, get_str,
+        get_usize, parse_consolidate_config, parse_embedding, parse_event_type, parse_fact_type,
+        parse_outcome, require_f64_if_present, validate_dump_path,
     };
     use memory_engine::types::{EventType, FactType, Outcome};
     use serde_json::json;
@@ -734,6 +765,101 @@ mod tests {
         // caller can fall back to its default.
         let v = get_usize(&cfg_args(&[]), "limit").unwrap();
         assert_eq!(v, None);
+    }
+
+    // --- #842: scalar getters reject present-but-wrong-type input ------------
+    // Each distinguishes absent/null (Ok(None) — caller may default) from a
+    // present-but-wrong-JSON-type value (Err(invalid_params)), instead of the old
+    // `and_then(as_*)` that let a wrong-typed value silently become the server default.
+
+    #[test]
+    fn get_i64_rejects_present_wrong_type() {
+        // A stringified number from an untrusted client is an ERROR, not a silent default.
+        let err = get_i64(&cfg_args(&[("n", json!("50"))]), "n").unwrap_err();
+        assert!(
+            err.message.contains("n must be an integer"),
+            "{}",
+            err.message
+        );
+        // A non-integral float is also wrong-type for an integer param.
+        assert!(get_i64(&cfg_args(&[("n", json!(1.5))]), "n").is_err());
+        // Absent, null → Ok(None); a real integer → Ok(Some).
+        assert_eq!(get_i64(&cfg_args(&[]), "n").unwrap(), None);
+        assert_eq!(
+            get_i64(&cfg_args(&[("n", json!(null))]), "n").unwrap(),
+            None
+        );
+        assert_eq!(
+            get_i64(&cfg_args(&[("n", json!(42))]), "n").unwrap(),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn get_str_rejects_present_wrong_type() {
+        let err = get_str(&cfg_args(&[("s", json!(5))]), "s").unwrap_err();
+        assert!(
+            err.message.contains("s must be a string"),
+            "{}",
+            err.message
+        );
+        assert_eq!(get_str(&cfg_args(&[]), "s").unwrap(), None);
+        assert_eq!(
+            get_str(&cfg_args(&[("s", json!(null))]), "s").unwrap(),
+            None
+        );
+        assert_eq!(
+            get_str(&cfg_args(&[("s", json!("hi"))]), "s").unwrap(),
+            Some("hi".to_owned())
+        );
+    }
+
+    #[test]
+    fn get_f64_rejects_present_wrong_type() {
+        let err = get_f64(&cfg_args(&[("w", json!("0.5"))]), "w").unwrap_err();
+        assert!(
+            err.message.contains("w must be a number"),
+            "{}",
+            err.message
+        );
+        assert_eq!(get_f64(&cfg_args(&[]), "w").unwrap(), None);
+        // A JSON integer is a valid number for an f64 param.
+        assert_eq!(
+            get_f64(&cfg_args(&[("w", json!(3))]), "w").unwrap(),
+            Some(3.0)
+        );
+        assert_eq!(
+            get_f64(&cfg_args(&[("w", json!(0.25))]), "w").unwrap(),
+            Some(0.25)
+        );
+    }
+
+    #[test]
+    fn get_bool_rejects_present_wrong_type() {
+        let err = get_bool(&cfg_args(&[("b", json!("true"))]), "b").unwrap_err();
+        assert!(
+            err.message.contains("b must be a boolean"),
+            "{}",
+            err.message
+        );
+        assert_eq!(get_bool(&cfg_args(&[]), "b").unwrap(), None);
+        assert_eq!(
+            get_bool(&cfg_args(&[("b", json!(true))]), "b").unwrap(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn get_usize_rejects_wrong_type_not_just_negative() {
+        // #842 crux: #339 fixed only the NEGATIVE case, but `get_usize` delegates to
+        // `get_i64`, so a stringified number ("50") used to slip through as `Ok(None)`
+        // and silently apply the default. Now the get_i64 type-gate rejects it first.
+        let err = get_usize(&cfg_args(&[("limit", json!("50"))]), "limit").unwrap_err();
+        assert!(
+            err.message.contains("limit must be an integer"),
+            "{}",
+            err.message
+        );
     }
 
     #[test]

--- a/crates/memory-engine-mcp/tests/embedding_integration.rs
+++ b/crates/memory-engine-mcp/tests/embedding_integration.rs
@@ -560,6 +560,61 @@ async fn flush_insights_partial_failure() {
     assert_eq!(body["failed_count"].as_u64().unwrap(), 2);
 }
 
+/// #842 regression: a present-but-WRONG-TYPE scalar in a batch entry (here a non-string
+/// `content`) must land in `failed` per-entry, NOT `?`-propagate and abort the whole batch
+/// (which would drop the valid sibling). Witness for the cross-model finding on PR #1008 —
+/// the uniform getter-fallibility sweep was wrong inside this partial-failure loop; without
+/// the per-entry catch, `dispatch` returns `invalid_params` and this test's `unwrap_ok`
+/// panics.
+#[tokio::test(flavor = "multi_thread")]
+async fn flush_insights_wrong_type_scalar_is_per_entry_failure() {
+    let server = MockServer::start().await;
+    let emb = make_embedding(DIM);
+    // Only the 1 valid insight reaches the batch embed.
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{ "index": 0, "embedding": emb }]
+        })))
+        .mount(&server)
+        .await;
+    let (engine, provider) = build_engine_and_provider(
+        format!("{}/v1/embeddings", server.uri()),
+        "test-model",
+        "test-provider",
+        None,
+        None,
+    )
+    .await;
+    let body = unwrap_ok(
+        tools::dispatch(
+            "memory_flush_insights",
+            args(json!({
+                "insights": [
+                    { "content": "Good insight" },
+                    { "content": 42 } // wrong type: non-string content
+                ]
+            })),
+            &engine,
+            Some(provider),
+            None,
+            DIM,
+            &cfg(),
+        )
+        .await,
+    );
+    assert_eq!(
+        body["added"].as_u64().unwrap(),
+        1,
+        "the valid sibling must still flush"
+    );
+    assert_eq!(
+        body["failed_count"].as_u64().unwrap(),
+        1,
+        "the wrong-typed entry is a per-entry failure, not a whole-batch abort"
+    );
+}
+
 /// A present-but-non-object `metadata` is rejected per-entry into `failed` (not
 /// silently coerced to `{}`), while a sibling insight with valid metadata still flushes.
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

The MCP scalar getters `get_str`/`get_i64`/`get_f64`/`get_bool` used `args.get(key).and_then(Value::as_*)`, collapsing **absent** and **present-but-wrong-type** into the same `None`. So a client sending `"limit": "50"` (string), a float where an int is expected, or `1e400` got `None` → the caller's `.unwrap_or(default)` **silently applied the server default**. Same untrusted-input-becomes-permissive-default vector #339 fixed for the negative case, via type-mismatch rather than sign.

**Also closes the hole `get_usize` inherited**: #339 guarded the `i64→usize` try_from (the sign), but `get_usize` delegates to `get_i64`, so a wrong-*type* value slipped through as `Ok(None)` too. Fixing the base getters closes it at the source.

## Change

- The 4 getters now return `Result<Option<T>, ErrorData>`: absent / JSON `null` → `Ok(None)` (caller may default); present-but-wrong-type → `Err(invalid_params)` with `"{key} must be a {type}"`, mirroring the existing `get_usize`/`get_datetime`/`require_f64_if_present` pattern.
- Threaded fallibility through **~56 call sites** (p0/p1/p2/outcome/cognitive/session handlers + `get_usize`/`get_datetime`/`parse_declared_fingerprint`) — each getter call `?`s the type-check `Result`, then applies its existing `Option` handling unchanged (every enclosing handler already returns `Result<_, ErrorData>`). Compiler-enumerated, not hand-found.
- Regression tests: each getter rejects wrong-type, treats absent/null as `Ok(None)`, accepts the right type; plus a witness that `get_usize` now rejects a stringified number (the inherited #339 hole).

## Verification

Full canonical 12-line gate matrix GREEN (fmt, `clippy --workspace --all-targets --all-features -D warnings`, build×2, test --workspace --all-features, check×2, doc×2, deny, +nightly fuzz build); anti-#903 +5 (new witnesses).

## Collateral (pre-existing, not fixed here)

`cargo clippy -p memory-engine-mcp --all-features` surfaces a `needless_pass_by_value` in `me-backend-sqlite/src/sqlite/mod.rs:210` (clippy 1.97) — a **feature-union-specific** lint (the canonical `--workspace --all-features` gate does not fire it; `-p mcp` propagates a different feature subset to the storage crate). #842 touched zero storage files; this is the exact drift **#849** already tracks (its title: "…clippy warnings in storage/sqlite (unused clone, **pass-by-value**, dead helper)"). Left to #849.

Classification: Bug fix (user-confirmed)

Closes #842
